### PR TITLE
removed link using typeform workflow for link using complete slack workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ To get started or to better understand kanister, see the
 
 For troubleshooting help, you can email the [mailing
 list](https://groups.google.com/forum/#!forum/kanisterio), reach out to us on
-[Slack](https://kasten.typeform.com/to/QBcw8T), or file a [Github
+[Slack](https://join.slack.com/t/kanisterio/shared_invite/enQtNzg2MDc4NzA0ODY4LTU1NDU2NDZhYjk3YmE5MWNlZWMwYzk1NjNjOGQ3NjAyMjcxMTIyNTE1YzZlMzgwYmIwNWFkNjU0NGFlMzNjNTk), or file a [Github
 issue](https://github.com/kanisterio/kanister/issues).
 
 ## Presentations


### PR DESCRIPTION
## Change Overview

Changing the slack link in the README doc from the typeform workflow to a completely slack workflow. Decreases complexity for new sign-ons

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [X] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
