### PR TITLE
Modify data test to not use default password

### DIFF
--- a/pkg/function/data_test.go
+++ b/pkg/function/data_test.go
@@ -611,7 +611,7 @@ func (s *DataSuite) TestDescribeBackupsRepoNotAvailable(c *C) {
 
 	// Test DescribeBackups
 	bp2 := *newDescribeBackupsBlueprint()
-	bp2.Actions["describeBackups"].Phases[0].Args[DescribeBackupsArtifactPrefixArg] = fmt.Sprintf("%s/%s", bp2.Actions["describeBackups"].Phases[0].Args[DescribeBackupsArtifactPrefixArg], "foobar")
+	bp2.Actions["describeBackups"].Phases[0].Args[DescribeBackupsArtifactPrefixArg] = fmt.Sprintf("%s/%s", bp2.Actions["describeBackups"].Phases[0].Args[DescribeBackupsArtifactPrefixArg], c.TestName())
 	out2 := runAction(c, bp2, "describeBackups", tp)
 	c.Assert(out2[DescribeBackupsRepoDoesNotExist].(string), Equals, "true")
 }

--- a/pkg/function/data_test.go
+++ b/pkg/function/data_test.go
@@ -35,7 +35,6 @@ import (
 	"github.com/kanisterio/kanister/pkg/objectstore"
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/resource"
-	"github.com/kanisterio/kanister/pkg/restic"
 	"github.com/kanisterio/kanister/pkg/testutil"
 )
 
@@ -588,15 +587,15 @@ func (s *DataSuite) TestDescribeBackupsWrongPassword(c *C) {
 
 	// Test backup
 	bp := *newBackupDataBlueprint()
-	bp.Actions["backup"].Phases[0].Args[BackupDataBackupArtifactPrefixArg] = fmt.Sprintf("%s/%s", bp.Actions["backup"].Phases[0].Args[BackupDataBackupArtifactPrefixArg], "abd")
-	bp.Actions["backup"].Phases[0].Args[BackupDataEncryptionKeyArg] = restic.GeneratePassword()
+	bp.Actions["backup"].Phases[0].Args[BackupDataBackupArtifactPrefixArg] = fmt.Sprintf("%s/%s", bp.Actions["backup"].Phases[0].Args[BackupDataBackupArtifactPrefixArg], "abcde")
+	bp.Actions["backup"].Phases[0].Args[BackupDataEncryptionKeyArg] = "foobar"
 	out := runAction(c, bp, "backup", tp)
 	c.Assert(out[BackupDataOutputBackupID].(string), Not(Equals), "")
 	c.Assert(out[BackupDataOutputBackupTag].(string), Not(Equals), "")
 
 	// Test DescribeBackups
 	bp2 := *newDescribeBackupsBlueprint()
-	bp2.Actions["describeBackups"].Phases[0].Args[DescribeBackupsArtifactPrefixArg] = fmt.Sprintf("%s/%s", bp2.Actions["describeBackups"].Phases[0].Args[DescribeBackupsArtifactPrefixArg], "abd")
+	bp2.Actions["describeBackups"].Phases[0].Args[DescribeBackupsArtifactPrefixArg] = fmt.Sprintf("%s/%s", bp2.Actions["describeBackups"].Phases[0].Args[DescribeBackupsArtifactPrefixArg], "abcde")
 	out2 := runAction(c, bp2, "describeBackups", tp)
 	c.Assert(out2[DescribeBackupsPasswordIncorrect].(string), Equals, "true")
 }


### PR DESCRIPTION
## Change Overview

<!-- Insert PR description-->

## Pull request type

