### PR TITLE
Fix chron pull test to use the artifact string

### DIFF
--- a/pkg/chronicle/chronicle_test.go
+++ b/pkg/chronicle/chronicle_test.go
@@ -44,7 +44,8 @@ func (s *ChronicleSuite) TestPushPull(c *C) {
 	c.Assert(err, IsNil)
 
 	a := filepath.Join(c.MkDir(), "artifact")
-	err = ioutil.WriteFile(a, []byte(rand.String(10)), os.ModePerm)
+	ap := rand.String(10)
+	err = ioutil.WriteFile(a, []byte(ap), os.ModePerm)
 	c.Assert(err, IsNil)
 	p := PushParams{
 		ProfilePath:  pp,
@@ -60,7 +61,8 @@ func (s *ChronicleSuite) TestPushPull(c *C) {
 
 		// Pull and check that we still get i
 		buf := bytes.NewBuffer(nil)
-		err = Pull(ctx, buf, s.profile, p.ArtifactFile)
+		c.Log("File: ", p.ArtifactFile)
+		err = Pull(ctx, buf, s.profile, ap)
 		c.Assert(err, IsNil)
 		str, err := ioutil.ReadAll(buf)
 		c.Assert(err, IsNil)


### PR DESCRIPTION
## Change Overview

Fixes broken test

## Pull request type

Please check the type of change your PR introduces:
- [ ] Work in Progress
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Trival/Minor
- [x] Bugfix
- [ ] Feature
- [ ] Documentation

## Test Plan
### Before
```
FAIL: chronicle_test.go:41: ChronicleSuite.TestPushPull

chronicle_test.go:64:
    c.Assert(err, IsNil)
... value *errors.withStack = getItem, getting the object: InvalidParameter: 1 validation error(s) found.
- minimum field size of 1, GetObjectInput.Key.
 ("getItem, getting the object: InvalidParameter: 1 validation error(s) found.\n- minimum field size of 1, GetObjectInput.Key.\n")

OOPS: 2 passed, 1 FAILED
--- FAIL: Test (3.65s)
FAIL
```
### After
```
/go/src/github.com/kanisterio/kanister/pkg/chronicle # go test -v -check.v -check.f TestPushPull
=== RUN   Test
PASS: chronicle_test.go:41: ChronicleSuite.TestPushPull 8.545s
OK: 1 passed
--- PASS: Test (8.55s)
PASS
```

- [ ] Manual
- [x] Unit test
- [ ] E2E
