### PR TITLE
Do not create build artifacts in GOOS directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,6 @@ shell: build-dirs
 		-v "${HOME}/.kube:/root/.kube"                          \
 		-v "$(PWD):/go/src/$(PKG)"                              \
 		-v "$(PWD)/bin/$(ARCH):/go/bin"                         \
-		-v "$(PWD)/bin/$(ARCH):/go/bin/$$(go env GOOS)_$(ARCH)" \
 		-v /var/run/docker.sock:/var/run/docker.sock            \
 		-w /go/src/$(PKG)                                       \
 		$(BUILD_IMAGE)                                          \
@@ -199,7 +198,7 @@ ifeq ($(DOCKER_BUILD),"true")
 		-v "$(PWD)/.go/pkg:/go/pkg"                                 \
 		-v "$(PWD)/.go/cache:/go/.cache"                            \
 		-v "$(PWD):/go/src/$(PKG)"                                  \
-		-v "$(PWD)/bin/$(ARCH)/$$(go env GOOS)_$(ARCH):/go/bin"     \
+		-v "$(PWD)/bin/$(ARCH):/go/bin"                             \
 		-v "$(PWD)/.go/std/$(ARCH):/usr/local/go/pkg/linux_$(ARCH)" \
 		-v /var/run/docker.sock:/var/run/docker.sock                \
 		-w /go/src/$(PKG)                                           \


### PR DESCRIPTION
## Change Overview

Mapping `"$(PWD)/bin/$(ARCH)/$$(go env GOOS)_$(ARCH)` to -> `/go/bin` inside the
build container would result in artifacts being placed under `bin/amd64/darwin_amd64`
when building on OS X - which is not correct since these are not OS X executables

This also broke `make deploy` and `make release-container` commands

## Pull request type

Please check the type of change your PR introduces:
- [ ] Work in Progress
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Trival/Minor
- [x] Bugfix
- [ ] Feature
- [ ] Documentation

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] Manual
- [ ] Unit test
- [ ] E2E

