### PR TITLE
Set snapshot size to original volume size

### DIFF
--- a/pkg/blockstorage/vmware/vmware.go
+++ b/pkg/blockstorage/vmware/vmware.go
@@ -175,7 +175,13 @@ func (p *fcdProvider) SnapshotCreate(ctx context.Context, volume blockstorage.Vo
 	if !ok {
 		return nil, errors.New("Unexpected type")
 	}
-	return p.SnapshotGet(ctx, snapshotFullID(volume.ID, id.Id))
+	snap, err := p.SnapshotGet(ctx, snapshotFullID(volume.ID, id.Id))
+	if err != nil {
+		return nil, err
+	}
+	// We don't get size information from `SnapshotGet` - so set this to the volume size for now
+	snap.Size = volume.Size
+	return snap, nil
 }
 
 func (p *fcdProvider) SnapshotCreateWaitForCompletion(ctx context.Context, snapshot *blockstorage.Snapshot) error {

--- a/pkg/blockstorage/vmware/vmware.go
+++ b/pkg/blockstorage/vmware/vmware.go
@@ -180,7 +180,9 @@ func (p *fcdProvider) SnapshotCreate(ctx context.Context, volume blockstorage.Vo
 		return nil, err
 	}
 	// We don't get size information from `SnapshotGet` - so set this to the volume size for now
-	snap.Size = volume.Size
+	if snap.Size == 0 {
+		snap.Size = volume.Size
+	}
 	return snap, nil
 }
 


### PR DESCRIPTION
## Change Overview

This addresses an issue where snapshot size for FCD snapshots was set to 0. 

We're not getting this information from vSphere so setting this to the original volume size 
for now while we investigate if this information is available

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