Please check the type of change your PR introduces:
- [ ] Work in Progress
- [ ] Refactoring (no functional changes, no api changes)
- [X] Trivial/Minor
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] Manual
- [x] Unit test
```
go test -check.vv -check.f=TestDescribeBackupsWrongPassword
go: finding github.com/graymeta/stow v0.0.0-00010101000000-000000000000
START: data_test.go:56: DataSuite.SetUpSuite
PASS: data_test.go:56: DataSuite.SetUpSuite	1.918s

START: data_test.go:585: DataSuite.TestDescribeBackupsWrongPassword
INFO[0006] Pod: test-statefulset-jqg56-0 Container: test-container Out: Fatal: unable to open config file: Stat: The specified key does not exist. 
INFO[0006] Pod: test-statefulset-jqg56-0 Container: test-container Out: Is there a repository at the following location? 
INFO[0006] Pod: test-statefulset-jqg56-0 Container: test-container Out: s3:s3.amazonaws.com/kio-store-tests/testBackupRestoreLocDelete/abcde 
INFO[0006] Pod: test-statefulset-jqg56-0 Container: test-container Out: Fatal: unable to open config file: Stat: The specified key does not exist. 
INFO[0006] Pod: test-statefulset-jqg56-0 Container: test-container Out: Is there a repository at the following location? 
INFO[0006] Pod: test-statefulset-jqg56-0 Container: test-container Out: s3:s3.amazonaws.com/kio-store-tests/testBackupRestoreLocDelete/abcde 
INFO[0009] Pod: test-statefulset-jqg56-0 Container: test-container Out: created restic repository c11bf13599 at s3:s3.amazonaws.com/kio-store-tests/testBackupRestoreLocDelete/abcde 
INFO[0009] Pod: test-statefulset-jqg56-0 Container: test-container Out: Please note that knowledge of your password is required to access 
INFO[0009] Pod: test-statefulset-jqg56-0 Container: test-container Out: the repository. Losing your password means that your data is 
INFO[0009] Pod: test-statefulset-jqg56-0 Container: test-container Out: irrecoverably lost. 
INFO[0012] Pod: test-statefulset-jqg56-0 Container: test-container Out: created new cache in /root/.cache/restic 
INFO[0012] Pod: test-statefulset-jqg56-0 Container: test-container Out: Files:          63 new,     0 changed,     0 unmodified 
INFO[0012] Pod: test-statefulset-jqg56-0 Container: test-container Out: Dirs:            0 new,     0 changed,     0 unmodified 
INFO[0012] Pod: test-statefulset-jqg56-0 Container: test-container Out: Added to the repo: 392.747 KiB 
INFO[0012] Pod: test-statefulset-jqg56-0 Container: test-container Out: processed 63 files, 631.953 KiB in 0:00 
INFO[0012] Pod: test-statefulset-jqg56-0 Container: test-container Out: snapshot 6355bbb0 saved 
INFO[0017] Pod: describe-backups-gq8xm Container: container Out: Fatal: wrong password or no key found 
PASS: data_test.go:585: DataSuite.TestDescribeBackupsWrongPassword	15.235s

START: data_test.go:107: DataSuite.TearDownSuite
PASS: data_test.go:107: DataSuite.TearDownSuite	1.293s

START: data_test.go:56: DataSuite.SetUpSuite
SKIP: data_test.go:56: DataSuite.SetUpSuite (Test  requires the environemnt variable 'GOOGLE_APPLICATION_CREDENTIALS')

START: data_test.go:585: DataSuite.TestDescribeBackupsWrongPassword
SKIP: data_test.go:585: DataSuite.TestDescribeBackupsWrongPassword

START: data_test.go:107: DataSuite.TearDownSuite
PASS: data_test.go:107: DataSuite.TearDownSuite	0.035s

OK: 1 passed, 1 skipped
PASS
ok  	github.com/kanisterio/kanister/pkg/function	20.306s

```
```
$ go test -check.vv -check.f=TestDescribeBackupsRepoNotAvailable
go: finding github.com/graymeta/stow v0.0.0-00010101000000-000000000000
START: data_test.go:56: DataSuite.SetUpSuite
PASS: data_test.go:56: DataSuite.SetUpSuite	1.929s

START: data_test.go:603: DataSuite.TestDescribeBackupsRepoNotAvailable
INFO[0006] Pod: test-statefulset-h58gr-0 Container: test-container Out: Fatal: unable to open config file: Stat: The specified key does not exist. 
INFO[0006] Pod: test-statefulset-h58gr-0 Container: test-container Out: Is there a repository at the following location? 
INFO[0006] Pod: test-statefulset-h58gr-0 Container: test-container Out: s3:s3.amazonaws.com/kio-store-tests/testBackupRestoreLocDelete 
INFO[0006] Pod: test-statefulset-h58gr-0 Container: test-container Out: Fatal: unable to open config file: Stat: The specified key does not exist. 
INFO[0006] Pod: test-statefulset-h58gr-0 Container: test-container Out: Is there a repository at the following location? 
INFO[0006] Pod: test-statefulset-h58gr-0 Container: test-container Out: s3:s3.amazonaws.com/kio-store-tests/testBackupRestoreLocDelete 
INFO[0010] Pod: test-statefulset-h58gr-0 Container: test-container Out: created restic repository c348679cf6 at s3:s3.amazonaws.com/kio-store-tests/testBackupRestoreLocDelete 
INFO[0010] Pod: test-statefulset-h58gr-0 Container: test-container Out: Please note that knowledge of your password is required to access 
INFO[0010] Pod: test-statefulset-h58gr-0 Container: test-container Out: the repository. Losing your password means that your data is 
INFO[0010] Pod: test-statefulset-h58gr-0 Container: test-container Out: irrecoverably lost. 
INFO[0012] Pod: test-statefulset-h58gr-0 Container: test-container Out: created new cache in /root/.cache/restic 
INFO[0012] Pod: test-statefulset-h58gr-0 Container: test-container Out: Files:          63 new,     0 changed,     0 unmodified 
INFO[0012] Pod: test-statefulset-h58gr-0 Container: test-container Out: Dirs:            0 new,     0 changed,     0 unmodified 
INFO[0012] Pod: test-statefulset-h58gr-0 Container: test-container Out: Added to the repo: 392.746 KiB 
INFO[0012] Pod: test-statefulset-h58gr-0 Container: test-container Out: processed 63 files, 631.953 KiB in 0:00 
INFO[0012] Pod: test-statefulset-h58gr-0 Container: test-container Out: snapshot 93c8acb6 saved 
INFO[0017] Pod: describe-backups-q7m8f Container: container Out: Fatal: unable to open config file: Stat: The specified key does not exist. 
INFO[0017] Pod: describe-backups-q7m8f Container: container Out: Is there a repository at the following location? 
INFO[0017] Pod: describe-backups-q7m8f Container: container Out: s3:s3.amazonaws.com/kio-store-tests/testBackupRestoreLocDelete/foobar 
PASS: data_test.go:603: DataSuite.TestDescribeBackupsRepoNotAvailable	15.230s

START: data_test.go:107: DataSuite.TearDownSuite
PASS: data_test.go:107: DataSuite.TearDownSuite	1.248s

START: data_test.go:56: DataSuite.SetUpSuite
SKIP: data_test.go:56: DataSuite.SetUpSuite (Test  requires the environemnt variable 'GOOGLE_APPLICATION_CREDENTIALS')

START: data_test.go:603: DataSuite.TestDescribeBackupsRepoNotAvailable
SKIP: data_test.go:603: DataSuite.TestDescribeBackupsRepoNotAvailable

START: data_test.go:107: DataSuite.TearDownSuite
PASS: data_test.go:107: DataSuite.TearDownSuite	0.030s

OK: 1 passed, 1 skipped
PASS
ok  	github.com/kanisterio/kanister/pkg/function	20.286s

```
- [ ] E2E
