### PR TITLE
Add secret type for Param.Credentials

### DIFF
--- a/pkg/param/param.go
+++ b/pkg/param/param.go
@@ -250,12 +250,13 @@ func fetchSecretCredential(ctx context.Context, cli kubernetes.Interface, sr *cr
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to fetch the secret")
 	}
-	switch string(s.Type) {
-	case secrets.AWSSecretType:
-		return fetchAWSSecretCredential(ctx, s)
-	default:
-		return nil, errors.Errorf("Unsupported type '%s' for secret", string(s.Type))
+	if err = secrets.ValidateCredentials(s); err != nil {
+		return nil, err
 	}
+	return &Credential{
+		Type:   CredentialTypeSecret,
+		Secret: s,
+	}, nil
 }
 
 func fetchAWSSecretCredential(ctx context.Context, s *v1.Secret) (*Credential, error) {

--- a/pkg/param/param.go
+++ b/pkg/param/param.go
@@ -259,16 +259,6 @@ func fetchSecretCredential(ctx context.Context, cli kubernetes.Interface, sr *cr
 	}, nil
 }
 
-func fetchAWSSecretCredential(ctx context.Context, s *v1.Secret) (*Credential, error) {
-	if err := secrets.ValidateAWSCredentials(s); err != nil {
-		return nil, err
-	}
-	return &Credential{
-		Type:   CredentialTypeSecret,
-		Secret: s,
-	}, nil
-}
-
 func filterByKind(refs map[string]crv1alpha1.ObjectReference, kind string) map[string]crv1alpha1.ObjectReference {
 	filtered := make(map[string]crv1alpha1.ObjectReference, len(refs))
 	for name, ref := range refs {

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -1,0 +1,21 @@
+package secrets
+
+import (
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+)
+
+// ValidateCredentials returns error if secret is failed at validation.
+// Currently supports following:
+// - AWS typed secret with required AWS secret fields.
+func ValidateCredentials(secret *v1.Secret) error {
+	if secret == nil {
+		return errors.New("Nil secret")
+	}
+	switch string(secret.Type) {
+	case AWSSecretType:
+		return ValidateAWSCredentials(secret)
+	default:
+		return errors.Errorf("Unsupported type '%s' for secret '%s:%s'", string(secret.Type), secret.Namespace, secret.Name)
+	}
+}


### PR DESCRIPTION
## Change Overview

Adds a union member for param.Credentials to accommodate generic secret types.

## Pull request type

Please check the type of change your PR introduces:
- [ ] Work in Progress
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Trivial/Minor
- [ ] Bugfix
- [X] Feature
- [ ] Documentation
