### PR TITLE
Run all CI commands inside the build container

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,7 +39,7 @@ dockers:
 - binaries:
   - controller
   image_templates:
-  - 'kanisterio/kanister-controller:{{ .Tag }}'
+  - 'kanisterio/controller:{{ .Tag }}'
   dockerfile: 'docker/controller/Dockerfile'
 - binaries:
   - kando

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
 
 cache:
   directories:
-  - .go/pkg/mod/
+  - .go/pkg/mod/cache
 
 script:
 - make docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,33 @@
 sudo: required
+
 services:
   - docker
 
-language: go
-
-go:
-  - "1.12.x"
+# Selecting C as the language keeps the container to a minimum footprint. All
+# go-specifc code is run in build container.
+language: c
 
 branches:
   only:
   - master
-
-# This moves Kubernetes specific config files.
-env:
-- CHANGE_MINIKUBE_NONE_USER=true GO111MODULE=on
 
 cache:
   directories:
   - .go/pkg/mod/cache
   - .go/cache
 
-script:
-- make docs
-- make go-mod-download
-- make build
-- make start-kind
-- make test
-
-after_script:
-- make stop-kind
+jobs:
+  include:
+    - stage: test
+      script:
+			- make docs
+    - stage: test
+			before_script:
+			- make start-kind
+      script:
+			- make go-mod-download
+			- make build
+			- make test
+			after_script:
+			- make stop-kind
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: required
 
 services:
-  - docker
+- docker
 
 # Selecting C as the language keeps the container to a minimum footprint. All
 # go-specifc code is run in build container.
@@ -20,14 +20,14 @@ jobs:
   include:
     - stage: test
       script:
-			- make docs
+      - make docs
     - stage: test
-			before_script:
-			- make start-kind
+      before_script:
+      - make start-kind
       script:
-			- make go-mod-download
-			- make build
-			- make test
-			after_script:
-			- make stop-kind
+      - make go-mod-download
+      - make build
+      - make test
+      after_script:
+      - make stop-kind
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
 cache:
   directories:
   - .go/pkg/mod/cache
+  - .go/cache
 
 script:
 - make docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,12 +22,15 @@ jobs:
       script:
       - make docs
     - stage: test
+      install:
+      - make go-mod-download
       before_script:
       - make start-kind
       script:
-      - make go-mod-download
       - make build
       - make test
+      before_cache:
+      - sudo chown -R travis:travis ./.go
       after_script:
       - make stop-kind
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,18 +15,17 @@ branches:
 env:
 - CHANGE_MINIKUBE_NONE_USER=true GO111MODULE=on
 
-before_install:
-- wget --progress=dot:mega https://storage.googleapis.com/kubernetes-release/release/v1.15.0/bin/linux/amd64/kubectl
-- sudo chmod +x kubectl
-- sudo mv kubectl /usr/local/bin/kubectl
+cache:
+  directories:
+  - .go/pkg/mod/
 
 script:
-- go mod download
-- sudo make build
 - make docs
-- docker run -ti --rm --net host -e GOPATH=/go -v ${GOPATH}:/go -v /var/run/docker.sock:/var/run/docker.sock -v ${HOME}/.kube:/root/.kube -v $(pwd):/data -w /data --entrypoint="bash" kanisterio/build:v0.0.1 -c "bash build/local_kubernetes.sh start_localkube"
-- sudo make test
+- make go-mod-download
+- make build
+- make start-kind
+- make test
 
 after_script:
-- docker run -ti --rm --net host -e GOPATH=/go -v ${GOPATH}:/go -v /var/run/docker.sock:/var/run/docker.sock -v ${HOME}/.kube:/root/.kube -v $(pwd):/data -w /data --entrypoint="bash" kanisterio/build:v0.0.1 -c "bash build/local_kubernetes.sh stop_localkube"
+- make stop-kind
 

--- a/Makefile
+++ b/Makefile
@@ -102,18 +102,18 @@ bin/$(ARCH)/$(BIN):
 shell: build-dirs
 	@echo "launching a shell in the containerized build environment"
 	@docker run                                                 \
