### PR TITLE
Check fatal password err and fallback if needed

### DIFF
--- a/pkg/function/backup_data.go
+++ b/pkg/function/backup_data.go
@@ -134,10 +134,10 @@ func backupData(ctx context.Context, cli kubernetes.Interface, namespace, pod, c
 		return "", "", err
 	}
 	defer cleanUpCredsFile(ctx, pw, namespace, pod, container)
-	if err = restic.GetOrCreateRepository(cli, namespace, pod, container, backupArtifactPrefix, encryptionKey, tp.Profile); err != nil {
+	encryptionKey, err = restic.GetOrCreateRepository(cli, namespace, pod, container, backupArtifactPrefix, encryptionKey, tp.Profile)
+	if err != nil {
 		return "", "", err
 	}
-
 	// Create backup and dump it on the object store
 	backupTag := rand.String(10)
 	cmd, err := restic.BackupCommandByTag(tp.Profile, backupArtifactPrefix, backupTag, includePath, encryptionKey)

--- a/pkg/function/copy_volume_data.go
+++ b/pkg/function/copy_volume_data.go
@@ -88,7 +88,8 @@ func copyVolumeDataPodFunc(cli kubernetes.Interface, tp param.TemplateParams, na
 		}
 		defer cleanUpCredsFile(ctx, pw, pod.Namespace, pod.Name, pod.Spec.Containers[0].Name)
 		// Get restic repository
-		if err := restic.GetOrCreateRepository(cli, namespace, pod.Name, pod.Spec.Containers[0].Name, targetPath, encryptionKey, tp.Profile); err != nil {
+		encryptionKey, err := restic.GetOrCreateRepository(cli, namespace, pod.Name, pod.Spec.Containers[0].Name, targetPath, encryptionKey, tp.Profile)
+		if err != nil {
 			return nil, err
 		}
 		// Copy data to object store

--- a/pkg/function/delete_data.go
+++ b/pkg/function/delete_data.go
@@ -84,6 +84,10 @@ func deleteDataPodFunc(cli kubernetes.Interface, tp param.TemplateParams, reclai
 		}
 		defer cleanUpCredsFile(ctx, pw, pod.Namespace, pod.Name, pod.Spec.Containers[0].Name)
 		for i, deleteTag := range deleteTags {
+			encryptionKey, err = restic.CheckIfRepoIsReachable(tp.Profile, cli, targetPaths[i], encryptionKey, namespace, pod.Name, pod.Spec.Containers[0].Name)
+			if err != nil {
+				return nil, err
+			}
 			cmd, err := restic.SnapshotsCommandByTag(tp.Profile, targetPaths[i], deleteTag, encryptionKey)
 			if err != nil {
 				return nil, err
@@ -101,6 +105,10 @@ func deleteDataPodFunc(cli kubernetes.Interface, tp param.TemplateParams, reclai
 			deleteIdentifiers = append(deleteIdentifiers, deleteIdentifier)
 		}
 		for i, deleteIdentifier := range deleteIdentifiers {
+			encryptionKey, err = restic.CheckIfRepoIsReachable(tp.Profile, cli, targetPaths[i], encryptionKey, namespace, pod.Name, pod.Spec.Containers[0].Name)
+			if err != nil {
+				return nil, err
+			}
 			cmd, err := restic.ForgetCommandByID(tp.Profile, targetPaths[i], deleteIdentifier, encryptionKey)
 			if err != nil {
 				return nil, err

--- a/pkg/function/restore_data.go
+++ b/pkg/function/restore_data.go
@@ -145,6 +145,10 @@ func restoreDataPodFunc(cli kubernetes.Interface, tp param.TemplateParams, names
 		}
 		defer cleanUpCredsFile(ctx, pw, pod.Namespace, pod.Name, pod.Spec.Containers[0].Name)
 		var cmd []string
+		encryptionKey, err := restic.CheckIfRepoIsReachable(tp.Profile, cli, backupArtifactPrefix, encryptionKey, namespace, pod.Name, pod.Spec.Containers[0].Name)
+		if err != nil {
+			return nil, err
+		}
 		// Generate restore command based on the identifier passed
 		if backupTag != "" {
 			cmd, err = restic.RestoreCommandByTag(tp.Profile, backupArtifactPrefix, backupTag, restorePath, encryptionKey)

--- a/pkg/restic/restic.go
+++ b/pkg/restic/restic.go
@@ -273,7 +273,7 @@ func CheckIfRepoIsReachable(profile *param.Profile, cli kubernetes.Interface, ar
 	if err == nil {
 		return encryptionKey, err
 	}
-	if passerr := IsPasswordIncorrect(stderr); passerr { // If password didn't work, continue with default password
+	if IsPasswordIncorrect(stderr) { // If password didn't work, continue with default password
 		log.Info("Falling back to default password")
 		encryptionKey = GeneratePassword()
 	}

--- a/pkg/restic/restic.go
+++ b/pkg/restic/restic.go
@@ -251,19 +251,17 @@ func resticAzureArgs(profile *param.Profile, repository string) []string {
 
 // GetOrCreateRepository will check if the repository already exists and initialize one if not
 func GetOrCreateRepository(cli kubernetes.Interface, namespace, pod, container, artifactPrefix, encryptionKey string, profile *param.Profile) error {
-	// Use the snapshots command to check if the repository exists
-	cmd, err := SnapshotsCommand(profile, artifactPrefix, encryptionKey)
+	stdout, stderr, err := checkIfRepoIsReachable(profile, cli, artifactPrefix, encryptionKey, namespace, pod, container)
 	if err != nil {
-		return errors.Wrap(err, "Failed to create snapshot command")
+		return err
 	}
-	stdout, stderr, err := kube.Exec(cli, namespace, pod, container, cmd, nil)
-	format.Log(pod, container, stdout)
-	format.Log(pod, container, stderr)
-	if err == nil {
-		return nil
+	passerr := IsPasswordIncorrectError(stdout)
+	if passerr { // If password didn't work, continue with default password
+		log.Info("Falling back to default password")
+		encryptionKey = GeneratePassword()
 	}
 	// Create a repository
-	cmd, err = InitCommand(profile, artifactPrefix, encryptionKey)
+	cmd, err := InitCommand(profile, artifactPrefix, encryptionKey)
 	if err != nil {
 		return errors.Wrap(err, "Failed to create init command")
 	}
@@ -271,6 +269,21 @@ func GetOrCreateRepository(cli kubernetes.Interface, namespace, pod, container, 
 	format.Log(pod, container, stdout)
 	format.Log(pod, container, stderr)
 	return errors.Wrapf(err, "Failed to create object store backup location")
+}
+
+func checkIfRepoIsReachable(profile *param.Profile, cli kubernetes.Interface, artifactPrefix, encryptionKey, namespace, pod, container string) (string, string, error) {
+	// Use the snapshots command to check if the repository exists
+	cmd, err := SnapshotsCommand(profile, artifactPrefix, encryptionKey)
+	if err != nil {
+		return "", "", errors.Wrap(err, "Failed to create snapshot command")
+	}
+	stdout, stderr, err := kube.Exec(cli, namespace, pod, container, cmd, nil)
+	format.Log(pod, container, stdout)
+	format.Log(pod, container, stderr)
+	if err != nil {
+		return "", "", errors.Wrap(err, "Failed to create snapshot command")
+	}
+	return stdout, stderr, err
 }
 
 // SnapshotIDFromSnapshotLog gets the SnapshotID from Snapshot Command log
@@ -341,4 +354,18 @@ func SnapshotStatsModeFromStatsLog(output string) string {
 		}
 	}
 	return ""
+}
+
+// IsPasswordIncorrectError check is password was wrong
+func IsPasswordIncorrectError(output string) bool {
+	logs := regexp.MustCompile("[\n]").Split(output, -1)
+	// Log should contain "Stats for .... in  xx mode"
+	pattern := regexp.MustCompile(`Fatal: wrong password or no key found`)
+	for _, l := range logs {
+		match := pattern.FindAllStringSubmatch(l, 1)
+		if len(match) > 0 && len(match[0]) > 1 {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/restic/restic.go
+++ b/pkg/restic/restic.go
@@ -280,9 +280,6 @@ func checkIfRepoIsReachable(profile *param.Profile, cli kubernetes.Interface, ar
 	stdout, stderr, err := kube.Exec(cli, namespace, pod, container, cmd, nil)
 	format.Log(pod, container, stdout)
 	format.Log(pod, container, stderr)
-	if err != nil {
-		return "", "", errors.Wrap(err, "Failed to create snapshot command")
-	}
 	return stdout, stderr, err
 }
 
@@ -363,7 +360,7 @@ func IsPasswordIncorrectError(output string) bool {
 	pattern := regexp.MustCompile(`Fatal: wrong password or no key found`)
 	for _, l := range logs {
 		match := pattern.FindAllStringSubmatch(l, 1)
-		if len(match) > 0 && len(match[0]) > 1 {
+		if len(match) > 0 {
 			return true
 		}
 	}


### PR DESCRIPTION
## Change Overview

WORK IN PROGRESS, testing

## Pull request type

Please check the type of change your PR introduces:
- [x] Work in Progress
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Trivial/Minor
- [ ] Bugfix
- [x] Feature
- [ ] Documentation

## Issues

- #XXX

## Test Plan

- [ ] Manual
- [X] Unit test
- [ ] E2E

## Test Results:

```
$ go test -check.vv -check.f=TestBackupWrongPassword
go: finding github.com/graymeta/stow v0.0.0-00010101000000-000000000000
START: data_test.go:56: DataSuite.SetUpSuite
PASS: data_test.go:56: DataSuite.SetUpSuite	2.041s

START: data_test.go:560: DataSuite.TestBackupWrongPassword
INFO[0006] Pod: test-statefulset-ngdqs-0 Container: test-container Out: Fatal: unable to open config file: Stat: The specified key does not exist. 
INFO[0006] Pod: test-statefulset-ngdqs-0 Container: test-container Out: Is there a repository at the following location? 
INFO[0006] Pod: test-statefulset-ngdqs-0 Container: test-container Out: s3:s3.amazonaws.com/kio-store-tests/testBackupRestoreLocDelete 
INFO[0008] Pod: test-statefulset-ngdqs-0 Container: test-container Out: Fatal: unable to open config file: Stat: The specified key does not exist. 
INFO[0008] Pod: test-statefulset-ngdqs-0 Container: test-container Out: Is there a repository at the following location? 
INFO[0008] Pod: test-statefulset-ngdqs-0 Container: test-container Out: s3:s3.amazonaws.com/kio-store-tests/testBackupRestoreLocDelete 
INFO[0011] Pod: test-statefulset-ngdqs-0 Container: test-container Out: created restic repository 191a615f08 at s3:s3.amazonaws.com/kio-store-tests/testBackupRestoreLocDelete 
INFO[0011] Pod: test-statefulset-ngdqs-0 Container: test-container Out: Please note that knowledge of your password is required to access 
INFO[0011] Pod: test-statefulset-ngdqs-0 Container: test-container Out: the repository. Losing your password means that your data is 
INFO[0011] Pod: test-statefulset-ngdqs-0 Container: test-container Out: irrecoverably lost. 
INFO[0013] Pod: test-statefulset-ngdqs-0 Container: test-container Out: created new cache in /root/.cache/restic 
INFO[0013] Pod: test-statefulset-ngdqs-0 Container: test-container Out: Files:          63 new,     0 changed,     0 unmodified 
INFO[0013] Pod: test-statefulset-ngdqs-0 Container: test-container Out: Dirs:            0 new,     0 changed,     0 unmodified 
INFO[0013] Pod: test-statefulset-ngdqs-0 Container: test-container Out: Added to the repo: 392.746 KiB 
INFO[0013] Pod: test-statefulset-ngdqs-0 Container: test-container Out: processed 63 files, 631.952 KiB in 0:00 
INFO[0013] Pod: test-statefulset-ngdqs-0 Container: test-container Out: snapshot 9a517988 saved 
INFO[0015] Pod: test-statefulset-ngdqs-0 Container: test-container Out: Fatal: wrong password or no key found 
INFO[0015] Falling back to default password             
INFO[0017] Pod: test-statefulset-ngdqs-0 Container: test-container Out: [{"time":"2019-09-27T00:05:20.188486711Z","tree":"b1e53f0b4ccf48ff41eb0b783b324e561c1e2a14b05e20e5a912a5b268d5d387","paths":["/etc"],"hostname":"test-statefulset-ngdqs-0","username":"root","tags":["6p6h5tkfwr"],"id":"9a517988d030ee9196e22f983b6f9512b4080798cb9388546cc36b1a5cee7b4a","short_id":"9a517988"}] 
INFO[0020] Pod: test-statefulset-ngdqs-0 Container: test-container Out: Files:           0 new,     0 changed,    63 unmodified 
INFO[0020] Pod: test-statefulset-ngdqs-0 Container: test-container Out: Dirs:            0 new,     0 changed,     0 unmodified 
INFO[0020] Pod: test-statefulset-ngdqs-0 Container: test-container Out: Added to the repo: 0 B   
INFO[0020] Pod: test-statefulset-ngdqs-0 Container: test-container Out: processed 63 files, 631.952 KiB in 0:00 
INFO[0020] Pod: test-statefulset-ngdqs-0 Container: test-container Out: snapshot 7c9e4450 saved 
PASS: data_test.go:560: DataSuite.TestBackupWrongPassword	17.983s

START: data_test.go:104: DataSuite.TearDownSuite
PASS: data_test.go:104: DataSuite.TearDownSuite	1.422s

OK: 1 passed
PASS
ok  	github.com/kanisterio/kanister/pkg/function	23.451s

$ go test -check.vv -check.f=TestBackupDeleteWrongPassword
go: finding github.com/graymeta/stow v0.0.0-00010101000000-000000000000
START: data_test.go:56: DataSuite.SetUpSuite
PASS: data_test.go:56: DataSuite.SetUpSuite	2.374s

START: data_test.go:576: DataSuite.TestBackupDeleteWrongPassword
INFO[0007] Pod: test-statefulset-sdvfn-0 Container: test-container Out: Fatal: unable to open config file: Stat: The specified key does not exist. 
INFO[0007] Pod: test-statefulset-sdvfn-0 Container: test-container Out: Is there a repository at the following location? 
INFO[0007] Pod: test-statefulset-sdvfn-0 Container: test-container Out: s3:s3.amazonaws.com/kio-store-tests/testBackupRestoreLocDelete 
INFO[0008] Pod: test-statefulset-sdvfn-0 Container: test-container Out: Fatal: unable to open config file: Stat: The specified key does not exist. 
INFO[0008] Pod: test-statefulset-sdvfn-0 Container: test-container Out: Is there a repository at the following location? 
INFO[0008] Pod: test-statefulset-sdvfn-0 Container: test-container Out: s3:s3.amazonaws.com/kio-store-tests/testBackupRestoreLocDelete 
INFO[0012] Pod: test-statefulset-sdvfn-0 Container: test-container Out: created restic repository 72d58fcdff at s3:s3.amazonaws.com/kio-store-tests/testBackupRestoreLocDelete 
INFO[0012] Pod: test-statefulset-sdvfn-0 Container: test-container Out: Please note that knowledge of your password is required to access 
INFO[0012] Pod: test-statefulset-sdvfn-0 Container: test-container Out: the repository. Losing your password means that your data is 
INFO[0012] Pod: test-statefulset-sdvfn-0 Container: test-container Out: irrecoverably lost. 
INFO[0014] Pod: test-statefulset-sdvfn-0 Container: test-container Out: created new cache in /root/.cache/restic 
INFO[0014] Pod: test-statefulset-sdvfn-0 Container: test-container Out: Files:          63 new,     0 changed,     0 unmodified 
INFO[0014] Pod: test-statefulset-sdvfn-0 Container: test-container Out: Dirs:            0 new,     0 changed,     0 unmodified 
INFO[0014] Pod: test-statefulset-sdvfn-0 Container: test-container Out: Added to the repo: 392.746 KiB 
INFO[0014] Pod: test-statefulset-sdvfn-0 Container: test-container Out: processed 63 files, 631.952 KiB in 0:00 
INFO[0014] Pod: test-statefulset-sdvfn-0 Container: test-container Out: snapshot 6b90416c saved 
INFO[0023] Pod: delete-data-jl7t8 Container: container Out: Fatal: wrong password or no key found 
INFO[0023] Falling back to default password             
INFO[0025] Pod: delete-data-jl7t8 Container: container Out: [{"time":"2019-09-27T00:05:56.758405361Z","tree":"669c0d1251b0db497d063652cf4d7d6a0c9b03b08a6b262d99c617fa8a8bdc23","paths":["/etc"],"hostname":"test-statefulset-sdvfn-0","username":"root","tags":["2bbrm8jznr"],"id":"6b90416c320d8bb668ec78dccc5193621ed1e6e916fa833f420d0c2f76845bdb","short_id":"6b90416c"}] 
INFO[0028] Pod: delete-data-jl7t8 Container: container Out: removed snapshot 6b90416c 
PASS: data_test.go:576: DataSuite.TestBackupDeleteWrongPassword	26.000s

START: data_test.go:104: DataSuite.TearDownSuite
PASS: data_test.go:104: DataSuite.TearDownSuite	1.475s

OK: 1 passed
PASS
ok  	github.com/kanisterio/kanister/pkg/function	31.926s

$ go test -check.vv -check.f=TestBackupRestoreWrongPassword
go: finding github.com/graymeta/stow v0.0.0-00010101000000-000000000000
START: data_test.go:56: DataSuite.SetUpSuite
PASS: data_test.go:56: DataSuite.SetUpSuite	2.030s

START: data_test.go:597: DataSuite.TestBackupRestoreWrongPassword
INFO[0007] Pod: test-statefulset-5tfx9-0 Container: test-container Out: Fatal: unable to open config file: Stat: The specified key does not exist. 
INFO[0007] Pod: test-statefulset-5tfx9-0 Container: test-container Out: Is there a repository at the following location? 
INFO[0007] Pod: test-statefulset-5tfx9-0 Container: test-container Out: s3:s3.amazonaws.com/kio-store-tests/testBackupRestoreLocDelete 
INFO[0008] Pod: test-statefulset-5tfx9-0 Container: test-container Out: Fatal: unable to open config file: Stat: The specified key does not exist. 
INFO[0008] Pod: test-statefulset-5tfx9-0 Container: test-container Out: Is there a repository at the following location? 
INFO[0008] Pod: test-statefulset-5tfx9-0 Container: test-container Out: s3:s3.amazonaws.com/kio-store-tests/testBackupRestoreLocDelete 
INFO[0011] Pod: test-statefulset-5tfx9-0 Container: test-container Out: created restic repository 322e46da7d at s3:s3.amazonaws.com/kio-store-tests/testBackupRestoreLocDelete 
INFO[0011] Pod: test-statefulset-5tfx9-0 Container: test-container Out: Please note that knowledge of your password is required to access 
INFO[0011] Pod: test-statefulset-5tfx9-0 Container: test-container Out: the repository. Losing your password means that your data is 
INFO[0011] Pod: test-statefulset-5tfx9-0 Container: test-container Out: irrecoverably lost. 
INFO[0014] Pod: test-statefulset-5tfx9-0 Container: test-container Out: created new cache in /root/.cache/restic 
INFO[0014] Pod: test-statefulset-5tfx9-0 Container: test-container Out: Files:          63 new,     0 changed,     0 unmodified 
INFO[0014] Pod: test-statefulset-5tfx9-0 Container: test-container Out: Dirs:            0 new,     0 changed,     0 unmodified 
INFO[0014] Pod: test-statefulset-5tfx9-0 Container: test-container Out: Added to the repo: 392.746 KiB 
INFO[0014] Pod: test-statefulset-5tfx9-0 Container: test-container Out: processed 63 files, 631.952 KiB in 0:00 
INFO[0014] Pod: test-statefulset-5tfx9-0 Container: test-container Out: snapshot 352f3ff6 saved 
INFO[0028] Pod: restore-data-x6nf8 Container: container Out: Fatal: wrong password or no key found 
INFO[0028] Falling back to default password             
INFO[0030] Pod: restore-data-x6nf8 Container: container Out: [{"time":"2019-09-27T00:06:55.526502935Z","tree":"106f4305c90aeddc3a09a2cbced2b1e1fcd81fbb7b8ee6481326258aeaa5740e","paths":["/etc"],"hostname":"test-statefulset-5tfx9-0","username":"root","tags":["xn8kbtkjks"],"id":"352f3ff62ed3f176292dcca891623005f84cc70c27e41502556280a63e115a18","short_id":"352f3ff6"}] 
INFO[0033] Pod: restore-data-x6nf8 Container: container Out: restoring <Snapshot 352f3ff6 of [/etc] at 2019-09-27 00:06:55.526502935 +0000 UTC by root@test-statefulset-5tfx9-0> to /mnt/data 
PASS: data_test.go:597: DataSuite.TestBackupRestoreWrongPassword	31.269s

START: data_test.go:104: DataSuite.TearDownSuite
PASS: data_test.go:104: DataSuite.TearDownSuite	1.428s

OK: 1 passed
PASS
ok  	github.com/kanisterio/kanister/pkg/function	36.739s
deepikadixit@deepikas-mbp ~/K10/kanister/kanister/pkg/function (fallback-password) $ 
```