### PR TITLE
Kan mod codegen (#6188)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,6 @@ test: build-dirs
 
 codegen:
 	@$(MAKE) run CMD='-c "                       \
-		PATH=$$GOPATH/bin:$$GOROOT/bin::$${PATH} \
 		./build/codegen.sh                       \
 	"'
 

--- a/build/codegen.sh
+++ b/build/codegen.sh
@@ -16,16 +16,15 @@
 
 set -o errexit
 set -o nounset
+set -o xtrace
 
-# This is a workaround for the fact that codegen requires this boilerplate file
-# to exist in GOPATH. If this file isn't present, we'll use an empty one.
-boilerplate="${GOPATH}/src/k8s.io/kubernetes/hack/boilerplate/boilerplate.go.txt"
-mkdir -p $(dirname "${boilerplate}")
-touch "${boilerplate}"
-
-pushd vendor/k8s.io/code-generator
-./generate-groups.sh                        \
-  all                                       \
-  github.com/kanisterio/kanister/pkg/client \
-  github.com/kanisterio/kanister/pkg/apis   \
-  "cr:v1alpha1"                             \
+export GO111MODULE=on
+go mod download
+execDir="/go/pkg/mod/k8s.io/code-generator@$(go list -f '{{.Version}}' -m k8s.io/code-generator)"
+chmod +x "${execDir}"/generate-groups.sh
+"${execDir}"/generate-groups.sh                         \
+  all                                        \
+  github.com/kanisterio/kanister/pkg/client  \
+  github.com/kanisterio/kanister/pkg/apis    \
+  "cr:v1alpha1"                              \
+  --go-header-file "${execDir}"/hack/boilerplate.go.txt

--- a/pkg/client/clientset/versioned/clientset.go
+++ b/pkg/client/clientset/versioned/clientset.go
@@ -28,8 +28,6 @@ import (
 type Interface interface {
 	Discovery() discovery.DiscoveryInterface
 	CrV1alpha1() crv1alpha1.CrV1alpha1Interface
-	// Deprecated: please explicitly pick a version if possible.
-	Cr() crv1alpha1.CrV1alpha1Interface
 }
 
 // Clientset contains the clients for groups. Each group has exactly one
@@ -41,12 +39,6 @@ type Clientset struct {
 
 // CrV1alpha1 retrieves the CrV1alpha1Client
 func (c *Clientset) CrV1alpha1() crv1alpha1.CrV1alpha1Interface {
-	return c.crV1alpha1
-}
-
-// Deprecated: Cr retrieves the default version of CrClient.
-// Please explicitly pick a version.
-func (c *Clientset) Cr() crv1alpha1.CrV1alpha1Interface {
 	return c.crV1alpha1
 }
 

--- a/pkg/client/clientset/versioned/fake/clientset_generated.go
+++ b/pkg/client/clientset/versioned/fake/clientset_generated.go
@@ -75,8 +75,3 @@ var _ clientset.Interface = &Clientset{}
 func (c *Clientset) CrV1alpha1() crv1alpha1.CrV1alpha1Interface {
 	return &fakecrv1alpha1.FakeCrV1alpha1{Fake: &c.Fake}
 }
-
-// Cr retrieves the CrV1alpha1Client
-func (c *Clientset) Cr() crv1alpha1.CrV1alpha1Interface {
-	return &fakecrv1alpha1.FakeCrV1alpha1{Fake: &c.Fake}
-}


### PR DESCRIPTION
* Fix codegen to support go mod
go mod has a dependency on workdir
the previous version was forcing kanister pull from master

