### PR TITLE
Bugfix: use getConfig() to get correct creds for blockstorage provider

### DIFF
--- a/pkg/function/create_volume_snapshot.go
+++ b/pkg/function/create_volume_snapshot.go
@@ -98,7 +98,7 @@ func ValidateLocationForBlockstorage(profile *param.Profile, sType blockstorage.
 			return errors.Errorf("Location type %s not supported for blockstorage type %s", profile.Location.Type, sType)
 		}
 	default:
-		return errors.Errorf("Storage provider not supported %s" + sType)
+		return errors.Errorf("Storage provider not supported %s", sType)
 	}
 	return nil
 }

--- a/pkg/function/create_volume_snapshot.go
+++ b/pkg/function/create_volume_snapshot.go
@@ -97,6 +97,8 @@ func ValidateLocationForBlockstorage(profile *param.Profile, sType blockstorage.
 		if profile.Location.Type != crv1alpha1.LocationTypeGCS {
 			return errors.Errorf("Location type %s not supported for blockstorage type %s", profile.Location.Type, sType)
 		}
+	default:
+		return errors.Errorf("Storage provider not supported %s" + sType)
 	}
 	return nil
 }

--- a/pkg/function/wait_for_snapshot_completion_test.go
+++ b/pkg/function/wait_for_snapshot_completion_test.go
@@ -19,10 +19,12 @@ import (
 	"encoding/json"
 
 	. "gopkg.in/check.v1"
+	v1 "k8s.io/api/core/v1"
 
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	"github.com/kanisterio/kanister/pkg/blockstorage"
 	"github.com/kanisterio/kanister/pkg/param"
+	"github.com/kanisterio/kanister/pkg/secrets"
 	"github.com/kanisterio/kanister/pkg/testutil/mockblockstorage"
 )
 
@@ -30,22 +32,9 @@ type WaitForSnapshotCompletionTestSuite struct{}
 
 var _ = Suite(&WaitForSnapshotCompletionTestSuite{})
 
-func (s *WaitForSnapshotCompletionTestSuite) TestWait(c *C) {
+func (s *WaitForSnapshotCompletionTestSuite) TestWaitwithRole(c *C) {
 	ctx := context.Background()
 	mockGetter := mockblockstorage.NewGetter()
-	profile := &param.Profile{
-		Location: crv1alpha1.Location{
-			Type:   crv1alpha1.LocationTypeS3Compliant,
-			Region: "us-west-2",
-		},
-		Credential: param.Credential{
-			Type: param.CredentialTypeKeyPair,
-			KeyPair: &param.KeyPair{
-				ID:     "foo",
-				Secret: "bar",
-			},
-		},
-	}
 	pvcData1 := []VolumeSnapshotInfo{
 		VolumeSnapshotInfo{SnapshotID: "snap-1", Type: blockstorage.TypeEBS, Region: "us-west-2", PVCName: "pvc-1", Az: "us-west-2a", VolumeType: "ssd"},
 		VolumeSnapshotInfo{SnapshotID: "snap-2", Type: blockstorage.TypeEBS, Region: "us-west-2", PVCName: "pvc-2", Az: "us-west-2a", VolumeType: "ssd"},
@@ -56,13 +45,48 @@ func (s *WaitForSnapshotCompletionTestSuite) TestWait(c *C) {
 	for _, tc := range []struct {
 		snapshotinfo string
 		check        Checker
+		profile      *param.Profile
 	}{
 		{
 			snapshotinfo: snapinfo,
 			check:        IsNil,
+			profile: &param.Profile{
+				Location: crv1alpha1.Location{
+					Type:   crv1alpha1.LocationTypeS3Compliant,
+					Region: "us-west-2",
+				},
+				Credential: param.Credential{
+					Type: param.CredentialTypeKeyPair,
+					KeyPair: &param.KeyPair{
+						ID:     "foo",
+						Secret: "bar",
+					},
+				},
+			},
+		},
+		{
+			snapshotinfo: snapinfo,
+			check:        IsNil,
+			profile: &param.Profile{
+				Location: crv1alpha1.Location{
+					Type:   crv1alpha1.LocationTypeS3Compliant,
+					Region: "us-west-2",
+				},
+				Credential: param.Credential{
+					Type: param.CredentialTypeSecret,
+					Secret: &v1.Secret{
+						Type: v1.SecretType(secrets.AWSSecretType),
+						Data: map[string][]byte{
+							secrets.AWSAccessKeyID:     []byte("key-id"),
+							secrets.AWSSecretAccessKey: []byte("access-key"),
+							secrets.ConfigRole:         []byte("role"),
+						},
+					},
+				},
+			},
 		},
 	} {
-		err := waitForSnapshotsCompletion(ctx, tc.snapshotinfo, profile, mockGetter)
+		err := waitForSnapshotsCompletion(ctx, tc.snapshotinfo, tc.profile, mockGetter)
 		c.Assert(err, tc.check)
 	}
 }


### PR DESCRIPTION
## Change Overview

Bugfix: use getConfig() to get correct creds for blockstorage provider when calling `provider.SnapshotCreateWaitForCompletion()` func

Without this change we did not check if `role` was set in param.Profile. With this PR, `getConfig()` will take care of providing correct configuration for the blockstorage provider. 

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E