### PR TITLE
Fix the bug where ListSnapshot failing to query deleted fs

### DIFF
--- a/pkg/blockstorage/awsefs/awsefs.go
+++ b/pkg/blockstorage/awsefs/awsefs.go
@@ -453,10 +453,9 @@ func (e *efs) snapshotsFromRecoveryPoints(ctx context.Context, rps []*backup.Rec
 		if err != nil {
 			return nil, errors.Wrap(err, "Failed to get volume ID from recovery point ARN")
 		}
-		vol, err := e.VolumeGet(ctx, volID, "")
-		if err != nil {
-			return nil, errors.Wrap(err, "Failed to get EFS volume")
-		}
+		// VolumeGet might return error since originating filesystem might have
+		// been deleted.
+		vol, _ := e.VolumeGet(ctx, volID, "")
 		snap, err := snapshotFromRecoveryPointByVault(rp, vol, tags, e.region)
 		if err != nil {
 			return nil, errors.Wrap(err, "Failed to get snapshot from the vault")

--- a/pkg/blockstorage/awsefs/conversion.go
+++ b/pkg/blockstorage/awsefs/conversion.go
@@ -65,6 +65,10 @@ func snapshotFromRecoveryPoint(rp *backup.DescribeRecoveryPointOutput, volume *b
 	if rp.RecoveryPointArn == nil {
 		return nil, errors.New("Recovery point has no RecoveryPointArn")
 	}
+	encrypted := false
+	if volume != nil {
+		encrypted = volume.Encrypted
+	}
 	return &blockstorage.Snapshot{
 		ID:           *rp.RecoveryPointArn,
 		CreationTime: blockstorage.TimeStamp(*rp.CreationDate),
@@ -72,7 +76,7 @@ func snapshotFromRecoveryPoint(rp *backup.DescribeRecoveryPointOutput, volume *b
 		Region:       region,
 		Type:         blockstorage.TypeEFS,
 		Volume:       volume,
-		Encrypted:    volume.Encrypted,
+		Encrypted:    encrypted,
 		Tags:         nil,
 	}, nil
 }

--- a/pkg/blockstorage/awsefs/conversion.go
+++ b/pkg/blockstorage/awsefs/conversion.go
@@ -90,8 +90,9 @@ func snapshotFromRecoveryPointByVault(rp *backup.RecoveryPointByBackupVault, vol
 	if rp.RecoveryPointArn == nil {
 		return nil, errors.New("Recovery point has no RecoveryPointArn")
 	}
-	if volume == nil {
-		return nil, errors.New("Nil volume as argument")
+	encrypted := false
+	if volume != nil {
+		encrypted = volume.Encrypted
 	}
 	return &blockstorage.Snapshot{
 		ID:           *rp.RecoveryPointArn,
@@ -100,7 +101,7 @@ func snapshotFromRecoveryPointByVault(rp *backup.RecoveryPointByBackupVault, vol
 		Region:       region,
 		Type:         blockstorage.TypeEFS,
 		Volume:       volume,
-		Encrypted:    volume.Encrypted,
+		Encrypted:    encrypted,
 		Tags:         blockstorage.MapToKeyValue(tags),
 	}, nil
 }

--- a/pkg/blockstorage/awsefs/error.go
+++ b/pkg/blockstorage/awsefs/error.go
@@ -8,11 +8,9 @@ import (
 )
 
 func isVolumeNotFound(err error) bool {
-	switch errV := err.(type) {
+	switch errV := errors.Cause(err).(type) {
 	case awserr.Error:
 		return errV.Code() == awsefs.ErrCodeFileSystemNotFound
-	case errors.Causer:
-		return isVolumeNotFound(errV.Cause())
 	default:
 		return false
 	}

--- a/pkg/blockstorage/awsefs/error.go
+++ b/pkg/blockstorage/awsefs/error.go
@@ -4,13 +4,18 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/backup"
 	awsefs "github.com/aws/aws-sdk-go/service/efs"
+	"github.com/pkg/errors"
 )
 
 func isVolumeNotFound(err error) bool {
-	if awsErr, ok := err.(awserr.Error); ok {
-		return awsErr.Code() == awsefs.ErrCodeFileSystemNotFound
+	switch errV := err.(type) {
+	case awserr.Error:
+		return errV.Code() == awsefs.ErrCodeFileSystemNotFound
+	case errors.Causer:
+		return isVolumeNotFound(errV.Cause())
+	default:
+		return false
 	}
-	return false
 }
 
 func isBackupVaultAlreadyExists(err error) bool {


### PR DESCRIPTION
Fixes the problem where EFS ListSnapshots fails to query already deleted filesystem.

* Do not fail when VolumeGet operation in ListSnapshots returns an error.
* Do not fail when volume argument in snapshotFromRecoveryPointByVault is nil.

Fixes #201 
