### PR TITLE
change kind to have different default storage class

### DIFF
--- a/build/local_kubernetes.sh
+++ b/build/local_kubernetes.sh
@@ -18,6 +18,7 @@ export KUBECONFIG=$HOME/.kube/config
 export KUBE_VERSION=${KUBE_VERSION:-"v1.13.7"}
 export KIND_VERSION=${KIND_VERSION:-"v0.5.1"}
 export LOCAL_CLUSTER_NAME=${LOCAL_CLUSTER_NAME:-"kanister"}
+export LOCAL_PATH_PROV_VERSION="v0.0.11"
 declare -a REQUIRED_BINS=( docker jq go )
 
 if command -v apt-get
@@ -61,7 +62,7 @@ start_localkube() {
     wait_for_pods
 
     kubectl patch storageclass standard -p '{"metadata": {"annotations":{"storageclass.beta.kubernetes.io/is-default-class":"false"}}}'
-    kubectl apply -f https://raw.githubusercontent.com/rancher/local-path-provisioner/v0.0.11/deploy/local-path-storage.yaml
+    kubectl apply -f https://raw.githubusercontent.com/rancher/local-path-provisioner/${LOCAL_PATH_PROV_VERSION}/deploy/local-path-storage.yaml
     kubectl patch storageclass local-path -p '{"metadata": {"annotations":{"storageclass.beta.kubernetes.io/is-default-class":"true"}}}'
 }
 

--- a/build/local_kubernetes.sh
+++ b/build/local_kubernetes.sh
@@ -59,6 +59,10 @@ start_localkube() {
     export KUBECONFIG=${KUBECONFIG}:${HOME}/.kube/config_bk; kubectl config view --flatten > "${HOME}/.kube/config"
     wait_for_nodes
     wait_for_pods
+
+    kubectl patch storageclass standard -p '{"metadata": {"annotations":{"storageclass.beta.kubernetes.io/is-default-class":"false"}}}'
+    kubectl apply -f https://raw.githubusercontent.com/rancher/local-path-provisioner/v0.0.11/deploy/local-path-storage.yaml
+    kubectl patch storageclass local-path -p '{"metadata": {"annotations":{"storageclass.beta.kubernetes.io/is-default-class":"true"}}}'
 }
 
 stop_localkube() {


### PR DESCRIPTION

## Change Overview
As part of this PR we have changed the kind cluster configuration to have another storage class (named `local-path`) and that will be the default storage class.
The storage class that get created by default and is default storage class (standard) doesnt work if app needs PV and PVCs.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan
Execute 
```
make start-kind
```
and wait for cluster to be created. Once cluster is created, check if another storage class named `local-path` has been created and is default storage class using below command
```
~ kubectl get storageclass      
NAME                   PROVISIONER               AGE
local-path (default)   rancher.io/local-path     6m2s
standard               kubernetes.io/host-path   6m21s
```

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
