### PR TITLE
Use MinIO as S3 storage for integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,4 +33,15 @@ jobs:
       - sudo chown -R travis:travis ./.go
       after_script:
       - make stop-kind
-
+    - stage: test
+      install:
+      - make go-mod-download
+      before_script:
+      - make start-kind
+      - make install-minio
+      script:
+      - make integration-test
+      before_cache:
+      - sudo chown -R travis:travis ./.go
+      after_script:
+      - make stop-kind

--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,7 @@ test: build-dirs
 	@$(MAKE) run CMD='-c "./build/test.sh $(SRC_DIRS)"'
 
 integration-test: build-dirs
-	@$(MAKE) run CMD='-c "TEST_INTEGRATION=true ./build/test.sh $(SRC_DIRS)"'
+	@$(MAKE) run CMD='-c "./build/integration-test.sh"'
 
 codegen:
 	@$(MAKE) run CMD='-c "./build/codegen.sh"'
@@ -256,6 +256,12 @@ start-kind:
 
 tiller:
 	@/bin/bash ./build/init_tiller.sh
+
+install-minio:
+	@$(MAKE) run CMD='-c "./build/minio.sh install_minio"'
+
+uninstall-minio:
+	@$(MAKE) run CMD='-c "./build/minio.sh uninstall_minio"'
 
 stop-kind:
 	@$(MAKE) run CMD='-c "./build/local_kubernetes.sh stop_localkube"'

--- a/build/integration-test.sh
+++ b/build/integration-test.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Copyright 2019 The Kanister Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+
+# Default bucket name
+INTEGRATION_TEST_DIR=pkg/testing
+# Degree of parallelism for integration tests
+DOP="8"
+TEST_TIMEOUT="30m"
+
+check_dependencies() {
+    # Check if minio is already deployed
+    if helm status minio -n minio > /dev/null 2>&1 ; then
+        # Setting env vars to access MinIO
+        export AWS_ACCESS_KEY_ID="AKIAIOSFODNN7EXAMPLE"
+        export AWS_SECRET_ACCESS_KEY="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+        export AWS_REGION="us-west-2"
+        export LOCATION_ENDPOINT="http://minio.minio.svc.cluster.local:9000"
+    else
+        echo "Please install MinIO using 'make install-minio' and try again."
+        exit 1
+    fi
+}
+
+check_dependencies
+echo "Running integration tests:"
+pushd ${INTEGRATION_TEST_DIR}
+TAGS="-tags=integration -timeout ${TEST_TIMEOUT} -check.suitep ${DOP}"
+go test -v ${TAGS} -installsuffix "static" . -check.v
+popd

--- a/build/minio.sh
+++ b/build/minio.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+# Copyright 2019 The Kanister Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+
+# Default bucket name
+S3_BUCKET="tests.kanister.io"
+MINIO_CHART_VERSION="3.0.1"
+
+install_minio ()
+{
+    echo "Deploying minio..."
+    # Add stable helm repo
+    helm repo add stable https://kubernetes-charts.storage.googleapis.com
+    helm repo update
+
+    # create minio namespace
+    kubectl create ns minio
+
+    # deploy minio
+    helm install minio --version ${MINIO_CHART_VERSION} --namespace minio \
+    --set defaultBucket.enabled=true,defaultBucket.name=${S3_BUCKET} \
+    --set environment.MINIO_SSE_AUTO_ENCRYPTION=on \
+    --set environment.MINIO_SSE_MASTER_KEY=my-minio-key:feb5bb6c5cf851e21dbc0376ca81012a9edc4ca0ceeb9df5064ccba2991ae9de \
+    stable/minio --wait --timeout 3m
+
+    # export default creds for minio
+    # https://github.com/helm/charts/tree/master/stable/minio
+    echo
+    echo "Use following creds to access MinIO"
+    echo AWS_ACCESS_KEY_ID="AKIAIOSFODNN7EXAMPLE"
+    echo AWS_SECRET_ACCESS_KEY="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+    echo AWS_REGION="us-west-2"
+    echo LOCATION_ENDPOINT="http://minio.minio.svc.cluster.local:9000"
+    echo
+    echo "minio deployment successful!"
+}
+
+uninstall_minio ()
+{
+    echo "Removing minio..."
+    helm delete minio -n minio
+    kubectl delete ns minio
+}
+
+usage() {
+    cat <<EOM
+Usage: ${0} <operation>
+Where operation is one of the following:
+  install_minio: installs minio on k8s cluster
+  uninstall_minio: uninstalls minio 
+EOM
+    exit 1
+}
+
+[ ${#@} -gt 0 ] || usage
+case "${1}" in
+        # Alphabetically sorted
+        install_minio)
+            time -p install_minio
+            ;;
+        uninstall_minio)
+            time -p uninstall_minio
+            ;;
+        *)
+            usage
+            exit 1
+esac

--- a/build/test.sh
+++ b/build/test.sh
@@ -25,11 +25,6 @@ export CGO_ENABLED=0
 export GO111MODULE=on
 
 TARGETS=$(for d in "$@"; do echo ./$d/...; done)
