### PR TITLE
Guard against empty tags

### DIFF
--- a/pkg/blockstorage/awsefs/awsefs.go
+++ b/pkg/blockstorage/awsefs/awsefs.go
@@ -390,6 +390,9 @@ func (e *efs) SetTags(ctx context.Context, resource interface{}, tags map[string
 }
 
 func (e *efs) setBackupTags(ctx context.Context, arn string, tags map[string]string) error {
+	if len(tags) == 0 {
+		return nil
+	}
 	req := &backup.TagResourceInput{
 		ResourceArn: &arn,
 		Tags:        convertToBackupTags(tags),
@@ -399,6 +402,9 @@ func (e *efs) setBackupTags(ctx context.Context, arn string, tags map[string]str
 }
 
 func (e *efs) setEFSTags(ctx context.Context, id string, tags map[string]string) error {
+	if len(tags) == 0 {
+		return nil
+	}
 	req := &awsefs.CreateTagsInput{
 		FileSystemId: &id,
 		Tags:         convertToEFSTags(tags),


### PR DESCRIPTION
This PR adds a guard against empty tags.

AWS methods give error when an empty or empty content map are passed to tag-setting methods.
To fix this problem, we need to check the size of the map before passing the maps.

* Adds a size check for setBackupTags.
* Adds a size check for setEFSTags.