### PR TITLE
Don't change roles in methods other than constructor

### DIFF
--- a/pkg/blockstorage/awsebs/awsebs.go
+++ b/pkg/blockstorage/awsebs/awsebs.go
@@ -229,7 +229,7 @@ func (s *ebsStorage) SnapshotCopy(ctx context.Context, from, to blockstorage.Sna
 		return nil, errors.Errorf("Snapshot %v destination ID must be empty", to)
 	}
 	// Copy operation must be initiated from the destination region.
-	ec2Cli, err := newEC2Client(to.Region, s.ec2Cli.Config.Copy(), s.role)
+	ec2Cli, err := newEC2Client(to.Region, s.ec2Cli.Config.Copy(), "")
 	if err != nil {
 		return nil, errors.Wrapf(err, "Could not get EC2 client")
 	}
@@ -237,7 +237,7 @@ func (s *ebsStorage) SnapshotCopy(ctx context.Context, from, to blockstorage.Sna
 	// independent of whether or not the snapshot is encrypted.
 	var presignedURL *string
 	if to.Region != from.Region {
-		fromCli, err2 := newEC2Client(from.Region, s.ec2Cli.Config.Copy(), s.role)
+		fromCli, err2 := newEC2Client(from.Region, s.ec2Cli.Config.Copy(), "")
 		if err2 != nil {
 			return nil, errors.Wrap(err2, "Could not create client to presign URL for snapshot copy request")
 		}
@@ -599,7 +599,7 @@ func (s *ebsStorage) FromRegion(ctx context.Context, region string) ([]string, e
 }
 
 func (s *ebsStorage) queryRegionToZones(ctx context.Context, region string) ([]string, error) {
-	ec2Cli, err := newEC2Client(region, s.ec2Cli.Config.Copy(), s.role)
+	ec2Cli, err := newEC2Client(region, s.ec2Cli.Config.Copy(), "")
 	if err != nil {
 		return nil, errors.Wrapf(err, "Could not get EC2 client")
 	}


### PR DESCRIPTION
## Change Overview

Role will be assumed in the constructor. 
Changing role in other methods will cause double assume role problem and probably will give an AccessDenied problem.
Fix the problem by giving empty string as role in methods other than the constructor.

## Pull request type

Please check the type of change your PR introduces:
- [ ] Work in Progress
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Trivial/Minor
- [X] Bugfix
- [ ] Feature
- [ ] Documentation

