### PR TITLE
Copy restic from official image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,4 @@
 /.go
 /.push-*
 /.vendor
-/bin
-/vendor
+/dist

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -37,15 +37,15 @@ builds:
   goarch: *goarch
 dockers:
 - binaries:
-  - kando
-  image_templates:
-  - 'kanisterio/kanister-tools:{{ .Tag }}'
-  dockerfile: 'docker/tools/Dockerfile'
-- binaries:
   - controller
   image_templates:
   - 'kanisterio/kanister-controller:{{ .Tag }}'
   dockerfile: 'docker/controller/Dockerfile'
+- binaries:
+  - kando
+  image_templates:
+  - 'kanisterio/kanister-tools:{{ .Tag }}'
+  dockerfile: 'docker/tools/Dockerfile'
 - binaries:
   - kando
   image_templates:

--- a/docker/controller/Dockerfile
+++ b/docker/controller/Dockerfile
@@ -1,0 +1,6 @@
+FROM alpine:3.10
+MAINTAINER Tom Manville<tom@kasten.io>
+RUN apk -v --update add --no-cache ca-certificates && \
+	rm -f /var/cache/apk/*
+ADD controller /controller
+ENTRYPOINT ["/controller"]

--- a/docker/postgres-kanister-tools/Dockerfile
+++ b/docker/postgres-kanister-tools/Dockerfile
@@ -11,6 +11,7 @@ RUN apk -v --update add --no-cache curl python py-pip groff less && \
     apk -v --purge del py-pip && \
     rm -f /var/cache/apk/*
 
-RUN curl https://raw.githubusercontent.com/kanisterio/kanister/master/scripts/get.sh | bash
+COPY --from=restic/restic:0.9.5 /usr/bin/restic /usr/local/bin/restic
+ADD kando /usr/local/bin/
 
 CMD ["tail", "-f", "/dev/null"]

--- a/docker/tools/Dockerfile
+++ b/docker/tools/Dockerfile
@@ -1,20 +1,10 @@
-FROM busybox:glibc as restbox
-
-# Get restic executable
-ENV RESTIC_VERSION=0.9.5
-ENV RESTIC_SHA=08cd75e56a67161e9b16885816f04b2bf1fb5b03bc0677b0ccf3812781c1a2ec
-ADD https://github.com/restic/restic/releases/download/v${RESTIC_VERSION}/restic_${RESTIC_VERSION}_linux_amd64.bz2 /
-RUN echo "${RESTIC_SHA}  restic_${RESTIC_VERSION}_linux_amd64.bz2" | sha256sum -c \
-    && bzip2 -d restic_${RESTIC_VERSION}_linux_amd64.bz2 && mv restic_${RESTIC_VERSION}_linux_amd64 /bin/restic && chmod +x /bin/restic
-
-FROM alpine:3.7
+FROM alpine:3.10
 MAINTAINER Tom Manville <tom@kasten.io>
-
-COPY --from=restbox /bin/restic /bin/restic
 
 RUN apk -v --update add --no-cache bash curl groff less mailcap ca-certificates && \
     rm -f /var/cache/apk/*
 
+COPY --from=restic/restic:0.9.5 /usr/bin/restic /usr/local/bin/restic
 ADD kando /usr/local/bin/
 
 CMD [ "/usr/bin/tail", "-f", "/dev/null" ]

--- a/examples/helm/kanister/kanister-mongodb-replicaset/image/Dockerfile
+++ b/examples/helm/kanister/kanister-mongodb-replicaset/image/Dockerfile
@@ -7,6 +7,7 @@ ADD ./examples/helm/kanister/kanister-mongodb-replicaset/image /kanister
 
 RUN /kanister/install.sh && rm -rf /kanister && rm -rf /tmp && mkdir /tmp
 
-RUN curl https://raw.githubusercontent.com/kanisterio/kanister/master/scripts/get.sh | bash
+COPY --from=restic/restic:0.9.5 /usr/bin/restic /usr/local/bin/restic
+ADD kando /usr/local/bin/
 
 CMD ["tail", "-f", "/dev/null"]


### PR DESCRIPTION
## Overview
Consistently copy restic from upstsream docker images when building our images.

Also adds a missing Dockerfile

## Test Plan
```
goreleaser --debug release --snapshot --rm-dist
```
https://gist.github.com/tdmanv/87e3e5b0e24523835cfa283a3fe2a211