### PR TITLE
Use a file to specify the chronicle artifact prefix

### DIFF
--- a/pkg/chronicle/chronicle_push.go
+++ b/pkg/chronicle/chronicle_push.go
@@ -22,7 +22,7 @@ import (
 
 type PushParams struct {
 	ProfilePath  string
-	ArtifactPath string
+	ArtifactFile string
 	Frequency    time.Duration
 	EnvDir       string
 	Command      []string
@@ -85,8 +85,9 @@ func push(ctx context.Context, p PushParams, ord int) error {
 			return err
 		}
 	}
+	ap, err := readArtifactPathFile(p.ArtifactFile)
 	log.Debugf("Pushing output from Command %d: %v. Environment: %v", ord, p.Command, env)
-	return pushWithEnv(ctx, p.Command, p.ArtifactPath, ord, prof, env)
+	return pushWithEnv(ctx, p.Command, ap, ord, prof, env)
 }
 
 func pushWithEnv(ctx context.Context, c []string, suffix string, ord int, prof param.Profile, env []string) error {
@@ -121,12 +122,17 @@ func pushWithEnv(ctx context.Context, c []string, suffix string, ord int, prof p
 	return nil
 }
 
+func readArtifactPathFile(path string) (string, error) {
+	buf, err := ioutil.ReadFile(path)
+	t := strings.TrimSuffix(string(buf), "\n")
+	return t, errors.Wrap(err, "Could not read artifact path file")
+}
+
 func readProfile(path string) (p param.Profile, ok bool, err error) {
 	var buf []byte
 	buf, err = ioutil.ReadFile(path)
 	switch {
 	case os.IsNotExist(err):
-		ok = true
 		err = nil
 		return
 	case err != nil:

--- a/pkg/chronicle/chronicle_push_test.go
+++ b/pkg/chronicle/chronicle_push_test.go
@@ -2,6 +2,8 @@ package chronicle
 
 import (
 	"context"
+	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	. "gopkg.in/check.v1"
@@ -28,9 +30,12 @@ func (s *ChroniclePushSuite) TestPush(c *C) {
 	err := writeProfile(pp, prof)
 	c.Assert(err, IsNil)
 
+	a := filepath.Join(c.MkDir(), "artifact")
+	err = ioutil.WriteFile(a, []byte(rand.String(10)), os.ModePerm)
+	c.Assert(err, IsNil)
 	p := PushParams{
 		ProfilePath:  pp,
-		ArtifactPath: rand.String(10),
+		ArtifactFile: a,
 		Command:      []string{"echo hello"},
 	}
 	ctx := context.Background()

--- a/pkg/chronicle/chronicle_test.go
+++ b/pkg/chronicle/chronicle_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -42,9 +43,12 @@ func (s *ChronicleSuite) TestPushPull(c *C) {
 	err := writeProfile(pp, s.profile)
 	c.Assert(err, IsNil)
 
+	a := filepath.Join(c.MkDir(), "artifact")
+	err = ioutil.WriteFile(a, []byte(rand.String(10)), os.ModePerm)
+	c.Assert(err, IsNil)
 	p := PushParams{
 		ProfilePath:  pp,
-		ArtifactPath: rand.String(10),
+		ArtifactFile: a,
 	}
 	ctx := context.Background()
 
@@ -56,7 +60,7 @@ func (s *ChronicleSuite) TestPushPull(c *C) {
 
 		// Pull and check that we still get i
 		buf := bytes.NewBuffer(nil)
-		err = Pull(ctx, buf, s.profile, p.ArtifactPath)
+		err = Pull(ctx, buf, s.profile, p.ArtifactFile)
 		c.Assert(err, IsNil)
 		str, err := ioutil.ReadAll(buf)
 		c.Assert(err, IsNil)

--- a/pkg/kando/chronicle_push.go
+++ b/pkg/kando/chronicle_push.go
@@ -30,7 +30,7 @@ func newChroniclePushCommand() *cobra.Command {
 	}
 	cmd.PersistentFlags().StringVarP(&params.ProfilePath, profilePathFlagName, "p", "", "Path to a Profile as a JSON string (required)")
 	cmd.MarkPersistentFlagRequired(profilePathFlagName)
-	cmd.PersistentFlags().StringVarP(&params.ArtifactFile, artifactPathFlagName, "s", "", "Specify a file that contains an object store suffix (optional)")
+	cmd.PersistentFlags().StringVarP(&params.ArtifactFile, artifactPathFlagName, "s", "", "Specify a file that contains an object store suffix")
 	cmd.MarkPersistentFlagRequired(artifactPathFlagName)
 	cmd.PersistentFlags().StringVarP(&params.EnvDir, envDirFlagName, "e", "", "Get environment variables from a envdir style directory(optional)")
 	cmd.PersistentFlags().DurationVarP(&params.Frequency, frequencyFlagName, "f", time.Minute, "The Frequency to push to object storage ")

--- a/pkg/kando/chronicle_push.go
+++ b/pkg/kando/chronicle_push.go
@@ -30,8 +30,9 @@ func newChroniclePushCommand() *cobra.Command {
 	}
 	cmd.PersistentFlags().StringVarP(&params.ProfilePath, profilePathFlagName, "p", "", "Path to a Profile as a JSON string (required)")
 	cmd.MarkPersistentFlagRequired(profilePathFlagName)
-	cmd.PersistentFlags().StringVarP(&params.ArtifactPath, artifactPathFlagName, "s", "", "Specify a path suffix (optional)")
-	cmd.PersistentFlags().StringVarP(&params.EnvDir, envDirFlagName, "e", "", "Get environment variables from a (optional)")
+	cmd.PersistentFlags().StringVarP(&params.ArtifactFile, artifactPathFlagName, "s", "", "Specify a file that contains an object store suffix (optional)")
+	cmd.MarkPersistentFlagRequired(artifactPathFlagName)
+	cmd.PersistentFlags().StringVarP(&params.EnvDir, envDirFlagName, "e", "", "Get environment variables from a envdir style directory(optional)")
 	cmd.PersistentFlags().DurationVarP(&params.Frequency, frequencyFlagName, "f", time.Minute, "The Frequency to push to object storage ")
 	return cmd
 }


### PR DESCRIPTION
## Change Overview

<!-- Insert PR description-->

## Pull request type

Please check the type of change your PR introduces:
- [ ] Work in Progress
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Trival/Minor
- [ ] Bugfix
- [x] Feature
- [ ] Documentation

## Issues

#216 

## Test Plan
```
/go/src/github.com/kanisterio/kanister # go run -v ./cmd/kando/main.go chronicle push
Error: requires at least 1 arg(s), only received 0
Usage:
  kando chronicle push <command> [flags]

Flags:
  -s, --artifact-path string   Specify a file that contains an object store suffix (optional)
  -e, --env-dir string         Get environment variables from a envdir style directory(optional)
  -f, --frequency duration     The Frequency to push to object storage  (default 1m0s)
  -h, --help                   help for push
  -p, --profile-path string    Path to a Profile as a JSON string (required)

Global Flags:
  -v, --verbosity string   Log level (debug, info, warn, error, fatal, panic) (default "warning")

ERRO[0000] requires at least 1 arg(s), only received 0
exit status 1
```
- [x] Manual
- [ ] Unit test
- [ ] E2E
