### PR TITLE
Add support for Cassandra app into integration suite

### DIFF
--- a/pkg/app/cassandra.go
+++ b/pkg/app/cassandra.go
@@ -49,8 +49,7 @@ type CassandraInstance struct {
 // NewCassandraInstance returns new cassandra application
 func NewCassandraInstance(name string) App {
 	return &CassandraInstance{
-		name:      name,
-		namespace: "cassandra-test",
+		name: name,
 		chart: helm.ChartInfo{
 			Release:  name,
 			RepoURL:  helm.IncubatorRepoURL,
@@ -164,6 +163,12 @@ func (cas *CassandraInstance) Count(ctx context.Context) (int, error) {
 		return 0, errors.Wrapf(err, "Error %s counting the number of records in the database.", stderr)
 	}
 	// parse stdout to get the number of rows in the table
+	// the count output from cqlsh is in below format
+	// count
+	// -------
+	// 	3
+	// (1 rows)
+
 	count, err := strconv.Atoi(strings.Trim(strings.Split(stdout, "\n")[2], " "))
 	if err != nil {
 		return 0, errors.Wrapf(err, "Error, converting count value into int.")

--- a/pkg/app/cassandra.go
+++ b/pkg/app/cassandra.go
@@ -58,7 +58,7 @@ func NewCassandraInstance(name string) App {
 			RepoName: helm.IncubatorRepoName,
 			Version:  "0.13.3",
 			Values: map[string]string{
-				"image.repo":          "kanisterio/cassandra",
+				"image.repo":          "viveksinghggits/cassandra",
 				"image.tag":           "0.22.0",
 				"config.cluster_size": "2",
 			},

--- a/pkg/app/cassandra.go
+++ b/pkg/app/cassandra.go
@@ -55,7 +55,7 @@ func NewCassandraInstance(name string) App {
 			RepoName: helm.IncubatorRepoName,
 			Version:  "0.13.3",
 			Values: map[string]string{
-				"image.repo":          "viveksinghggits/cassandra",
+				"image.repo":          "kanisterio/cassandra",
 				"image.tag":           "0.22.0",
 				"config.cluster_size": "2",
 			},

--- a/pkg/app/cassandra.go
+++ b/pkg/app/cassandra.go
@@ -58,7 +58,7 @@ func NewCassandraInstance(name string) App {
 			RepoName: helm.IncubatorRepoName,
 			Version:  "0.13.3",
 			Values: map[string]string{
-				"image.repo":          "viveksinghggits/cassandra",
+				"image.repo":          "kanisterio/cassandra",
 				"image.tag":           "0.22.0",
 				"config.cluster_size": "2",
 			},

--- a/pkg/blueprint/blueprints/cassandra-blueprint.yaml
+++ b/pkg/blueprint/blueprints/cassandra-blueprint.yaml
@@ -1,0 +1,187 @@
+apiVersion: cr.kanister.io/v1alpha1
+kind: Blueprint
+metadata:
+  name: cassandra-blueprint
+actions:
+  backup:
+    type: StatefulSet
+    outputArtifacts:
+      params:
+        keyValue:
+          backupPrefixLocation: "{{ .Phases.getBackupPrefixLocation.Output.backupPrefixLocation }}"
+          snapshotPrefix: "{{ .Phases.getBackupPrefixLocation.Output.localSnapshotPrefixLocation }}"
+          replicaCount: "{{ .Phases.getBackupPrefixLocation.Output.replicaCount }}"
+          backupInfo: "{{ .Phases.backupToObjectStore.Output.BackupAllInfo }}"
+    phases:
+    - func: KubeExecAll 
+      name: getBackupPrefixLocation
+      args:
+        namespace: "{{ .StatefulSet.Namespace }}"
+        pods: "{{ range .StatefulSet.Pods }} {{.}}{{end}}"
+        containers: cassandra
+        command:
+          - bash
+          - -o
+          - errexit
+          - -o
+          - xtrace
+          - -o
+          - pipefail
+          - -c
+          - |
+            BACKUP_PREFIX_LOCATION={{ .Profile.Location.Bucket }}/cassandra_backups/{{ .StatefulSet.Namespace }}/{{ .StatefulSet.Name }}
+            LOCAL_SNAPSHOT_PREFIX_LOCATION=/cassandra_data/kanister_backups
+            kando output backupPrefixLocation $BACKUP_PREFIX_LOCATION
+            kando output localSnapshotPrefixLocation $LOCAL_SNAPSHOT_PREFIX_LOCATION
+            kando output replicaCount {{ len .StatefulSet.Pods }}
+    - func: KubeExecAll
+      name: takeSnapshots
+      args:
+        namespace: "{{ .StatefulSet.Namespace }}"
+        pods: "{{ range .StatefulSet.Pods }} {{.}}{{end}}"
+        containers: "cassandra"
+        command:
+          - bash
+          - -o
+          - errexit
+          - -o
+          - xtrace
+          - -o
+          - pipefail
+          - -c
+          - |
+            nodetool cleanup
+            nodetool snapshot -t ${HOSTNAME}
+            snapshot_prefix={{ .Phases.getBackupPrefixLocation.Output.localSnapshotPrefixLocation }}
+            mkdir -p ${snapshot_prefix}/${HOSTNAME}
+            cd /var/lib/cassandra/data
+            if [ -n "$(ls -A | grep -v  -w "system" | grep -v  -w "system_traces")" ]
+            then
+              cp -r `ls -A | grep -v  -w "system" | grep -v  -w "system_traces"` ${snapshot_prefix}/${HOSTNAME}/
+              cd ${snapshot_prefix}/${HOSTNAME}/
+              cqlsh -e "DESCRIBE SCHEMA" > schema.cql
+            fi  
+            sleep 300
+            nodetool clearsnapshot
+    - func: BackupDataAll
+      name: backupToObjectStore
+      args:
+        namespace: "{{ .StatefulSet.Namespace }}"
+        pods: "{{ range .StatefulSet.Pods }} {{.}}{{end}}"
+        container: cassandra
+        includePath: "{{ .Phases.getBackupPrefixLocation.Output.localSnapshotPrefixLocation }}"
+        backupArtifactPrefix: "{{ .Phases.getBackupPrefixLocation.Output.backupPrefixLocation }}"
+    - func: KubeExec
+      name: deleteLocalBackup
+      args:
+        namespace: "{{ .StatefulSet.Namespace }}"
+        pod: "{{ index .StatefulSet.Pods 0}}"
+        containers: "cassandra"
+        command:
+          - bash
+          - -o
+          - errexit
+          - -o
+          - xtrace
+          - -o
+          - pipefail
+          - -c
+          - |
+            rm -rf {{ .Phases.getBackupPrefixLocation.Output.localSnapshotPrefixLocation }}
+  restore:
+    type: StatefulSet
+    inputArtifactNames:
+      - params
+    phases:
+    - func: ScaleWorkload
+      name: shutdownPod
+      args:
+        namespace: "{{ .StatefulSet.Namespace }}"
+        name: "{{ .StatefulSet.Name }}"
+        kind: StatefulSet
+        replicas: 0
+    - func: RestoreDataAll
+      name: restoreFromObjectStore
+      args:
+        namespace: "{{ .StatefulSet.Namespace }}"
+        image: kanisterio/kanister-tools:0.21.0
+        backupArtifactPrefix: "{{ .ArtifactsIn.params.KeyValue.backupPrefixLocation }}"
+        pods: "{{ range .StatefulSet.Pods }} {{.}}{{end}}"
+        restorePath: "/var/lib/cassandra"
+        backupInfo: "{{ .ArtifactsIn.params.KeyValue.backupInfo }}"
+    - func: ScaleWorkload
+      name: bringupPod
+      args:
+        namespace: "{{ .StatefulSet.Namespace }}"
+        name: "{{ .StatefulSet.Name }}"
+        kind: StatefulSet
+        replicas: "{{ .ArtifactsIn.params.KeyValue.replicaCount }}"
+    - func: KubeExec
+      name: restoreSnapshot
+      args:
+        namespace: "{{ .StatefulSet.Namespace }}"
+        pod: "{{ index .StatefulSet.Pods 0 }}"
+        containers: "cassandra"
+        command:
+          - bash
+          - -o
+          - xtrace
+          - -o
+          - pipefail
+          - -c
+          - |
+            local_snapshot_prefix=/var/lib/cassandra/cassandra_data/kanister_backups/${HOSTNAME}
+            echo $(ls $local_snapshot_prefix)
+            echo 'local_snapshot_prefix is -'$local_snapshot_prefix
+            if [ -n "$(ls ${local_snapshot_prefix}/)" ]
+            then
+              timeout=300
+              while true
+              do
+                VAR=$((cqlsh -e "DESCRIBE keyspaces;" --request-timeout=6000) 2>&1)
+                if [[ $VAR != *"Could not connect to localhost"* ]]
+                then
+                  break
+                fi
+                if [[ $timeout -le 0 ]]
+                then
+                   echo "Timed out waiting for cqlsh to configure.."
+                   exit 1
+                fi
+                sleep 2
+                timeout=$((timeout-2))
+              done
+              set -o errexit
+              keyspacestodel=$(echo DESCRIBE keyspaces | cqlsh --request-timeout=6000 | xargs -n1 echo | grep -v ^system || true)
+              for ks in $keyspacestodel; do
+                echo "drop keyspace if exists $ks;" | cqlsh --request-timeout=6000
+              done
+              cqlsh -e "$(cat ${local_snapshot_prefix}/schema.cql)" --request-timeout=6000
+              rm ${local_snapshot_prefix}/schema.cql
+              list="$(ls ${local_snapshot_prefix}/)"
+              cp -r ${local_snapshot_prefix}/. /var/lib/cassandra/data/
+              cd /var/lib/cassandra/data/
+              for keyspace in $list
+              do
+                cd $keyspace
+                for table in *
+                do
+                  sstableloader -d ${HOSTNAME} $table/
+                done
+                cd ..
+              done
+              #nodetool clearsnapshot
+            fi
+            rm -rf {{ .ArtifactsIn.params.KeyValue.snapshotPrefix }}
+  delete:
+    type: StatefulSet
+    inputArtifactNames:
+      - params
+    phases:
+    - func: DeleteDataAll
+      name: deleteFromObjectStore
+      args:
+        namespace: "{{ .StatefulSet.Namespace }}"
+        backupArtifactPrefix: "{{ .ArtifactsIn.params.KeyValue.backupPrefixLocation }}"
+        backupInfo: "{{ .ArtifactsIn.params.KeyValue.backupInfo }}"
+        reclaimSpace: true

--- a/pkg/blueprint/blueprints/cassandra-blueprint.yaml
+++ b/pkg/blueprint/blueprints/cassandra-blueprint.yaml
@@ -12,6 +12,7 @@ actions:
           snapshotPrefix: "{{ .Phases.getBackupPrefixLocation.Output.localSnapshotPrefixLocation }}"
           replicaCount: "{{ .Phases.getBackupPrefixLocation.Output.replicaCount }}"
           backupInfo: "{{ .Phases.backupToObjectStore.Output.BackupAllInfo }}"
+          restorePathPrefix: "/var/lib/cassandra"
     phases:
     - func: KubeExecAll 
       name: getBackupPrefixLocation
@@ -107,7 +108,7 @@ actions:
         image: kanisterio/kanister-tools:0.21.0
         backupArtifactPrefix: "{{ .ArtifactsIn.params.KeyValue.backupPrefixLocation }}"
         pods: "{{ range .StatefulSet.Pods }} {{.}}{{end}}"
-        restorePath: "/var/lib/cassandra"
+        restorePath: "{{ .ArtifactsIn.params.KeyValue.restorePathPrefix }}"
         backupInfo: "{{ .ArtifactsIn.params.KeyValue.backupInfo }}"
     - func: ScaleWorkload
       name: bringupPod
@@ -128,17 +129,17 @@ actions:
           - xtrace
           - -o
           - pipefail
+          - -o
+          - errexit
           - -c
           - |
             local_snapshot_prefix=/var/lib/cassandra/cassandra_data/kanister_backups/${HOSTNAME}
-            echo $(ls $local_snapshot_prefix)
-            echo 'local_snapshot_prefix is -'$local_snapshot_prefix
             if [ -n "$(ls ${local_snapshot_prefix}/)" ]
             then
               timeout=300
               while true
               do
-                VAR=$((cqlsh -e "DESCRIBE keyspaces;" --request-timeout=6000) 2>&1)
+                VAR=$((cqlsh -e "DESCRIBE keyspaces;" --request-timeout=300) 2>&1)
                 if [[ $VAR != *"Could not connect to localhost"* ]]
                 then
                   break
@@ -151,12 +152,12 @@ actions:
                 sleep 2
                 timeout=$((timeout-2))
               done
-              set -o errexit
-              keyspacestodel=$(echo DESCRIBE keyspaces | cqlsh --request-timeout=6000 | xargs -n1 echo | grep -v ^system || true)
+              allkeyspaces=$(cqlsh -e "DESCRIBE keyspaces" --request-timeout=300)
+              keyspacestodel=$(echo $allkeyspaces | xargs -n1 echo | grep -v ^system || true)
               for ks in $keyspacestodel; do
-                echo "drop keyspace if exists $ks;" | cqlsh --request-timeout=6000
+                cqlsh -e "drop keyspace if exists $ks;" --request-timeout=300
               done
-              cqlsh -e "$(cat ${local_snapshot_prefix}/schema.cql)" --request-timeout=6000
+              cqlsh -e "$(cat ${local_snapshot_prefix}/schema.cql)" --request-timeout=300
               rm ${local_snapshot_prefix}/schema.cql
               list="$(ls ${local_snapshot_prefix}/)"
               cp -r ${local_snapshot_prefix}/. /var/lib/cassandra/data/
@@ -170,7 +171,6 @@ actions:
                 done
                 cd ..
               done
-              #nodetool clearsnapshot
             fi
             rm -rf {{ .ArtifactsIn.params.KeyValue.snapshotPrefix }}
   delete:

--- a/pkg/blueprint/blueprints/cassandra-blueprint.yaml
+++ b/pkg/blueprint/blueprints/cassandra-blueprint.yaml
@@ -105,7 +105,7 @@ actions:
       name: restoreFromObjectStore
       args:
         namespace: "{{ .StatefulSet.Namespace }}"
-        image: kanisterio/kanister-tools:0.21.0
+        image: kanisterio/kanister-tools:0.22.0
         backupArtifactPrefix: "{{ .ArtifactsIn.params.KeyValue.backupPrefixLocation }}"
         pods: "{{ range .StatefulSet.Pods }} {{.}}{{end}}"
         restorePath: "{{ .ArtifactsIn.params.KeyValue.restorePathPrefix }}"

--- a/pkg/helm/client.go
+++ b/pkg/helm/client.go
@@ -34,6 +34,10 @@ const (
 	ElasticRepoName = "elastic"
 	ElasticRepoURL  = "https://helm.elastic.co"
 
+	// Add incubator charts url
+	IncubatorRepoName = "incubator"
+	IncubatorRepoURL  = "https://kubernetes-charts-incubator.storage.googleapis.com"
+
 	// Add stable charts url
 	StableRepoName = "stable"
 	StableRepoURL  = "https://kubernetes-charts.storage.googleapis.com"

--- a/pkg/testing/integration_test.go
+++ b/pkg/testing/integration_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/pkg/errors"
 	. "gopkg.in/check.v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
@@ -116,6 +116,15 @@ var _ = Suite(&IntegrationSuite{
 	app:       app.NewMongoDB("mongo"),
 	bp:        app.NewBlueprint("mongo"),
 	profile:   newSecretProfile(),
+})
+
+// Cassandra App
+var _ = Suite(&IntegrationSuite{
+	name:      "cassandra",
+	namespace: "cassandra-test",
+	app:       app.NewCassandraInstance("cassandra"),
+	bp:        app.NewBlueprint("cassandra"),
+	profile:   newSecretProfile("infracloud.kanister.io", "", ""),
 })
 
 func newSecretProfile() *secretProfile {

--- a/pkg/testing/integration_test.go
+++ b/pkg/testing/integration_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/pkg/errors"
 	. "gopkg.in/check.v1"
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 

--- a/pkg/testing/integration_test.go
+++ b/pkg/testing/integration_test.go
@@ -124,7 +124,7 @@ var _ = Suite(&IntegrationSuite{
 	namespace: "cassandra-test",
 	app:       app.NewCassandraInstance("cassandra"),
 	bp:        app.NewBlueprint("cassandra"),
-	profile:   newSecretProfile("infracloud.kanister.io", "", ""),
+	profile:   newSecretProfile(),
 })
 
 func newSecretProfile() *secretProfile {


### PR DESCRIPTION
## Change Overview
This change includes cassandra app in our integration suite. 

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [x] :robot: Test

## Issues

- #XXX

## Test Plan
Since we dont have the official `kanisterio/cassandra` yet, to make the CI work I made the last commit to use the image that I tested the application with locally and the CI worked as expected. 

We can run command 
```
make integration-test
```
Below are some of the manual tests that I did
1. Create three keyspaces, respective tables and insert some data into those tables. Takes backup and restore them.
2. Create two keyspaces, respective tables and insert some data into those tables. Take backup, delete the keyspaces, and create some extra keyspaces, make a note that these new keyspaces are not backed up. Now if you restore the backup you should only get the database state that was there before taking the backup. So we will not be getting the keyspaces that were created after backup.

to test the integration suite locally.

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
