### PR TITLE
Avoid assigning nil value to required field in podSpec: Containers

### DIFF
--- a/pkg/kube/pod.go
+++ b/pkg/kube/pod.go
@@ -156,11 +156,11 @@ func WaitForPodCompletion(ctx context.Context, cli kubernetes.Interface, namespa
 func PodSpecOverride(ctx context.Context, defaultSpecs, overrideSpecs v1.PodSpec) (v1.PodSpec, error) {
 	containers := defaultSpecs.Containers
 	// - Marshal override specs
-	// - Unmarshal override specs on default object so that it overrides only the fields that are present in override specs
 	override, err := json.Marshal(overrideSpecs)
 	if err != nil {
 		return v1.PodSpec{}, err
 	}
+	// - Unmarshal override specs on default object so that it overrides only the fields that are present in override specs
 	err = json.Unmarshal(override, &defaultSpecs)
 	if err != nil {
 		return v1.PodSpec{}, err

--- a/pkg/kube/pod.go
+++ b/pkg/kube/pod.go
@@ -154,6 +154,7 @@ func WaitForPodCompletion(ctx context.Context, cli kubernetes.Interface, namespa
 
 // PodSpecOverride override default pod Spec with the ones provided via specs
 func PodSpecOverride(ctx context.Context, defaultSpecs, overrideSpecs v1.PodSpec) (v1.PodSpec, error) {
+	containers := defaultSpecs.Containers
 	// - Marshal override specs
 	// - Unmarshal override specs on default object so that it overrides only the fields that are present in override specs
 	override, err := json.Marshal(overrideSpecs)
@@ -163,6 +164,9 @@ func PodSpecOverride(ctx context.Context, defaultSpecs, overrideSpecs v1.PodSpec
 	err = json.Unmarshal(override, &defaultSpecs)
 	if err != nil {
 		return v1.PodSpec{}, err
+	}
+	if defaultSpecs.Containers == nil {
+		defaultSpecs.Containers = containers
 	}
 	return defaultSpecs, nil
 }


### PR DESCRIPTION
## Change Overview

Avoid assigning nil value to required field in podSpec: Containers
Fixing error: 
```
Failed to restore data for pod pod_name: Failed to create pod: Failed to create pod. Namespace: test-ns, NameFmt: restore-data-all-: Pod \"restore-data-all-abcd\" is invalid: spec.containers: Required value
```
## Pull request type

Please check the type of change your PR introduces:
- [ ] Work in Progress
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Trivial/Minor
- [x] Bugfix
- [ ] Feature
- [ ] Documentation
