### PR TITLE
Update helm/pg blueprint to set aws credentials according to credential type

### DIFF
--- a/examples/helm/kanister/kanister-postgresql/kanister/postgres-blueprint.yaml
+++ b/examples/helm/kanister/kanister-postgresql/kanister/postgres-blueprint.yaml
@@ -70,8 +70,13 @@ actions:
             {{- end }}
 
             set +o xtrace
-            echo "{{ .Profile.Credential.KeyPair.Secret }}" > "${env_wal_secret_access_key}"
-            echo "{{ .Profile.Credential.KeyPair.ID }}" > "${env_wal_access_key_id}"
+            {{- if eq .Profile.Credential.Type "keyPair" }}
+              echo "{{ .Profile.Credential.KeyPair.Secret }}" > "${env_wal_secret_access_key}"
+              echo "{{ .Profile.Credential.KeyPair.ID }}" > "${env_wal_access_key_id}"
+            {{- else }}
+              echo "{{ .Profile.Credential.Secret.Data.aws_secret_access_key | toString }}" > "${env_wal_secret_access_key}"
+              echo "{{ .Profile.Credential.Secret.Data.aws_access_key_id | toString }}" > "${env_wal_access_key_id}"
+            {{- end }}
             set -o xtrace
 
             # Create and push a base-backup to the object store.
@@ -93,8 +98,13 @@ actions:
             s3_cmd+=(s3 cp - "${s3_path}")
 
             set +o xtrace
-            export AWS_SECRET_ACCESS_KEY="{{ .Profile.Credential.KeyPair.Secret }}"
-            export AWS_ACCESS_KEY_ID="{{ .Profile.Credential.KeyPair.ID }}"
+            {{- if eq .Profile.Credential.Type "keyPair" }}
+              export AWS_SECRET_ACCESS_KEY="{{ .Profile.Credential.KeyPair.Secret }}"
+              export AWS_ACCESS_KEY_ID="{{ .Profile.Credential.KeyPair.ID }}"
+            {{- else }}
+              export AWS_SECRET_ACCESS_KEY="{{ .Profile.Credential.Secret.Data.aws_secret_access_key | toString }}"
+              export AWS_ACCESS_KEY_ID="{{ .Profile.Credential.Secret.Data.aws_access_key_id | toString }}"
+            {{- end }}
             set -o xtrace
 
             cat << EOF | ${s3_cmd[@]}
@@ -157,8 +167,13 @@ actions:
             s3_cmd+=(s3 cp "${s3_path}" -)
 
             set +o xtrace
-            export AWS_SECRET_ACCESS_KEY="{{ .Profile.Credential.KeyPair.Secret }}"
-            export AWS_ACCESS_KEY_ID="{{ .Profile.Credential.KeyPair.ID }}"
+            {{- if eq .Profile.Credential.Type "keyPair" }}
+              export AWS_SECRET_ACCESS_KEY="{{ .Profile.Credential.KeyPair.Secret }}"
+              export AWS_ACCESS_KEY_ID="{{ .Profile.Credential.KeyPair.ID }}"
+            {{- else }}
+              export AWS_SECRET_ACCESS_KEY="{{ .Profile.Credential.Secret.Data.aws_secret_access_key | toString }}"
+              export AWS_ACCESS_KEY_ID="{{ .Profile.Credential.Secret.Data.aws_access_key_id | toString }}"
+            {{- end }}
             set -o xtrace
 
             backup_name=$(${s3_cmd[@]} | grep 'backup_name' | cut -d'=' -f2)
@@ -257,8 +272,13 @@ actions:
           - |
             # Set S3 access keys.
             set +o xtrace
-            export AWS_SECRET_ACCESS_KEY="{{ .Profile.Credential.KeyPair.Secret }}"
-            export AWS_ACCESS_KEY_ID="{{ .Profile.Credential.KeyPair.ID }}"
+            {{- if eq .Profile.Credential.Type "keyPair" }}
+              export AWS_SECRET_ACCESS_KEY="{{ .Profile.Credential.KeyPair.Secret }}"
+              export AWS_ACCESS_KEY_ID="{{ .Profile.Credential.KeyPair.ID }}"
+            {{- else }}
+              export AWS_SECRET_ACCESS_KEY="{{ .Profile.Credential.Secret.Data.aws_secret_access_key | toString }}"
+              export AWS_ACCESS_KEY_ID="{{ .Profile.Credential.Secret.Data.aws_access_key_id | toString }}"
+            {{- end }}
             set -o xtrace
 
             # Setup configuration for the S3 client.


### PR DESCRIPTION
## Change Overview

Update helm/pg blueprint to set aws credentials according to credential type
Else e2e test will fail if we test it with S3 profile of credential type secret.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [x] :green_heart: E2E