### PR TITLE
Update base pg image in kan-tool-pg to alpine12.0

### DIFF
--- a/docker/postgres-kanister-tools/Dockerfile
+++ b/docker/postgres-kanister-tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:9.6-alpine
+FROM postgres:12.0-alpine
 LABEL maintainer="vkamra@kasten.io"
 
 ENV DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
## Change Overview

Required to work with the latest helm chart:
```
time="2019-11-15T03:09:37Z" level=info Pod_Out="server version: 11.5; pg_dumpall version: 9.6.15"
time="2019-11-15T03:09:37Z" level=info Pod_Out="aborting because of server version mismatch"
```

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
