### PR TITLE
Accept strings for bool phase arguments

### DIFF
--- a/pkg/function/args.go
+++ b/pkg/function/args.go
@@ -23,7 +23,7 @@ import (
 // It will return an error if the argument type does not match the result type
 func Arg(args map[string]interface{}, argName string, result interface{}) error {
 	if val, ok := args[argName]; ok {
-		if err := mapstructure.Decode(val, result); err != nil {
+		if err := mapstructure.WeakDecode(val, result); err != nil {
 			return errors.Wrapf(err, "Failed to decode arg `%s`", argName)
 		}
 		return nil


### PR DESCRIPTION
## Change Overview

This change allows string arguments to be used for bool and int arguments to kanister functions in blueprints.  This in turn allows those to be templatized and filled in as Options.

## Pull request type

Please check the type of change your PR introduces:
- [ ] Work in Progress
- [ ] Refactoring (no functional changes, no api changes)
- [x] Trivial/Minor
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation

## Issues

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] Manual
- [ ] Unit test
- [ ] E2E
