### PR TITLE
Use default container if not specified in KubeExec function

### DIFF
--- a/docs/functions.rst
+++ b/docs/functions.rst
@@ -49,7 +49,7 @@ KubeExec is similar to running
 
    `namespace`, Yes, `string`, namespace in which to execute
    `pod`, Yes, `string`, name of the pod in which to execute
-   `container`, Yes, `string`, name of the container in which to execute
+   `container`, No , `string`, (required if pod contains more than 1 container) name of the container in which to execute
    `command`, Yes, `[]string`,  command list to execute
 
 Example:

--- a/pkg/function/kube_exec.go
+++ b/pkg/function/kube_exec.go
@@ -85,7 +85,7 @@ func (kef *kubeExecFunc) Exec(ctx context.Context, tp param.TemplateParams, args
 	if err = Arg(args, KubeExecPodNameArg, &pod); err != nil {
 		return nil, err
 	}
-	if err = Arg(args, KubeExecContainerNameArg, &container); err != nil {
+	if err = OptArg(args, KubeExecContainerNameArg, &container, ""); err != nil {
 		return nil, err
 	}
 	if err = Arg(args, KubeExecCommandArg, &cmd); err != nil {
@@ -105,5 +105,5 @@ func (kef *kubeExecFunc) Exec(ctx context.Context, tp param.TemplateParams, args
 }
 
 func (*kubeExecFunc) RequiredArgs() []string {
-	return []string{KubeExecNamespaceArg, KubeExecPodNameArg, KubeExecContainerNameArg, KubeExecCommandArg}
+	return []string{KubeExecNamespaceArg, KubeExecPodNameArg, KubeExecCommandArg}
 }

--- a/pkg/kube/exec.go
+++ b/pkg/kube/exec.go
@@ -64,8 +64,12 @@ func ExecWithOptions(kubeCli kubernetes.Interface, options ExecOptions) (string,
 		Resource("pods").
 		Name(options.PodName).
 		Namespace(options.Namespace).
-		SubResource("exec").
-		Param("container", options.ContainerName)
+		SubResource("exec")
+
+	// Add container name if passed
+	if len(options.ContainerName) != 0 {
+		req.Param("container", options.ContainerName)
+	}
 	for _, c := range options.Command {
 		req.Param("command", c)
 	}

--- a/pkg/kube/exec_test.go
+++ b/pkg/kube/exec_test.go
@@ -74,6 +74,7 @@ func (s *ExecSuite) TearDownSuite(c *C) {
 		c.Assert(err, IsNil)
 	}
 }
+
 func (s *ExecSuite) TestExecEcho(c *C) {
 	cmd := []string{"sh", "-c", "cat -"}
 	c.Assert(s.pod.Status.Phase, Equals, v1.PodRunning)
@@ -84,4 +85,14 @@ func (s *ExecSuite) TestExecEcho(c *C) {
 		c.Assert(stdout, Equals, "badabing")
 		c.Assert(stderr, Equals, "")
 	}
+}
+
+func (s *ExecSuite) TestExecEchoDefaultContainer(c *C) {
+	cmd := []string{"sh", "-c", "cat -"}
+	c.Assert(s.pod.Status.Phase, Equals, v1.PodRunning)
+	c.Assert(len(s.pod.Status.ContainerStatuses) > 0, Equals, true)
+	stdout, stderr, err := Exec(s.cli, s.pod.Namespace, s.pod.Name, "", cmd, bytes.NewBufferString("badabing"))
+	c.Assert(err, IsNil)
+	c.Assert(stdout, Equals, "badabing")
+	c.Assert(stderr, Equals, "")
 }


### PR DESCRIPTION
## Change Overview
Add support in KubeExec function to use default container if container name not specified and pod contains single container

<!-- Insert PR description-->

## Pull request type

Please check the type of change your PR introduces:
- [ ] Work in Progress
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Trivial/Minor
- [ ] Bugfix
- [x] Feature
- [ ] Documentation

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] Manual
- [ ] Unit test
- [ ] E2E
