### PR TITLE
Return backup stats in backup action

### DIFF
--- a/pkg/function/backup_data.go
+++ b/pkg/function/backup_data.go
@@ -166,10 +166,14 @@ func backupData(ctx context.Context, cli kubernetes.Interface, namespace, pod, c
 	}
 	// Get the file count and size of the backup from log
 	fileCount, backupSize := restic.SnapshotStatsFromBackupLog(stdout)
+	if fileCount == "" || backupSize == "" {
+		log.Debug("Could not parse backup stats from backup log")
+	}
 	return backupDataParsedOutput{
-		backupID:  backupID,
-		backupTag: backupTag,
-		fileCount: fileCount, backupSize: backupSize}, nil
+		backupID:   backupID,
+		backupTag:  backupTag,
+		fileCount:  fileCount,
+		backupSize: backupSize}, nil
 }
 
 func getPodWriter(cli kubernetes.Interface, ctx context.Context, namespace, podName, containerName string, profile *param.Profile) (*kube.PodWriter, error) {

--- a/pkg/function/backup_data.go
+++ b/pkg/function/backup_data.go
@@ -112,15 +112,15 @@ func (*backupDataFunc) Exec(ctx context.Context, tp param.TemplateParams, args m
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed to create Kubernetes client")
 	}
-	backupID, backupTag, fileCount, backupSize, err := backupData(ctx, cli, namespace, pod, container, backupArtifactPrefix, includePath, encryptionKey, tp)
+	backupOutputs, err := backupData(ctx, cli, namespace, pod, container, backupArtifactPrefix, includePath, encryptionKey, tp)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed to backup data")
 	}
 	output := map[string]interface{}{
-		BackupDataOutputBackupID:       backupID,
-		BackupDataOutputBackupTag:      backupTag,
-		BackupDataStatsOutputFileCount: fileCount,
-		BackupDataStatsOutputSize:      backupSize,
+		BackupDataOutputBackupID:       backupOutputs.backupID,
+		BackupDataOutputBackupTag:      backupOutputs.backupTag,
+		BackupDataStatsOutputFileCount: backupOutputs.fileCount,
+		BackupDataStatsOutputSize:      backupOutputs.backupSize,
 	}
 	return output, nil
 }
@@ -130,36 +130,46 @@ func (*backupDataFunc) RequiredArgs() []string {
 		BackupDataIncludePathArg, BackupDataBackupArtifactPrefixArg}
 }
 
