### PR TITLE
Adding backup stats to copy function

### DIFF
--- a/pkg/function/backup_data.go
+++ b/pkg/function/backup_data.go
@@ -50,7 +50,7 @@ const (
 	BackupDataOutputBackupID = "backupID"
 	// BackupDataOutputBackupTag is the key used for returning backupTag output
 	BackupDataOutputBackupTag = "backupTag"
-	// BackupDataOutputBackupFileCount is the key used for returning backup size
+	// BackupDataOutputBackupFileCount is the key used for returning backup file count
 	BackupDataOutputBackupFileCount = "fileCount"
 	// BackupDataOutputBackupSize is the key used for returning backup size
 	BackupDataOutputBackupSize = "size"

--- a/pkg/function/backup_data.go
+++ b/pkg/function/backup_data.go
@@ -50,6 +50,10 @@ const (
 	BackupDataOutputBackupID = "backupID"
 	// BackupDataOutputBackupTag is the key used for returning backupTag output
 	BackupDataOutputBackupTag = "backupTag"
+	// BackupDataOutputBackupFileCount is the key used for returning backup size
+	BackupDataOutputBackupFileCount = "fileCount"
+	// BackupDataOutputBackupSize is the key used for returning backup size
+	BackupDataOutputBackupSize = "size"
 )
 
 func init() {
@@ -117,10 +121,10 @@ func (*backupDataFunc) Exec(ctx context.Context, tp param.TemplateParams, args m
 		return nil, errors.Wrapf(err, "Failed to backup data")
 	}
 	output := map[string]interface{}{
-		BackupDataOutputBackupID:       backupOutputs.backupID,
-		BackupDataOutputBackupTag:      backupOutputs.backupTag,
-		BackupDataStatsOutputFileCount: backupOutputs.fileCount,
-		BackupDataStatsOutputSize:      backupOutputs.backupSize,
+		BackupDataOutputBackupID:        backupOutputs.backupID,
+		BackupDataOutputBackupTag:       backupOutputs.backupTag,
+		BackupDataOutputBackupFileCount: backupOutputs.fileCount,
+		BackupDataOutputBackupSize:      backupOutputs.backupSize,
 	}
 	return output, nil
 }

--- a/pkg/function/copy_volume_data.go
+++ b/pkg/function/copy_volume_data.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
@@ -28,6 +27,7 @@ import (
 	kanister "github.com/kanisterio/kanister/pkg"
 	"github.com/kanisterio/kanister/pkg/format"
 	"github.com/kanisterio/kanister/pkg/kube"
+	"github.com/kanisterio/kanister/pkg/log"
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/restic"
 )

--- a/pkg/function/copy_volume_data.go
+++ b/pkg/function/copy_volume_data.go
@@ -115,7 +115,7 @@ func copyVolumeDataPodFunc(cli kubernetes.Interface, tp param.TemplateParams, na
 		}
 		fileCount, backupSize := restic.SnapshotStatsFromBackupLog(stdout)
 		if backupSize == "" {
-			log.Error("Could not parse backup size from backup output")
+			log.Debug().Print("Could not parse backup stats from backup log")
 		}
 		return map[string]interface{}{
 				CopyVolumeDataOutputBackupID:               backupID,


### PR DESCRIPTION
## Change Overview

Adding size and file count outputs to Copy Volume function and changing backup stats output keys to be defined as their own named keys.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [x] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
