### PR TITLE
Refactore ES app to not have full json respose as struct

### DIFF
--- a/pkg/app/elasticsearch.go
+++ b/pkg/app/elasticsearch.go
@@ -38,21 +38,10 @@ const (
 // if, due to any reason, there is change in how Elasticsearch responds to  above query, below
 // struct is subject to change.
 type ElasticsearchPingOutput struct {
-	Took     int  `json:"took"`
-	TimedOut bool `json:"timed_out"`
-	Shards   struct {
-		Total      int `json:"total"`
-		Successful int `json:"successful"`
-		Skipped    int `json:"skipped"`
-		Failed     int `json:"failed"`
-	} `json:"_shards"`
 	Hits struct {
 		Total struct {
-			Value    int    `json:"value"`
-			Relation string `json:"relation"`
+			Value int `json:"value"`
 		} `json:"total"`
-		MaxScore interface{}   `json:"max_score"`
-		Hits     []interface{} `json:"hits"`
 	} `json:"hits"`
 }
 


### PR DESCRIPTION
## Change Overview
In ElasticSearch application of Integration Suite, we had the struct equivalent to the entire output of the document count. But was reading only a field of that struct to actually read the count. This PR changes that struct to only have the field that we read for count.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan
Manually ran below command to test the app
```
make integration-test 
```

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