-TAGS=""
-INTEGRATION_TEST_DIR=pkg/testing
-# Degree of parallelism for integration tests
-DOP="4"
-
 
 echo -n "Checking gofmt: "
 ERRS=$(find "$@" -type f -name \*.go | xargs gofmt -l 2>&1 || true)
@@ -57,18 +52,10 @@ fi
 echo
 
 echo "Running tests:"
-if [[ -n "${TEST_INTEGRATION+x}" ]]; then
-    pushd ${INTEGRATION_TEST_DIR}
-    TAGS="-tags=integration -timeout 50m -check.suitep ${DOP}"
-    TARGETS="."
-    go test -v ${TAGS} -installsuffix "static" ${TARGETS} -check.v
-    popd
-else
-   go test -v ${TAGS} -installsuffix "static" -i ${TARGETS}
-   go test -v ${TAGS} ${TARGETS} -list .
-   go test -v ${TAGS} -installsuffix "static" ${TARGETS} -check.v
-   echo
-fi
+go test -v -installsuffix "static" -i ${TARGETS}
+go test -v ${TARGETS} -list .
+go test -v -installsuffix "static" ${TARGETS} -check.v
+echo
 
 echo "PASS"
 echo

--- a/pkg/blueprint/blueprints/pitr-postgres-blueprint.yaml
+++ b/pkg/blueprint/blueprints/pitr-postgres-blueprint.yaml
@@ -66,14 +66,13 @@ actions:
 
               # Region will be ignored for S3 compatible object store so skipping.
               rm -rf ${env_wal_region}
-            {{- else }}
-              # Region is required when no endpoint is used (AWS S3).
-              wale_s3_region="us-east-1"
-              {{- if .Profile.Location.Region }}
-                wale_s3_region="{{ .Profile.Location.Region | quote}}"
-              {{- end }}
-              echo "${wale_s3_region}" > "${env_wal_region}"
             {{- end }}
+            # Region is required when no endpoint is used (AWS S3).
+            wale_s3_region="us-east-1"
+            {{- if .Profile.Location.Region }}
+              wale_s3_region="{{ .Profile.Location.Region | quote}}"
+            {{- end }}
+            echo "${wale_s3_region}" > "${env_wal_region}"
 
             set +o xtrace
             {{- if .Profile.Credential.KeyPair }}
@@ -201,15 +200,15 @@ actions:
               export WALE_S3_ENDPOINT="${wale_s3_endpoint}"
 
               # Region will be ignored for S3 compatible object store so skipping.
-            {{- else }}
-              # Region is required when no endpoint is used (AWS S3).
-              {{- if .Profile.Location.Region }}
-                wale_s3_region="{{ .Profile.Location.Region | quote}}"
-              {{- else }}
-                wale_s3_region="us-east-1"
-              {{- end }}
-              export AWS_REGION="${wale_s3_region}"
             {{- end }}
+
+            # Region is required when no endpoint is used (AWS S3).
+            {{- if .Profile.Location.Region }}
+              wale_s3_region="{{ .Profile.Location.Region | quote}}"
+            {{- else }}
+              wale_s3_region="us-east-1"
+            {{- end }}
+            export AWS_REGION="${wale_s3_region}"
 
             # Can now get the backup with the old prefix
             wal-e --s3-prefix "${old_wale_prefix}" backup-fetch "${recover_dir}" "${backup_name}"
@@ -329,28 +328,27 @@ actions:
             # Setup configuration for wal-e.
             {{- if .Profile.Location.Endpoint }}
               wale_s3_endpoint="{{ .Profile.Location.Endpoint | quote}}"
-              wale_s3_endpoint-${wale_s3_endpoint,,}
+              wale_s3_endpoint=${wale_s3_endpoint,,}
               {{- if .Profile.SkipSSLVerify }}
                 # Since wal-e does not support skip-ssl-verify switch to http://
                 wale_s3_endpoint="${wale_s3_endpoint/https/http}"
               {{- end }}
 
               # Add the scheme that wal-e requires
-              wale_s3_endpoint="${wale_s3_endpoint/https\:\/\//https+path://}"
-              wale_s3_endpoint="${wale_s3_endpoint/http\:\/\//http+path://}"
+              wale_s3_endpoint="${wale_s3_endpoint//https\:\/\//https+path://}"
+              wale_s3_endpoint="${wale_s3_endpoint//http\:\/\//http+path://}"
 
               export WALE_S3_ENDPOINT="${wale_s3_endpoint}"
 
               # Region will be ignored for S3 compatible object store so skipping.
-            {{- else }}
-              # Region is required when no endpoint is used (AWS S3).
-              {{- if .Profile.Location.Region }}
-                wale_s3_region="{{ .Profile.Location.Region | quote}}"
-              {{- else }}
-                wale_s3_region="us-east-1"
-              {{- end }}
-              export AWS_REGION="${wale_s3_region}"
             {{- end }}
