### PR TITLE
Succeed CSI Snapshot Delete if the snapshot wasn't found

### DIFF
--- a/pkg/kube/snapshot/snapshot.go
+++ b/pkg/kube/snapshot/snapshot.go
@@ -95,7 +95,7 @@ func Get(ctx context.Context, snapCli snapshotclient.Interface, name, namespace 
 // 'name' is the name of the VolumeSnapshot that will be deleted.
 // 'namespace' is the namespace of the VolumeSnapshot that will be deleted.
 func Delete(ctx context.Context, snapCli snapshotclient.Interface, name, namespace string) error {
-	if err := snapCli.VolumesnapshotV1alpha1().VolumeSnapshots(namespace).Delete(name, &metav1.DeleteOptions{}); err == nil || !apierrors.IsNotFound(err) {
+	if err := snapCli.VolumesnapshotV1alpha1().VolumeSnapshots(namespace).Delete(name, &metav1.DeleteOptions{}); !apierrors.IsNotFound(err) {
 		return err
 	}
 	// If the Snapshot does not exist, that's an acceptable error and we ignore it

--- a/pkg/kube/snapshot/snapshot.go
+++ b/pkg/kube/snapshot/snapshot.go
@@ -19,9 +19,9 @@ import (
 
 	snapshot "github.com/kubernetes-csi/external-snapshotter/pkg/apis/volumesnapshot/v1alpha1"
 	snapshotclient "github.com/kubernetes-csi/external-snapshotter/pkg/client/clientset/versioned"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	k8errors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"

--- a/pkg/kube/snapshot/snapshot_test.go
+++ b/pkg/kube/snapshot/snapshot_test.go
@@ -146,7 +146,7 @@ func (s *SnapshotTestSuite) TestVolumeSnapshotFake(c *C) {
 	err = Delete(context.Background(), fakeSnapCli, snap.Name, snap.Namespace)
 	c.Assert(err, IsNil)
 	err = Delete(context.Background(), fakeSnapCli, snap.Name, snap.Namespace)
-	c.Assert(err, NotNil)
+	c.Assert(err, IsNil)
 }
 
 func (s *SnapshotTestSuite) TestVolumeSnapshotCloneFake(c *C) {


### PR DESCRIPTION
## Change Overview

Ignore "not found" errors when deleting a `VolumeSnapshot`. Handles cases where the 
VS was manually deleted or deleted due to a namespace cleanup.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
