### PR TITLE
Dynamic registration of Kanister functions with multiple versions

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -381,7 +381,7 @@ func (c *Controller) runAction(ctx context.Context, as *crv1alpha1.ActionSet, aI
 	if err != nil {
 		return err
 	}
-	phases, err := kanister.GetPhases(*bp, action.Name, *tp)
+	phases, err := kanister.GetPhases(*bp, action.Name, action.Version, *tp)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -23,11 +23,12 @@ import (
 	"github.com/pkg/errors"
 	. "gopkg.in/check.v1"
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/record"
 
+	kanister "github.com/kanisterio/kanister/pkg"
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	"github.com/kanisterio/kanister/pkg/client/clientset/versioned/scheme"
 	crclientv1alpha1 "github.com/kanisterio/kanister/pkg/client/clientset/versioned/typed/cr/v1alpha1"
@@ -268,42 +269,57 @@ func (s *ControllerSuite) TestExecActionSet(c *C) {
 			funcNames []string
 			args      [][]string
 			name      string
+			version   string
 		}{
 			{
 				funcNames: []string{testutil.WaitFuncName},
 				name:      "WaitFunc",
+				version:   kanister.DefaultVersion,
 			},
 			{
 				funcNames: []string{testutil.WaitFuncName, testutil.WaitFuncName},
 				name:      "WaitWait",
+				version:   kanister.DefaultVersion,
 			},
 			{
 				funcNames: []string{testutil.FailFuncName},
 				name:      "FailFunc",
+				version:   kanister.DefaultVersion,
 			},
 			{
 				funcNames: []string{testutil.WaitFuncName, testutil.FailFuncName},
 				name:      "WaitFail",
+				version:   kanister.DefaultVersion,
 			},
 			{
 				funcNames: []string{testutil.FailFuncName, testutil.WaitFuncName},
 				name:      "FailWait",
+				version:   kanister.DefaultVersion,
 			},
 			{
 				funcNames: []string{testutil.ArgFuncName},
 				name:      "ArgFunc",
+				version:   kanister.DefaultVersion,
 			},
 			{
 				funcNames: []string{testutil.ArgFuncName, testutil.FailFuncName},
 				name:      "ArgFail",
+				version:   kanister.DefaultVersion,
 			},
 			{
 				funcNames: []string{testutil.OutputFuncName},
 				name:      "OutputFunc",
+				version:   kanister.DefaultVersion,
 			},
 			{
 				funcNames: []string{testutil.CancelFuncName},
 				name:      "CancelFunc",
+				version:   kanister.DefaultVersion,
+			},
+			{
+				funcNames: []string{testutil.ArgFuncName, testutil.FailFuncName},
+				name:      "ArgFailVersion",
+				version:   testutil.TestVersion,
 			},
 		} {
 			var err error
@@ -324,7 +340,7 @@ func (s *ControllerSuite) TestExecActionSet(c *C) {
 			}
 
 			// Add an actionset that references that blueprint.
-			as := testutil.NewTestActionSet(s.namespace, bp.GetName(), pok, n, s.namespace)
+			as := testutil.NewTestActionSet(s.namespace, bp.GetName(), pok, n, s.namespace, tc.version)
 			as = testutil.ActionSetWithConfigMap(as, s.confimap.GetName())
 			as, err = s.crCli.ActionSets(s.namespace).Create(as)
 			c.Assert(err, IsNil, Commentf("Failed case: %s", tc.name))
@@ -442,7 +458,7 @@ func (s *ControllerSuite) TestPhaseOutputAsArtifact(c *C) {
 	c.Assert(err, IsNil)
 
 	// Add an actionset that references that blueprint.
-	as := testutil.NewTestActionSet(s.namespace, bp.GetName(), "Deployment", s.deployment.GetName(), s.namespace)
+	as := testutil.NewTestActionSet(s.namespace, bp.GetName(), "Deployment", s.deployment.GetName(), s.namespace, kanister.DefaultVersion)
 	as = testutil.ActionSetWithConfigMap(as, s.confimap.GetName())
 	as, err = s.crCli.ActionSets(s.namespace).Create(as)
 	c.Assert(err, IsNil)
@@ -472,7 +488,7 @@ func (s *ControllerSuite) TestRenderArtifactsFailure(c *C) {
 	c.Assert(err, IsNil)
 
 	// Add an actionset that references that blueprint.
-	as := testutil.NewTestActionSet(s.namespace, bp.GetName(), "Deployment", s.deployment.GetName(), s.namespace)
+	as := testutil.NewTestActionSet(s.namespace, bp.GetName(), "Deployment", s.deployment.GetName(), s.namespace, kanister.DefaultVersion)
 	as = testutil.ActionSetWithConfigMap(as, s.confimap.GetName())
 	as, err = s.crCli.ActionSets(s.namespace).Create(as)
 	c.Assert(err, IsNil)

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -317,9 +317,24 @@ func (s *ControllerSuite) TestExecActionSet(c *C) {
 				version:   kanister.DefaultVersion,
 			},
 			{
-				funcNames: []string{testutil.ArgFuncName, testutil.FailFuncName},
-				name:      "ArgFailVersion",
+				funcNames: []string{testutil.ArgFuncName},
+				name:      "ArgFuncVersion",
 				version:   testutil.TestVersion,
+			},
+			{
+				funcNames: []string{testutil.ArgFuncName},
+				name:      "ArgFuncVersionFallback",
+				version:   "v1.2.3",
+			},
+			{
+				funcNames: []string{testutil.ArgFuncName},
+				name:      "ArgFuncNoActionSetVersion",
+				version:   "",
+			},
+			{
+				funcNames: []string{testutil.VersionMismatchFuncName},
+				name:      "VersionMismatchFunc",
+				version:   "v1.2.3",
 			},
 		} {
 			var err error
@@ -368,6 +383,9 @@ func (s *ControllerSuite) TestExecActionSet(c *C) {
 					c.Assert(err, IsNil)
 					c.Assert(testutil.CancelFuncOut().Error(), DeepEquals, "context canceled")
 					cancel = true
+				case testutil.VersionMismatchFuncName:
+					final = crv1alpha1.StateFailed
+					c.Assert(err, IsNil)
 				}
 			}
 

--- a/pkg/function/data_test.go
+++ b/pkg/function/data_test.go
@@ -532,7 +532,7 @@ func (s *DataSuite) TestCopyData(c *C) {
 }
 
 func runAction(c *C, bp crv1alpha1.Blueprint, action string, tp *param.TemplateParams) map[string]interface{} {
-	phases, err := kanister.GetPhases(bp, action, *tp)
+	phases, err := kanister.GetPhases(bp, action, kanister.DefaultVersion, *tp)
 	c.Assert(err, IsNil)
 	out := make(map[string]interface{})
 	for _, p := range phases {

--- a/pkg/function/e2e_volume_snapshot_test.go
+++ b/pkg/function/e2e_volume_snapshot_test.go
@@ -311,7 +311,7 @@ func (s *VolumeSnapshotTestSuite) TestVolumeSnapshot(c *C) {
 	actions := []string{"backup", "restore", "delete"}
 	bp := newVolumeSnapshotBlueprint()
 	for _, action := range actions {
-		phases, err := kanister.GetPhases(*bp, action, *s.tp)
+		phases, err := kanister.GetPhases(*bp, action, kanister.DefaultVersion, *s.tp)
 		c.Assert(err, IsNil)
 		for _, p := range phases {
 			c.Assert(param.InitPhaseParams(ctx, s.cli, s.tp, p.Name(), p.Objects()), IsNil)

--- a/pkg/function/kube_exec_all_test.go
+++ b/pkg/function/kube_exec_all_test.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 
 	. "gopkg.in/check.v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes"
@@ -129,7 +129,7 @@ func (s *KubeExecAllTest) TestKubeExecAllDeployment(c *C) {
 
 	action := "echo"
 	bp := newExecAllBlueprint(kind)
-	phases, err := kanister.GetPhases(*bp, action, *tp)
+	phases, err := kanister.GetPhases(*bp, action, kanister.DefaultVersion, *tp)
 	c.Assert(err, IsNil)
 	for _, p := range phases {
 		_, err = p.Exec(ctx, *bp, action, *tp)
@@ -163,7 +163,7 @@ func (s *KubeExecAllTest) TestKubeExecAllStatefulSet(c *C) {
 
 	action := "echo"
 	bp := newExecAllBlueprint(kind)
-	phases, err := kanister.GetPhases(*bp, action, *tp)
+	phases, err := kanister.GetPhases(*bp, action, kanister.DefaultVersion, *tp)
 	c.Assert(err, IsNil)
 	for _, p := range phases {
 		_, err = p.Exec(ctx, *bp, action, *tp)

--- a/pkg/function/kube_exec_test.go
+++ b/pkg/function/kube_exec_test.go
@@ -158,7 +158,7 @@ func (s *KubeExecTest) TestKubeExec(c *C) {
 
 	action := "echo"
 	bp := newKubeExecBlueprint()
-	phases, err := kanister.GetPhases(*bp, action, *tp)
+	phases, err := kanister.GetPhases(*bp, action, kanister.DefaultVersion, *tp)
 	c.Assert(err, IsNil)
 	for _, p := range phases {
 		_, err = p.Exec(context.Background(), *bp, action, *tp)

--- a/pkg/function/kube_task_test.go
+++ b/pkg/function/kube_task_test.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	. "gopkg.in/check.v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	sp "k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/client-go/kubernetes"
@@ -153,7 +153,7 @@ func (s *KubeTaskSuite) TestKubeTask(c *C) {
 		},
 	} {
 
-		phases, err := kanister.GetPhases(*tc.bp, action, tp)
+		phases, err := kanister.GetPhases(*tc.bp, action, kanister.DefaultVersion, tp)
 		c.Assert(err, IsNil)
 		c.Assert(phases, HasLen, len(tc.outs))
 		for i, p := range phases {

--- a/pkg/function/prepare_data_test.go
+++ b/pkg/function/prepare_data_test.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 
 	. "gopkg.in/check.v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
@@ -144,7 +144,7 @@ func (s *PrepareDataSuite) TestPrepareData(c *C) {
 		}
 		action := "test"
 		bp := newPrepareDataBlueprint(kind, createdPVC.Name)
-		phases, err := kanister.GetPhases(*bp, action, tp)
+		phases, err := kanister.GetPhases(*bp, action, kanister.DefaultVersion, tp)
 		c.Assert(err, IsNil)
 		for _, p := range phases {
 			_, err = p.Exec(ctx, *bp, action, tp)

--- a/pkg/function/scale_test.go
+++ b/pkg/function/scale_test.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 
 	. "gopkg.in/check.v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes"
@@ -159,7 +159,7 @@ func (s *ScaleSuite) TestScaleDeployment(c *C) {
 		tp, err := param.New(ctx, s.cli, fake.NewSimpleDynamicClient(k8sscheme.Scheme, d), s.crCli, as)
 		c.Assert(err, IsNil)
 		bp := newScaleBlueprint(kind)
-		phases, err := kanister.GetPhases(*bp, action, *tp)
+		phases, err := kanister.GetPhases(*bp, action, kanister.DefaultVersion, *tp)
 		c.Assert(err, IsNil)
 		for _, p := range phases {
 			_, err = p.Exec(context.Background(), *bp, action, *tp)
@@ -208,7 +208,7 @@ func (s *ScaleSuite) TestScaleStatefulSet(c *C) {
 		tp, err := param.New(ctx, s.cli, fake.NewSimpleDynamicClient(k8sscheme.Scheme, ss), s.crCli, as)
 		c.Assert(err, IsNil)
 		bp := newScaleBlueprint(kind)
-		phases, err := kanister.GetPhases(*bp, action, *tp)
+		phases, err := kanister.GetPhases(*bp, action, kanister.DefaultVersion, *tp)
 		c.Assert(err, IsNil)
 		for _, p := range phases {
 			_, err = p.Exec(context.Background(), *bp, action, *tp)

--- a/pkg/testing/e2e_test.go
+++ b/pkg/testing/e2e_test.go
@@ -20,10 +20,11 @@ import (
 
 	"github.com/pkg/errors"
 	. "gopkg.in/check.v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
+	kanister "github.com/kanisterio/kanister/pkg"
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	crclient "github.com/kanisterio/kanister/pkg/client/clientset/versioned/typed/cr/v1alpha1"
 	"github.com/kanisterio/kanister/pkg/controller"
@@ -145,6 +146,7 @@ func (s *E2ESuite) TestKubeExec(c *C) {
 						Name:      p.GetName(),
 						Namespace: s.namespace,
 					},
+					Version: kanister.DefaultVersion,
 				},
 			},
 		},
@@ -268,6 +270,7 @@ func (s *E2ESuite) TestKubeTask(c *C) {
 					PodOverride: map[string]interface{}{
 						"dnsPolicy": "ClusterFirst",
 					},
+					Version: kanister.DefaultVersion,
 				},
 			},
 		},

--- a/pkg/testing/e2e_test.go
+++ b/pkg/testing/e2e_test.go
@@ -24,7 +24,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
-	kanister "github.com/kanisterio/kanister/pkg"
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	crclient "github.com/kanisterio/kanister/pkg/client/clientset/versioned/typed/cr/v1alpha1"
 	"github.com/kanisterio/kanister/pkg/controller"
@@ -146,7 +145,6 @@ func (s *E2ESuite) TestKubeExec(c *C) {
 						Name:      p.GetName(),
 						Namespace: s.namespace,
 					},
-					Version: kanister.DefaultVersion,
 				},
 			},
 		},
@@ -270,7 +268,6 @@ func (s *E2ESuite) TestKubeTask(c *C) {
 					PodOverride: map[string]interface{}{
 						"dnsPolicy": "ClusterFirst",
 					},
-					Version: kanister.DefaultVersion,
 				},
 			},
 		},

--- a/pkg/testutil/func.go
+++ b/pkg/testutil/func.go
@@ -24,12 +24,13 @@ import (
 )
 
 const (
-	FailFuncName   = "FailFunc"
-	WaitFuncName   = "WaitFunc"
-	ArgFuncName    = "ArgFunc"
-	OutputFuncName = "OutputFunc"
-	CancelFuncName = "CancelFunc"
-	TestVersion    = "v1.0.0"
+	FailFuncName            = "FailFunc"
+	WaitFuncName            = "WaitFunc"
+	ArgFuncName             = "ArgFunc"
+	OutputFuncName          = "OutputFunc"
+	CancelFuncName          = "CancelFunc"
+	VersionMismatchFuncName = "VerMisFunc"
+	TestVersion             = "v1.0.0"
 )
 
 var (
@@ -67,6 +68,10 @@ func cancelFunc(ctx context.Context, tp param.TemplateParams, args map[string]in
 	return nil, ctx.Err()
 }
 
+func versionMismatchFunc(ctx context.Context, tp param.TemplateParams, args map[string]interface{}) (map[string]interface{}, error) {
+	return nil, nil
+}
+
 func init() {
 	failFuncCh = make(chan error)
 	waitFuncCh = make(chan struct{})
@@ -79,6 +84,7 @@ func init() {
 	registerMockKanisterFunc(OutputFuncName, outputFunc)
 	registerMockKanisterFunc(CancelFuncName, cancelFunc)
 	registerMockKanisterFuncWithVersion(ArgFuncName, TestVersion, argsFunc)
+	registerMockKanisterFuncWithVersion(VersionMismatchFuncName, TestVersion, versionMismatchFunc)
 }
 
 func registerMockKanisterFunc(name string, f func(context.Context, param.TemplateParams, map[string]interface{}) (map[string]interface{}, error)) {

--- a/pkg/testutil/func.go
+++ b/pkg/testutil/func.go
@@ -29,6 +29,7 @@ const (
 	ArgFuncName    = "ArgFunc"
 	OutputFuncName = "OutputFunc"
 	CancelFuncName = "CancelFunc"
+	TestVersion    = "v1.0.0"
 )
 
 var (
@@ -77,10 +78,15 @@ func init() {
 	registerMockKanisterFunc(ArgFuncName, argsFunc)
 	registerMockKanisterFunc(OutputFuncName, outputFunc)
 	registerMockKanisterFunc(CancelFuncName, cancelFunc)
+	registerMockKanisterFuncWithVersion(ArgFuncName, TestVersion, argsFunc)
 }
 
 func registerMockKanisterFunc(name string, f func(context.Context, param.TemplateParams, map[string]interface{}) (map[string]interface{}, error)) {
 	kanister.Register(&mockKanisterFunc{name: name, f: f})
+}
+
+func registerMockKanisterFuncWithVersion(name, version string, f func(context.Context, param.TemplateParams, map[string]interface{}) (map[string]interface{}, error)) {
+	kanister.RegisterVersion(&mockKanisterFunc{name: name, f: f}, version)
 }
 
 var _ kanister.Func = (*mockKanisterFunc)(nil)

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -141,7 +141,7 @@ func NewTestProfile(namespace string, secretName string) *crv1alpha1.Profile {
 }
 
 // NewTestActionSet function returns a pointer to a new ActionSet test object
-func NewTestActionSet(namespace, blueprintName, poKind, poName, poNamespace string) *crv1alpha1.ActionSet {
+func NewTestActionSet(namespace, blueprintName, poKind, poName, poNamespace, version string) *crv1alpha1.ActionSet {
 	return &crv1alpha1.ActionSet{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "test-actionset-",
@@ -162,6 +162,7 @@ func NewTestActionSet(namespace, blueprintName, poKind, poName, poNamespace stri
 						Name:      TestProfileName,
 						Namespace: namespace,
 					},
+					Version: version,
 				},
 			},
 		},

--- a/pkg/testutil/testutil_test.go
+++ b/pkg/testutil/testutil_test.go
@@ -20,6 +20,7 @@ import (
 	. "gopkg.in/check.v1"
 	"k8s.io/client-go/kubernetes"
 
+	kanister "github.com/kanisterio/kanister/pkg"
 	crclientv1alpha1 "github.com/kanisterio/kanister/pkg/client/clientset/versioned/typed/cr/v1alpha1"
 	"github.com/kanisterio/kanister/pkg/kube"
 )
@@ -98,7 +99,7 @@ func testCRs(c *C, cli crclientv1alpha1.CrV1alpha1Interface, namespace, poKind, 
 		c.Assert(err, IsNil)
 	}()
 
-	as := NewTestActionSet(namespace, bp.GetName(), poKind, poName, namespace)
+	as := NewTestActionSet(namespace, bp.GetName(), poKind, poName, namespace, kanister.DefaultVersion)
 	as = ActionSetWithConfigMap(as, "")
 	as, err = cli.ActionSets(namespace).Create(as)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
## Change Overview

The PR can be reviewed commit wise.
- Register multiple functions with different versions
- Select appropriate version during execution of an `ActionSet` using `Version` supplied
- Add unit tests to verify registration of multiple functions, fall back mechanism, no version specified in `ActionSet` as well as no version found.
- Minor changes to signatures in existing tests

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [x] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [x] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
