### PR TITLE
Add mode to restic stats

### DIFF
--- a/pkg/restic/restic.go
+++ b/pkg/restic/restic.go
@@ -120,9 +120,9 @@ func PruneCommand(profile *param.Profile, repository, encryptionKey string) []st
 }
 
 // StatsCommandByID returns restic stats command
-func StatsCommandByID(profile *param.Profile, repository, id, encryptionKey string) []string {
+func StatsCommandByID(profile *param.Profile, repository, id, mode, encryptionKey string) []string {
 	cmd := resticArgs(profile, repository, encryptionKey)
-	cmd = append(cmd, "stats", id)
+	cmd = append(cmd, "stats", id, "--mode", mode)
 	command := strings.Join(cmd, " ")
 	return shCommand(command)
 }


### PR DESCRIPTION
## Change Overview

Add mode param to specify stats mode

## Pull request type

Please check the type of change your PR introduces:
- [ ] Work in Progress
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Trival/Minor
- [ ] Bugfix
- [X] Feature
- [ ] Documentation

## Issues

- #258 

## Test Plan

The modes are:

* restore-size: (default) Counts the size of the restored files.
* files-by-contents: Counts total size of files, where a file is
   considered unique if it has unique contents.
* raw-data: Counts the size of blobs in the repository, regardless of
  how many files reference them.
* blobs-per-file: A combination of files-by-contents and raw-data.
* Refer to the online manual for more details about each mode.

- [ ] Manual
- [ ] Unit test
- [ ] E2E