-func backupData(ctx context.Context, cli kubernetes.Interface, namespace, pod, container, backupArtifactPrefix, includePath, encryptionKey string, tp param.TemplateParams) (string, string, string, string, error) {
+type backupDataParsedOutput struct {
+	backupID   string
+	backupTag  string
+	fileCount  string
+	backupSize string
+}
+
+func backupData(ctx context.Context, cli kubernetes.Interface, namespace, pod, container, backupArtifactPrefix, includePath, encryptionKey string, tp param.TemplateParams) (backupDataParsedOutput, error) {
 	pw, err := getPodWriter(cli, ctx, namespace, pod, container, tp.Profile)
 	if err != nil {
-		return "", "", "", "", err
+		return backupDataParsedOutput{}, err
 	}
 	defer cleanUpCredsFile(ctx, pw, namespace, pod, container)
 	if err = restic.GetOrCreateRepository(cli, namespace, pod, container, backupArtifactPrefix, encryptionKey, tp.Profile); err != nil {
-		return "", "", "", "", err
+		return backupDataParsedOutput{}, err
 	}
 
 	// Create backup and dump it on the object store
 	backupTag := rand.String(10)
 	cmd, err := restic.BackupCommandByTag(tp.Profile, backupArtifactPrefix, backupTag, includePath, encryptionKey)
 	if err != nil {
-		return "", "", "", "", err
+		return backupDataParsedOutput{}, err
 	}
 	stdout, stderr, err := kube.Exec(cli, namespace, pod, container, cmd, nil)
 	format.Log(pod, container, stdout)
 	format.Log(pod, container, stderr)
 	if err != nil {
-		return "", "", "", "", errors.Wrapf(err, "Failed to create and upload backup")
+		return backupDataParsedOutput{}, errors.Wrapf(err, "Failed to create and upload backup")
 	}
 	// Get the snapshot ID from log
 	backupID := restic.SnapshotIDFromBackupLog(stdout)
 	if backupID == "" {
-		return "", "", "", "", errors.New("Failed to parse the backup ID from logs")
+		return backupDataParsedOutput{}, errors.New("Failed to parse the backup ID from logs")
 	}
 	// Get the file count and size of the backup from log
 	fileCount, backupSize := restic.SnapshotStatsFromBackupLog(stdout)
-	return backupID, backupTag, fileCount, backupSize, nil
+	return backupDataParsedOutput{
+		backupID:  backupID,
+		backupTag: backupTag,
+		fileCount: fileCount, backupSize: backupSize}, nil
 }
 
 func getPodWriter(cli kubernetes.Interface, ctx context.Context, namespace, podName, containerName string, profile *param.Profile) (*kube.PodWriter, error) {

--- a/pkg/function/backup_data.go
+++ b/pkg/function/backup_data.go
@@ -157,7 +157,7 @@ func backupData(ctx context.Context, cli kubernetes.Interface, namespace, pod, c
 	if backupID == "" {
 		return "", "", "", "", errors.New("Failed to parse the backup ID from logs")
 	}
-	// Get the snapshot ID from log
+	// Get the file count and size of the backup from log
 	fileCount, backupSize := restic.SnapshotStatsFromBackupLog(stdout)
 	return backupID, backupTag, fileCount, backupSize, nil
 }

--- a/pkg/function/backup_data.go
+++ b/pkg/function/backup_data.go
@@ -158,7 +158,7 @@ func backupData(ctx context.Context, cli kubernetes.Interface, namespace, pod, c
 		return "", "", "", "", errors.New("Failed to parse the backup ID from logs")
 	}
 	// Get the snapshot ID from log
-	fileCount, backupSize := restic.SnapshotSizeFromBackupLog(stdout)
+	fileCount, backupSize := restic.SnapshotStatsFromBackupLog(stdout)
 	return backupID, backupTag, fileCount, backupSize, nil
 }
 

--- a/pkg/function/backup_data.go
+++ b/pkg/function/backup_data.go
@@ -112,13 +112,15 @@ func (*backupDataFunc) Exec(ctx context.Context, tp param.TemplateParams, args m
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed to create Kubernetes client")
 	}
-	backupID, backupTag, err := backupData(ctx, cli, namespace, pod, container, backupArtifactPrefix, includePath, encryptionKey, tp)
+	backupID, backupTag, fileCount, backupSize, err := backupData(ctx, cli, namespace, pod, container, backupArtifactPrefix, includePath, encryptionKey, tp)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed to backup data")
 	}
 	output := map[string]interface{}{
-		BackupDataOutputBackupID:  backupID,
-		BackupDataOutputBackupTag: backupTag,
+		BackupDataOutputBackupID:       backupID,
+		BackupDataOutputBackupTag:      backupTag,
+		BackupDataStatsOutputFileCount: fileCount,
+		BackupDataStatsOutputSize:      backupSize,
 	}
 	return output, nil
 }
@@ -128,34 +130,36 @@ func (*backupDataFunc) RequiredArgs() []string {
 		BackupDataIncludePathArg, BackupDataBackupArtifactPrefixArg}
 }
 
