### PR TITLE
[380] Update docs with correct command to install Kanister tools

### DIFF
--- a/docs/tooling.rst
+++ b/docs/tooling.rst
@@ -383,11 +383,8 @@ Installation of the tools requires `Go <https://golang.org/doc/install>`_ to be 
 
 .. code-block:: bash
 
-  # Installing kanctl
-  $ go install -v github.com/kanisterio/kanister/cmd/kanctl
-
-  # Installing kando
-  $ go install -v github.com/kanisterio/kanister/cmd/kando
+  # The script installs both kanctl and kando
+  $ curl https://raw.githubusercontent.com/kanisterio/kanister/master/scripts/get.sh | bash
 
 
 Docker Image

--- a/scripts/get.sh
+++ b/scripts/get.sh
@@ -59,7 +59,7 @@ verifySupported() {
         exit 1
     fi
 
-    local required_tools=("curl")
+    local required_tools=("curl" "shasum")
     for tool in "${required_tools[@]}"; do
         if ! type "${tool}" > /dev/null; then
             echo "${tool} is required"
@@ -103,7 +103,7 @@ downloadFile() {
     pushd "${KANISTER_TMP_ROOT}"
     local filtered_checksum="./${kanister_dist}.sha256"
     grep "${kanister_dist}" < "${kanister_checksum}" > "${filtered_checksum}"
-    sha256sum -c "${filtered_checksum}"
+    shasum -a 256 -c "${filtered_checksum}"
     popd
 }
 


### PR DESCRIPTION
## Change Overview

- Update docs with `get.sh` command.
- Changing `sha256sum` to `shasum -a 256` which is natively supported in both Linux and OSX.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #380 

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
