### PR TITLE
Revert "Revert "Stream logs from kube-task" (#233)"

### DIFF
--- a/pkg/format/format.go
+++ b/pkg/format/format.go
@@ -15,6 +15,8 @@
 package format
 
 import (
+	"bufio"
+	"io"
 	"regexp"
 	"strings"
 
@@ -25,9 +27,30 @@ func Log(podName string, containerName string, output string) {
 	if output != "" {
 		logs := regexp.MustCompile("[\r\n]").Split(output, -1)
 		for _, l := range logs {
-			if strings.TrimSpace(l) != "" {
-				log.Info("Pod: ", podName, " Container: ", containerName, " Out: ", l)
-			}
+			info(podName, containerName, l)
 		}
+	}
+}
+
+func LogStream(podName string, containerName string, output io.ReadCloser) chan string {
+	logCh := make(chan string, 100)
+	s := bufio.NewScanner(output)
+	go func() {
+		defer close(logCh)
+		for s.Scan() {
+			l := s.Text()
+			info(podName, containerName, l)
+			logCh <- l
+		}
+		if err := s.Err(); err != nil {
+			log.Error("Pod: ", podName, " Container: ", containerName, " Failed to stream log from pod: ", err.Error())
+		}
+	}()
+	return logCh
+}
+
+func info(podName string, containerName string, l string) {
+	if strings.TrimSpace(l) != "" {
+		log.Info("Pod: ", podName, " Container: ", containerName, " Out: ", l)
 	}
 }

--- a/pkg/function/kube_task.go
+++ b/pkg/function/kube_task.go
@@ -73,18 +73,32 @@ func kubeTask(ctx context.Context, cli kubernetes.Interface, namespace, image st
 
 func kubeTaskPodFunc(cli kubernetes.Interface) func(ctx context.Context, pod *v1.Pod) (map[string]interface{}, error) {
 	return func(ctx context.Context, pod *v1.Pod) (map[string]interface{}, error) {
-		// Wait for pod completion
-		if err := kube.WaitForPodCompletion(ctx, cli, pod.Namespace, pod.Name); err != nil {
+		if err := kube.WaitForPodReady(ctx, cli, pod.Namespace, pod.Name); err != nil {
 			return nil, errors.Wrapf(err, "Failed while waiting for Pod %s to complete", pod.Name)
 		}
 		// Fetch logs from the pod
-		logs, err := kube.GetPodLogs(ctx, cli, pod.Namespace, pod.Name)
+		r, err := kube.StreamPodLogs(ctx, cli, pod.Namespace, pod.Name)
 		if err != nil {
 			return nil, errors.Wrapf(err, "Failed to fetch logs from the pod")
 		}
-		format.Log(pod.Name, pod.Spec.Containers[0].Name, logs)
-		out, err := parseLogAndCreateOutput(logs)
-		return out, errors.Wrap(err, "Failed to parse phase output")
+		defer r.Close()
+		logCh := format.LogStream(pod.Name, pod.Spec.Containers[0].Name, r)
+		// Wait for pod completion
+		err = kube.WaitForPodCompletion(ctx, cli, pod.Namespace, pod.Name)
+		if err != nil {
+			return nil, errors.Wrapf(err, "Failed while waiting for Pod %s to complete", pod.Name)
+		}
+		out := make(map[string]interface{})
+		for l := range logCh {
+			op, err := parseLogLineForOutput(l)
+			if err != nil {
+				return nil, errors.Wrap(err, "Failed to parse phase output")
+			}
+			if op != nil {
+				out[op.Key] = op.Value
+			}
+		}
+		return out, nil
 	}
 }
 

--- a/pkg/function/kube_task_test.go
+++ b/pkg/function/kube_task_test.go
@@ -61,61 +61,96 @@ func (s *KubeTaskSuite) TearDownSuite(c *C) {
 	}
 }
 
-func newTaskBlueprint(namespace string) *crv1alpha1.Blueprint {
+func outputPhase(namespace string) crv1alpha1.BlueprintPhase {
+	return crv1alpha1.BlueprintPhase{
+		Name: "testOutput",
+		Func: "KubeTask",
+		Args: map[string]interface{}{
+			KubeTaskNamespaceArg: namespace,
+			KubeTaskImageArg:     "kanisterio/kanister-tools:0.20.0",
+			KubeTaskCommandArg: []string{
+				"sh",
+				"-c",
+				"kando output version 0.21.0",
+			},
+		},
+	}
+}
+
+func sleepPhase(namespace string) crv1alpha1.BlueprintPhase {
+	return crv1alpha1.BlueprintPhase{
+		Name: "testSleep",
+		Func: "KubeTask",
+		Args: map[string]interface{}{
+			KubeTaskNamespaceArg: namespace,
+			KubeTaskImageArg:     "ubuntu:latest",
+			KubeTaskCommandArg: []string{
+				"sleep",
+				"2",
+			},
+		},
+	}
+}
+
+func tickPhase(namespace string) crv1alpha1.BlueprintPhase {
+	return crv1alpha1.BlueprintPhase{
+		Name: "testTick",
+		Func: "KubeTask",
+		Args: map[string]interface{}{
+			KubeTaskNamespaceArg: namespace,
+			KubeTaskImageArg:     "alpine:3.10",
+			KubeTaskCommandArg: []string{
+				"sh",
+				"-c",
+				`for i in $(seq 3); do echo Tick: "${i}"; sleep 1; done`,
+			},
+		},
+	}
+}
+
+func newTaskBlueprint(phases ...crv1alpha1.BlueprintPhase) *crv1alpha1.Blueprint {
 	return &crv1alpha1.Blueprint{
 		Actions: map[string]*crv1alpha1.BlueprintAction{
 			"test": {
-				Kind: "StatefulSet",
-				Phases: []crv1alpha1.BlueprintPhase{
-					{
-						Name: "testOutput",
-						Func: "KubeTask",
-						Args: map[string]interface{}{
-							KubeTaskNamespaceArg: namespace,
-							KubeTaskImageArg:     "kanisterio/kanister-tools:0.21.0",
-							KubeTaskCommandArg: []string{
-								"sh",
-								"-c",
-								"kando output version 0.21.0",
-							},
-						},
-					},
-					{
-						Name: "testSleep",
-						Func: "KubeTask",
-						Args: map[string]interface{}{
-							KubeTaskNamespaceArg: namespace,
-							KubeTaskImageArg:     "ubuntu:latest",
-							KubeTaskCommandArg: []string{
-								"sleep",
-								"2",
-							},
-						},
-					},
-				},
+				Kind:   "StatefulSet",
+				Phases: phases,
 			},
 		},
 	}
 }
 
 func (s *KubeTaskSuite) TestKubeTask(c *C) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 	defer cancel()
 	tp := param.TemplateParams{
 		StatefulSet: &param.StatefulSetParams{
 			Namespace: s.namespace,
 		},
 	}
-
 	action := "test"
-	bp := newTaskBlueprint(s.namespace)
-	phases, err := kanister.GetPhases(*bp, action, tp)
-	c.Assert(err, IsNil)
-	for _, p := range phases {
-		out, err := p.Exec(ctx, *bp, action, tp)
-		c.Assert(err, IsNil, Commentf("Phase %s failed", p.Name()))
-		if out != nil {
-			c.Assert(out["version"], NotNil)
+	for _, tc := range []struct {
+		bp   *crv1alpha1.Blueprint
+		outs []map[string]interface{}
+	}{
+		{
+			bp: newTaskBlueprint(outputPhase(s.namespace), sleepPhase(s.namespace), tickPhase(s.namespace)),
+			outs: []map[string]interface{}{
+				map[string]interface{}{
+					"version": "0.21.0",
+				},
+				map[string]interface{}{},
+				map[string]interface{}{},
+			},
+		},
+	} {
+
+		phases, err := kanister.GetPhases(*tc.bp, action, tp)
+		c.Assert(err, IsNil)
+		c.Assert(phases, HasLen, len(tc.outs))
+		for i, p := range phases {
+			out, err := p.Exec(ctx, *tc.bp, action, tp)
+			c.Assert(err, IsNil, Commentf("Phase %s failed", p.Name()))
+			c.Assert(out, DeepEquals, tc.outs[i])
 		}
 	}
 }


### PR DESCRIPTION
This reverts commit e36c0220607177db5b16081e8a3a9f6e8b17c377, which remerges https://github.com/kanisterio/kanister/pull/228

## Change Overview

* Prints logs from kube task pod as soon as they're ready in the controller
* Fixes some issues with WaitForPod* hanging

## Issues

* https://github.com/kanisterio/kanister/issues/231

## Pull request type

Please check the type of change your PR introduces:
- [ ] Work in Progress
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Trival/Minor
- [ ] Bugfix
- [x] Feature
- [ ] Documentation

## Test Plan
```
/go/src/github.com/kanisterio/kanister # go test -v ./pkg/function -check.v -check.f TestKubeTask
=== RUN   Test
time="2019-08-29T01:21:55Z" level=info msg="Pod: kanister-job-vgzg4 Container: container Out: ###Phase-output###: {\"key\":\"version\",\"value\":\"0.21.0\"}"
time="2019-08-29T01:22:11Z" level=info msg="Pod: kanister-job-84vfl Container: container Out: Tick: 1"
time="2019-08-29T01:22:11Z" level=info msg="Pod: kanister-job-84vfl Container: container Out: Tick: 2"
time="2019-08-29T01:22:11Z" level=info msg="Pod: kanister-job-84vfl Container: container Out: Tick: 3"
PASS: kube_task_test.go:122: KubeTaskSuite.TestKubeTask 19.720s
OK: 1 passed
--- PASS: Test (20.03s)
PASS
ok      github.com/kanisterio/kanister/pkg/function     20.042s
```

- [ ] Manual
- [x] Unit test
- [ ] E2E
