### PR TITLE
Filter out pods that aren't running. (#2360)

### DIFF
--- a/pkg/kube/workload.go
+++ b/pkg/kube/workload.go
@@ -153,7 +153,7 @@ func FetchReplicaSet(cli kubernetes.Interface, namespace string, uid types.UID, 
 	return nil, fmt.Errorf("Could not find a single replicaset for deployment")
 }
 
-// FetchPods fetches the pods matching the specified labels and owner UID
+// FetchPods fetches the running pods matching the specified labels and owner UID
 func FetchPods(cli kubernetes.Interface, namespace string, uid types.UID, labels map[string]string) ([]v1.Pod, error) {
 	sel := labelSelector(labels)
 	opts := metav1.ListOptions{LabelSelector: sel}
@@ -165,6 +165,9 @@ func FetchPods(cli kubernetes.Interface, namespace string, uid types.UID, labels
 	for _, pod := range pods.Items {
 		if len(pod.OwnerReferences) != 1 ||
 			pod.OwnerReferences[0].UID != uid {
+			continue
+		}
+		if pod.Status.Phase != v1.PodRunning {
 			continue
 		}
 		ps = append(ps, pod)


### PR DESCRIPTION
This prevents executing pods in containers that aren't running.