### PR TITLE
Return version as function output

### DIFF
--- a/pkg/function/backup_data.go
+++ b/pkg/function/backup_data.go
@@ -107,6 +107,7 @@ func (*backupDataFunc) Exec(ctx context.Context, tp param.TemplateParams, args m
 		BackupDataOutputBackupTag:       backupOutputs.backupTag,
 		BackupDataOutputBackupFileCount: backupOutputs.fileCount,
 		BackupDataOutputBackupSize:      backupOutputs.backupSize,
+		FunctionOutputVersion:           kanister.DefaultVersion,
 	}
 	return output, nil
 }

--- a/pkg/function/backup_data_all.go
+++ b/pkg/function/backup_data_all.go
@@ -148,5 +148,8 @@ func backupDataAll(ctx context.Context, cli kubernetes.Interface, namespace stri
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed to encode JSON data")
 	}
-	return map[string]interface{}{BackupDataAllOutput: string(manifestData)}, nil
+	return map[string]interface{}{
+		BackupDataAllOutput:   string(manifestData),
+		FunctionOutputVersion: kanister.DefaultVersion,
+	}, nil
 }

--- a/pkg/function/backup_data_stats.go
+++ b/pkg/function/backup_data_stats.go
@@ -102,6 +102,7 @@ func backupDataStatsPodFunc(cli kubernetes.Interface, tp param.TemplateParams, n
 				BackupDataStatsOutputMode:      mode,
 				BackupDataStatsOutputFileCount: fc,
 				BackupDataStatsOutputSize:      size,
+				FunctionOutputVersion:          kanister.DefaultVersion,
 			},
 			nil
 	}

--- a/pkg/function/checkRepository.go
+++ b/pkg/function/checkRepository.go
@@ -75,27 +75,25 @@ func CheckRepositoryPodFunc(cli kubernetes.Interface, tp param.TemplateParams, n
 			break
 		case strings.Contains(err.Error(), restic.PasswordIncorrect):
 			return map[string]interface{}{
-					CheckRepositoryPasswordIncorrect: "true",
-					CheckRepositoryRepoDoesNotExist:  "false",
-				},
-				nil
-
+				CheckRepositoryPasswordIncorrect: "true",
+				CheckRepositoryRepoDoesNotExist:  "false",
+				FunctionOutputVersion:            kanister.DefaultVersion,
+			}, nil
 		case strings.Contains(err.Error(), restic.RepoDoesNotExist):
 			return map[string]interface{}{
-
-					CheckRepositoryPasswordIncorrect: "false",
-					CheckRepositoryRepoDoesNotExist:  "true",
-				},
-				nil
+				CheckRepositoryPasswordIncorrect: "false",
+				CheckRepositoryRepoDoesNotExist:  "true",
+				FunctionOutputVersion:            kanister.DefaultVersion,
+			}, nil
 		default:
 			return nil, err
 
 		}
 		return map[string]interface{}{
-				CheckRepositoryPasswordIncorrect: "false",
-				CheckRepositoryRepoDoesNotExist:  "false",
-			},
-			nil
+			CheckRepositoryPasswordIncorrect: "false",
+			CheckRepositoryRepoDoesNotExist:  "false",
+			FunctionOutputVersion:            kanister.DefaultVersion,
+		}, nil
 	}
 }
 

--- a/pkg/function/copy_volume_data.go
+++ b/pkg/function/copy_volume_data.go
@@ -126,6 +126,7 @@ func copyVolumeDataPodFunc(cli kubernetes.Interface, tp param.TemplateParams, na
 				CopyVolumeDataOutputBackupTag:              backupTag,
 				CopyVolumeDataOutputBackupFileCount:        fileCount,
 				CopyVolumeDataOutputBackupSize:             backupSize,
+				FunctionOutputVersion:                      kanister.DefaultVersion,
 			},
 			nil
 	}

