### PR TITLE
Return controller version in healthcheck

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -37,5 +37,5 @@ export GOARCH="${ARCH}"
 
 go install -v                                                      \
     -installsuffix "static"                                        \
-    -ldflags "-X ${PKG}/pkg/version.VERSION=${VERSION}"            \
+    -ldflags "-X ${PKG}/pkg.VERSION=${VERSION}"            \
     ./...

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -1,14 +1,22 @@
 package handler
 
 import (
+	"encoding/json"
 	"io"
 	"net/http"
+
+	kanister "github.com/kanisterio/kanister/pkg"
 )
 
 const (
 	healthCheckPath = "/v0/healthz"
 	healthCheckAddr = ":8000"
 )
+
+type Info struct {
+	Alive   bool   `json:"alive"`
+	Version string `json:"version"`
+}
 
 var _ http.Handler = (*healthCheckHandler)(nil)
 
@@ -19,9 +27,16 @@ func NewHealthCheckHandler() *healthCheckHandler {
 }
 
 func (*healthCheckHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	version := kanister.VERSION
+	info := Info{true, version}
+	js, err := json.Marshal(info)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 	w.WriteHeader(http.StatusOK)
 	w.Header().Set("Content-Type", "application/json")
-	io.WriteString(w, `{"alive": true}`)
+	io.WriteString(w, string(js))
 }
 
 func NewServer() *http.Server {


### PR DESCRIPTION
The command used inside the kanister-operator pod is: curl localhost:8000/v0/healthz
Output:  `{"alive":true,"version":"v1.1.5-30-g606b4fb7"}`
