### PR TITLE
Handle panic in IBM initialization

### DIFF
--- a/pkg/blockstorage/ibm/client_test.go
+++ b/pkg/blockstorage/ibm/client_test.go
@@ -23,6 +23,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	ibmcfg "github.com/IBM/ibmcloud-storage-volume-lib/config"
+
 	. "gopkg.in/check.v1"
 )
 
@@ -125,4 +127,26 @@ func (s *ClientSuite) TestErrorsCases(c *C) {
 	ibmCli, err = newClient(context.Background(), make(map[string]string))
 	c.Assert(err, NotNil)
 	c.Assert(ibmCli, IsNil)
+}
+
+func (s *ClientSuite) TestPanic(c *C) {
+	for _, f := range []func() (*client, error){
+		func() (*client, error) {
+			panic("TEST")
+		},
+		func() (*client, error) {
+			var cfg *client
+			cfg.SLCfg = ibmcfg.SoftlayerConfig{}
+			return nil, nil
+		},
+		func() (*client, error) {
+			var x []int
+			x[0]++
+			return nil, nil
+		},
+	} {
+		cfg, err := handleClientPanic(f)
+		c.Assert(err, NotNil)
+		c.Assert(cfg, IsNil)
+	}
 }


### PR DESCRIPTION
## Change Overview

This wraps the IBM client initialization and will return an error instead of panicking. 

## Pull request type

Please check the type of change your PR introduces:
- [ ] Work in Progress
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Trivial/Minor
- [ ] Bugfix
- [x] Feature
- [ ] Documentation

## Issues

- https://github.com/IBM/ibmcloud-storage-volume-lib/issues/172
- https://github.com/IBM/ibmcloud-storage-volume-lib/issues/33
- https://github.com/IBM/ibmcloud-storage-volume-lib/issues/79

## Test Plan

```
[14:56:24]tom@tom-XPS-13-9360: (master)~/src/kanister/ go test -v ./pkg/blockstorage/ibm -check.v -check.f TestPanic
=== RUN   Test
PASS: client_test.go:134: ClientSuite.TestPanic 0.000s
OK: 1 passed
--- PASS: Test (0.00s)
PASS
ok      github.com/kanisterio/kanister/pkg/blockstorage/ibm     0.008s
```

- [ ] Manual
- [x] Unit test
- [ ] E2E