--- a/pkg/function/data_test.go
+++ b/pkg/function/data_test.go
@@ -360,6 +360,7 @@ func (s *DataSuite) TestBackupRestoreDeleteData(c *C) {
 		c.Assert(out[BackupDataOutputBackupTag].(string), Not(Equals), "")
 		c.Check(out[BackupDataStatsOutputFileCount].(string), Not(Equals), "")
 		c.Check(out[BackupDataStatsOutputSize].(string), Not(Equals), "")
+		c.Assert(out[FunctionOutputVersion].(string), Equals, kanister.DefaultVersion)
 
 		options := map[string]string{
 			BackupDataOutputBackupID:  out[BackupDataOutputBackupID].(string),
@@ -387,6 +388,7 @@ func (s *DataSuite) TestBackupRestoreDataWithSnapshotID(c *C) {
 		c.Assert(out[BackupDataOutputBackupTag].(string), Not(Equals), "")
 		c.Check(out[BackupDataStatsOutputFileCount].(string), Not(Equals), "")
 		c.Check(out[BackupDataStatsOutputSize].(string), Not(Equals), "")
+		c.Assert(out[FunctionOutputVersion].(string), Equals, kanister.DefaultVersion)
 
 		options := map[string]string{
 			BackupDataOutputBackupID:  out[BackupDataOutputBackupID].(string),
@@ -409,6 +411,7 @@ func (s *DataSuite) TestBackupRestoreDeleteDataAll(c *C) {
 	bp := *newBackupDataAllBlueprint()
 	out := runAction(c, bp, "backup", tp)
 	c.Assert(out[BackupDataAllOutput].(string), Not(Equals), "")
+	c.Assert(out[FunctionOutputVersion].(string), Equals, kanister.DefaultVersion)
 
 	output := make(map[string]BackupInfo)
 	c.Assert(json.Unmarshal([]byte(out[BackupDataAllOutput].(string)), &output), IsNil)
@@ -532,6 +535,7 @@ func (s *DataSuite) TestCopyData(c *C) {
 	c.Assert(out[CopyVolumeDataOutputBackupRoot].(string), Not(Equals), "")
 	c.Assert(out[CopyVolumeDataOutputBackupArtifactLocation].(string), Not(Equals), "")
 	c.Assert(out[CopyVolumeDataOutputBackupTag].(string), Not(Equals), "")
+	c.Assert(out[FunctionOutputVersion].(string), Equals, kanister.DefaultVersion)
 	options := map[string]string{
 		CopyVolumeDataOutputBackupID:               out[CopyVolumeDataOutputBackupID].(string),
 		CopyVolumeDataOutputBackupRoot:             out[CopyVolumeDataOutputBackupRoot].(string),
@@ -591,6 +595,7 @@ func (s *DataSuite) TestDescribeBackups(c *C) {
 	out := runAction(c, bp, "backup", tp)
 	c.Assert(out[BackupDataOutputBackupID].(string), Not(Equals), "")
 	c.Assert(out[BackupDataOutputBackupTag].(string), Not(Equals), "")
+	c.Assert(out[FunctionOutputVersion].(string), Equals, kanister.DefaultVersion)
 
 	// Test DescribeBackups
 	bp2 := *newDescribeBackupsBlueprint()
@@ -599,6 +604,7 @@ func (s *DataSuite) TestDescribeBackups(c *C) {
 	c.Assert(out2[DescribeBackupsSize].(string), Not(Equals), "")
 	c.Assert(out2[DescribeBackupsPasswordIncorrect].(string), Not(Equals), "")
 	c.Assert(out2[DescribeBackupsRepoDoesNotExist].(string), Not(Equals), "")
+	c.Assert(out2[FunctionOutputVersion].(string), Equals, kanister.DefaultVersion)
 }
 
 func (s *DataSuite) TestDescribeBackupsWrongPassword(c *C) {
@@ -611,12 +617,14 @@ func (s *DataSuite) TestDescribeBackupsWrongPassword(c *C) {
 	out := runAction(c, bp, "backup", tp)
 	c.Assert(out[BackupDataOutputBackupID].(string), Not(Equals), "")
 	c.Assert(out[BackupDataOutputBackupTag].(string), Not(Equals), "")
+	c.Assert(out[FunctionOutputVersion].(string), Equals, kanister.DefaultVersion)
 
 	// Test DescribeBackups
 	bp2 := *newDescribeBackupsBlueprint()
 	bp2.Actions["describeBackups"].Phases[0].Args[DescribeBackupsArtifactPrefixArg] = fmt.Sprintf("%s/%s", bp2.Actions["describeBackups"].Phases[0].Args[DescribeBackupsArtifactPrefixArg], "abcde")
 	out2 := runAction(c, bp2, "describeBackups", tp)
 	c.Assert(out2[DescribeBackupsPasswordIncorrect].(string), Equals, "true")
+	c.Assert(out2[FunctionOutputVersion].(string), Equals, kanister.DefaultVersion)
 }
 
 func (s *DataSuite) TestDescribeBackupsRepoNotAvailable(c *C) {
@@ -627,12 +635,14 @@ func (s *DataSuite) TestDescribeBackupsRepoNotAvailable(c *C) {
 	out := runAction(c, bp, "backup", tp)
 	c.Assert(out[BackupDataOutputBackupID].(string), Not(Equals), "")
 	c.Assert(out[BackupDataOutputBackupTag].(string), Not(Equals), "")
+	c.Assert(out[FunctionOutputVersion].(string), Equals, kanister.DefaultVersion)
 
 	// Test DescribeBackups
 	bp2 := *newDescribeBackupsBlueprint()
 	bp2.Actions["describeBackups"].Phases[0].Args[DescribeBackupsArtifactPrefixArg] = fmt.Sprintf("%s/%s", bp2.Actions["describeBackups"].Phases[0].Args[DescribeBackupsArtifactPrefixArg], c.TestName())
 	out2 := runAction(c, bp2, "describeBackups", tp)
 	c.Assert(out2[DescribeBackupsRepoDoesNotExist].(string), Equals, "true")
+	c.Assert(out2[FunctionOutputVersion].(string), Equals, kanister.DefaultVersion)
 }
 
 func (s *DataSuite) TestCheckRepository(c *C) {
@@ -643,12 +653,14 @@ func (s *DataSuite) TestCheckRepository(c *C) {
 	out := runAction(c, bp, "backup", tp)
 	c.Assert(out[BackupDataOutputBackupID].(string), Not(Equals), "")
 	c.Assert(out[BackupDataOutputBackupTag].(string), Not(Equals), "")
+	c.Assert(out[FunctionOutputVersion].(string), Equals, kanister.DefaultVersion)
 
 	// Test CheckRepository
 	bp2 := *newCheckRepositoryBlueprint()
 	out2 := runAction(c, bp2, "checkRepository", tp)
 	c.Assert(out2[CheckRepositoryPasswordIncorrect].(string), Equals, "false")
 	c.Assert(out2[CheckRepositoryRepoDoesNotExist].(string), Equals, "false")
+	c.Assert(out2[FunctionOutputVersion].(string), Equals, kanister.DefaultVersion)
 }
 
 func (s *DataSuite) TestCheckRepositoryWrongPassword(c *C) {
@@ -661,6 +673,7 @@ func (s *DataSuite) TestCheckRepositoryWrongPassword(c *C) {
 	out := runAction(c, bp, "backup", tp)
 	c.Assert(out[BackupDataOutputBackupID].(string), Not(Equals), "")
 	c.Assert(out[BackupDataOutputBackupTag].(string), Not(Equals), "")
+	c.Assert(out[FunctionOutputVersion].(string), Equals, kanister.DefaultVersion)
 
 	// Test CheckRepository
 	bp2 := *newCheckRepositoryBlueprint()
@@ -677,10 +690,12 @@ func (s *DataSuite) TestCheckRepositoryRepoNotAvailable(c *C) {
 	out := runAction(c, bp, "backup", tp)
 	c.Assert(out[BackupDataOutputBackupID].(string), Not(Equals), "")
 	c.Assert(out[BackupDataOutputBackupTag].(string), Not(Equals), "")
+	c.Assert(out[FunctionOutputVersion].(string), Equals, kanister.DefaultVersion)
 
 	// Test CheckRepository
 	bp2 := *newCheckRepositoryBlueprint()
 	bp2.Actions["checkRepository"].Phases[0].Args[CheckRepositoryArtifactPrefixArg] = fmt.Sprintf("%s/%s", bp2.Actions["checkRepository"].Phases[0].Args[CheckRepositoryArtifactPrefixArg], c.TestName())
 	out2 := runAction(c, bp2, "checkRepository", tp)
 	c.Assert(out2[CheckRepositoryRepoDoesNotExist].(string), Equals, "true")
+	c.Assert(out2[FunctionOutputVersion].(string), Equals, kanister.DefaultVersion)
 }

--- a/pkg/function/describe_backups.go
+++ b/pkg/function/describe_backups.go
@@ -97,6 +97,7 @@ func describeBackupsPodFunc(cli kubernetes.Interface, tp param.TemplateParams, n
 					DescribeBackupsSize:              nil,
 					DescribeBackupsPasswordIncorrect: "true",
 					DescribeBackupsRepoDoesNotExist:  "false",
+					FunctionOutputVersion:            kanister.DefaultVersion,
 				},
 				nil
 
@@ -106,6 +107,7 @@ func describeBackupsPodFunc(cli kubernetes.Interface, tp param.TemplateParams, n
 					DescribeBackupsSize:              nil,
 					DescribeBackupsPasswordIncorrect: "false",
 					DescribeBackupsRepoDoesNotExist:  "true",
+					FunctionOutputVersion:            kanister.DefaultVersion,
 				},
 				nil
 		default:
@@ -132,6 +134,7 @@ func describeBackupsPodFunc(cli kubernetes.Interface, tp param.TemplateParams, n
 				DescribeBackupsSize:              size,
 				DescribeBackupsPasswordIncorrect: "false",
 				DescribeBackupsRepoDoesNotExist:  "false",
+				FunctionOutputVersion:            kanister.DefaultVersion,
 			},
 			nil
 	}

--- a/pkg/function/utils.go
+++ b/pkg/function/utils.go
@@ -15,6 +15,10 @@ import (
 	"github.com/kanisterio/kanister/pkg/secrets"
 )
 
+const (
+	FunctionOutputVersion = "version"
+)
+
 // ValidateCredentials verifies if the given credentials have appropriate values set
 func ValidateCredentials(creds *param.Credential) error {
 	if creds == nil {


### PR DESCRIPTION
## Change Overview

- Returning `DefaultVersion` as a part of the output for data related functions.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [x] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
