### PR TITLE
Explicitly install npm in elastic image

### DIFF
--- a/examples/helm/kanister/kanister-elasticsearch/image/esdump-setup.sh
+++ b/examples/helm/kanister/kanister-elasticsearch/image/esdump-setup.sh
@@ -1,10 +1,9 @@
 #! /bin/sh
 
 apk add --update nodejs
-# install the latest version if not installed already!
-npm install -g npm
+apk add --update npm
 
-npm install -g yo grunt-cli bower express
+npm install -g npm yo grunt-cli bower express
 
 # check locations and packages are correct
 which node


### PR DESCRIPTION
## Change Overview

Should fix the following:
```
/esdump-setup.sh: line 5: npm: not found
/esdump-setup.sh: line 7: npm: not found
/usr/bin/node
v10.16.3
/esdump-setup.sh: line 13: npm: not found
/esdump-setup.sh: line 14: npm: not found
/esdump-setup.sh: line 15: npm: not found
The command '/bin/sh -c chmod +x /esdump-setup.sh && sync && /esdump-setup.sh' returned a non-zero code: 127
: exit status 127
make[1]: *** [run] Error 1
make: *** [gorelease] Error 2
```

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Test Plan

We should test building the image prior to merging.

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
