### PR TITLE
Update getOSSecret to use Secret credentials in AWS

### DIFF
--- a/pkg/location/location.go
+++ b/pkg/location/location.go
@@ -24,6 +24,7 @@ import (
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	"github.com/kanisterio/kanister/pkg/objectstore"
 	"github.com/kanisterio/kanister/pkg/param"
+	"github.com/kanisterio/kanister/pkg/secrets"
 )
 
 const (
@@ -144,11 +145,7 @@ func getOSSecret(pType objectstore.ProviderType, cred param.Credential) (*object
 	secret := &objectstore.Secret{}
 	switch pType {
 	case objectstore.ProviderTypeS3:
-		secret.Type = objectstore.SecretTypeAwsAccessKey
-		secret.Aws = &objectstore.SecretAws{
-			AccessKeyID:     cred.KeyPair.ID,
-			SecretAccessKey: cred.KeyPair.Secret,
-		}
+		return getAWSSecret(cred)
 	case objectstore.ProviderTypeGCS:
 		secret.Type = objectstore.SecretTypeGcpServiceAccountKey
 		secret.Gcp = &objectstore.SecretGcp{
@@ -165,4 +162,31 @@ func getOSSecret(pType objectstore.ProviderType, cred param.Credential) (*object
 		return nil, errors.Errorf("unknown or unsupported provider type '%s'", pType)
 	}
 	return secret, nil
+}
+
+func getAWSSecret(cred param.Credential) (*objectstore.Secret, error) {
+	os := &objectstore.Secret{
+		Type: objectstore.SecretTypeAwsAccessKey,
+	}
+	switch cred.Type {
+	case param.CredentialTypeKeyPair:
+		os.Aws = &objectstore.SecretAws{
+			AccessKeyID:     cred.KeyPair.ID,
+			SecretAccessKey: cred.KeyPair.Secret,
+		}
+		return os, nil
+	case param.CredentialTypeSecret:
+		creds, err := secrets.ExtractAWSCredentials(cred.Secret)
+		if err != nil {
+			return nil, err
+		}
+		os.Aws = &objectstore.SecretAws{
+			AccessKeyID:     creds.AccessKeyID,
+			SecretAccessKey: creds.SecretAccessKey,
+			SessionToken:    creds.SessionToken,
+		}
+		return os, nil
+	default:
+		return nil, errors.Errorf("Unsupport type '%s' for credential", cred.Type)
+	}
 }

--- a/pkg/location/location.go
+++ b/pkg/location/location.go
@@ -187,6 +187,6 @@ func getAWSSecret(cred param.Credential) (*objectstore.Secret, error) {
 		}
 		return os, nil
 	default:
-		return nil, errors.Errorf("Unsupport type '%s' for credential", cred.Type)
+		return nil, errors.Errorf("Unsupported type '%s' for credential", cred.Type)
 	}
 }

--- a/pkg/testutil/fixture.go
+++ b/pkg/testutil/fixture.go
@@ -41,10 +41,10 @@ func ObjectStoreProfileOrSkip(c *check.C, osType objectstore.ProviderType, locat
 
 	switch osType {
 	case objectstore.ProviderTypeS3:
-		session, ok := os.LookupEnv(awsconfig.SessionToken)
+
 		key = GetEnvOrSkip(c, awsconfig.AccessKeyID)
 		val = GetEnvOrSkip(c, awsconfig.SecretAccessKey)
-		if ok {
+		if session, ok := os.LookupEnv(awsconfig.SessionToken); ok {
 			return s3ProfileWithSecretCredential(location, key, val, session)
 		}
 	case objectstore.ProviderTypeGCS:

--- a/pkg/testutil/fixture.go
+++ b/pkg/testutil/fixture.go
@@ -38,10 +38,8 @@ const (
 
 func ObjectStoreProfileOrSkip(c *check.C, osType objectstore.ProviderType, location crv1alpha1.Location) *param.Profile {
 	var key, val string
-
 	switch osType {
 	case objectstore.ProviderTypeS3:
-
 		key = GetEnvOrSkip(c, awsconfig.AccessKeyID)
 		val = GetEnvOrSkip(c, awsconfig.SecretAccessKey)
 		if session, ok := os.LookupEnv(awsconfig.SessionToken); ok {


### PR DESCRIPTION
## Change Overview

Support secret credential type in S3.

* Adds a function to properly extract AWS credentials.
* Support both keypair and secret credentials in S3.

## Pull request type

Please check the type of change your PR introduces:
- [ ] Work in Progress
- [ ] Refactoring (no functional changes, no api changes)
- [X] Trivial/Minor
- [ ] Bugfix
- [X] Feature
- [ ] Documentation

