### PR TITLE
Process Restic stats output

### DIFF
--- a/pkg/restic/restic.go
+++ b/pkg/restic/restic.go
@@ -244,11 +244,11 @@ func SnapshotStatsFromStatsLog(output string) (string, string, string) {
 	pattern2 := regexp.MustCompile(`Total Size: \s+(.*?)$`)
 	for _, l := range logs {
 		match1 := pattern1.FindAllStringSubmatch(l, 1)
-		if match1 != nil && match1[0] != nil {
+		if len(match1) > 0 && len(match1[0]) > 1 {
 			fileCount = match1[0][1]
 		}
 		match2 := pattern2.FindAllStringSubmatch(l, 1)
-		if match2 != nil && match2[0] != nil {
+		if len(match2) > 0 && len(match2[0]) > 1 {
 			size = match2[0][1]
 		}
 	}
@@ -262,7 +262,7 @@ func SnapshotStatsModeFromStatsLog(output string) string {
 	pattern := regexp.MustCompile(`Stats for.*in\s+(.*?)\s+mode:`)
 	for _, l := range logs {
 		match := pattern.FindAllStringSubmatch(l, 1)
-		if match != nil && match[0] != nil {
+		if len(match) > 0 && len(match[0]) > 1 {
 			return match[0][1]
 		}
 	}

--- a/pkg/restic/restic.go
+++ b/pkg/restic/restic.go
@@ -231,9 +231,9 @@ func SnapshotIDFromBackupLog(output string) string {
 }
 
 // SnapshotStatsFromStatsLog gets the Snapshot Stats from Stats Command log
-func SnapshotStatsFromStatsLog(output string) (string, string) {
+func SnapshotStatsFromStatsLog(output string) (string, string, string) {
 	if output == "" {
-		return "", ""
+		return "", "", ""
 	}
 	var fileCount string
 	var size string
@@ -252,5 +252,19 @@ func SnapshotStatsFromStatsLog(output string) (string, string) {
 			size = match2[0][1]
 		}
 	}
-	return fileCount, size
+	return SnapshotStatsModeFromStatsLog(output), fileCount, size
+}
+
+// SnapshotStatsModeFromStatsLog gets the Stats mode from Stats Command log
+func SnapshotStatsModeFromStatsLog(output string) string {
+	logs := regexp.MustCompile("[\n]").Split(output, -1)
+	for _, l := range logs {
+		// Log should contain "Total File Count:   xx"
+		pattern := regexp.MustCompile(`Stats for.*in\s+(.*?)\s+mode:`)
+		match := pattern.FindAllStringSubmatch(l, 1)
+		if match != nil {
+			return match[0][1]
+		}
+	}
+	return ""
 }

--- a/pkg/restic/restic.go
+++ b/pkg/restic/restic.go
@@ -238,17 +238,17 @@ func SnapshotStatsFromStatsLog(output string) (string, string, string) {
 	var fileCount string
 	var size string
 	logs := regexp.MustCompile("[\n]").Split(output, -1)
+	// Log should contain "Total File Count:   xx"
+	pattern1 := regexp.MustCompile(`Total File Count:\s+(.*?)$`)
+	// Log should contain "Total Size:   xx"
+	pattern2 := regexp.MustCompile(`Total Size: \s+(.*?)$`)
 	for _, l := range logs {
-		// Log should contain "Total File Count:   xx"
-		pattern1 := regexp.MustCompile(`Total File Count:\s+(.*?)$`)
 		match1 := pattern1.FindAllStringSubmatch(l, 1)
-		if match1 != nil {
+		if match1 != nil && match1[0] != nil {
 			fileCount = match1[0][1]
 		}
-		// Log should contain "Total Size:   xx"
-		pattern2 := regexp.MustCompile(`Total Size: \s+(.*?)$`)
 		match2 := pattern2.FindAllStringSubmatch(l, 1)
-		if match2 != nil {
+		if match2 != nil && match2[0] != nil {
 			size = match2[0][1]
 		}
 	}
@@ -258,11 +258,11 @@ func SnapshotStatsFromStatsLog(output string) (string, string, string) {
 // SnapshotStatsModeFromStatsLog gets the Stats mode from Stats Command log
 func SnapshotStatsModeFromStatsLog(output string) string {
 	logs := regexp.MustCompile("[\n]").Split(output, -1)
+	// Log should contain "Stats for .... in  xx mode"
+	pattern := regexp.MustCompile(`Stats for.*in\s+(.*?)\s+mode:`)
 	for _, l := range logs {
-		// Log should contain "Total File Count:   xx"
-		pattern := regexp.MustCompile(`Stats for.*in\s+(.*?)\s+mode:`)
 		match := pattern.FindAllStringSubmatch(l, 1)
-		if match != nil {
+		if match != nil && match[0] != nil {
 			return match[0][1]
 		}
 	}

--- a/pkg/restic/restic.go
+++ b/pkg/restic/restic.go
@@ -229,3 +229,28 @@ func SnapshotIDFromBackupLog(output string) string {
 	}
 	return ""
 }
+
+// SnapshotStatsFromStatsLog gets the Snapshot Stats from Stats Command log
+func SnapshotStatsFromStatsLog(output string) (string, string) {
+	if output == "" {
+		return "", ""
+	}
+	var fileCount string
+	var size string
+	logs := regexp.MustCompile("[\n]").Split(output, -1)
+	for _, l := range logs {
+		// Log should contain "Total File Count:   xx"
+		pattern1 := regexp.MustCompile(`Total File Count:\s+(.*?)$`)
+		match1 := pattern1.FindAllStringSubmatch(l, 1)
+		if match1 != nil {
+			fileCount = match1[0][1]
+		}
+		// Log should contain "Total Size:   xx"
+		pattern2 := regexp.MustCompile(`Total Size: \s+(.*?)$`)
+		match2 := pattern2.FindAllStringSubmatch(l, 1)
+		if match2 != nil {
+			size = match2[0][1]
+		}
+	}
+	return fileCount, size
+}

--- a/pkg/restic/restic_test.go
+++ b/pkg/restic/restic_test.go
@@ -157,8 +157,24 @@ func (s *ResticDataSuite) TestGetSnapshotStatsFromStatsLog(c *C) {
 		{log: "      Total File Count:   9", expectedfc: "9", expectedsize: ""},
 		{log: "    Total Size:   10.322 KiB", expectedfc: "", expectedsize: "10.322 KiB"},
 	} {
-		fc, s := SnapshotStatsFromStatsLog(tc.log)
+		_, fc, s := SnapshotStatsFromStatsLog(tc.log)
 		c.Assert(fc, Equals, tc.expectedfc)
 		c.Assert(s, Equals, tc.expectedsize)
+	}
+}
+
+func (s *ResticDataSuite) TestGetSnapshotStatsModeFromStatsLog(c *C) {
+	for _, tc := range []struct {
+		log      string
+		expected string
+	}{
+		{log: "Stats for all snapshots in restore-size mode:", expected: "restore-size"},
+		{log: "Stats for 7e17e764 in restore-size mode:", expected: "restore-size"},
+		{log: "Stats for all snapshots in raw-data mode:", expected: "raw-data"},
+		{log: "Stats for all snapshots in blobs-per-file mode:", expected: "blobs-per-file"},
+		{log: "sudhufehfuijbfjbruifhoiwhf", expected: ""},
+	} {
+		mode := SnapshotStatsModeFromStatsLog(tc.log)
+		c.Assert(mode, Equals, tc.expected)
 	}
 }

--- a/pkg/restic/restic_test.go
+++ b/pkg/restic/restic_test.go
@@ -144,3 +144,21 @@ func (s *ResticDataSuite) TestResticArgs(c *C) {
 		c.Assert(resticArgs(tc.profile, tc.repo, tc.password), DeepEquals, tc.expected)
 	}
 }
+
+func (s *ResticDataSuite) TestGetSnapshotStatsFromStatsLog(c *C) {
+	for _, tc := range []struct {
+		log          string
+		expectedfc   string
+		expectedsize string
+	}{
+		{log: "Total File Count:   9", expectedfc: "9", expectedsize: ""},
+		{log: "Total Size:   10.322 KiB", expectedfc: "", expectedsize: "10.322 KiB"},
+		{log: "sudhufehfuijbfjbruifhoiwhf", expectedfc: "", expectedsize: ""},
+		{log: "      Total File Count:   9", expectedfc: "9", expectedsize: ""},
+		{log: "    Total Size:   10.322 KiB", expectedfc: "", expectedsize: "10.322 KiB"},
+	} {
+		fc, s := SnapshotStatsFromStatsLog(tc.log)
+		c.Assert(fc, Equals, tc.expectedfc)
+		c.Assert(s, Equals, tc.expectedsize)
+	}
+}


### PR DESCRIPTION
## Change Overview

Process Restic stats output to get file count and size

## Pull request type

Please check the type of change your PR introduces:
- [ ] Work in Progress
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Trival/Minor
- [ ] Bugfix
- [X] Feature
- [ ] Documentation

## Issues

- #261 

## Test Plan

- [ ] Manual
- [X] Unit test

```
restic stats 7e17e764
repository c6746ff5 opened successfully, password is correct
found 2 old cache directories in /Users/deepikadixit/Library/Caches/restic, pass --cleanup-cache to remove them
scanning...
Stats for 7e17e764 in restore-size mode:
  Total File Count:   9
        Total Size:   10.322 KiB
```
- [ ] E2E