+            # Region is required when no endpoint is used (AWS S3).
+            {{- if .Profile.Location.Region }}
+              wale_s3_region="{{ .Profile.Location.Region | quote}}"
+            {{- else }}
+              wale_s3_region="us-east-1"
+            {{- end }}
+            export AWS_REGION="${wale_s3_region}"
 
             # Count the number of backups. If there are none left, delete the WALs as well.
             wal-e --s3-prefix "${wale_prefix}" backup-list

--- a/pkg/testing/integration_test.go
+++ b/pkg/testing/integration_test.go
@@ -63,14 +63,15 @@ type IntegrationSuite struct {
 
 // INTEGRATION TEST APPLICATIONS
 
-// rds-postgres app
-var _ = Suite(&IntegrationSuite{
-	name:      "rds-postgres",
-	namespace: "rds-postgres-test",
-	app:       app.NewRDSPostgresDB("rds-postgres"),
-	bp:        app.NewBlueprint("rds-postgres"),
-	profile:   newSecretProfile("", "", ""),
-})
+// Skipping rds-postgres app since it doesn't work with MinIO
+//// rds-postgres app
+//var _ = Suite(&IntegrationSuite{
+//	name:      "rds-postgres",
+//	namespace: "rds-postgres-test",
+//	app:       app.NewRDSPostgresDB("rds-postgres"),
+//	bp:        app.NewBlueprint("rds-postgres"),
+//	profile:   newSecretProfile("", "", ""),
+//})
 
 // pitr-postgresql app
 var _ = Suite(&IntegrationSuite{
@@ -78,7 +79,7 @@ var _ = Suite(&IntegrationSuite{
 	namespace: "pitr-postgres-test",
 	app:       app.NewPostgresDB("pitr-postgres"),
 	bp:        app.NewPITRBlueprint("pitr-postgres"),
-	profile:   newSecretProfile("infracloud.kanister.io", "", ""),
+	profile:   newSecretProfile(),
 })
 
 // postgres app
@@ -87,7 +88,7 @@ var _ = Suite(&IntegrationSuite{
 	namespace: "postgres-test",
 	app:       app.NewPostgresDB("postgres"),
 	bp:        app.NewBlueprint("postgres"),
-	profile:   newSecretProfile("infracloud.kanister.io", "", ""),
+	profile:   newSecretProfile(),
 })
 
 // mysql app
@@ -96,7 +97,7 @@ var _ = Suite(&IntegrationSuite{
 	namespace: "mysql-test",
 	app:       app.NewMysqlDB("mysql"),
 	bp:        app.NewBlueprint("mysql"),
-	profile:   newSecretProfile("infracloud.kanister.io", "", ""),
+	profile:   newSecretProfile(),
 })
 
 // Elasticsearch app
@@ -105,7 +106,7 @@ var _ = Suite(&IntegrationSuite{
 	namespace: "es-test",
 	app:       app.NewElasticsearchInstance("elasticsearch"),
 	bp:        app.NewBlueprint("elasticsearch"),
-	profile:   newSecretProfile("infracloud.kanister.io", "", ""),
+	profile:   newSecretProfile(),
 })
 
 // Mongodb app
@@ -114,15 +115,11 @@ var _ = Suite(&IntegrationSuite{
 	namespace: "mongo-test",
 	app:       app.NewMongoDB("mongo"),
 	bp:        app.NewBlueprint("mongo"),
-	profile:   newSecretProfile("infracloud.kanister.io", "", ""),
+	profile:   newSecretProfile(),
 })
 
-func newSecretProfile(bucket, endpoint, prefix string) *secretProfile {
+func newSecretProfile() *secretProfile {
 	_, location := testutil.GetObjectstoreLocation()
-	location.Bucket = bucket
-	location.Endpoint = endpoint
-	location.Prefix = prefix
-
 	secret, profile, err := testutil.NewSecretProfileFromLocation(location)
 	if err != nil {
 		return nil

--- a/pkg/testutil/fixture.go
+++ b/pkg/testutil/fixture.go
@@ -65,6 +65,20 @@ func GetObjectstoreLocation() (objectstore.ProviderType, crv1alpha1.Location) {
 		}
 		provider = objectstore.ProviderTypeAzure
 	}
+
+	// Set location bucket, endpoints and prefix
+	location.Bucket = TestS3BucketName
+
+	// Override values if env vars are set
+	if buck, ok := os.LookupEnv("LOCATION_BUCKET"); ok {
+		location.Bucket = buck
+	}
+	if ep, ok := os.LookupEnv("LOCATION_ENDPOINT"); ok {
+		location.Endpoint = ep
+	}
+	if pre, ok := os.LookupEnv("LOCATION_PREFIX"); ok {
+		location.Prefix = pre
+	}
 	return provider, location
 }
 


### PR DESCRIPTION
## Change Overview

- Use MinIO as S3 storage for integ tests 
- Skip rds-postgres test

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [x] :robot: Test

## Issues

- #XXX

## Test Plan

https://travis-ci.org/kanisterio/kanister/jobs/620014356?utm_medium=notification&utm_source=github_status

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [x] :green_heart: E2E