-	    -ti                                                     \
-	    --rm                                                    \
-	    --privileged                                            \
+		-ti                                                     \
+		--rm                                                    \
+		--privileged                                            \
 		--net host                                              \
-	    -v "$(PWD)/.go/pkg:/go/pkg"                             \
+		-v "$(PWD)/.go/pkg:/go/pkg"                             \
 		-v "$(PWD)/.go/cache:/go/.cache"                        \
-	    -v "$(PWD):/go/src/$(PKG)"                              \
-	    -v "$(PWD)/bin/$(ARCH):/go/bin"                         \
-	    -v "$(PWD)/bin/$(ARCH):/go/bin/$$(go env GOOS)_$(ARCH)" \
-	    -v /var/run/docker.sock:/var/run/docker.sock            \
-	    -w /go/src/$(PKG)                                       \
-	    $(BUILD_IMAGE)                                          \
+		-v "$(PWD):/go/src/$(PKG)"                              \
+		-v "$(PWD)/bin/$(ARCH):/go/bin"                         \
+		-v "$(PWD)/bin/$(ARCH):/go/bin/$$(go env GOOS)_$(ARCH)" \
+		-v /var/run/docker.sock:/var/run/docker.sock            \
+		-w /go/src/$(PKG)                                       \
+		$(BUILD_IMAGE)                                          \
 		/bin/sh
 
 DOTFILE_IMAGE = $(subst :,_,$(subst /,_,$(IMAGE))-$(VERSION))
@@ -153,9 +153,9 @@ version:
 deploy: release-controller .deploy-$(DOTFILE_IMAGE)
 .deploy-$(DOTFILE_IMAGE):
 	@sed                        \
-	    -e 's|IMAGE|$(IMAGE)|g' \
-	    -e 's|TAG|$(VERSION)|g' \
-	    bundle.yaml.in > .deploy-$(DOTFILE_IMAGE)
+		-e 's|IMAGE|$(IMAGE)|g' \
+		-e 's|TAG|$(VERSION)|g' \
+		bundle.yaml.in > .deploy-$(DOTFILE_IMAGE)
 	@kubectl apply -f .deploy-$(DOTFILE_IMAGE)
 
 test: build-dirs
@@ -218,16 +218,16 @@ bin-clean:
 
 release-docs: docs
 	@if [ -z ${AWS_ACCESS_KEY_ID} ] || [ -z ${AWS_SECRET_ACCESS_KEY} ]; then\
-	    echo "Please set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY. Exiting.";\
-	    exit 1;\
+		echo "Please set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY. Exiting.";\
+		exit 1;\
 	fi;\
 
 	@if [ -f "docs/_build/html/index.html" ]; then\
-	    aws s3 sync docs/_build/html $(DOCS_RELEASE_BUCKET) --delete;\
-	    echo "Success";\
+		aws s3 sync docs/_build/html $(DOCS_RELEASE_BUCKET) --delete;\
+		echo "Success";\
 	else\
-	    echo "No built docs found";\
-	    exit 1;\
+		echo "No built docs found";\
+		exit 1;\
 	fi;\
 
 release-helm:

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ IMAGE_NAME := $(BIN)
 
 IMAGE := $(REGISTRY)/$(IMAGE_NAME)
 
-BUILD_IMAGE ?= kanisterio/build:v0.0.1
+BUILD_IMAGE ?= kanisterio/build:v0.0.2
 DOCS_BUILD_IMAGE ?= kanisterio/docker-sphinx
 
 DOCS_RELEASE_BUCKET ?= s3://docs.kanister.io
@@ -147,7 +147,7 @@ push-name:
 version:
 	@echo $(VERSION)
 
-.PHONY: deploy test codegen build-dirs run clean container-clean bin-clean vendor-clean docs start-kind stop-kind
+.PHONY: deploy test codegen build-dirs run clean container-clean bin-clean docs start-kind stop-kind release-snapshot go-mod-download
 
 deploy: release-controller .deploy-$(DOTFILE_IMAGE)
 .deploy-$(DOTFILE_IMAGE):
