### PR TITLE
Mount the kubeconfig in make shell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,7 @@ shell: build-dirs
 		--net host                                              \
 		-v "$(PWD)/.go/pkg:/go/pkg"                             \
 		-v "$(PWD)/.go/cache:/go/.cache"                        \
+		-v "${HOME}/.kube:/root/.kube"                          \
 		-v "$(PWD):/go/src/$(PKG)"                              \
 		-v "$(PWD)/bin/$(ARCH):/go/bin"                         \
 		-v "$(PWD)/bin/$(ARCH):/go/bin/$$(go env GOOS)_$(ARCH)" \


### PR DESCRIPTION
## Change Overview

Updated the make shell target to mount the kubeconfig. Verfied that go test -check.f works now.

## Pull request type

Please check the type of change your PR introduces:
- [ ] Work in Progress
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Trival/Minor
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation



## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] Manual
- [ ] Unit test
- [ ] E2E
