### PR TITLE
Add support for Web Identity Provider to AWS client

### DIFF
--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -16,15 +16,16 @@ package aws
 
 import (
 	"context"
+	"os"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/pkg/errors"
 
 	awsrole "github.com/kanisterio/kanister/pkg/aws/role"
-	"github.com/kanisterio/kanister/pkg/param"
-	"github.com/kanisterio/kanister/pkg/secrets"
 )
 
 const (
@@ -42,24 +43,36 @@ const (
 	// Region represents AWS region
 	Region = "AWS_REGION"
 
+	// From AWS SDK "aws/session/env_config.go"
+	webIdentityTokenFilePathEnvKey = "AWS_WEB_IDENTITY_TOKEN_FILE"
+	roleARNEnvKey                  = "AWS_ROLE_ARN"
+
 	assumeRoleDuration = 25 * time.Minute
 )
 
-// GetConfigFromProfile extracts AWS creds from profile
-func GetConfigFromProfile(ctx context.Context, profile *param.Profile) (*aws.Config, string, error) {
-	config := make(map[string]string)
-
-	if profile.Credential.Type == param.CredentialTypeKeyPair {
-		config[AccessKeyID] = profile.Credential.KeyPair.ID
-		config[SecretAccessKey] = profile.Credential.KeyPair.Secret
-	} else if profile.Credential.Type == param.CredentialTypeSecret {
-		config[AccessKeyID] = string(profile.Credential.Secret.Data[secrets.AWSAccessKeyID])
-		config[SecretAccessKey] = string(profile.Credential.Secret.Data[secrets.AWSSecretAccessKey])
-		config[ConfigRole] = string(profile.Credential.Secret.Data[secrets.ConfigRole])
-		config[SessionToken] = string(profile.Credential.Secret.Data[secrets.AWSSessionToken])
+// GetCredentials returns credentials to use for AWS operations
+func GetCredentials(ctx context.Context, config map[string]string) (*credentials.Credentials, error) {
+	var creds *credentials.Credentials
+	switch {
+	case config[AccessKeyID] != "" && config[SecretAccessKey] != "":
+		// If AccessKeys were provided - use those
+		creds = credentials.NewStaticCredentials(config[AccessKeyID], config[SecretAccessKey], "")
+	case os.Getenv(webIdentityTokenFilePathEnvKey) != "" && os.Getenv(roleARNEnvKey) != "":
+		// If we have credentials to use with a Web Identity provider - use those
+		creds = stscreds.NewWebIdentityCredentials(session.New(), os.Getenv(roleARNEnvKey), "", os.Getenv(webIdentityTokenFilePathEnvKey))
+	default:
+		return nil, errors.New("AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY required to initialize AWS credentials")
 	}
-	config[ConfigRegion] = profile.Location.Region
-	return GetConfig(ctx, config)
+	// If the caller wants to use a specific role, use the credentials initialized above to assume that
+	// role and return those credentials
+	if role := config[ConfigRole]; role != "" {
+		credsForAssumedRole, err := awsrole.Switch(ctx, creds, role, assumeRoleDuration)
+		if err != nil {
+			return nil, errors.Wrap(err, "Failed to switch roles")
+		}
+		creds = credsForAssumedRole
+	}
+	return creds, nil
 }
 
 // GetConfig returns a configuration to establish AWS connection and connected region name.
@@ -68,29 +81,9 @@ func GetConfig(ctx context.Context, config map[string]string) (awsConfig *aws.Co
 	if !ok {
 		return nil, "", errors.New("region required for storage type EBS/EFS")
 	}
-	accessKey, ok := config[AccessKeyID]
-	if !ok {
-		return nil, "", errors.New("AWS_ACCESS_KEY_ID required for storage type EBS/EFS")
-	}
-	secretAccessKey, ok := config[SecretAccessKey]
-	if !ok {
-		return nil, "", errors.New("AWS_SECRET_ACCESS_KEY required for storage type EBS/EFS")
-	}
-	role := config[ConfigRole]
-	if role != "" {
-		config, err := assumeRole(ctx, accessKey, secretAccessKey, role)
-		if err != nil {
-			return nil, "", errors.Wrap(err, "Failed to get temporary security credentials")
-		}
-		return config, region, nil
-	}
-	return &aws.Config{Credentials: credentials.NewStaticCredentials(accessKey, secretAccessKey, "")}, region, nil
-}
-
-func assumeRole(ctx context.Context, accessKey, secretAccessKey, role string) (*aws.Config, error) {
-	creds, err := awsrole.Switch(ctx, accessKey, secretAccessKey, role, assumeRoleDuration)
+	creds, err := GetCredentials(ctx, config)
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to switch roles")
+		return nil, "", errors.New("could not initialize AWS credentials for operation")
 	}
-	return &aws.Config{Credentials: creds}, nil
+	return &aws.Config{Credentials: creds}, region, nil
 }

--- a/pkg/aws/role/role.go
+++ b/pkg/aws/role/role.go
@@ -26,14 +26,12 @@ import (
 )
 
 // Switch func uses credentials API to automatically generates New Credentials for a given role.
-func Switch(ctx context.Context, accessKeyID string, secretAccessKey string, role string, duration time.Duration) (*credentials.Credentials, error) {
-	creds := credentials.NewStaticCredentials(accessKeyID, secretAccessKey, "")
-	sess, err := session.NewSession(aws.NewConfig().WithCredentials(creds))
+func Switch(ctx context.Context, creds *credentials.Credentials, role string, duration time.Duration) (*credentials.Credentials, error) {
+	sess, err := session.NewSession(aws.NewConfig().WithCredentials((creds)))
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create session")
 	}
-	creds = stscreds.NewCredentials(sess, role, func(p *stscreds.AssumeRoleProvider) {
+	return stscreds.NewCredentials(sess, role, func(p *stscreds.AssumeRoleProvider) {
 		p.Duration = duration
-	})
-	return creds, nil
+	}), nil
 }

--- a/pkg/objectstore/objectstore.go
+++ b/pkg/objectstore/objectstore.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"time"
 
 	"github.com/graymeta/stow"
 	stowaz "github.com/graymeta/stow/azure"
@@ -29,8 +28,6 @@ import (
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/compute/v1"
 )
-
-const assumeRoleDuration = 90 * time.Minute
 
 // Provider abstracts actions on cloud provider bucket
 type Provider interface {

--- a/pkg/objectstore/objectstore_test.go
+++ b/pkg/objectstore/objectstore_test.go
@@ -32,7 +32,6 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/kanisterio/kanister/pkg/aws"
-	awsrole "github.com/kanisterio/kanister/pkg/aws/role"
 )
 
 func Test(t *testing.T) { TestingT(t) }
@@ -75,7 +74,7 @@ func (s *ObjectStoreProviderSuite) SetUpSuite(c *C) {
 
 	s.rand = rand.New(rand.NewSource(time.Now().UnixNano()))
 	pc := ProviderConfig{Type: s.osType}
-	secret := getSecret(c, ctx, s.osType)
+	secret := getSecret(ctx, c, s.osType)
 	s.provider, err = NewProvider(ctx, pc, secret)
 	c.Check(err, IsNil)
 	c.Assert(s.provider, NotNil)
@@ -450,27 +449,25 @@ func (s *ObjectStoreProviderSuite) TestBucketGetRegions(c *C) {
 	}
 }
 
-func getSecret(c *C, ctx context.Context, osType ProviderType) *Secret {
+func getSecret(ctx context.Context, c *C, osType ProviderType) *Secret {
 	secret := &Secret{}
 	switch osType {
 	case ProviderTypeS3:
 		secret.Type = SecretTypeAwsAccessKey
-		awsAccessKeyID := os.Getenv("AWS_ACCESS_KEY_ID")
-		awsSecretAccessKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
-		var awsSessionToken string
-		if role, ok := os.LookupEnv(aws.ConfigRole); ok {
-			creds, err := awsrole.Switch(ctx, awsAccessKeyID, awsSecretAccessKey, role, assumeRoleDuration)
-			c.Check(err, IsNil)
-			val, err := creds.Get()
-			c.Check(err, IsNil)
-			awsAccessKeyID = val.AccessKeyID
-			awsSecretAccessKey = val.SecretAccessKey
-			awsSessionToken = val.SessionToken
+		config := map[string]string{
+			aws.AccessKeyID:     os.Getenv("AWS_ACCESS_KEY_ID"),
+			aws.SecretAccessKey: os.Getenv("AWS_SECRET_ACCESS_KEY"),
+			aws.ConfigRole:      os.Getenv("AWS_ROLE"),
 		}
+		creds, err := aws.GetCredentials(ctx, config)
+		c.Assert(err, IsNil)
+
+		val, err := creds.Get()
+		c.Check(err, IsNil)
 		secret.Aws = &SecretAws{
-			AccessKeyID:     awsAccessKeyID,
-			SecretAccessKey: awsSecretAccessKey,
-			SessionToken:    awsSessionToken,
+			AccessKeyID:     val.AccessKeyID,
+			SecretAccessKey: val.SecretAccessKey,
+			SessionToken:    val.SessionToken,
 		}
 		c.Check(secret.Aws.AccessKeyID, Not(Equals), "")
 		c.Check(secret.Aws.SecretAccessKey, Not(Equals), "")

--- a/pkg/secrets/aws.go
+++ b/pkg/secrets/aws.go
@@ -2,7 +2,6 @@ package secrets
 
 import (
 	"context"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	v1 "k8s.io/api/core/v1"
@@ -23,8 +22,7 @@ const (
 	AWSSessionToken string = "aws_session_token"
 	// ConfigRole represents the key for the ARN of the role which can be assumed.
 	// It is optional.
-	ConfigRole         = "role"
-	assumeRoleDuration = 90 * time.Minute
+	ConfigRole = "role"
 )
 
 // ValidateAWSCredentials validates secret has all necessary information

--- a/pkg/secrets/aws.go
+++ b/pkg/secrets/aws.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	v1 "k8s.io/api/core/v1"
 
-	awsrole "github.com/kanisterio/kanister/pkg/aws/role"
+	"github.com/kanisterio/kanister/pkg/aws"
 	"github.com/pkg/errors"
 )
 
@@ -41,13 +41,13 @@ func ValidateAWSCredentials(secret *v1.Secret) error {
 	if string(secret.Type) != AWSSecretType {
 		return errors.New("Secret is not AWS secret")
 	}
-	if _, ok := secret.Data[AWSAccessKeyID]; !ok {
-		return errors.New("awsAccessKeyID is a required field")
+	count := 0
+	if _, ok := secret.Data[AWSAccessKeyID]; ok {
+		count++
 	}
-	if _, ok := secret.Data[AWSSecretAccessKey]; !ok {
-		return errors.New("awsSecretAccessKey is a required field")
+	if _, ok := secret.Data[AWSSecretAccessKey]; ok {
+		count++
 	}
-	count := 2
 	if _, ok := secret.Data[ConfigRole]; ok {
 		count++
 	}
@@ -70,23 +70,18 @@ func ExtractAWSCredentials(ctx context.Context, secret *v1.Secret) (*credentials
 	if err := ValidateAWSCredentials(secret); err != nil {
 		return nil, err
 	}
-	accessKeyID := string(secret.Data[AWSAccessKeyID])
-	secretAccessKey := string(secret.Data[AWSSecretAccessKey])
-	role := string(secret.Data[ConfigRole])
-	if role != "" {
-		creds, err := awsrole.Switch(ctx, accessKeyID, secretAccessKey, role, assumeRoleDuration)
-		if err != nil {
-			return nil, err
-		}
-		val, err := creds.Get()
-		if err != nil {
-			return nil, errors.Wrap(err, "Failed to get AWS credentials")
-		}
-		return &val, nil
+	config := map[string]string{
+		aws.AccessKeyID:     string(secret.Data[AWSAccessKeyID]),
+		aws.SecretAccessKey: string(secret.Data[AWSSecretAccessKey]),
+		aws.ConfigRole:      string(secret.Data[ConfigRole]),
 	}
-	return &credentials.Value{
-		AccessKeyID:     accessKeyID,
-		SecretAccessKey: secretAccessKey,
-		SessionToken:    "",
-	}, nil
+	creds, err := aws.GetCredentials(ctx, config)
+	if err != nil {
+		return nil, err
+	}
+	val, err := creds.Get()
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to get AWS credentials")
+	}
+	return &val, nil
 }

--- a/pkg/secrets/aws_test.go
+++ b/pkg/secrets/aws_test.go
@@ -31,6 +31,7 @@ func (s *AWSSecretSuite) TestExtractAWSCredentials(c *C) {
 			expected: &credentials.Value{
 				AccessKeyID:     "key_id",
 				SecretAccessKey: "secret_key",
+				ProviderName:    credentials.StaticProviderName,
 			},
 			errChecker: IsNil,
 		},


### PR DESCRIPTION
## Change Overview

This PR adds support to the AWS package to initialize credentials using a
WebIdentityProvider via the following changes:

- Refactor the code to use the same pkg/function to initialize AWS credentials
- Make AWS access key/secret optional when initializing AWS credentials
- *If* AWS access key/secret is not provided, use WebIdentityProvider
    to assume an AWS IAM role if possible

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [x] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

Existing tests validate AWS access key/secret based usage. WebIdentityProvider functionality
has been validated manually in AWS EKS. Automated testing for this is TBD given
the AWS EKS requirement

- [x] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
