### PR TITLE
Return error instead of crashing

### DIFF
--- a/pkg/kanctl/perform_from.go
+++ b/pkg/kanctl/perform_from.go
@@ -52,7 +52,7 @@ func performFrom(ctx context.Context, cmd *cobra.Command, namespace string, acti
 	}
 	cli, err := crclientv1alpha1.NewForConfig(config)
 	if err != nil {
-		errors.Wrap(err, "Could not get CRD client")
+		return errors.Wrap(err, "Could not get CRD client")
 	}
 	pas, err := cli.ActionSets(namespace).Get(parentName, metav1.GetOptions{})
 	if err != nil {


### PR DESCRIPTION
Since we don't return this error, we panic when the client can't be initialized
```
kanctl --namespace kanister perform restore --from s3backup-dbqhh
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0xe1a11a]
goroutine 1 [running]:
github.com/kanisterio/kanister/pkg/client/clientset/versioned/typed/cr/v1alpha1.(*actionSets).Get(0xc4201d2920, 0x7fff9fb0388d, 0xe, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
    /go/src/github.com/kanisterio/kanister/pkg/client/clientset/versioned/typed/cr/v1alpha1/actionset.go:48 +0xaa
github.com/kanisterio/kanister/pkg/kanctl.performFrom(0x1119da0, 0xc4200a0030, 0xc420480d80, 0x7fff9fb0386d, 0x8, 0x7fff9fb0387e, 0x7, 0x7fff9fb0388d, 0xe, 0xc4204221e0, ...)
    /go/src/github.com/kanisterio/kanister/pkg/kanctl/perform_from.go:57 +0x13c
github.com/kanisterio/kanister/pkg/kanctl.runPerformFrom(0xc420480d80, 0xc4200ea6e0, 0x1, 0x5, 0x0, 0x0)
    /go/src/github.com/kanisterio/kanister/pkg/kanctl/perform_from.go:45 +0x150
github.com/kanisterio/kanister/pkg/kanctl.newPerformFromCommand.func1(0xc420480d80, 0xc4200ea6e0, 0x1, 0x5, 0x0, 0x0)
    /go/src/github.com/kanisterio/kanister/pkg/kanctl/perform_from.go:24 +0x49
github.com/kanisterio/kanister/vendor/github.com/spf13/cobra.(*Command).execute(0xc420480d80, 0xc4200ea690, 0x5, 0x5, 0xc420480d80, 0xc4200ea690)
    /go/src/github.com/kanisterio/kanister/vendor/github.com/spf13/cobra/command.go:698 +0x46d
github.com/kanisterio/kanister/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc4204806c0, 0xc4203c9b70, 0xc4204806c0, 0xc420480d80)
    /go/src/github.com/kanisterio/kanister/vendor/github.com/spf13/cobra/command.go:783 +0x2e4
github.com/kanisterio/kanister/vendor/github.com/spf13/cobra.(*Command).Execute(0xc4204806c0, 0x0, 0x0)
    /go/src/github.com/kanisterio/kanister/vendor/github.com/spf13/cobra/command.go:736 +0x2b
github.com/kanisterio/kanister/pkg/kanctl.Execute()
    /go/src/github.com/kanisterio/kanister/pkg/kanctl/kanctl.go:18 +0x27
main.main()
    /go/src/github.com/kanisterio/kanister/cmd/kanctl/main.go:14 +0x20
```