### PR TITLE
Add restic stats command

### DIFF
--- a/pkg/restic/restic.go
+++ b/pkg/restic/restic.go
@@ -119,6 +119,14 @@ func PruneCommand(profile *param.Profile, repository, encryptionKey string) []st
 	return shCommand(command)
 }
 
+// StatsCommandByID returns restic stats command
+func StatsCommandByID(profile *param.Profile, repository, id, encryptionKey string) []string {
+	cmd := resticArgs(profile, repository, encryptionKey)
+	cmd = append(cmd, "stats", id)
+	command := strings.Join(cmd, " ")
+	return shCommand(command)
+}
+
 const (
 	ResticPassword   = "RESTIC_PASSWORD"
 	ResticRepository = "RESTIC_REPOSITORY"


### PR DESCRIPTION
## Change Overview

Add Restic stats command to query stats given a snapshot ID

## Pull request type

Please check the type of change your PR introduces:
- [ ] Work in Progress
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Trival/Minor
- [ ] Bugfix
- [X] Feature
- [ ] Documentation

## Issues

- #258 

## Test Plan

- [ ] Manual
- [ ] Unit test
- [ ] E2E

`Restic Command`

```
$ restic stats 7e17e764
repository c6746ff5 opened successfully, password is correct
found 2 old cache directories in /Users/deepikadixit/Library/Caches/restic, pass --cleanup-cache to remove them
scanning...
Stats for 7e17e764 in restore-size mode:
  Total File Count:   9
        Total Size:   10.322 KiB
```