### PR TITLE
Phy size consts for backup and delete

### DIFF
--- a/pkg/function/backup_data.go
+++ b/pkg/function/backup_data.go
@@ -54,6 +54,8 @@ const (
 	BackupDataOutputBackupFileCount = "fileCount"
 	// BackupDataOutputBackupSize is the key used for returning backup size
 	BackupDataOutputBackupSize = "size"
+	// BackupDataOutputBackupPhysicalSize is the key used for returning physical size taken by the snapshot
+	BackupDataOutputBackupPhysicalSize = "phySize"
 )
 
 func init() {
@@ -107,11 +109,12 @@ func (*backupDataFunc) Exec(ctx context.Context, tp param.TemplateParams, args m
 		return nil, errors.Wrapf(err, "Failed to backup data")
 	}
 	output := map[string]interface{}{
-		BackupDataOutputBackupID:        backupOutputs.backupID,
-		BackupDataOutputBackupTag:       backupOutputs.backupTag,
-		BackupDataOutputBackupFileCount: backupOutputs.fileCount,
-		BackupDataOutputBackupSize:      backupOutputs.backupSize,
-		FunctionOutputVersion:           kanister.DefaultVersion,
+		BackupDataOutputBackupID:           backupOutputs.backupID,
+		BackupDataOutputBackupTag:          backupOutputs.backupTag,
+		BackupDataOutputBackupFileCount:    backupOutputs.fileCount,
+		BackupDataOutputBackupSize:         backupOutputs.backupSize,
+		BackupDataOutputBackupPhysicalSize: backupOutputs.phySize,
+		FunctionOutputVersion:              kanister.DefaultVersion,
 	}
 	return output, nil
 }

--- a/pkg/function/delete_data.go
+++ b/pkg/function/delete_data.go
@@ -49,6 +49,8 @@ const (
 	// DeleteDataPodOverrideArg contains pod specs to override default pod specs
 	DeleteDataPodOverrideArg = "podOverride"
 	deleteDataJobPrefix      = "delete-data-"
+	// DeleteDataOutputSpaceFreed is the key for the output reporting the space freed
+	DeleteDataOutputSpaceFreed = "spaceFreed"
 )
 
 func init() {
@@ -129,7 +131,7 @@ func deleteDataPodFunc(cli kubernetes.Interface, tp param.TemplateParams, reclai
 		}
 
 		return map[string]interface{}{
-			"spaceFreed": fmt.Sprintf("%d B", spaceFreedTotal),
+			DeleteDataOutputSpaceFreed: fmt.Sprintf("%d B", spaceFreedTotal),
 		}, nil
 	}
 }


### PR DESCRIPTION
## Change Overview

Refactor: using constants for field keys instead of hardcoded string literals.
Also adding the physical size to the backups output, which had not been wired up in the earlier PR.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [x] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [x] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

