### PR TITLE
Fix get.sh to support go-releaser checksum filename

### DIFF
--- a/scripts/get.sh
+++ b/scripts/get.sh
@@ -86,7 +86,7 @@ downloadFile() {
 
     local release_url="${RELEASES_URL}/download/${version}"
     local kanister_dist="${DIST_NAME}_${version}_${OS}_${ARCH}.tar.gz"
-    local kanister_checksum="${DIST_NAME}_${version}_checksums.txt"
+    local kanister_checksum="checksums.txt"
 
     local download_url="${release_url}/${kanister_dist}"
     local checksum_url="${release_url}/${kanister_checksum}"


### PR DESCRIPTION
## Change Overview

The checksum filename format change. See https://github.com/kanisterio/kanister/issues/385

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

https://github.com/kanisterio/kanister/issues/385

## Test Plan

...
```
+ grep kanister_0.21.0_linux_amd64.tar.gz
+ shasum -a 256 -c ./kanister_0.21.0_linux_amd64.tar.gz.sha256
kanister_0.21.0_linux_amd64.tar.gz: OK
+ popd
/tmp
+ installFile
+ pushd /tmp/kanister-installer-TZR2zP
/tmp/kanister-installer-TZR2zP /tmp
+ tar xvf /tmp/kanister-installer-TZR2zP/kanister_0.21.0_linux_amd64.tar.gz
LICENSE
README.md
kanctl
kando
controller
+ rm /tmp/kanister-installer-TZR2zP/kanister_0.21.0_linux_amd64.tar.gz
+ echo 'Preparing to install into /usr/local/bin'
Preparing to install into /usr/local/bin
+ for bin_name in "${BIN_NAMES[@]}"
+ runAsRoot cp ./kanctl /usr/local/bin
+ local 'cmd=cp ./kanctl /usr/local/bin'
+ '[' 0 -ne 0 ']'
+ cp ./kanctl /usr/local/bin
+ for bin_name in "${BIN_NAMES[@]}"
+ runAsRoot cp ./kando /usr/local/bin
+ local 'cmd=cp ./kando /usr/local/bin'
+ '[' 0 -ne 0 ']'
+ cp ./kando /usr/local/bin
+ popd
/tmp
+ testBinaries
+ for bin_name in "${BIN_NAMES[@]}"
+ echo 'kanctl installed into /usr/local/bin/kanctl'
kanctl installed into /usr/local/bin/kanctl
+ type kanctl
+ for bin_name in "${BIN_NAMES[@]}"
+ echo 'kando installed into /usr/local/bin/kando'
kando installed into /usr/local/bin/kando
+ type kando
+ cleanup
+ [[ -d /tmp/kanister-installer-TZR2zP ]]
+ rm -rf /tmp/kanister-installer-TZR2zP
```

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
