### PR TITLE
Add Version field to ActionSetSpec

### DIFF
--- a/pkg/apis/cr/v1alpha1/types.go
+++ b/pkg/apis/cr/v1alpha1/types.go
@@ -105,6 +105,9 @@ type ActionSpec struct {
 	// Options will be used to specify additional values
 	// to be used in the Blueprint.
 	Options map[string]string `json:"options"`
+	// Version will be used to select the version of Kanister functions
+	// to be executed for this action
+	Version string `json:"version"`
 }
 
 // ActionSetStatus is the status for the actionset. This should only be updated by the controller.


### PR DESCRIPTION
## Change Overview

- Add a `Version` field to `ActionSetSpec`. This will be used to select the version of functions to run for an action.
This is the first of many small PRs coming out for dynamic function registration.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [x] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
