### PR TITLE
Fix failure due to changes done on ScaleWorkload replicas type

### DIFF
--- a/pkg/function/scale_test.go
+++ b/pkg/function/scale_test.go
@@ -269,7 +269,7 @@ func (s *ScaleSuite) TestGetArgs(c *C) {
 				},
 			},
 			args: map[string]interface{}{
-				ScaleWorkloadReplicas: "2",
+				ScaleWorkloadReplicas: int64(2),
 			},
 			wantKind:      param.DeploymentKind,
 			wantName:      "app",
@@ -285,7 +285,7 @@ func (s *ScaleSuite) TestGetArgs(c *C) {
 				},
 			},
 			args: map[string]interface{}{
-				ScaleWorkloadReplicas:     2,
+				ScaleWorkloadReplicas:     int32(2),
 				ScaleWorkloadNamespaceArg: "notfoo",
 				ScaleWorkloadNameArg:      "notapp",
 				ScaleWorkloadKindArg:      param.DeploymentKind,

--- a/pkg/function/scale_workload.go
+++ b/pkg/function/scale_workload.go
@@ -70,6 +70,10 @@ func getArgs(tp param.TemplateParams, args map[string]interface{}) (namespace, k
 	switch rep.(type) {
 	case int:
 		val = rep.(int)
+	case int32:
+		val = int(rep.(int32))
+	case int64:
+		val = int(rep.(int64))
 	case string:
 		if val, err = strconv.Atoi(rep.(string)); err != nil {
 			err = errors.Wrapf(err, "Cannot convert %s to int ", rep.(string))


### PR DESCRIPTION
## Change Overview

This PR fixes the e2e test failure:
```
 Invalid arg type int64 for Arg replicas
```

## Pull request type

Please check the type of change your PR introduces:
- [ ] Work in Progress
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Trival/Minor
- [x] Bugfix
- [ ] Feature
- [ ] Documentation


## Test Plan


- [ ] Manual
- [x] Unit test
- [ ] E2E