### PR TITLE
Fix echo/base64 examples commands

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -296,7 +296,7 @@ Base64 credentials and put them below.
 
 .. code-block:: bash
 
-  echo "YOUR_KEY" | base64
+  echo -n "YOUR_KEY" | base64
 
 
 .. code-block:: yaml

--- a/examples/mongo-sidecar/README.md
+++ b/examples/mongo-sidecar/README.md
@@ -32,7 +32,7 @@ Next create a Blueprint which describes how backup and restore actions can be ex
 
 ```bash
 # Get base64 encoded aws keys
-$ echo "YOUR_KEY" | base64
+$ echo -n "YOUR_KEY" | base64
 
 # Create the ConfigMap with an S3 path
 $ kubectl apply -f ./examples/mongo-sidecar/s3-location-configmap.yaml

--- a/examples/mongo-sidecar/secrets.yaml
+++ b/examples/mongo-sidecar/secrets.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kanister
 type: Opaque
 # Note: the aws keys below must be base64 encoded:
-# echo "YOUR_KEY" | base64
+# echo -n "YOUR_KEY" | base64
 data:
   aws_access_key_id: XXXX
   aws_secret_access_key: XXXX

--- a/examples/postgres-basic-pgdump/README.md
+++ b/examples/postgres-basic-pgdump/README.md
@@ -30,8 +30,8 @@ You should also update secrets.yaml to contain the necessary AWS credentials to 
 
 ```bash
 # Get base64 encoded aws keys
-$ echo ${AWS_ACCESS_KEY_ID} | base64
-$ echo ${AWS_SECRET_ACCESS_KEY} | base64
+$ echo -n ${AWS_ACCESS_KEY_ID} | base64
+$ echo -n ${AWS_SECRET_ACCESS_KEY} | base64
 
 # Edit the secret spec and add the base64 encoded AWS keys
 $ vim secrets.yaml

--- a/examples/postgres-basic-pgdump/secrets.yaml
+++ b/examples/postgres-basic-pgdump/secrets.yaml
@@ -4,7 +4,7 @@ metadata:
   name: aws-creds
 type: Opaque
 # Note: the aws keys below must be base64 encoded:
-# echo "YOUR_KEY" | base64
+# echo -n "YOUR_KEY" | base64
 data:
   aws_access_key_id: XXXX
   aws_secret_access_key: XXXX

--- a/examples/time-log/README.md
+++ b/examples/time-log/README.md
@@ -19,7 +19,7 @@ Next create a Blueprint which describes how backup and restore actions can be ex
 
 ```bash
 # Get base64 encoded aws keys
-$ echo "YOUR_KEY" | base64
+$ echo -n "YOUR_KEY" | base64
 
 # Create secrets containing the necessary AWS credentials
 $ kubectl apply -f examples/time-log/secrets.yaml

--- a/examples/time-log/secrets.yaml
+++ b/examples/time-log/secrets.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kanister
 type: Opaque
 # Note: the aws keys below must be base64 encoded:
-# echo "YOUR_KEY" | base64
+# echo -n "YOUR_KEY" | base64
 data:
   aws_access_key_id: XXXX
   aws_secret_access_key: XXXX


### PR DESCRIPTION
## Change Overview

The commands to create base64 encoded strings for manual secret creation are wrong. The `echo` command prints a new line by default. This alters the actual value to be encoded.

To keep this from happening you can add the parameter `-n` or use the command `printf`.

`echo "YOUR_KEY" | base64` returns `WU9VUl9LRVkK` and
`echo -n "YOUR_KEY" | base64` returns `WU9VUl9LRVk=`.

The Kubernetes documentation also suggests the `echo -n` command. <https://kubernetes.io/docs/concepts/configuration/secret/#creating-a-secret-manually>

## Pull request type

Please check the type of change your PR introduces:
- [ ] Work in Progress
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Trival/Minor
- [ ] Bugfix
- [ ] Feature
- [x] Documentation

## Issues

I have not created an issue.

## Test Plan

For testing see command above.

- [x] Manual
- [ ] Unit test
- [ ] E2E