@@ -211,7 +211,7 @@ endif
 clean: dotfile-clean bin-clean
 
 dotfile-clean:
-	rm -rf .container-* .dockerfile-* .push-* .vendor .deploy-*
+	rm -rf .container-* .dockerfile-* .push-* .deploy-*
 
 bin-clean:
 	rm -rf .go bin
@@ -236,8 +236,15 @@ release-helm:
 release-kanctl:
 	@$(MAKE) run CMD='-c "./build/release_kanctl.sh"'
 
+release-snapshot:
+	@$(MAKE) run CMD='-c "goreleaser --debug release --rm-dist --snapshot"'
+
+go-mod-download:
+	@$(MAKE) run CMD='-c "go mod download"'
+
 start-kind:
 	@$(MAKE) run CMD='-c "./build/local_kubernetes.sh start_localkube"'
 
 stop-kind:
 	@$(MAKE) run CMD='-c "./build/local_kubernetes.sh stop_localkube"'
+

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ IMAGE_NAME := $(BIN)
 
 IMAGE := $(REGISTRY)/$(IMAGE_NAME)
 
-BUILD_IMAGE ?= kanisterio/build:v0.0.3
+BUILD_IMAGE ?= kanisterio/build:v0.0.4
 DOCS_BUILD_IMAGE ?= kanisterio/docker-sphinx
 
 DOCS_RELEASE_BUCKET ?= s3://docs.kanister.io

--- a/Makefile
+++ b/Makefile
@@ -101,18 +101,19 @@ bin/$(ARCH)/$(BIN):
 # Example: make shell CMD="-c 'date > datefile'"
 shell: build-dirs
 	@echo "launching a shell in the containerized build environment"
-	@docker run                                                            \
-	    -ti                                                                \
-	    --rm                                                               \
-	    --privileged                                                       \
-		--net host                                                         \
-	    -v "$(PWD)/.go/pkg:/go/pkg"                                        \
-	    -v "$(PWD):/go/src/$(PKG)"                                         \
-	    -v "$(PWD)/bin/$(ARCH):/go/bin"                                    \
-	    -v "$(PWD)/bin/$(ARCH):/go/bin/$$(go env GOOS)_$(ARCH)"            \
-	    -v /var/run/docker.sock:/var/run/docker.sock                       \
-	    -w /go/src/$(PKG)                                                  \
-	    $(BUILD_IMAGE)                                                     \
+	@docker run                                                 \
+	    -ti                                                     \
+	    --rm                                                    \
+	    --privileged                                            \
+		--net host                                              \
+	    -v "$(PWD)/.go/pkg:/go/pkg"                             \
+		-v "$(PWD)/.go/cache:/go/.cache"                        \
+	    -v "$(PWD):/go/src/$(PKG)"                              \
+	    -v "$(PWD)/bin/$(ARCH):/go/bin"                         \
+	    -v "$(PWD)/bin/$(ARCH):/go/bin/$$(go env GOOS)_$(ARCH)" \
+	    -v /var/run/docker.sock:/var/run/docker.sock            \
+	    -w /go/src/$(PKG)                                       \
+	    $(BUILD_IMAGE)                                          \
 		/bin/sh
 
 DOTFILE_IMAGE = $(subst :,_,$(subst /,_,$(IMAGE))-$(VERSION))

--- a/build/release_kanctl.sh
+++ b/build/release_kanctl.sh
@@ -11,4 +11,4 @@ then
 	echo "You can generate a token here: https://github.com/settings/tokens/new"
 	exit 1
 fi
-goreleaser --rm-dist
+goreleaser release --parallelism=1 --rm-dist

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -2,15 +2,19 @@ FROM golang:1.12-alpine3.10
 MAINTAINER Tom Manville <tom@kasten.io>
 
 RUN apk add --update --no-cache ca-certificates bash git docker jq \
