### PR TITLE
Update ScaleWorkload to provide replicas as string & int value

### DIFF
--- a/pkg/function/scale_test.go
+++ b/pkg/function/scale_test.go
@@ -101,7 +101,7 @@ func newScaleBlueprint(kind string) *crv1alpha1.Blueprint {
 						Name: "testScale",
 						Func: "ScaleWorkload",
 						Args: map[string]interface{}{
-							ScaleWorkloadReplicas: 2,
+							ScaleWorkloadReplicas: "2",
 						},
 					},
 				},
@@ -234,7 +234,7 @@ func (s *ScaleSuite) TestGetArgs(c *C) {
 		{
 			tp: param.TemplateParams{},
 			args: map[string]interface{}{
-				ScaleWorkloadReplicas:     2,
+				ScaleWorkloadReplicas:     "2",
 				ScaleWorkloadNamespaceArg: "foo",
 				ScaleWorkloadNameArg:      "app",
 				ScaleWorkloadKindArg:      param.StatefulSetKind,
@@ -269,7 +269,7 @@ func (s *ScaleSuite) TestGetArgs(c *C) {
 				},
 			},
 			args: map[string]interface{}{
-				ScaleWorkloadReplicas: 2,
+				ScaleWorkloadReplicas: "2",
 			},
 			wantKind:      param.DeploymentKind,
 			wantName:      "app",


### PR DESCRIPTION
## Change Overview

ScaleWorkload only allowed static int values for `replicas` parameter. With these changes, we can provide string values to `replicas` in addition to int, kanister will take care of conversion.

## Pull request type

Please check the type of change your PR introduces:
- [ ] Work in Progress
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Trival/Minor
- [ ] Bugfix
- [x] Feature
- [ ] Documentation

## Test Plan

- [ ] Manual
- [x] Unit test
- [ ] E2E