### PR TITLE
Only download kando on linux via get.sh

### DIFF
--- a/scripts/get.sh
+++ b/scripts/get.sh
@@ -11,7 +11,7 @@ set -o xtrace
 set -o pipefail
 
 DIST_NAME="kanister"
-BIN_NAMES=("kanctl" "kando")
+BIN_NAMES=("kanctl")
 RELEASES_URL="https://github.com/kanisterio/kanister/releases"
 
 : ${KANISTER_INSTALL_DIR:="/usr/local/bin"}
@@ -35,6 +35,8 @@ initArch() {
 initOS() {
     OS=$(uname | tr '[:upper:]' '[:lower:]')
     case "$OS" in
+        # On linux we also support kando
+        linux) BIN_NAMES=("kanctl" "kando");;
         # Minimalist GNU for Windows
         mingw*) OS='windows';;
     esac


### PR DESCRIPTION
## Change Overview

Should fix this on mac:
```
+ local 'cmd=cp ./kando /usr/local/bin'
+ '[' 501 -ne 0 ']'
+ cmd='sudo cp ./kando /usr/local/bin'
+ sudo cp ./kando /usr/local/bin
cp: ./kando: No such file or directory
```

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Test Plan

works on linux

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
