### PR TITLE
Refactor Log Parsing

### DIFF
--- a/pkg/function/kube_exec.go
+++ b/pkg/function/kube_exec.go
@@ -17,7 +17,6 @@ package function
 import (
 	"context"
 	"regexp"
-	"strings"
 
 	"github.com/pkg/errors"
 
@@ -56,7 +55,7 @@ func parseLogAndCreateOutput(out string) (map[string]interface{}, error) {
 	var op map[string]interface{}
 	logs := regexp.MustCompile("[\n]").Split(out, -1)
 	for _, l := range logs {
-		opObj, err := parseLogLineForOutput(l)
+		opObj, err := output.Parse(l)
 		if err != nil {
 			return nil, err
 		}
@@ -67,20 +66,6 @@ func parseLogAndCreateOutput(out string) (map[string]interface{}, error) {
 			op = make(map[string]interface{})
 		}
 		op[opObj.Key] = opObj.Value
-	}
-	return op, nil
-}
-
-var outputRE = regexp.MustCompile(`###Phase-output###:(.*?)*$`)
-
-func parseLogLineForOutput(l string) (*output.Output, error) {
-	if !strings.Contains(l, output.PhaseOpString) {
-		return nil, nil
-	}
-	match := outputRE.FindAllStringSubmatch(l, 1)
-	op, err := output.UnmarshalOutput(match[0][1])
-	if err != nil {
-		return nil, err
 	}
 	return op, nil
 }

--- a/pkg/output/output_test.go
+++ b/pkg/output/output_test.go
@@ -15,6 +15,7 @@
 package output
 
 import (
+	"bytes"
 	"testing"
 
 	. "gopkg.in/check.v1"
@@ -41,5 +42,43 @@ func (s *OutputSuite) TestValidateKey(c *C) {
 	} {
 		err := ValidateKey(tc.key)
 		c.Check(err, tc.checker, Commentf("Key (%s) failed!", tc.key))
+	}
+}
+
+func (s *OutputSuite) TestParseValid(c *C) {
+	key, val := "foo", "bar"
+	b := bytes.NewBuffer(nil)
+	err := fPrintOutput(b, key, val)
+	c.Check(err, IsNil)
+
+	o, err := Parse(b.String())
+	c.Assert(err, IsNil)
+	c.Assert(o, NotNil)
+	c.Assert(o.Key, Equals, key)
+	c.Assert(o.Value, Equals, val)
+}
+
+func (s *OutputSuite) TestParseNoOutput(c *C) {
+	key, val := "foo", "bar"
+	b := bytes.NewBuffer(nil)
+	err := fPrintOutput(b, key, val)
+	c.Check(err, IsNil)
+	valid := b.String()
+	for _, tc := range []struct {
+		s       string
+		checker Checker
+	}{
+		{
+			s:       valid[0 : len(valid)-2],
+			checker: NotNil,
+		},
+		{
+			s:       valid[1 : len(valid)-1],
+			checker: IsNil,
+		},
+	} {
+		o, err := Parse(tc.s)
+		c.Assert(err, tc.checker)
+		c.Assert(o, IsNil)
 	}
 }

--- a/pkg/output/stream.go
+++ b/pkg/output/stream.go
@@ -1,0 +1,73 @@
+// Copyright 2019 The Kanister Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package output
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"strings"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+func splitLines(ctx context.Context, r io.ReadCloser, f func(context.Context, string) error) error {
+	// Call r.Close() if the context is canceled or if s.Scan() == false.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	go func() {
+		<-ctx.Done()
+		_ = r.Close()
+	}()
+
+	// Scan log lines when ready.
+	s := bufio.NewScanner(r)
+	for s.Scan() {
+		l := s.Text()
+		l = strings.TrimSpace(l)
+		if l == "" {
+			continue
+		}
+		if err := f(ctx, l); err != nil {
+			return err
+		}
+	}
+	return errors.Wrap(s.Err(), "Split lines failed")
+}
+
+func LogAndParse(ctx context.Context, r io.ReadCloser) (map[string]interface{}, error) {
+	out := make(map[string]interface{})
+	err := splitLines(ctx, r, func(ctx context.Context, l string) error {
+		log.Info("Pod Out:", l)
+		o, err := Parse(l)
+		if err != nil {
+			return err
+		}
+		if o != nil {
+			out[o.Key] = o.Value
+		}
+		return nil
+	})
+	return out, err
+}
+
+func Log(ctx context.Context, r io.ReadCloser) error {
+	err := splitLines(ctx, r, func(ctx context.Context, l string) error {
+		log.Info("Pod Out:", l)
+		return nil
+	})
+	return err
+}


### PR DESCRIPTION
## Change Overview

* Makes log handling synchronous
* Adds parse function to output package

## Pull request type

Please check the type of change your PR introduces:
- [ ] Work in Progress
- [x] Refactoring (no functional changes, no api changes)
- [ ] Trival/Minor
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation

## Issues

- https://github.com/kanisterio/kanister/issues/231

## Test Plan

```
[09:59:15]tom@tom-XPS-13-9360: (refactor-pod-runner)~/src/kanister/ make shell
launching a shell in the containerized build environment
/go/src/github.com/kanisterio/kanister # go test -v ./pkg/function -check.v -check.f TestKubeTask
=== RUN   Test
time="2019-08-29T17:00:15Z" level=info msg="Out: ###Phase-output###: {\"key\":\"version\",\"value\":\"0.21.0\"}"
time="2019-08-29T17:00:30Z" level=info msg="Out: Tick: 1"
time="2019-08-29T17:00:30Z" level=info msg="Out: Tick: 2"
time="2019-08-29T17:00:31Z" level=info msg="Out: Tick: 3"
PASS: kube_task_test.go:122: KubeTaskSuite.TestKubeTask 44.716s
OK: 1 passed
--- PASS: Test (44.74s)
PASS
ok      github.com/kanisterio/kanister/pkg/function     44.759s
```

- [ ] Manual
- [x] Unit test
- [ ] E2E
