### PR TITLE
EFS will use STS instead of IAM

### DIFF
--- a/pkg/blockstorage/awsefs/awsefs.go
+++ b/pkg/blockstorage/awsefs/awsefs.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
-	awsarn "github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/backup"
 	awsefs "github.com/aws/aws-sdk-go/service/efs"


### PR DESCRIPTION
## Change Overview

EFS provider will use STS instead of IAM.

IAM.GetUser() cannot be used with roles without giving the user ID as an argument.
STS.GetCallerIdentity() supports roles and users without giving any arguments.

* Removes IAM calls.
* Adds STS call to get account ID.

## Pull request type

Please check the type of change your PR introduces:
- [ ] Work in Progress
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Trival/Minor
- [X] Bugfix
- [ ] Feature
- [ ] Documentation
