### PR TITLE
Add helm 3.0.0 in build docker image

### DIFF
--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -9,6 +9,8 @@ COPY --from=bitnami/kubectl:1.13.4 /opt/bitnami/kubectl/bin/kubectl /usr/local/b
 
 COPY --from=goreleaser/goreleaser:v0.116.0 /bin/goreleaser /usr/local/bin/
 
+COPY --from=alpine/helm:3.0.0 /usr/bin/helm /usr/local/bin/
+
 RUN wget -O /usr/local/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/v0.5.1/kind-linux-amd64 \
     && chmod +x /usr/local/bin/kind
 


### PR DESCRIPTION
Signed-off-by: Prasad Ghangal <prasad.ghangal@gmail.com>

## Change Overview

<!-- Insert PR description-->

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

```
$ docker build -t kanisterio/build:latest ./docker/build/
$ docker run kanisterio/build:latest helm version
version.BuildInfo{Version:"v3.0.0", GitCommit:"e29ce2a54e96cd02ccfce88bee4f58bb6e2a28b6", GitTreeState:"clean", GoVersion:"go1.13.4"}
```

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