-func backupData(ctx context.Context, cli kubernetes.Interface, namespace, pod, container, backupArtifactPrefix, includePath, encryptionKey string, tp param.TemplateParams) (string, string, error) {
+func backupData(ctx context.Context, cli kubernetes.Interface, namespace, pod, container, backupArtifactPrefix, includePath, encryptionKey string, tp param.TemplateParams) (string, string, string, string, error) {
 	pw, err := getPodWriter(cli, ctx, namespace, pod, container, tp.Profile)
 	if err != nil {
-		return "", "", err
+		return "", "", "", "", err
 	}
 	defer cleanUpCredsFile(ctx, pw, namespace, pod, container)
 	if err = restic.GetOrCreateRepository(cli, namespace, pod, container, backupArtifactPrefix, encryptionKey, tp.Profile); err != nil {
-		return "", "", err
+		return "", "", "", "", err
 	}
 
 	// Create backup and dump it on the object store
 	backupTag := rand.String(10)
 	cmd, err := restic.BackupCommandByTag(tp.Profile, backupArtifactPrefix, backupTag, includePath, encryptionKey)
 	if err != nil {
-		return "", "", err
+		return "", "", "", "", err
 	}
 	stdout, stderr, err := kube.Exec(cli, namespace, pod, container, cmd, nil)
 	format.Log(pod, container, stdout)
 	format.Log(pod, container, stderr)
 	if err != nil {
-		return "", "", errors.Wrapf(err, "Failed to create and upload backup")
+		return "", "", "", "", errors.Wrapf(err, "Failed to create and upload backup")
 	}
 	// Get the snapshot ID from log
 	backupID := restic.SnapshotIDFromBackupLog(stdout)
 	if backupID == "" {
-		return "", "", errors.New("Failed to parse the backup ID from logs")
+		return "", "", "", "", errors.New("Failed to parse the backup ID from logs")
 	}
-	return backupID, backupTag, nil
+	// Get the snapshot ID from log
+	fileCount, backupSize := restic.SnapshotSizeFromBackupLog(stdout)
+	return backupID, backupTag, fileCount, backupSize, nil
 }
 
 func getPodWriter(cli kubernetes.Interface, ctx context.Context, namespace, podName, containerName string, profile *param.Profile) (*kube.PodWriter, error) {

--- a/pkg/function/backup_data_all.go
+++ b/pkg/function/backup_data_all.go
@@ -125,9 +125,9 @@ func backupDataAll(ctx context.Context, cli kubernetes.Interface, namespace stri
 	for _, pod := range ps {
 		go func(pod string, container string) {
 			ctx = field.Context(ctx, consts.PodNameKey, pod)
-			backupID, backupTag, _, _, err := backupData(ctx, cli, namespace, pod, container, fmt.Sprintf("%s/%s", backupArtifactPrefix, pod), includePath, encryptionKey, tp)
+			backupOutputs, err := backupData(ctx, cli, namespace, pod, container, fmt.Sprintf("%s/%s", backupArtifactPrefix, pod), includePath, encryptionKey, tp)
 			errChan <- errors.Wrapf(err, "Failed to backup data for pod %s", pod)
-			outChan <- BackupInfo{PodName: pod, BackupID: backupID, BackupTag: backupTag}
+			outChan <- BackupInfo{PodName: pod, BackupID: backupOutputs.backupID, BackupTag: backupOutputs.backupTag}
 		}(pod, container)
 	}
 	errs := make([]string, 0, len(ps))

--- a/pkg/function/backup_data_all.go
+++ b/pkg/function/backup_data_all.go
@@ -125,7 +125,7 @@ func backupDataAll(ctx context.Context, cli kubernetes.Interface, namespace stri
 	for _, pod := range ps {
 		go func(pod string, container string) {
 			ctx = field.Context(ctx, consts.PodNameKey, pod)
-			backupID, backupTag, err := backupData(ctx, cli, namespace, pod, container, fmt.Sprintf("%s/%s", backupArtifactPrefix, pod), includePath, encryptionKey, tp)
+			backupID, backupTag, _, _, err := backupData(ctx, cli, namespace, pod, container, fmt.Sprintf("%s/%s", backupArtifactPrefix, pod), includePath, encryptionKey, tp)
 			errChan <- errors.Wrapf(err, "Failed to backup data for pod %s", pod)
 			outChan <- BackupInfo{PodName: pod, BackupID: backupID, BackupTag: backupTag}
 		}(pod, container)

--- a/pkg/function/data_test.go
+++ b/pkg/function/data_test.go
@@ -314,6 +314,8 @@ func (s *DataSuite) TestBackupRestoreDeleteData(c *C) {
 		out := runAction(c, bp, "backup", tp)
 		c.Assert(out[BackupDataOutputBackupID].(string), Not(Equals), "")
 		c.Assert(out[BackupDataOutputBackupTag].(string), Not(Equals), "")
+		c.Check(out[BackupDataStatsOutputFileCount].(string), Not(Equals), "")
+		c.Check(out[BackupDataStatsOutputSize].(string), Not(Equals), "")
 
 		options := map[string]string{
 			BackupDataOutputBackupID:  out[BackupDataOutputBackupID].(string),
@@ -339,6 +341,8 @@ func (s *DataSuite) TestBackupRestoreDataWithSnapshotID(c *C) {
 		out := runAction(c, bp, "backup", tp)
 		c.Assert(out[BackupDataOutputBackupID].(string), Not(Equals), "")
 		c.Assert(out[BackupDataOutputBackupTag].(string), Not(Equals), "")
+		c.Check(out[BackupDataStatsOutputFileCount].(string), Not(Equals), "")
+		c.Check(out[BackupDataStatsOutputSize].(string), Not(Equals), "")
 
 		options := map[string]string{
 			BackupDataOutputBackupID:  out[BackupDataOutputBackupID].(string),

--- a/pkg/restic/restic.go
+++ b/pkg/restic/restic.go
@@ -298,7 +298,9 @@ func SnapshotIDFromBackupLog(output string) string {
 	for _, l := range logs {
 		match := pattern.FindAllStringSubmatch(l, 1)
 		if match != nil {
-			return match[0][1]
+			if len(match) >= 1 && len(match[0]) >= 2 {
+				return match[0][1]
+			}
 		}
 	}
 	return ""
@@ -315,7 +317,13 @@ func SnapshotStatsFromBackupLog(output string) (fileCount string, backupSize str
 	for _, l := range logs {
 		match := pattern.FindAllStringSubmatch(l, 1)
 		if match != nil {
-			return match[0][1], match[0][2]
+			if len(match) >= 1 && len(match[0]) >= 3 {
+				// Expect in order:
+				// 0: entire match,
+				// 1: first submatch == file count,
+				// 2: second submatch == size string
+				return match[0][1], match[0][2]
+			}
 		}
 	}
 	return "", ""

--- a/pkg/restic/restic.go
+++ b/pkg/restic/restic.go
@@ -293,9 +293,9 @@ func SnapshotIDFromBackupLog(output string) string {
 		return ""
 	}
 	logs := regexp.MustCompile("[\n]").Split(output, -1)
+	// Log should contain "snapshot ABC123 saved"
+	pattern := regexp.MustCompile(`snapshot\s(.*?)\ssaved$`)
 	for _, l := range logs {
-		// Log should contain "snapshot ABC123 saved"
-		pattern := regexp.MustCompile(`snapshot\s(.*?)\ssaved$`)
 		match := pattern.FindAllStringSubmatch(l, 1)
 		if match != nil {
 			return match[0][1]
@@ -310,9 +310,9 @@ func SnapshotStatsFromBackupLog(output string) (fileCount string, backupSize str
 		return "", ""
 	}
 	logs := regexp.MustCompile("[\n]").Split(output, -1)
+	// Log should contain "processed %d files, %.3f [Xi]B in mm:ss"
+	pattern := regexp.MustCompile(`processed\s([\d]+)\sfiles,\s([\d]+(\.[\d]+)?\s([TGMK]i)?B)\sin\s`)
 	for _, l := range logs {
-		// Log should contain "processed %d files, %.3f [Xi]B in mm:ss"
-		pattern := regexp.MustCompile(`processed\s([\d]+)\sfiles,\s([\d]+(\.[\d]+)?\s([TGMK]i)?B)\sin\s`)
 		match := pattern.FindAllStringSubmatch(l, 1)
 		if match != nil {
 			return match[0][1], match[0][2]

--- a/pkg/restic/restic.go
+++ b/pkg/restic/restic.go
@@ -304,6 +304,23 @@ func SnapshotIDFromBackupLog(output string) string {
 	return ""
 }
 
+// SnapshotStatsFromBackupLog gets the Snapshot file count and size from Backup Command log
+func SnapshotStatsFromBackupLog(output string) (fileCount string, backupSize string) {
+	if output == "" {
+		return "", ""
+	}
+	logs := regexp.MustCompile("[\n]").Split(output, -1)
+	for _, l := range logs {
+		// Log should contain "processed %d files, %.3f [Xi]B in mm:ss"
+		pattern := regexp.MustCompile(`processed\s([\d]+)\sfiles,\s([\d]+(\.[\d]+)?\s([TGMK]i)?B)\sin\s`)
+		match := pattern.FindAllStringSubmatch(l, 1)
+		if match != nil {
+			return match[0][1], match[0][2]
+		}
+	}
+	return "", ""
+}
+
 // SnapshotStatsFromStatsLog gets the Snapshot Stats from Stats Command log
 func SnapshotStatsFromStatsLog(output string) (string, string, string) {
 	if output == "" {

--- a/pkg/restic/restic_test.go
+++ b/pkg/restic/restic_test.go
@@ -237,3 +237,49 @@ func (s *ResticDataSuite) TestGetSnapshotStatsModeFromStatsLog(c *C) {
 		c.Assert(mode, Equals, tc.expected)
 	}
 }
+
+func (s *ResticDataSuite) TestGetSnapshotStatsFromBackupLog(c *C) {
+	for _, tc := range []struct {
+		log          string
+		expectedfc   string
+		expectedsize string
+	}{
+		{log: "processed 9 files, 11.235 KiB in 0:00", expectedfc: "9", expectedsize: "11.235 KiB"},
+		{log: "processed 9 files, 11 KiB in 0:00", expectedfc: "9", expectedsize: "11 KiB"},
+		{log: "processed 9 files, 11. KiB in 0:00", expectedfc: "", expectedsize: ""},
+		{log: "processed 9 files, . KiB in 0:00", expectedfc: "", expectedsize: ""},
+		{log: "processed 9 files, .111 KiB in 0:00", expectedfc: "", expectedsize: ""},
+		{log: "processed 9 files, 0.111 KiB in 0:00", expectedfc: "9", expectedsize: "0.111 KiB"},
+		{log: "processed   9 files, 11.235 KiB in 0:00", expectedfc: "", expectedsize: ""},
+		{log: "processed asdf files, 11.235 KiB in 0:00", expectedfc: "", expectedsize: ""},
+		{log: "processed 9 files,  11.235 KiB in 0:00", expectedfc: "", expectedsize: ""},
+		{log: "asdf 9 files, 11.235 KiB in 0:00", expectedfc: "", expectedsize: ""},
+		{log: "processed 9,999,999 files, 11.235 KiB in 0:00", expectedfc: "", expectedsize: ""},
+		{log: "processed 9.999 files, 11.235 KiB in 0:00", expectedfc: "", expectedsize: ""},
+		{log: "processed  9  files,  11.235 KiB  in  0:00", expectedfc: "", expectedsize: ""},
+		{log: "processed  9  files,  11.235 KiB", expectedfc: "", expectedsize: ""},
+		{log: "processed 9 files, 11.235 KiB in", expectedfc: "", expectedsize: ""},
+		{log: "processed 9 files, 11.235 KiB in ", expectedfc: "9", expectedsize: "11.235 KiB"},
+		{log: "processed 9 files, 11.235  KiB in ", expectedfc: "", expectedsize: ""},
+		{log: "processed 9 files, 11.235 in ", expectedfc: "", expectedsize: ""},
+		{log: "processed 9 , 11.235 KiB in ", expectedfc: "", expectedsize: ""},
+		{log: "processed 9 files 11.235 KiB in 0:00", expectedfc: "", expectedsize: ""},
+		{log: "processed 9 files, 11.235 B in 0:00", expectedfc: "9", expectedsize: "11.235 B"},
+		{log: "processed 9 files, 11.235 MiB in 0:00", expectedfc: "9", expectedsize: "11.235 MiB"},
+		{log: "processed 9 files, 11.235 GiB in 0:00", expectedfc: "9", expectedsize: "11.235 GiB"},
+		{log: "processed 9 files, 11.235 TiB in 0:00", expectedfc: "9", expectedsize: "11.235 TiB"},
+		{log: "processed 9 files, 11.235 PiB in 0:00", expectedfc: "", expectedsize: ""},
+		{log: "processed 9 files, 11.235 asdf in 0:00", expectedfc: "", expectedsize: ""},
+		{log: "processed 9 files, 11.235 iB in 0:00", expectedfc: "", expectedsize: ""},
+		{log: "processed 9 files, 11.235 KB in 0:00", expectedfc: "", expectedsize: ""},
+		{log: "processed 9 files, 11.235 MB in 0:00", expectedfc: "", expectedsize: ""},
+		{log: "processed 9 files, 11.235 GB in 0:00", expectedfc: "", expectedsize: ""},
+		{log: "processed 9 files, 11.235 TB in 0:00", expectedfc: "", expectedsize: ""},
+		{log: "processed 9 files, 11.235 PB in 0:00", expectedfc: "", expectedsize: ""},
+		{log: "processed 9 files, 11.235 asdfB in 0:00", expectedfc: "", expectedsize: ""},
+	} {
+		fc, s := SnapshotStatsFromBackupLog(tc.log)
+		c.Check(fc, Equals, tc.expectedfc)
+		c.Check(s, Equals, tc.expectedsize)
+	}
+}

--- a/pkg/restic/restic_test.go
+++ b/pkg/restic/restic_test.go
@@ -277,6 +277,8 @@ func (s *ResticDataSuite) TestGetSnapshotStatsFromBackupLog(c *C) {
 		{log: "processed 9 files, 11.235 TB in 0:00", expectedfc: "", expectedsize: ""},
 		{log: "processed 9 files, 11.235 PB in 0:00", expectedfc: "", expectedsize: ""},
 		{log: "processed 9 files, 11.235 asdfB in 0:00", expectedfc: "", expectedsize: ""},
+		{log: "processed  files, 11.235 asdfB in 0:00", expectedfc: "", expectedsize: ""},
+		{log: "processed files, 11.235 asdfB in 0:00", expectedfc: "", expectedsize: ""},
 	} {
 		fc, s := SnapshotStatsFromBackupLog(tc.log)
 		c.Check(fc, Equals, tc.expectedfc)

--- a/pkg/restic/restic_test.go
+++ b/pkg/restic/restic_test.go
@@ -279,6 +279,9 @@ func (s *ResticDataSuite) TestGetSnapshotStatsFromBackupLog(c *C) {
 		{log: "processed 9 files, 11.235 asdfB in 0:00", expectedfc: "", expectedsize: ""},
 		{log: "processed  files, 11.235 asdfB in 0:00", expectedfc: "", expectedsize: ""},
 		{log: "processed files, 11.235 asdfB in 0:00", expectedfc: "", expectedsize: ""},
+		{log: "processed 9 files, KiB in 0:00", expectedfc: "", expectedsize: ""},
+		{log: "processed 9 files,  KiB in 0:00", expectedfc: "", expectedsize: ""},
+		{log: "processed 9 files, in 0:00", expectedfc: "", expectedsize: ""},
 	} {
 		fc, s := SnapshotStatsFromBackupLog(tc.log)
 		c.Check(fc, Equals, tc.expectedfc)


### PR DESCRIPTION
## Change Overview

Backup action will also return backup size and file count. These data can be parsed from the backup execution output log. File count and backup size are returned as empty strings if parsing was unsuccessful.

## Pull request type

Please check the type of change your PR introduces:
- [ ] Work in Progress
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Trivial/Minor
- [ ] Bugfix
- [x] Feature
- [ ] Documentation


## Test Plan

Unit test to verify correct parsing of the backup output log
Adding checks to the outputs of the backup tests in the Data suite

- [ ] Manual
- [x] Unit test
- [ ] E2E
