### PR TITLE
Use upstream mysql helm chart in the examples

### DIFF
--- a/examples/helm/kanister/kanister-mysql/.helmignore
+++ b/examples/helm/kanister/kanister-mysql/.helmignore
@@ -1,1 +1,3 @@
 .git
+OWNERS
+

--- a/examples/helm/kanister/kanister-mysql/Chart.yaml
+++ b/examples/helm/kanister/kanister-mysql/Chart.yaml
@@ -1,4 +1,6 @@
-description: MySQL w/ Kanister support based on stable/mysql
+apiVersion: v1
+description: Fast, reliable, scalable, and easy to use open-source relational database
+  system.
 engine: gotpl
 home: https://www.mysql.com/
 icon: https://www.mysql.com/common/logos/logo-mysql-170x115.png

--- a/examples/helm/kanister/kanister-mysql/OWNERS
+++ b/examples/helm/kanister/kanister-mysql/OWNERS
@@ -1,0 +1,5 @@
+approvers:
+- olemarkus
+reviewers:
+- olemarkus
+

--- a/examples/helm/kanister/kanister-mysql/README.md
+++ b/examples/helm/kanister/kanister-mysql/README.md
@@ -10,7 +10,7 @@ This chart bootstraps a single node MySQL deployment on a [Kubernetes](http://ku
 
 - Kubernetes 1.6+ with Beta APIs enabled
 - PV provisioner support in the underlying infrastructure
-- Kanister version 0.7.0 with `profiles.cr.kanister.io` CRD installed
+- Kanister version 0.21.0 with `profiles.cr.kanister.io` CRD installed
 
 ## Installing the Chart
 
@@ -20,7 +20,12 @@ For basic installation, you can install using the provided Helm chart that will 
 Prior to install you will need to have the Kanister Helm repository added to your local setup.
 
 ```bash
-$ helm repo add kanister http://charts.kanister.io
+$ helm repo add kanister https://charts.kanister.io
+```
+You can use following command to install Kanister if not installed already
+
+```bash
+$ helm install --name kanister --namespace kasten-io kanister/kanister-operator --set image.tag=0.21.0
 ```
 
 Then install the sample MySQL application in its own namespace.
@@ -61,11 +66,149 @@ $ helm install kanister/kanister-mysql -n my-release --namespace mysql-test \
 
 By default a random password will be generated for the root user. If you'd like to set your own password change the mysqlRootPassword in the values.yaml.
 
-You can retrieve your root password by running the following command. Make sure to replace [YOUR_RELEASE_NAME]:
+You can retrieve your root password by running the following command:
 
-    printf $(printf '\%o' `kubectl get secret [YOUR_RELEASE_NAME]-mysql -o jsonpath="{.data.mysql-root-password[*]}"`)
+    kubectl get secret my-release-kanister-mysql -n mysql-test -o jsonpath="{.data.mysql-root-password}" | base64 -d
 
 > **Tip**: List all releases using `helm list`
+
+Once MySQL is running, you can populate it with some data. Let's add a table called "pets" to a test database:
+
+```bash
+# Connect to MySQL by running a shell inside MySQL's pod
+$ kubectl exec -ti $(kubectl get pods -n mysql-test --selector=app=my-release-kanister-mysql -o=jsonpath='{.items[0].metadata.name}') -n mysql-test -- bash
+
+# From inside the shell, use the mysql CLI to insert some data into the test database
+# Create "test" db
+
+$ mysql --user=root --password=asd#45@mysqlEXAMPLE
+
+mysql> CREATE DATABASE test;
+Query OK, 1 row affected (0.00 sec)
+
+mysql> USE test;
+Database changed
+
+# Create "pets" table
+mysql> CREATE TABLE pets (name VARCHAR(20), owner VARCHAR(20), species VARCHAR(20), sex CHAR(1), birth DATE, death DATE);
+Query OK, 0 rows affected (0.02 sec)
+
+# Insert row to the table
+mysql> INSERT INTO pets VALUES ('Puffball','Diane','hamster','f','1999-03-30',NULL);
+Query OK, 1 row affected (0.01 sec)
+
+# View data in "pets" table
+mysql> SELECT * FROM pets;
++----------+-------+---------+------+------------+-------+
+| name     | owner | species | sex  | birth      | death |
++----------+-------+---------+------+------------+-------+
+| Puffball | Diane | hamster | f    | 1999-03-30 | NULL  |
++----------+-------+---------+------+------------+-------+
+1 row in set (0.00 sec)
+
+```
+
+## Protect the Application
+
+You can now take a backup of the MySQL data using an ActionSet defining backup for this application. Create an ActionSet in the same namespace as the controller.
+
+```bash
+$ kanctl create actionset --action backup --namespace kasten-io --blueprint my-release-kanister-mysql-blueprint --deployment mysql-test/my-release-kanister-mysql --profile mysql-test/mysql-test-profile
+actionset backup-rslmb created
+
+$ kubectl --namespace kasten-io get actionsets.cr.kanister.io
+NAME                 AGE
+backup-rslmb         1m
+
+# View the status of the actionset
+$ kubectl --namespace kasten-io describe actionset backup-rslmb
+```
+
+### Disaster strikes!
+
+Let's say someone accidentally deleted the test database using the following command:
+```bash
+# Connect to MySQL by running a shell inside MySQL's pod
+$ kubectl exec -ti $(kubectl get pods -n mysql-test --selector=app=my-release-kanister-mysql -o=jsonpath='{.items[0].metadata.name}') -n mysql-test -- bash
+
+# Drop the test database
+$ mysql> SHOW DATABASES;
++--------------------+
+| Database           |
++--------------------+
+| information_schema |
+| mysql              |
+| performance_schema |
+| sys                |
+| test               |
++--------------------+
+5 rows in set (0.00 sec)
+
+mysql> DROP DATABASE test;
+Query OK, 1 row affected (0.03 sec)
+
+mysql> SHOW DATABASES;
++--------------------+
+| Database           |
++--------------------+
+| information_schema |
+| mysql              |
+| performance_schema |
+| sys                |
++--------------------+
+4 rows in set (0.00 sec)
+
+```
+
+### Restore the Application
+
+To restore the missing data, you should use the backup that you created before. An easy way to do this is to leverage `kanctl`, a command-line tool that helps create ActionSets that depend on other ActionSets:
+
+```bash
+$ kanctl --namespace kasten-io create actionset --action restore --from "backup-llfb8"
+actionset restore-backup-62vxm-2hdsz created
+
+# View the status of the ActionSet
+kubectl --namespace kasten-io describe actionset restore-backup-62vxm-2hdsz
+```
+
+Once the ActionSet status is set to "complete", you can see that the data has been successfully restored to MySQL
+
+```bash
+mysql> SHOW DATABASES;
++--------------------+
+| Database           |
++--------------------+
+| information_schema |
+| mysql              |
+| performance_schema |
+| sys                |
+| test               |
++--------------------+
+5 rows in set (0.00 sec)
+
+mysql> USE test;
+Reading table information for completion of table and column names
+You can turn off this feature to get a quicker startup with -A
+
+Database changed
+mysql> SHOW TABLES;
++----------------+
+| Tables_in_test |
++----------------+
+| pets           |
++----------------+
+1 row in set (0.00 sec)
+
+mysql> SELECT * FROM pets;
++----------+-------+---------+------+------------+-------+
+| name     | owner | species | sex  | birth      | death |
++----------+-------+---------+------+------------+-------+
+| Puffball | Diane | hamster | f    | 1999-03-30 | NULL  |
++----------+-------+---------+------+------------+-------+
+1 row in set (0.00 sec)
+
+```
 
 ## Uninstalling the Chart
 
@@ -94,38 +237,83 @@ default values. The Profile CR parameters are passed to the profile sub-chart.
 | `profile.location.region` | (Optional if creating profile) Region to be used for the bucket. | `nil` |
 | `profile.location.endpoint` | (Optional if creating profile) The URL for an s3 compatible object store provider. Can be omitted if provider is AWS. Required for any other provider. | `nil` |
 | `profile.verifySSL` | (Optional if creating profile) Set to ``false`` to disable SSL verification on the s3 endpoint. | `true` |
-| `kanister.controller_namespace` | (Optional) Specify the namespace where the Kanister controller is running. | kanister |
+| `kanister.controller_namespace` | (Optional) Specify the namespace where the Kanister controller is running. | kasten-io |
 
 The following table lists the configurable parameters of the MySQL chart and their default values.
 
-| Parameter                            | Description                               | Default                                              |
-| ------------------------------------ | ----------------------------------------- | ---------------------------------------------------- |
-| `imageTag`                           | `mysql` image tag.                        | Most recent release                                  |
-| `imagePullPolicy`                    | Image pull policy                         | `IfNotPresent`                                       |
-| `mysqlRootPassword`                  | Password for the `root` user.             | `nil`                                                |
-| `mysqlUser`                          | Username of new user to create.           | `nil`                                                |
-| `mysqlPassword`                      | Password for the new user.                | `nil`                                                |
-| `mysqlDatabase`                      | Name for new database to create.          | `nil`                                                |
-| `livenessProbe.initialDelaySeconds`  | Delay before liveness probe is initiated  | 30                                                   |
-| `livenessProbe.periodSeconds`        | How often to perform the probe            | 10                                                   |
-| `livenessProbe.timeoutSeconds`       | When the probe times out                  | 5                                                    |
-| `livenessProbe.successThreshold`     | Minimum consecutive successes for the probe to be considered successful after having failed. | 1 |
-| `livenessProbe.failureThreshold`     | Minimum consecutive failures for the probe to be considered failed after having succeeded.   | 3 |
-| `readinessProbe.initialDelaySeconds` | Delay before readiness probe is initiated | 5                                                    |
-| `readinessProbe.periodSeconds`       | How often to perform the probe            | 10                                                   |
-| `readinessProbe.timeoutSeconds`      | When the probe times out                  | 1                                                    |
-| `readinessProbe.successThreshold`    | Minimum consecutive successes for the probe to be considered successful after having failed. | 1 |
-| `readinessProbe.failureThreshold`    | Minimum consecutive failures for the probe to be considered failed after having succeeded.   | 3 |
-| `persistence.enabled`                | Create a volume to store data             | true                                                 |
-| `persistence.size`                   | Size of persistent volume claim           | 8Gi RW                                               |
-| `persistence.storageClass`           | Type of persistent volume claim           | nil (uses alpha storage class annotation)      |
-| `persistence.accessMode`             | ReadWriteOnce or ReadOnly                 | ReadWriteOnce                                        |
-| `persistence.existingClaim`          | Name of existing persistent volume        | `nil`                                                |
-| `persistence.subPath`                | Subdirectory of the volume to mount       | `nil`                                                |
-| `resources`                          | CPU/Memory resource requests/limits       | Memory: `256Mi`<br>CPU: `100m`                       |
-| `configurationFiles`                 | List of mysql configuration files         | `nil`                                                |
-
-## Using Configuration Parameters
+| Parameter                                    | Description                                                                                  | Default                                              |
+| -------------------------------------------- | -------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| `args`                                       | Additional arguments to pass to the MySQL container.                                         | `[]`                                                 |
+| `initContainer.resources`                    | initContainer resource requests/limits                                                       | Memory: `10Mi`, CPU: `10m`                           |
+| `image`                                      | `mysql` image repository.                                                                    | `mysql`                                              |
+| `imageTag`                                   | `mysql` image tag.                                                                           | `5.7.14`                                             |
+| `busybox.image`                              | `busybox` image repository.                                                                  | `busybox`                                            |
+| `busybox.tag`                                | `busybox` image tag.                                                                         | `1.29.3`                                             |
+| `testFramework.image`                        | `test-framework` image repository.                                                           | `dduportal/bats`                                     |
+| `testFramework.tag`                          | `test-framework` image tag.                                                                  | `0.4.0`                                              |
+| `imagePullPolicy`                            | Image pull policy                                                                            | `IfNotPresent`                                       |
+| `existingSecret`                             | Use Existing secret for Password details                                                     | `nil`                                                |
+| `extraVolumes`                               | Additional volumes as a string to be passed to the `tpl` function                            |                                                      |
+| `extraVolumeMounts`                          | Additional volumeMounts as a string to be passed to the `tpl` function                       |                                                      |
+| `extraInitContainers`                        | Additional init containers as a string to be passed to the `tpl` function                    |                                                      |
+| `mysqlRootPassword`                          | Password for the `root` user. Ignored if existing secret is provided                         | Random 10 characters                                 |
+| `mysqlUser`                                  | Username of new user to create.                                                              | `nil`                                                |
+| `mysqlPassword`                              | Password for the new user. Ignored if existing secret is provided                            | Random 10 characters                                 |
+| `mysqlDatabase`                              | Name for new database to create.                                                             | `nil`                                                |
+| `livenessProbe.initialDelaySeconds`          | Delay before liveness probe is initiated                                                     | 30                                                   |
+| `livenessProbe.periodSeconds`                | How often to perform the probe                                                               | 10                                                   |
+| `livenessProbe.timeoutSeconds`               | When the probe times out                                                                     | 5                                                    |
+| `livenessProbe.successThreshold`             | Minimum consecutive successes for the probe to be considered successful after having failed. | 1                                                    |
+| `livenessProbe.failureThreshold`             | Minimum consecutive failures for the probe to be considered failed after having succeeded.   | 3                                                    |
+| `readinessProbe.initialDelaySeconds`         | Delay before readiness probe is initiated                                                    | 5                                                    |
+| `readinessProbe.periodSeconds`               | How often to perform the probe                                                               | 10                                                   |
+| `readinessProbe.timeoutSeconds`              | When the probe times out                                                                     | 1                                                    |
+| `readinessProbe.successThreshold`            | Minimum consecutive successes for the probe to be considered successful after having failed. | 1                                                    |
+| `readinessProbe.failureThreshold`            | Minimum consecutive failures for the probe to be considered failed after having succeeded.   | 3                                                    |
+| `schedulerName`                              | Name of the k8s scheduler (other than default)                                               | `nil`                                                |
+| `persistence.enabled`                        | Create a volume to store data                                                                | true                                                 |
+| `persistence.size`                           | Size of persistent volume claim                                                              | 8Gi RW                                               |
+| `persistence.storageClass`                   | Type of persistent volume claim                                                              | nil                                                  |
+| `persistence.accessMode`                     | ReadWriteOnce or ReadOnly                                                                    | ReadWriteOnce                                        |
+| `persistence.existingClaim`                  | Name of existing persistent volume                                                           | `nil`                                                |
+| `persistence.subPath`                        | Subdirectory of the volume to mount                                                          | `nil`                                                |
+| `persistence.annotations`                    | Persistent Volume annotations                                                                | {}                                                   |
+| `nodeSelector`                               | Node labels for pod assignment                                                               | {}                                                   |
+| `tolerations`                                | Pod taint tolerations for deployment                                                         | {}                                                   |
+| `metrics.enabled`                            | Start a side-car prometheus exporter                                                         | `false`                                              |
+| `metrics.image`                              | Exporter image                                                                               | `prom/mysqld-exporter`                               |
+| `metrics.imageTag`                           | Exporter image                                                                               | `v0.10.0`                                            |
+| `metrics.imagePullPolicy`                    | Exporter image pull policy                                                                   | `IfNotPresent`                                       |
+| `metrics.resources`                          | Exporter resource requests/limit                                                             | `nil`                                                |
+| `metrics.livenessProbe.initialDelaySeconds`  | Delay before metrics liveness probe is initiated                                             | 15                                                   |
+| `metrics.livenessProbe.timeoutSeconds`       | When the probe times out                                                                     | 5                                                    |
+| `metrics.readinessProbe.initialDelaySeconds` | Delay before metrics readiness probe is initiated                                            | 5                                                    |
+| `metrics.readinessProbe.timeoutSeconds`      | When the probe times out                                                                     | 1                                                    |
+| `metrics.flags`                              | Additional flags for the mysql exporter to use                                               | `[]`                                                 |
+| `metrics.serviceMonitor.enabled`             | Set this to `true` to create ServiceMonitor for Prometheus operator                          | `false`                                              |
+| `metrics.serviceMonitor.additionalLabels`    | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus        | `{}`                                                 |
+| `resources`                                  | CPU/Memory resource requests/limits                                                          | Memory: `256Mi`, CPU: `100m`                         |
+| `configurationFiles`                         | List of mysql configuration files                                                            | `nil`                                                |
+| `configurationFilesPath`                     | Path of mysql configuration files                                                            | `/etc/mysql/conf.d/`                                 |
+| `securityContext.enabled`                    | Enable security context (mysql pod)                                                          | `false`                                              |
+| `securityContext.fsGroup`                    | Group ID for the container (mysql pod)                                                       | 999                                                  |
+| `securityContext.runAsUser`                  | User ID for the container (mysql pod)                                                        | 999                                                  |
+| `service.annotations`                        | Kubernetes annotations for mysql                                                             | {}                                                   |
+| `service.type`                               | Kubernetes service type                                                                      | ClusterIP                                            |
+| `service.loadBalancerIP`                     | LoadBalancer service IP                                                                      | `""`                                                 |
+| `ssl.enabled`                                | Setup and use SSL for MySQL connections                                                      | `false`                                              |
+| `ssl.secret`                                 | Name of the secret containing the SSL certificates                                           | mysql-ssl-certs                                      |
+| `ssl.certificates[0].name`                   | Name of the secret containing the SSL certificates                                           | `nil`                                                |
+| `ssl.certificates[0].ca`                     | CA certificate                                                                               | `nil`                                                |
+| `ssl.certificates[0].cert`                   | Server certificate (public key)                                                              | `nil`                                                |
+| `ssl.certificates[0].key`                    | Server key (private key)                                                                     | `nil`                                                |
+| `imagePullSecrets`                           | Name of Secret resource containing private registry credentials                              | `nil`                                                |
+| `initializationFiles`                        | List of SQL files which are run after the container started                                  | `nil`                                                |
+| `timezone`                                   | Container and mysqld timezone (TZ env)                                                       | `nil` (UTC depending on image)                       |
+| `podAnnotations`                             | Map of annotations to add to the pods                                                        | `{}`                                                 |
+| `podLabels`                                  | Map of labels to add to the pods                                                             | `{}`                                                 |
+| `priorityClassName`                          | Set pod priorityClassName                                                                    | `{}`                                                 |
+| `deploymentAnnotations`		       | Map of annotations for deployment							      | `{}`						     |
 
 Some of the parameters above map to the env variables defined in the [MySQL DockerHub image](https://hub.docker.com/_/mysql/).
 
@@ -156,6 +344,8 @@ you can change the values.yaml to disable persistence and use an emptyDir instea
 
 > *"An emptyDir volume is first created when a Pod is assigned to a Node, and exists as long as that Pod is running on that node. When a Pod is removed from a node for any reason, the data in the emptyDir is deleted forever."*
 
+**Notice**: You may need to increase the value of `livenessProbe.initialDelaySeconds` when enabling persistence by using PersistentVolumeClaim from PersistentVolume with varying properties. Since its IO performance has impact on the database initialization performance. The default limit for database initialization is `60` seconds (`livenessProbe.initialDelaySeconds` + `livenessProbe.periodSeconds` * `livenessProbe.failureThreshold`). Once such initialization process takes more time than this limit, kubelet will restart the database container, which will interrupt database initialization then causing persisent data in an unusable state.
+
 ## Custom MySQL configuration files
 
 The [MySQL](https://hub.docker.com/_/mysql/) image accepts custom configuration files at the path `/etc/mysql/conf.d`. If you want to use a customized MySQL configuration, you can create your alternative configuration files by passing the file contents on the `configurationFiles` attribute. Note that according to the MySQL documentation only files ending with `.cnf` are loaded.
@@ -169,4 +359,76 @@ configurationFiles:
     sql-mode=STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION
   mysql_custom.cnf: |-
     [mysqld]
+```
+
+## MySQL initialization files
+
+The [MySQL](https://hub.docker.com/_/mysql/) image accepts *.sh, *.sql and *.sql.gz files at the path `/docker-entrypoint-initdb.d`.
+These files are being run exactly once for container initialization and ignored on following container restarts.
+If you want to use initialization scripts, you can create initialization files by passing the file contents on the `initializationFiles` attribute.
+
+
+```yaml
+initializationFiles:
+  first-db.sql: |-
+    CREATE DATABASE IF NOT EXISTS first DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;
+  second-db.sql: |-
+    CREATE DATABASE IF NOT EXISTS second DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;
+```
+
+## SSL
+
+This chart supports configuring MySQL to use [encrypted connections](https://dev.mysql.com/doc/refman/5.7/en/encrypted-connections.html) with TLS/SSL certificates provided by the user. This is accomplished by storing the required Certificate Authority file, the server public key certificate, and the server private key as a Kubernetes secret. The SSL options for this chart support the following use cases:
+
+* Manage certificate secrets with helm
+* Manage certificate secrets outside of helm
+
+## Manage certificate secrets with helm
+
+Include your certificate data in the `ssl.certificates` section. For example:
+
+```
+ssl:
+  enabled: false
+  secret: mysql-ssl-certs
+  certificates:
+  - name: mysql-ssl-certs
+    ca: |-
+      -----BEGIN CERTIFICATE-----
+      ...
+      -----END CERTIFICATE-----
+    cert: |-
+      -----BEGIN CERTIFICATE-----
+      ...
+      -----END CERTIFICATE-----
+    key: |-
+      -----BEGIN RSA PRIVATE KEY-----
+      ...
+      -----END RSA PRIVATE KEY-----
+```
+
+> **Note**: Make sure your certificate data has the correct formatting in the values file.
+
+## Manage certificate secrets outside of helm
+
+1. Ensure the certificate secret exist before installation of this chart.
+2. Set the name of the certificate secret in `ssl.secret`.
+3. Make sure there are no entries underneath `ssl.certificates`.
+
+To manually create the certificate secret from local files you can execute:
+```
+kubectl create secret generic mysql-ssl-certs \
+  --from-file=ca.pem=./ssl/certificate-authority.pem \
+  --from-file=server-cert.pem=./ssl/server-public-key.pem \
+  --from-file=server-key.pem=./ssl/server-private-key.pem
+```
+> **Note**: `ca.pem`, `server-cert.pem`, and `server-key.pem` **must** be used as the key names in this generic secret.
+
+If you are using a certificate your configurationFiles must include the three ssl lines under [mysqld]
+
+```
+[mysqld]
+    ssl-ca=/ssl/ca.pem
+    ssl-cert=/ssl/server-cert.pem
+    ssl-key=/ssl/server-key.pem
 ```

--- a/examples/helm/kanister/kanister-mysql/templates/NOTES.txt
+++ b/examples/helm/kanister/kanister-mysql/templates/NOTES.txt
@@ -1,13 +1,29 @@
 MySQL can be accessed via port 3306 on the following DNS name from within your cluster:
 {{ template "mysql.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
 
+{{- if .Values.existingSecret }}
+If you have not already created the mysql password secret:
+
+   kubectl create secret generic {{ .Values.existingSecret }} --namespace {{ .Release.Namespace }} --from-file=./mysql-root-password --from-file=./mysql-password
+{{ else }}
+
 To get your root password run:
 
     MYSQL_ROOT_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "mysql.fullname" . }} -o jsonpath="{.data.mysql-root-password}" | base64 --decode; echo)
+{{- end }}
 
 To connect to your database:
 
-    kubectl run --namespace {{ .Release.Namespace }} -it --rm --image=mysql:5.7.14 --restart=Never mysql-client -- mysql -h {{ template "mysql.fullname" . }} -p${MYSQL_ROOT_PASSWORD}
+1. Run an Ubuntu pod that you can use as a client:
+
+    kubectl run -i --tty ubuntu --image=ubuntu:16.04 --restart=Never -- bash -il
+
+2. Install the mysql client:
+
+    $ apt-get update && apt-get install mysql-client -y
+
+3. Connect using the mysql cli, then provide your password:
+    $ mysql -h {{ template "mysql.fullname" . }} -p
 
 To connect to your database directly from outside the K8s cluster:
     {{- if contains "NodePort" .Values.service.type }}
@@ -16,11 +32,10 @@ To connect to your database directly from outside the K8s cluster:
 
     {{- else if contains "ClusterIP" .Values.service.type }}
     MYSQL_HOST=127.0.0.1
-    MYSQL_PORT={{ default "3306" .Values.service.port }}
+    MYSQL_PORT={{ .Values.service.port }}
 
-    # Execute the following commands to route the connection:
-    export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "mysql.fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
-    kubectl port-forward $POD_NAME {{ default "3306" .Values.service.port }}:{{ default "3306" .Values.service.port }}
+    # Execute the following command to route the connection:
+    kubectl port-forward svc/{{ template "mysql.fullname" . }} {{ .Values.service.port }}
 
     {{- end }}
 

--- a/examples/helm/kanister/kanister-mysql/templates/_helpers.tpl
+++ b/examples/helm/kanister/kanister-mysql/templates/_helpers.tpl
@@ -9,8 +9,25 @@ Expand the name of the chart.
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
 */}}
 {{- define "mysql.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- printf .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Generate chart secret name
+*/}}
+{{- define "mysql.secretName" -}}
+{{ default (include "mysql.fullname" .) .Values.existingSecret }}
+{{- end -}}
+

--- a/examples/helm/kanister/kanister-mysql/templates/configurationFiles-configmap.yaml
+++ b/examples/helm/kanister/kanister-mysql/templates/configurationFiles-configmap.yaml
@@ -2,7 +2,8 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "mysql.fullname" . }}
+  name: {{ template "mysql.fullname" . }}-configuration
+  namespace: {{ .Release.Namespace }}
 data:
 {{- range $key, $val := .Values.configurationFiles }}
   {{ $key }}: |-

--- a/examples/helm/kanister/kanister-mysql/templates/deployment.yaml
+++ b/examples/helm/kanister/kanister-mysql/templates/deployment.yaml
@@ -2,23 +2,52 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: {{ template "mysql.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "mysql.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+{{- with .Values.deploymentAnnotations }}
   annotations:
     kanister.kasten.io/blueprint: {{ template "mysql.fullname" . }}-blueprint
+{{ toYaml . | indent 4 }}
+{{- end }}
+
 spec:
   template:
     metadata:
       labels:
         app: {{ template "mysql.fullname" . }}
+{{- with .Values.podLabels }}
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.podAnnotations }}
+      annotations:
+{{ toYaml . | indent 8 }}
+{{- end }}
     spec:
+      {{- if .Values.schedulerName }}
+      schedulerName: "{{ .Values.schedulerName }}"
+      {{- end }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
+      {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+      {{- end }}
+      {{- if .Values.securityContext.enabled }}
+      securityContext:
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+      {{- end }}
       initContainers:
       - name: "remove-lost-found"
-        image: "busybox:1.25.0"
+        image: "{{ .Values.busybox.image}}:{{ .Values.busybox.tag }}"
         imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
+        resources:
+{{ toYaml .Values.initContainer.resources | indent 10 }}
         command:  ["rm", "-fr", "/var/lib/mysql/lost+found"]
         volumeMounts:
         - name: data
@@ -26,32 +55,59 @@ spec:
           {{- if .Values.persistence.subPath }}
           subPath: {{ .Values.persistence.subPath }}
           {{- end }}
+      {{- if .Values.extraInitContainers }}
+{{ tpl .Values.extraInitContainers . | indent 6 }}
+      {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+      {{- end }}
       containers:
       - name: {{ template "mysql.fullname" . }}
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
         imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
+
+        {{- with .Values.args }}
+        args:
+        {{- range . }}
+          - {{ . | quote }}
+        {{- end }}
+        {{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         env:
         {{- if .Values.mysqlAllowEmptyPassword }}
         - name: MYSQL_ALLOW_EMPTY_PASSWORD
           value: "true"
-        {{- else }}
+        {{- end }}
         - name: MYSQL_ROOT_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ template "mysql.fullname" . }}
+              name: {{ template "mysql.secretName" . }}
               key: mysql-root-password
+              {{- if .Values.mysqlAllowEmptyPassword }}
+              optional: true
+              {{- end }}
         - name: MYSQL_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ template "mysql.fullname" . }}
+              name: {{ template "mysql.secretName" . }}
               key: mysql-password
-        {{- end }}
+              {{- if or .Values.mysqlAllowEmptyPassword (empty .Values.mysqlUser) }}
+              optional: true
+              {{- end }}
         - name: MYSQL_USER
           value: {{ default "" .Values.mysqlUser | quote }}
         - name: MYSQL_DATABASE
           value: {{ default "" .Values.mysqlDatabase | quote }}
+        {{- if .Values.timezone }}
+        - name: TZ
+          value: {{ .Values.timezone }}
+        {{- end }}
         ports:
         - name: mysql
           containerPort: 3306
@@ -96,8 +152,62 @@ spec:
           subPath: {{ .Values.persistence.subPath }}
           {{- end }}
         {{- if .Values.configurationFiles }}
+        {{- range $key, $val := .Values.configurationFiles }}
         - name: configurations
-          mountPath: /etc/mysql/conf.d
+          mountPath: {{ $.Values.configurationFilesPath }}{{ $key }}
+          subPath: {{ $key }}
+        {{- end -}}
+        {{- end }}
+        {{- if .Values.initializationFiles }}
+        - name: migrations
+          mountPath: /docker-entrypoint-initdb.d
+        {{- end }}
+        {{- if .Values.ssl.enabled }}
+        - name: certificates
+          mountPath: /ssl
+        {{- end }}
+        {{- if .Values.extraVolumeMounts }}
+{{ tpl .Values.extraVolumeMounts . | indent 8 }}
+        {{- end }}
+      {{- if .Values.metrics.enabled }}
+      - name: metrics
+        image: "{{ .Values.metrics.image }}:{{ .Values.metrics.imageTag }}"
+        imagePullPolicy: {{ .Values.metrics.imagePullPolicy | quote }}
+        {{- if .Values.mysqlAllowEmptyPassword }}
+        command:
+        - 'sh'
+        - '-c'
+        - 'DATA_SOURCE_NAME="root@(localhost:3306)/" /bin/mysqld_exporter'
+        {{- else }}
+        env:
+        - name: MYSQL_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "mysql.secretName" . }}
+              key: mysql-root-password
+        command:
+        - 'sh'
+        - '-c'
+        - 'DATA_SOURCE_NAME="root:$MYSQL_ROOT_PASSWORD@(localhost:3306)/" /bin/mysqld_exporter'
+        {{- end }}
+        {{- range $f := .Values.metrics.flags }}
+        - {{ $f | quote }}
+        {{- end }}
+        ports:
+        - name: metrics
+          containerPort: 9104
+        livenessProbe:
+          httpGet:
+            path: /
+            port: metrics
+          initialDelaySeconds: {{ .Values.metrics.livenessProbe.initialDelaySeconds }}
+          timeoutSeconds: {{ .Values.metrics.livenessProbe.timeoutSeconds }}
+        readinessProbe:
+          httpGet:
+            path: /
+            port: metrics
+          initialDelaySeconds: {{ .Values.metrics.readinessProbe.initialDelaySeconds }}
+          timeoutSeconds: {{ .Values.metrics.readinessProbe.timeoutSeconds }}
         {{- end }}
       - name: kanister-sidecar
         image: kanisterio/mysql-sidecar:0.21.0
@@ -117,17 +227,29 @@ spec:
             secretKeyRef:
               name: {{ template "mysql.fullname" . }}
               key: mysql-password
-        {{- end }}
         volumeMounts:
         - name: var-run-mysql
           mountPath: /var/run/mysqld/
+        resources:
+{{ toYaml .Values.metrics.resources | indent 10 }}
+      {{- end }}
       volumes:
       - name: var-run-mysql
         emptyDir: {}
       {{- if .Values.configurationFiles }}
       - name: configurations
         configMap:
-          name: {{ template "mysql.fullname" . }}
+          name: {{ template "mysql.fullname" . }}-configuration
+      {{- end }}
+      {{- if .Values.initializationFiles }}
+      - name: migrations
+        configMap:
+          name: {{ template "mysql.fullname" . }}-initialization
+      {{- end }}
+      {{- if .Values.ssl.enabled }}
+      - name: certificates
+        secret:
+          secretName: {{ .Values.ssl.secret }}
       {{- end }}
       - name: data
       {{- if .Values.persistence.enabled }}
@@ -136,3 +258,6 @@ spec:
       {{- else }}
         emptyDir: {}
       {{- end -}}
+      {{- if .Values.extraVolumes }}
+{{ tpl .Values.extraVolumes . | indent 6 }}
+      {{- end }}

--- a/examples/helm/kanister/kanister-mysql/templates/initializationFiles-configmap.yaml
+++ b/examples/helm/kanister/kanister-mysql/templates/initializationFiles-configmap.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.initializationFiles }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "mysql.fullname" . }}-initialization
+  namespace: {{ .Release.Namespace }}
+data:
+{{- range $key, $val := .Values.initializationFiles }}
+  {{ $key }}: |-
+{{ $val | indent 4}}
+{{- end }}
+{{- end -}}
+

--- a/examples/helm/kanister/kanister-mysql/templates/pvc.yaml
+++ b/examples/helm/kanister/kanister-mysql/templates/pvc.yaml
@@ -3,6 +3,11 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ template "mysql.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+{{- with .Values.persistence.annotations  }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
   labels:
     app: {{ template "mysql.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/examples/helm/kanister/kanister-mysql/templates/secrets.yaml
+++ b/examples/helm/kanister/kanister-mysql/templates/secrets.yaml
@@ -1,7 +1,9 @@
+{{- if not .Values.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "mysql.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "mysql.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -19,3 +21,26 @@ data:
   {{ else }}
   mysql-password: {{ randAlphaNum 10 | b64enc | quote }}
   {{ end }}
+{{- if .Values.ssl.enabled }}
+{{ if .Values.ssl.certificates }}
+{{- range .Values.ssl.certificates }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .name }}
+  labels:
+    app: {{ template "mysql.fullname" $ }}
+    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    release: "{{ $.Release.Name }}"
+    heritage: "{{ $.Release.Service }}"
+type: Opaque
+data:
+  ca.pem: {{ .ca | b64enc }}
+  server-cert.pem: {{ .cert | b64enc }}
+  server-key.pem: {{ .key | b64enc }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+

--- a/examples/helm/kanister/kanister-mysql/templates/servicemonitor.yaml
+++ b/examples/helm/kanister/kanister-mysql/templates/servicemonitor.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "mysql.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "mysql.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    {{- if .Values.metrics.serviceMonitor.additionalLabels }}
+{{ toYaml .Values.metrics.serviceMonitor.additionalLabels | indent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+    - port: metrics
+      interval: 30s
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app: {{ include "mysql.fullname" . }}
+      release: {{ .Release.Name }}
+{{- end }}

--- a/examples/helm/kanister/kanister-mysql/templates/svc.yaml
+++ b/examples/helm/kanister/kanister-mysql/templates/svc.yaml
@@ -2,16 +2,35 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "mysql.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "mysql.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  annotations:
+{{- if .Values.service.annotations }}
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
+{{- if and (.Values.metrics.enabled) (.Values.metrics.annotations) }}
+{{ toYaml .Values.metrics.annotations | indent 4 }}
+{{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if (and (eq .Values.service.type "LoadBalancer") (not (empty .Values.service.loadBalancerIP))) }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
   ports:
   - name: mysql
     port: {{ .Values.service.port }}
     targetPort: mysql
+    {{- if .Values.service.nodePort }}
+    nodePort: {{ .Values.service.nodePort }}
+    {{- end }}
+  {{- if .Values.metrics.enabled }}
+  - name: metrics
+    port: 9104
+    targetPort: metrics
+  {{- end }}
   selector:
     app: {{ template "mysql.fullname" . }}

--- a/examples/helm/kanister/kanister-mysql/templates/tests/test-configmap.yaml
+++ b/examples/helm/kanister/kanister-mysql/templates/tests/test-configmap.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "mysql.fullname" . }}-test
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "mysql.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+data:
+  run.sh: |-
+    {{- if .Values.ssl.enabled | and .Values.mysqlRootPassword }}
+    @test "Testing SSL MySQL Connection" {
+      mysql --host={{ template "mysql.fullname" . }} --port={{ .Values.service.port | default "3306" }} --ssl-cert=/ssl/server-cert.pem --ssl-key=ssl/server-key.pem -u root -p{{ .Values.mysqlRootPassword }}
+    }
+    {{- else if .Values.mysqlRootPassword }}
+    @test "Testing MySQL Connection" {
+      mysql --host={{ template "mysql.fullname" . }} --port={{ .Values.service.port | default "3306" }} -u root -p{{ .Values.mysqlRootPassword }}
+    }
+    {{- end }}
+

--- a/examples/helm/kanister/kanister-mysql/templates/tests/test.yaml
+++ b/examples/helm/kanister/kanister-mysql/templates/tests/test.yaml
@@ -1,0 +1,52 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ template "mysql.fullname" . }}-test
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "mysql.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  initContainers:
+    - name: test-framework
+      image: "{{ .Values.testFramework.image}}:{{ .Values.testFramework.tag }}"
+      command:
+      - "bash"
+      - "-c"
+      - |
+        set -ex
+        # copy bats to tools dir
+        cp -R /usr/local/libexec/ /tools/bats/
+      volumeMounts:
+      - mountPath: /tools
+        name: tools
+  containers:
+    - name: {{ .Release.Name }}-test
+      image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+      command: ["/tools/bats/bats", "-t", "/tests/run.sh"]
+      volumeMounts:
+      - mountPath: /tests
+        name: tests
+        readOnly: true
+      - mountPath: /tools
+        name: tools
+      {{- if .Values.ssl.enabled }}
+      - name: certificates
+        mountPath: /ssl
+      {{- end }}
+  volumes:
+  - name: tests
+    configMap:
+      name: {{ template "mysql.fullname" . }}-test
+  - name: tools
+    emptyDir: {}
+  {{- if .Values.ssl.enabled }}
+  - name: certificates
+    secret:
+      secretName: {{ .Values.ssl.secret }}
+  {{- end }}
+  restartPolicy: Never

--- a/examples/helm/kanister/kanister-mysql/values.yaml
+++ b/examples/helm/kanister/kanister-mysql/values.yaml
@@ -1,7 +1,16 @@
-## mysql image version ## ref: https://hub.docker.com/r/library/mysql/tags/
+## mysql image version
+## ref: https://hub.docker.com/r/library/mysql/tags/
 ##
 image: "mysql"
 imageTag: "5.7.14"
+
+busybox:
+  image: "busybox"
+  tag: "1.29.3"
+
+testFramework:
+  image: "dduportal/bats"
+  tag: "0.4.0"
 
 ## Specify password for root user
 ##
@@ -11,6 +20,7 @@ imageTag: "5.7.14"
 ## Create a database user
 ##
 # mysqlUser:
+## Default: random 10 character string
 # mysqlPassword:
 
 ## Allow unauthenticated access, uncomment to enable
@@ -26,6 +36,40 @@ imageTag: "5.7.14"
 ## ref: http://kubernetes.io/docs/user-guide/images/#updating-images
 ##
 imagePullPolicy: IfNotPresent
+
+## Additionnal arguments that are passed to the MySQL container.
+## For example use --default-authentication-plugin=mysql_native_password if older clients need to
+## connect to a MySQL 8 instance.
+args: []
+
+extraVolumes: |
+  # - name: extras
+  #   emptyDir: {}
+
+extraVolumeMounts: |
+  # - name: extras
+  #   mountPath: /usr/share/extras
+  #   readOnly: true
+
+extraInitContainers: |
+  # - name: do-something
+  #   image: busybox
+  #   command: ['do', 'something']
+
+# Optionally specify an array of imagePullSecrets.
+# Secrets must be manually created in the namespace.
+# ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+# imagePullSecrets:
+  # - name: myRegistryKeySecretName
+
+## Node selector
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+nodeSelector: {}
+
+## Tolerations for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+##
+tolerations: []
 
 livenessProbe:
   initialDelaySeconds: 30
@@ -54,6 +98,18 @@ persistence:
   # storageClass: "-"
   accessMode: ReadWriteOnce
   size: 8Gi
+  annotations: {}
+
+## Use an alternate scheduler, e.g. "stork".
+## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+##
+# schedulerName:
+
+## Security context
+securityContext:
+  enabled: false
+  runAsUser: 999
+  fsGroup: 999
 
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
@@ -63,20 +119,98 @@ resources:
     memory: 256Mi
     cpu: 100m
 
+# Custom mysql configuration files path
+configurationFilesPath: /etc/mysql/conf.d/
+
 # Custom mysql configuration files used to override default mysql settings
-configurationFiles:
+configurationFiles: {}
 #  mysql.cnf: |-
 #    [mysqld]
 #    skip-name-resolve
+#    ssl-ca=/ssl/ca.pem
+#    ssl-cert=/ssl/server-cert.pem
+#    ssl-key=/ssl/server-key.pem
 
+# Custom mysql init SQL files used to initialize the database
+initializationFiles: {}
+#  first-db.sql: |-
+#    CREATE DATABASE IF NOT EXISTS first DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;
+#  second-db.sql: |-
+#    CREATE DATABASE IF NOT EXISTS second DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;
+
+metrics:
+  enabled: false
+  image: prom/mysqld-exporter
+  imageTag: v0.10.0
+  imagePullPolicy: IfNotPresent
+  resources: {}
+  annotations: {}
+    # prometheus.io/scrape: "true"
+    # prometheus.io/port: "9104"
+  livenessProbe:
+    initialDelaySeconds: 15
+    timeoutSeconds: 5
+  readinessProbe:
+    initialDelaySeconds: 5
+    timeoutSeconds: 1
+  flags: []
+  serviceMonitor:
+    enabled: false
+    additionalLabels: {}
 
 ## Configure the service
 ## ref: http://kubernetes.io/docs/user-guide/services/
 service:
+  annotations: {}
   ## Specify a service type
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services---service-types
   type: ClusterIP
   port: 3306
+  # nodePort: 32000
+  # loadBalancerIP:
+
+ssl:
+  enabled: false
+  secret: mysql-ssl-certs
+  certificates:
+#  - name: mysql-ssl-certs
+#    ca: |-
+#      -----BEGIN CERTIFICATE-----
+#      ...
+#      -----END CERTIFICATE-----
+#    cert: |-
+#      -----BEGIN CERTIFICATE-----
+#      ...
+#      -----END CERTIFICATE-----
+#    key: |-
+#      -----BEGIN RSA PRIVATE KEY-----
+#      ...
+#      -----END RSA PRIVATE KEY-----
+
+## Populates the 'TZ' system timezone environment variable
+## ref: https://dev.mysql.com/doc/refman/5.7/en/time-zone-support.html
+##
+## Default: nil (mysql will use image's default timezone, normally UTC)
+## Example: 'Australia/Sydney'
+# timezone:
+
+# Deployment Annotations
+deploymentAnnotations: {}
+
+# To be added to the database server pod(s)
+podAnnotations: {}
+podLabels: {}
+
+## Set pod priorityClassName
+# priorityClassName: {}
+
+
+## Init container resources defaults
+initContainer:
+  resources:
+    requests:
+      memory: 10Mi
+      cpu: 10m
 
 # Configure profile for mysql, the profile CR is installed in the release namespace
 profile:


### PR DESCRIPTION
## Change Overview
This PR:
- Updates mysql helm chart for kanister-mysql to the latest stable version (Chart link: https://github.com/helm/charts/tree/8f6192fdb70032986dda893e419d34508391853b)
- Adds steps to take data backup and restore in README
- Fixes default values for helm chart in README
 

## Pull request type

Please check the type of change your PR introduces:
- [ ] Work in Progress
- [x] Refactoring (no functional changes, no api changes)
- [ ] Trival/Minor
- [ ] Bugfix
- [ ] Feature
- [x] Documentation

## Test Plan

Tested data backup and restore on S3 as per the steps documented in README

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] Manual
- [ ] Unit test
- [ ] E2E
