### PR TITLE
Fix empty filesystem ID usage in EFS VolumeGet

### DIFF
--- a/pkg/blockstorage/awsefs/awsefs.go
+++ b/pkg/blockstorage/awsefs/awsefs.go
@@ -88,10 +88,13 @@ func (e *efs) VolumeCreate(ctx context.Context, volume blockstorage.Volume) (*bl
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create EFS instance")
 	}
+	if fd.FileSystemId == nil {
+		return nil, errors.New("Empty filesystem ID")
+	}
 	if err = e.waitUntilFileSystemAvailable(ctx, *fd.FileSystemId); err != nil {
 		return nil, errors.Wrap(err, "EFS instance is not available")
 	}
-	vol, err := e.VolumeGet(ctx, volume.ID, volume.Az)
+	vol, err := e.VolumeGet(ctx, *fd.FileSystemId, volume.Az)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to get recently create EFS instance")
 	}


### PR DESCRIPTION
## Change Overview

Fixes the problem where VolumeGet uses an empty filesystem ID.

## Pull request type

Please check the type of change your PR introduces:
- [ ] Work in Progress
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Trival/Minor
- [X] Bugfix
- [ ] Feature
- [ ] Documentation

