### PR TITLE
Omit helm specific labels (#2285)

### DIFF
--- a/pkg/kube/workload.go
+++ b/pkg/kube/workload.go
@@ -109,10 +109,11 @@ func WaitOnDeploymentReady(ctx context.Context, kubeCli kubernetes.Interface, d 
 	}
 }
 
-// TODO(tom): We should figure out why these helm labels are not getting passed on.
+// We omit helm specific labels.
 var labelBlackList = map[string]struct{}{
 	"chart":    struct{}{},
 	"heritage": struct{}{},
+	"release":  struct{}{},
 }
 
 func labelSelector(labels map[string]string) string {


### PR DESCRIPTION
## Overview
Label propagation is not enforced, so we cannot rely on it. This patch handles the specific case where helm charts only propagate their app label as we've seen with stable/mysql.

## Followup
We'll deep to come up with a more robust way of going from Deployment to ReplicaSets. One approach would be to remove label filtering alltogether.

## Test Plan
Unit tests pass and manually tested on the stable/mysql chart. This exposes a gap in our testing infra where we only test with constructed specs. we should be testing with externally defined specs/charts.