### PR TITLE
Fix data_test

### DIFF
--- a/pkg/function/data_test.go
+++ b/pkg/function/data_test.go
@@ -588,7 +588,7 @@ func (s *DataSuite) TestDescribeBackupsWrongPassword(c *C) {
 
 	// Test backup
 	bp := *newBackupDataBlueprint()
-	bp.Actions["backup"].Phases[0].Args[BackupDataBackupArtifactPrefixArg] = "abc-foo-bar"
+	bp.Actions["backup"].Phases[0].Args[BackupDataBackupArtifactPrefixArg] = fmt.Sprintf("%s/%s", bp.Actions["backup"].Phases[0].Args[BackupDataBackupArtifactPrefixArg], "abd")
 	bp.Actions["backup"].Phases[0].Args[BackupDataEncryptionKeyArg] = restic.GeneratePassword()
 	out := runAction(c, bp, "backup", tp)
 	c.Assert(out[BackupDataOutputBackupID].(string), Not(Equals), "")
@@ -596,7 +596,7 @@ func (s *DataSuite) TestDescribeBackupsWrongPassword(c *C) {
 
 	// Test DescribeBackups
 	bp2 := *newDescribeBackupsBlueprint()
-	bp2.Actions["describeBackups"].Phases[0].Args[DescribeBackupsArtifactPrefixArg] = "abc-foo-bar"
+	bp2.Actions["describeBackups"].Phases[0].Args[DescribeBackupsArtifactPrefixArg] = fmt.Sprintf("%s/%s", bp2.Actions["describeBackups"].Phases[0].Args[DescribeBackupsArtifactPrefixArg], "abd")
 	out2 := runAction(c, bp2, "describeBackups", tp)
 	c.Assert(out2[DescribeBackupsPasswordIncorrect].(string), Equals, "true")
 }
@@ -612,7 +612,7 @@ func (s *DataSuite) TestDescribeBackupsRepoNotAvailable(c *C) {
 
 	// Test DescribeBackups
 	bp2 := *newDescribeBackupsBlueprint()
-	bp2.Actions["describeBackups"].Phases[0].Args[DescribeBackupsArtifactPrefixArg] = "foobar"
+	bp2.Actions["describeBackups"].Phases[0].Args[DescribeBackupsArtifactPrefixArg] = fmt.Sprintf("%s/%s", bp2.Actions["describeBackups"].Phases[0].Args[DescribeBackupsArtifactPrefixArg], "foobar")
 	out2 := runAction(c, bp2, "describeBackups", tp)
 	c.Assert(out2[DescribeBackupsRepoDoesNotExist].(string), Equals, "true")
 }


### PR DESCRIPTION
## Change Overview

`data_test` failing due to wrong/incorrect directory path. 

## Pull request type

Please check the type of change your PR introduces:
- [ ] Work in Progress
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Trivial/Minor
- [X] Bugfix
- [ ] Feature
- [ ] Documentation

## Test Plan

`travis ci` does not run `data_test`. It passed locally, should have been caught earlier

- [ ] Manual
- [X] Unit test

```
$ go test -check.vv -check.f=TestDescribeBackupsWrongPassword
go: finding github.com/graymeta/stow v0.0.0-00010101000000-000000000000
START: data_test.go:57: DataSuite.SetUpSuite
PASS: data_test.go:57: DataSuite.SetUpSuite	5.132s

START: data_test.go:586: DataSuite.TestDescribeBackupsWrongPassword
INFO[0013] Pod: test-statefulset-b5w4h-0 Container: test-container Out: Fatal: unable to open config file: Stat: The specified key does not exist. 
INFO[0013] Pod: test-statefulset-b5w4h-0 Container: test-container Out: Is there a repository at the following location? 
INFO[0013] Pod: test-statefulset-b5w4h-0 Container: test-container Out: s3:s3.amazonaws.com/kio-store-tests/testBackupRestoreLocDelete/abd 
INFO[0013] Pod: test-statefulset-b5w4h-0 Container: test-container Out: Fatal: unable to open config file: Stat: The specified key does not exist. 
INFO[0013] Pod: test-statefulset-b5w4h-0 Container: test-container Out: Is there a repository at the following location? 
INFO[0013] Pod: test-statefulset-b5w4h-0 Container: test-container Out: s3:s3.amazonaws.com/kio-store-tests/testBackupRestoreLocDelete/abd 
INFO[0015] Pod: test-statefulset-b5w4h-0 Container: test-container Out: created restic repository 0c1fd09cb4 at s3:s3.amazonaws.com/kio-store-tests/testBackupRestoreLocDelete/abd 
INFO[0015] Pod: test-statefulset-b5w4h-0 Container: test-container Out: Please note that knowledge of your password is required to access 
INFO[0015] Pod: test-statefulset-b5w4h-0 Container: test-container Out: the repository. Losing your password means that your data is 
INFO[0015] Pod: test-statefulset-b5w4h-0 Container: test-container Out: irrecoverably lost. 
INFO[0018] Pod: test-statefulset-b5w4h-0 Container: test-container Out: created new cache in /root/.cache/restic 
INFO[0018] Pod: test-statefulset-b5w4h-0 Container: test-container Out: Files:          63 new,     0 changed,     0 unmodified 
INFO[0018] Pod: test-statefulset-b5w4h-0 Container: test-container Out: Dirs:            0 new,     0 changed,     0 unmodified 
INFO[0018] Pod: test-statefulset-b5w4h-0 Container: test-container Out: Added to the repo: 392.751 KiB 
INFO[0018] Pod: test-statefulset-b5w4h-0 Container: test-container Out: processed 63 files, 631.952 KiB in 0:00 
INFO[0018] Pod: test-statefulset-b5w4h-0 Container: test-container Out: snapshot ebdf7350 saved 
INFO[0026] Pod: describe-backups-6b5h9 Container: container Out: Fatal: wrong password or no key found 
PASS: data_test.go:586: DataSuite.TestDescribeBackupsWrongPassword	21.161s

START: data_test.go:108: DataSuite.TearDownSuite
PASS: data_test.go:108: DataSuite.TearDownSuite	1.276s

START: data_test.go:57: DataSuite.SetUpSuite
SKIP: data_test.go:57: DataSuite.SetUpSuite (Test  requires the environemnt variable 'GOOGLE_APPLICATION_CREDENTIALS')

START: data_test.go:586: DataSuite.TestDescribeBackupsWrongPassword
SKIP: data_test.go:586: DataSuite.TestDescribeBackupsWrongPassword

START: data_test.go:108: DataSuite.TearDownSuite
PASS: data_test.go:108: DataSuite.TearDownSuite	0.029s

OK: 1 passed, 1 skipped
PASS
ok  	github.com/kanisterio/kanister/pkg/function	29.477s

$ go test -check.vv -check.f=TestDescribeBackupsRepoNotAvailable
go: finding github.com/graymeta/stow v0.0.0-00010101000000-000000000000
START: data_test.go:57: DataSuite.SetUpSuite
PASS: data_test.go:57: DataSuite.SetUpSuite	1.917s

START: data_test.go:604: DataSuite.TestDescribeBackupsRepoNotAvailable
INFO[0006] Pod: test-statefulset-8xxkb-0 Container: test-container Out: Fatal: unable to open config file: Stat: The specified key does not exist. 
INFO[0006] Pod: test-statefulset-8xxkb-0 Container: test-container Out: Is there a repository at the following location? 
INFO[0006] Pod: test-statefulset-8xxkb-0 Container: test-container Out: s3:s3.amazonaws.com/kio-store-tests/testBackupRestoreLocDelete 
INFO[0006] Pod: test-statefulset-8xxkb-0 Container: test-container Out: Fatal: unable to open config file: Stat: The specified key does not exist. 
INFO[0006] Pod: test-statefulset-8xxkb-0 Container: test-container Out: Is there a repository at the following location? 
INFO[0006] Pod: test-statefulset-8xxkb-0 Container: test-container Out: s3:s3.amazonaws.com/kio-store-tests/testBackupRestoreLocDelete 
INFO[0010] Pod: test-statefulset-8xxkb-0 Container: test-container Out: created restic repository 1d5784def5 at s3:s3.amazonaws.com/kio-store-tests/testBackupRestoreLocDelete 
INFO[0010] Pod: test-statefulset-8xxkb-0 Container: test-container Out: Please note that knowledge of your password is required to access 
INFO[0010] Pod: test-statefulset-8xxkb-0 Container: test-container Out: the repository. Losing your password means that your data is 
INFO[0010] Pod: test-statefulset-8xxkb-0 Container: test-container Out: irrecoverably lost. 
INFO[0012] Pod: test-statefulset-8xxkb-0 Container: test-container Out: created new cache in /root/.cache/restic 
INFO[0012] Pod: test-statefulset-8xxkb-0 Container: test-container Out: Files:          63 new,     0 changed,     0 unmodified 
INFO[0012] Pod: test-statefulset-8xxkb-0 Container: test-container Out: Dirs:            0 new,     0 changed,     0 unmodified 
INFO[0012] Pod: test-statefulset-8xxkb-0 Container: test-container Out: Added to the repo: 392.751 KiB 
INFO[0012] Pod: test-statefulset-8xxkb-0 Container: test-container Out: processed 63 files, 631.952 KiB in 0:00 
INFO[0012] Pod: test-statefulset-8xxkb-0 Container: test-container Out: snapshot 2339564f saved 
INFO[0017] Pod: describe-backups-xp222 Container: container Out: Fatal: unable to open config file: Stat: The specified key does not exist. 
INFO[0017] Pod: describe-backups-xp222 Container: container Out: Is there a repository at the following location? 
INFO[0017] Pod: describe-backups-xp222 Container: container Out: s3:s3.amazonaws.com/kio-store-tests/testBackupRestoreLocDelete/foobar 
PASS: data_test.go:604: DataSuite.TestDescribeBackupsRepoNotAvailable	15.085s

START: data_test.go:108: DataSuite.TearDownSuite
PASS: data_test.go:108: DataSuite.TearDownSuite	1.235s

START: data_test.go:57: DataSuite.SetUpSuite
SKIP: data_test.go:57: DataSuite.SetUpSuite (Test  requires the environemnt variable 'GOOGLE_APPLICATION_CREDENTIALS')

START: data_test.go:604: DataSuite.TestDescribeBackupsRepoNotAvailable
SKIP: data_test.go:604: DataSuite.TestDescribeBackupsRepoNotAvailable

START: data_test.go:108: DataSuite.TearDownSuite
PASS: data_test.go:108: DataSuite.TearDownSuite	0.034s

OK: 1 passed, 1 skipped
PASS
ok  	github.com/kanisterio/kanister/pkg/function	20.144s
```

- [ ] E2E