- && update-ca-certificates \
- && rm -rf /var/cache/apk/*
+    && update-ca-certificates \
+    && rm -rf /var/cache/apk/*
 
 COPY --from=bitnami/kubectl:1.13.4 /opt/bitnami/kubectl/bin/kubectl /usr/local/bin/
 
 COPY --from=goreleaser/goreleaser:v0.115.0 /bin/goreleaser /usr/local/bin/
 
+RUN wget -O /usr/local/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/v0.4.0/kind-darwin-amd64 \
+    && chmod +x /usr/local/bin/kind
+
 ENV CGO_ENABLED=0 \
     GO111MODULE="on" \
     GOROOT="/usr/local/go" \
+    GOCACHE=/go/.cache/go-build \
     GO_EXTLINK_ENABLED=0 \
     PATH="/usr/local/go/bin:${PATH}" 

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -1,13 +1,13 @@
-FROM golang:1.12.4-alpine3.9
+FROM golang:1.12-alpine3.10
 MAINTAINER Tom Manville <tom@kasten.io>
 
-RUN apk add --update --no-cache ca-certificates bash git \
+RUN apk add --update --no-cache ca-certificates bash git docker jq \
  && update-ca-certificates \
  && rm -rf /var/cache/apk/*
 
 COPY --from=bitnami/kubectl:1.13.4 /opt/bitnami/kubectl/bin/kubectl /usr/local/bin/
 
-COPY --from=goreleaser/goreleaser:v0.112.2 /bin/goreleaser /usr/local/bin/
+COPY --from=goreleaser/goreleaser:v0.115.0 /bin/goreleaser /usr/local/bin/
 
 ENV CGO_ENABLED=0 \
     GO111MODULE="on" \

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -9,7 +9,7 @@ COPY --from=bitnami/kubectl:1.13.4 /opt/bitnami/kubectl/bin/kubectl /usr/local/b
 
 COPY --from=goreleaser/goreleaser:v0.115.0 /bin/goreleaser /usr/local/bin/
 
-RUN wget -O /usr/local/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/v0.4.0/kind-darwin-amd64 \
+RUN wget -O /usr/local/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/v0.4.0/kind-linux-amd64 \
     && chmod +x /usr/local/bin/kind
 
 ENV CGO_ENABLED=0 \

--- a/helm/kanister-operator/values.yaml
+++ b/helm/kanister-operator/values.yaml
@@ -2,8 +2,8 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 image:
-  repository: tdmanville/kanister-controller
-  tag: 0.0.0
+  repository: kanisterio/kanister-controller
+  tag: 0.20.0
   pullPolicy: IfNotPresent
 rbac:
   create: true

--- a/helm/kanister-operator/values.yaml
+++ b/helm/kanister-operator/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 image:
-  repository: kanisterio/kanister-controller
+  repository: kanisterio/controller
   tag: 0.20.0
   pullPolicy: IfNotPresent
 rbac:

--- a/helm/kanister-operator/values.yaml
+++ b/helm/kanister-operator/values.yaml
@@ -2,8 +2,8 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 image:
-  repository: kanisterio/controller
-  tag: 0.20.0
+  repository: tdmanville/kanister-controller
+  tag: 0.0.0
   pullPolicy: IfNotPresent
 rbac:
   create: true


### PR DESCRIPTION
## Change Overview
* Performance improvements
  * Use simple travis VM since all commands are containerized
  * Use https://docs.travis-ci.com/user/caching/
    * go mod source files
    * go build cache
  * Parallel jobs for docs and go tests
  * Add binaries to build image
    * kind, docker, jq
* travis config simplificiations
  * uses start/stop-kind instead of directly invoking local_kube.sh 
* Makefile updates
  * Use tabs consistently
  * add go-mod-download
  * add release-snapshot

## Pull request type

Please check the type of change your PR introduces:
- [ ] Work in Progress
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Trival/Minor
- [ ] Bugfix
- [x] Feature
- [ ] Documentation

