### PR TITLE
Split Vsphere login URL to its parts

### DIFF
--- a/pkg/blockstorage/vmware/vmware.go
+++ b/pkg/blockstorage/vmware/vmware.go
@@ -2,6 +2,7 @@ package vmware
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
@@ -24,6 +25,13 @@ const (
 	// It should contain the username and the password.
 	VSphereLoginURLKey = "VSphereLoginURL"
 
+	// VSphereEndpointKey represents key for the login endpoint.
+	VSphereEndpointKey = "VSphereEndpoint"
+	// VSphereUsernameKey represents key for the username.
+	VSphereUsernameKey = "VSphereUsername"
+	// VSpherePasswordKey represents key for the password.
+	VSpherePasswordKey = "VSpherePasswordKey"
+
 	noDescription   = ""
 	defaultWaitTime = 10 * time.Minute
 )
@@ -36,7 +44,19 @@ type fcdProvider struct {
 // NewProvider creates new VMWare FCD provider with the config.
 // URL taken from config helps to establish connection.
 func NewProvider(config map[string]string) (blockstorage.Provider, error) {
-	u, err := soap.ParseURL(config[VSphereLoginURLKey])
+	ep, ok := config[VSphereEndpointKey]
+	if !ok {
+		return nil, errors.New("Failed to find VSphere endpoint value")
+	}
+	username, ok := config[VSphereUsernameKey]
+	if !ok {
+		return nil, errors.New("Failed to find VSphere username value")
+	}
+	password, ok := config[VSpherePasswordKey]
+	if !ok {
+		return nil, errors.New("Failed to find VSphere password value")
+	}
+	u, err := soap.ParseURL(constructLoginURL(ep, username, password))
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to get config")
 	}
@@ -65,6 +85,10 @@ func NewProvider(config map[string]string) (blockstorage.Provider, error) {
 		cns: cnsCli,
 		gom: gom,
 	}, nil
+}
+
+func constructLoginURL(endpoint, username, password string) string {
+	return fmt.Sprintf("https://%s:%s@%s/sdk", username, password, endpoint)
 }
 
 func (p *fcdProvider) Type() blockstorage.Type {


### PR DESCRIPTION
## Change Overview

Instead of getting one login url, construct login url by its parts.
Users will be asked to provide endpoint, username and password.

## Pull request type

Please check the type of change your PR introduces:
- [ ] Work in Progress
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Trivial/Minor
- [ ] Bugfix
- [X] Feature
- [ ] Documentation
