### PR TITLE
Fix dereference of optional deletion policy field

### DIFF
--- a/pkg/kube/snapshot/snapshot.go
+++ b/pkg/kube/snapshot/snapshot.go
@@ -191,7 +191,7 @@ func CreateFromSource(ctx context.Context, snapCli snapshotclient.Interface, sou
 				Name:      snapshotName,
 			},
 			VolumeSnapshotClassName: source.VolumeSnapshotClassName,
-			DeletionPolicy:          &deletionPolicy,
+			DeletionPolicy:          deletionPolicy,
 		},
 	}
 	snap := &snapshot.VolumeSnapshot{
@@ -239,10 +239,10 @@ func getContent(ctx context.Context, snapCli snapshotclient.Interface, contentNa
 	return snapCli.VolumesnapshotV1alpha1().VolumeSnapshotContents().Get(contentName, metav1.GetOptions{})
 }
 
-func getDeletionPolicyFromClass(snapCli snapshotclient.Interface, snapClassName string) (snapshot.DeletionPolicy, error) {
+func getDeletionPolicyFromClass(snapCli snapshotclient.Interface, snapClassName string) (*snapshot.DeletionPolicy, error) {
 	vsc, err := snapCli.VolumesnapshotV1alpha1().VolumeSnapshotClasses().Get(snapClassName, metav1.GetOptions{})
 	if err != nil {
-		return "", errors.Wrapf(err, "Failed to find VolumeSnapshotClass: %s", snapClassName)
+		return nil, errors.Wrapf(err, "Failed to find VolumeSnapshotClass: %s", snapClassName)
 	}
-	return *vsc.DeletionPolicy, nil
+	return vsc.DeletionPolicy, nil
 }


### PR DESCRIPTION
## Change Overview

The `DeletionPolicy` field in a VolumeStorageClass is optional and should not be
dereferenced without a `nil` check. This fixes that.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test