### PR TITLE
Make empty config an error in EBS client constructor

### DIFF
--- a/pkg/blockstorage/awsebs/awsebs.go
+++ b/pkg/blockstorage/awsebs/awsebs.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -77,16 +76,13 @@ func NewProvider(config map[string]string) (blockstorage.Provider, error) {
 // newEC2Client returns ec2 client struct.
 func newEC2Client(awsRegion string, config *aws.Config, role string) (*EC2, error) {
 	if config == nil {
-		config = aws.NewConfig()
+		return nil, errors.New("Invalid empty AWS config")
 	}
 	s, err := session.NewSession(config)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create session for EFS")
 	}
-	var creds *credentials.Credentials
-	if config != nil {
-		creds = config.Credentials
-	}
+	creds := config.Credentials
 	if role != "" {
 		creds = stscreds.NewCredentials(s, role)
 	}
@@ -233,7 +229,7 @@ func (s *ebsStorage) SnapshotCopy(ctx context.Context, from, to blockstorage.Sna
 		return nil, errors.Errorf("Snapshot %v destination ID must be empty", to)
 	}
 	// Copy operation must be initiated from the destination region.
-	ec2Cli, err := newEC2Client(to.Region, nil, s.role)
+	ec2Cli, err := newEC2Client(to.Region, s.ec2Cli.Config.Copy(), s.role)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Could not get EC2 client")
 	}
@@ -241,7 +237,7 @@ func (s *ebsStorage) SnapshotCopy(ctx context.Context, from, to blockstorage.Sna
 	// independent of whether or not the snapshot is encrypted.
 	var presignedURL *string
 	if to.Region != from.Region {
-		fromCli, err2 := newEC2Client(from.Region, nil, s.role)
+		fromCli, err2 := newEC2Client(from.Region, s.ec2Cli.Config.Copy(), s.role)
 		if err2 != nil {
 			return nil, errors.Wrap(err2, "Could not create client to presign URL for snapshot copy request")
 		}
@@ -603,7 +599,7 @@ func (s *ebsStorage) FromRegion(ctx context.Context, region string) ([]string, e
 }
 
 func (s *ebsStorage) queryRegionToZones(ctx context.Context, region string) ([]string, error) {
-	ec2Cli, err := newEC2Client(region, nil, s.role)
+	ec2Cli, err := newEC2Client(region, s.ec2Cli.Config.Copy(), s.role)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Could not get EC2 client")
 	}

--- a/pkg/blockstorage/awsebs/awsebs.go
+++ b/pkg/blockstorage/awsebs/awsebs.go
@@ -76,6 +76,9 @@ func NewProvider(config map[string]string) (blockstorage.Provider, error) {
 
 // newEC2Client returns ec2 client struct.
 func newEC2Client(awsRegion string, config *aws.Config, role string) (*EC2, error) {
+	if config == nil {
+		config = aws.NewConfig()
+	}
 	s, err := session.NewSession(config)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create session for EFS")

--- a/pkg/blockstorage/awsebs/awsebs_test.go
+++ b/pkg/blockstorage/awsebs/awsebs_test.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
 	. "gopkg.in/check.v1"
 )
 
@@ -32,7 +34,7 @@ func (s AWSEBSSuite) TestQueryRegionToZones(c *C) {
 	c.Skip("Only works on AWS")
 	ctx := context.Background()
 	region := "us-east-1"
-	ec2Cli, err := newEC2Client(region, nil, "")
+	ec2Cli, err := newEC2Client(region, aws.NewConfig().WithCredentials(credentials.NewEnvCredentials()), "")
 	c.Assert(err, IsNil)
 	provider := &ebsStorage{ec2Cli: ec2Cli}
 	zs, err := provider.queryRegionToZones(ctx, region)


### PR DESCRIPTION
## Change Overview

This PR fixes the panic problem where the argument config is nil.

## Pull request type

Please check the type of change your PR introduces:
- [ ] Work in Progress
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Trivial/Minor
- [X] Bugfix
- [ ] Feature
- [ ] Documentation

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [X] Manual
- [ ] Unit test
- [ ] E2E
