### PR TITLE
An implementation for field.Field

### DIFF
--- a/pkg/field/context.go
+++ b/pkg/field/context.go
@@ -16,9 +16,9 @@ func FromContext(ctx context.Context) Fields {
 	return nil
 }
 
-// AddToContext returns a new context that has ctx as its parent context and
+// Context returns a new context that has ctx as its parent context and
 // has a Field with the given key and value.
-func AddToContext(ctx context.Context, key string, v interface{}) context.Context {
+func Context(ctx context.Context, key string, v interface{}) context.Context {
 	return context.WithValue(ctx, ctxKey, Add(FromContext(ctx), key, v))
 }
 

--- a/pkg/field/field.go
+++ b/pkg/field/field.go
@@ -23,8 +23,7 @@ func New(key string, value interface{}) Fields {
 // Add returns a collection with all the fields in s plus a new field with the
 // given key and value. Duplicates are not eliminated.
 func Add(s Fields, key string, value interface{}) Fields {
-	// TODO: implement
-	return nil
+	return newField(s, key, value)
 }
 
 // M contains fields with unique keys. Used to facilitate adding multiple

--- a/pkg/field/field_test.go
+++ b/pkg/field/field_test.go
@@ -28,8 +28,8 @@ func ExampleAdd() {
 
 type M = field.M
 
-func ExampleAddToContext() {
-	ctx := field.AddToContext(context.Background(), "foo", "bar")
+func ExampleContext() {
+	ctx := field.Context(context.Background(), "foo", "bar")
 	fmt.Print(field.FromContext(ctx))
 	// Output: ["foo":"bar"]
 }

--- a/pkg/field/field_test.go
+++ b/pkg/field/field_test.go
@@ -1,0 +1,47 @@
+package field_test
+
+import (
+	"context"
+	"fmt"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/kanisterio/kanister/pkg/field"
+)
+
+type FieldSuite struct{}
+
+var _ = Suite(&FieldSuite{})
+
+func ExampleNew() {
+	f := field.New("foo", "bar")
+	fmt.Print(f)
+	// Output: ["foo":"bar"]
+}
+
+func ExampleAdd() {
+	f := field.New("foo", "bar")
+	f = field.Add(f, "baz", "x")
+	fmt.Print(f)
+	// Output: ["foo":"bar","baz":"x"]
+}
+
+type M = field.M
+
+func ExampleAddToContext() {
+	ctx := field.AddToContext(context.Background(), "foo", "bar")
+	fmt.Print(field.FromContext(ctx))
+	// Output: ["foo":"bar"]
+}
+
+func ExampleAddMapToContext() {
+	ctx := field.AddMapToContext(context.Background(), M{"foo": "bar"})
+	fmt.Print(field.FromContext(ctx))
+	// Output: ["foo":"bar"]
+}
+
+func ExampleAddMapToContext_multiple() {
+	ctx := field.AddMapToContext(context.Background(), M{"foo": "bar", "x": "y"})
+	// Output is not specified because the order of the fields in 'M' is non-deterministic
+	fmt.Print(field.FromContext(ctx))
+}

--- a/pkg/field/linked_field.go
+++ b/pkg/field/linked_field.go
@@ -1,0 +1,83 @@
+package field
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Fields are exposed as an interface instead of directly as pointer to this
+// struct. That enforces the immutability of fields outside this package. Once
+// a field is created, its contents cannot be changed or overwritten outside
+// this package by simply assigning one field to another, via
+// f1 = f2 or *fp1 = *fp2.
+type field struct {
+	key   string
+	value interface{}
+}
+
+func (f field) Key() string {
+	return f.key
+}
+
+func (f field) Value() interface{} {
+	return f.value
+}
+
+func (f field) String() string {
+	return fmt.Sprintf("%q:%q", f.key, f.value)
+}
+
+type linkedField struct {
+	field
+	prev *linkedField
+}
+
+func newField(prev Fields, key string, value interface{}) *linkedField {
+	return &linkedField{prev: asLinkedFields(prev), field: field{key: key, value: value}}
+}
+
+func (f *linkedField) Fields() []Field {
+	return f.fields(0)
+}
+
+func (f *linkedField) fields(n int) []Field {
+	if f != nil {
+		return append(f.prev.fields(n+1), f.field)
+	}
+	return make([]Field, 0, n)
+}
+
+func (f *linkedField) String() string {
+	var b strings.Builder
+	b.WriteByte('[')
+	if f != nil {
+		f.buildString(&b)
+	}
+	b.WriteByte(']')
+	return b.String()
+}
+
+func (f *linkedField) buildString(b *strings.Builder) {
+	if f.prev != nil {
+		f.prev.buildString(b)
+		b.WriteByte(',')
+	}
+	fmt.Fprintf(b, "%q:%q", f.key, f.value)
+}
+
+func asLinkedFields(fs Fields) *linkedField {
+	if f, ok := fs.(*linkedField); ok {
+		return f
+	}
+	return toLinkedFields(nil, fs)
+}
+
+func toLinkedFields(prev *linkedField, fs Fields) *linkedField {
+	if fs == nil {
+		return prev
+	}
+	for _, o := range fs.Fields() {
+		prev = &linkedField{prev: prev, field: field{key: o.Key(), value: o.Value()}}
+	}
+	return prev
+}

--- a/pkg/field/linked_field.go
+++ b/pkg/field/linked_field.go
@@ -15,6 +15,8 @@ type field struct {
 	value interface{}
 }
 
+var _ fmt.Stringer = field{}
+
 func (f field) Key() string {
 	return f.key
 }
@@ -31,6 +33,8 @@ type linkedField struct {
 	field
 	prev *linkedField
 }
+
+var _ fmt.Stringer = (*linkedField)(nil)
 
 func newField(prev Fields, key string, value interface{}) *linkedField {
 	return &linkedField{prev: asLinkedFields(prev), field: field{key: key, value: value}}


### PR DESCRIPTION
## Change Overview

Linked-list based implementation.
The approach attempts to prevent/limit the mutability of the fields outside the `field` package.

Also, in the package the contents of `linkedField struct` are not modified after the struct has been created.

<!-- Insert PR description-->

## Pull request type

Please check the type of change your PR introduces:
- [x] Work in Progress
- [x] Feature

## Issues

- #273 

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] Unit test

