### PR TITLE
Add new Kanister function RestoreRDSSnapshot 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -57,6 +57,7 @@ require (
 	github.com/softlayer/softlayer-go v0.0.0-20190615201252-ba6e7f295217 // indirect
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/teris-io/shortid v0.0.0-20171029131806-771a37caa5cf
 	github.com/vmware/govmomi v0.21.1-0.20191008161538-40aebf13ba45
 	go.uber.org/atomic v1.4.0 // indirect
 	go.uber.org/multierr v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -67,6 +67,7 @@ github.com/elazarl/goproxy v0.0.0-20190711103511-473e67f1d7d2/go.mod h1:/Zj4wYkg
 github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2/go.mod h1:gNh8nYJoAm43RfaxurUnxr+N1PwuFV3ZMl/efxlIlY8=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.11.1+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
+github.com/evanphx/json-patch v4.5.0+incompatible h1:ouOWdg56aJriqS0huScTkVXPC5IcNrDCXZ6OoTAWu7M=
 github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=

--- a/go.sum
+++ b/go.sum
@@ -216,6 +216,8 @@ github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoH
 github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/teris-io/shortid v0.0.0-20171029131806-771a37caa5cf h1:Z2X3Os7oRzpdJ75iPqWZc0HeJWFYNCvKsfpQwFpRNTA=
+github.com/teris-io/shortid v0.0.0-20171029131806-771a37caa5cf/go.mod h1:M8agBzgqHIhgj7wEn9/0hJUZcrvt9VY+Ln+S1I5Mha0=
 github.com/vmware/govmomi v0.21.1-0.20191008161538-40aebf13ba45/go.mod h1:zbnFoBQ9GIjs2RVETy8CNEpb+L+Lwkjs3XZUL0B3/m0=
 github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728/go.mod h1:x9oS4Wk2s2u4tS29nEaDLdzvuHdB19CvSGJjPgkZJNk=
 go.opencensus.io v0.20.1/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=

--- a/pkg/app/rds_postgres.go
+++ b/pkg/app/rds_postgres.go
@@ -54,7 +54,7 @@ type RDSPostgresDB struct {
 	secretKey       string
 	region          string
 	sessionToken    string
-	securityGroupID string
+	securityGroupID *string
 	sqlDB           *sql.DB
 }
 
@@ -123,7 +123,7 @@ func (pdb *RDSPostgresDB) Install(ctx context.Context, ns string) error {
 	if err != nil {
 		return err
 	}
-	pdb.securityGroupID = *sg.GroupId
+	pdb.securityGroupID = sg.GroupId
 
 	// Add ingress rule
 	log.Info().Print("Adding ingress rule to security group.", field.M{"app": pdb.name})
@@ -140,7 +140,7 @@ func (pdb *RDSPostgresDB) Install(ctx context.Context, ns string) error {
 
 	// Create RDS instance
 	log.Info().Print("Creating RDS instance.", field.M{"app": pdb.name, "id": pdb.id})
-	_, err = rdsCli.CreateDBInstance(ctx, 20, "db.t2.micro", pdb.id, "postgres", pdb.username, pdb.password, pdb.securityGroupID)
+	_, err = rdsCli.CreateDBInstance(ctx, 20, "db.t2.micro", pdb.id, "postgres", pdb.username, pdb.password, []*string{pdb.securityGroupID})
 	if err != nil {
 		return err
 	}

--- a/pkg/app/rds_postgres.go
+++ b/pkg/app/rds_postgres.go
@@ -107,12 +107,12 @@ func (pdb *RDSPostgresDB) Install(ctx context.Context, ns string) error {
 	pdb.namespace = ns
 
 	// Create AWS config
-	awsConfig, _, err := pdb.getAWSConfig(ctx)
+	awsConfig, region, err := pdb.getAWSConfig(ctx)
 	if err != nil {
 		return errors.Wrapf(err, "app=%s", pdb.name)
 	}
 	// Create ec2 client
-	ec2Cli, err := ec2.NewClient(ctx, awsConfig)
+	ec2Cli, err := ec2.NewClient(ctx, awsConfig, region)
 	if err != nil {
 		return err
 	}
@@ -133,7 +133,7 @@ func (pdb *RDSPostgresDB) Install(ctx context.Context, ns string) error {
 	}
 
 	// Create rds client
-	rdsCli, err := rds.NewClient(ctx, awsConfig)
+	rdsCli, err := rds.NewClient(ctx, awsConfig, region)
 	if err != nil {
 		return err
 	}
@@ -308,12 +308,12 @@ func (pdb RDSPostgresDB) Secrets() map[string]crv1alpha1.ObjectReference {
 
 func (pdb RDSPostgresDB) Uninstall(ctx context.Context) error {
 	// Create AWS config
-	awsConfig, _, err := pdb.getAWSConfig(ctx)
+	awsConfig, region, err := pdb.getAWSConfig(ctx)
 	if err != nil {
 		return errors.Wrapf(err, "app=%s", pdb.name)
 	}
 	// Create rds client
-	rdsCli, err := rds.NewClient(ctx, awsConfig)
+	rdsCli, err := rds.NewClient(ctx, awsConfig, region)
 	if err != nil {
 		return errors.Wrap(err, "Failed to create rds client. You may need to delete RDS resources manually. app=rds-postgresql")
 	}
@@ -342,7 +342,7 @@ func (pdb RDSPostgresDB) Uninstall(ctx context.Context) error {
 	}
 
 	// Create ec2 client
-	ec2Cli, err := ec2.NewClient(ctx, awsConfig)
+	ec2Cli, err := ec2.NewClient(ctx, awsConfig, region)
 	if err != nil {
 		return errors.Wrap(err, "Failed to ec2 client. You may need to delete EC2 resources manually. app=rds-postgresql")
 	}

--- a/pkg/aws/ec2/ec2.go
+++ b/pkg/aws/ec2/ec2.go
@@ -23,6 +23,10 @@ import (
 	"github.com/pkg/errors"
 )
 
+const (
+	maxRetries = 10
+)
+
 // EC2 is a wrapper around ec2.EC2 structs
 type EC2 struct {
 	*ec2.EC2
@@ -30,12 +34,12 @@ type EC2 struct {
 }
 
 // NewEC2Client returns ec2 client struct.
-func NewClient(ctx context.Context, awsConfig *aws.Config) (*EC2, error) {
+func NewClient(ctx context.Context, awsConfig *aws.Config, region string) (*EC2, error) {
 	s, err := session.NewSession(awsConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create session")
 	}
-	return &EC2{EC2: ec2.New(s, awsConfig)}, nil
+	return &EC2{EC2: ec2.New(s, awsConfig.WithMaxRetries(maxRetries).WithRegion(region).WithCredentials(awsConfig.Credentials))}, nil
 }
 
 func (e EC2) DescribeSecurityGroup(ctx context.Context, groupName string) (*ec2.DescribeSecurityGroupsOutput, error) {

--- a/pkg/aws/rds/rds.go
+++ b/pkg/aws/rds/rds.go
@@ -16,6 +16,7 @@ package rds
 
 import (
 	"context"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -24,7 +25,8 @@ import (
 )
 
 const (
-	maxRetries = 10
+	maxRetries      = 10
+	rdsReadyTimeout = 20 * time.Minute
 )
 
 // RDS is a wrapper around ec2.RDS structs
@@ -56,6 +58,8 @@ func (r RDS) CreateDBInstance(ctx context.Context, storage int64, instanceClass,
 }
 
 func (r RDS) WaitUntilDBInstanceAvailable(ctx context.Context, instanceID string) error {
+	ctx, cancel := context.WithTimeout(ctx, rdsReadyTimeout)
+	defer cancel()
 	dba := &rds.DescribeDBInstancesInput{
 		DBInstanceIdentifier: &instanceID,
 	}
@@ -63,6 +67,8 @@ func (r RDS) WaitUntilDBInstanceAvailable(ctx context.Context, instanceID string
 }
 
 func (r RDS) WaitUntilDBInstanceDeleted(ctx context.Context, instanceID string) error {
+	ctx, cancel := context.WithTimeout(ctx, rdsReadyTimeout)
+	defer cancel()
 	dba := &rds.DescribeDBInstancesInput{
 		DBInstanceIdentifier: &instanceID,
 	}
@@ -94,6 +100,8 @@ func (r RDS) CreateDBSnapshot(ctx context.Context, instanceID, snapshotID string
 }
 
 func (r RDS) WaitUntilDBSnapshotAvailable(ctx context.Context, snapshotID string) error {
+	ctx, cancel := context.WithTimeout(ctx, rdsReadyTimeout)
+	defer cancel()
 	sni := &rds.DescribeDBSnapshotsInput{
 		DBSnapshotIdentifier: &snapshotID,
 	}
@@ -108,6 +116,8 @@ func (r RDS) DeleteDBSnapshot(ctx context.Context, snapshotID string) (*rds.Dele
 }
 
 func (r RDS) WaitUntilDBSnapshotDeleted(ctx context.Context, snapshotID string) error {
+	ctx, cancel := context.WithTimeout(ctx, rdsReadyTimeout)
+	defer cancel()
 	sni := &rds.DescribeDBSnapshotsInput{
 		DBSnapshotIdentifier: &snapshotID,
 	}

--- a/pkg/aws/rds/rds.go
+++ b/pkg/aws/rds/rds.go
@@ -44,11 +44,11 @@ func NewClient(ctx context.Context, awsConfig *aws.Config, region string) (*RDS,
 }
 
 // CreateDBInstanceWithContext
-func (r RDS) CreateDBInstance(ctx context.Context, storage int64, instanceClass, instanceID, engine, username, password, sgid string) (*rds.CreateDBInstanceOutput, error) {
+func (r RDS) CreateDBInstance(ctx context.Context, storage int64, instanceClass, instanceID, engine, username, password string, sgIDs []*string) (*rds.CreateDBInstanceOutput, error) {
 	dbi := &rds.CreateDBInstanceInput{
 		AllocatedStorage:     &storage,
 		DBInstanceIdentifier: &instanceID,
-		VpcSecurityGroupIds:  []*string{&sgid},
+		VpcSecurityGroupIds:  sgIDs,
 		DBInstanceClass:      &instanceClass,
 		Engine:               &engine,
 		MasterUsername:       &username,
@@ -124,11 +124,11 @@ func (r RDS) WaitUntilDBSnapshotDeleted(ctx context.Context, snapshotID string) 
 	return r.WaitUntilDBSnapshotDeletedWithContext(ctx, sni)
 }
 
-func (r RDS) RestoreDBInstanceFromDBSnapshot(ctx context.Context, instanceID, snapshotID, sgID string) (*rds.RestoreDBInstanceFromDBSnapshotOutput, error) {
+func (r RDS) RestoreDBInstanceFromDBSnapshot(ctx context.Context, instanceID, snapshotID string, sgIDs []*string) (*rds.RestoreDBInstanceFromDBSnapshotOutput, error) {
 	rdbi := &rds.RestoreDBInstanceFromDBSnapshotInput{
 		DBInstanceIdentifier: &instanceID,
 		DBSnapshotIdentifier: &snapshotID,
-		VpcSecurityGroupIds:  []*string{&sgID},
+		VpcSecurityGroupIds:  sgIDs,
 	}
 	return r.RestoreDBInstanceFromDBSnapshotWithContext(ctx, rdbi)
 }

--- a/pkg/function/create_rds_snapshot.go
+++ b/pkg/function/create_rds_snapshot.go
@@ -17,16 +17,13 @@ package function
 import (
 	"context"
 
-	awssdk "github.com/aws/aws-sdk-go/aws"
 	"github.com/pkg/errors"
 
 	kanister "github.com/kanisterio/kanister/pkg"
-	"github.com/kanisterio/kanister/pkg/aws"
 	"github.com/kanisterio/kanister/pkg/aws/rds"
 	"github.com/kanisterio/kanister/pkg/field"
 	"github.com/kanisterio/kanister/pkg/log"
 	"github.com/kanisterio/kanister/pkg/param"
-	"github.com/kanisterio/kanister/pkg/secrets"
 )
 
 func init() {
@@ -108,20 +105,4 @@ func (crs *createRDSSnapshotFunc) Exec(ctx context.Context, tp param.TemplatePar
 
 func (*createRDSSnapshotFunc) RequiredArgs() []string {
 	return []string{CreateRDSSnapshotInstanceIDArg, CreateRDSSnapshotSecurityGroupIDArg, CreateRDSSnapshotSnapshotIDArg}
-}
-
-func getAWSConfigFromProfile(ctx context.Context, profile *param.Profile) (*awssdk.Config, string, error) {
-	// Validate profile secret
-	config := make(map[string]string)
-	if profile.Credential.Type == param.CredentialTypeKeyPair {
-		config[aws.AccessKeyID] = profile.Credential.KeyPair.ID
-		config[aws.SecretAccessKey] = profile.Credential.KeyPair.Secret
-	} else if profile.Credential.Type == param.CredentialTypeSecret {
-		config[aws.AccessKeyID] = string(profile.Credential.Secret.Data[secrets.AWSAccessKeyID])
-		config[aws.SecretAccessKey] = string(profile.Credential.Secret.Data[secrets.AWSSecretAccessKey])
-		config[aws.ConfigRole] = string(profile.Credential.Secret.Data[secrets.ConfigRole])
-		config[aws.SessionToken] = string(profile.Credential.Secret.Data[secrets.AWSSessionToken])
-	}
-	config[aws.ConfigRegion] = profile.Location.Region
-	return aws.GetConfig(ctx, config)
 }

--- a/pkg/function/create_rds_snapshot.go
+++ b/pkg/function/create_rds_snapshot.go
@@ -16,7 +16,6 @@ package function
 
 import (
 	"context"
-	"time"
 
 	"github.com/pkg/errors"
 
@@ -45,8 +44,6 @@ const (
 	CreateRDSSnapshotSecurityGroupIDArg = "securityGroupID"
 	// RDSSnapshotID provides RDS snapshot ID
 	CreateRDSSnapshotSnapshotIDArg = "snapshotID"
-
-	rdsReadyTimeout = 20 * time.Minute
 )
 
 type createRDSSnapshotFunc struct{}
@@ -78,8 +75,6 @@ func createRDSSnapshot(ctx context.Context, instanceID, sgID, snapshotID string,
 		return nil, errors.Wrapf(err, "Failed to create snapshot")
 	}
 	// Wait until snapshot becomes available
-	ctx, cancel := context.WithTimeout(ctx, rdsReadyTimeout)
-	defer cancel()
 	log.Print("Waiting for RDS snapshot to be available", field.M{"SnapshotID": snapshotID})
 	if err := rdsCli.WaitUntilDBSnapshotAvailable(ctx, snapshotID); err != nil {
 		return nil, err

--- a/pkg/function/create_rds_snapshot.go
+++ b/pkg/function/create_rds_snapshot.go
@@ -39,8 +39,6 @@ const (
 	CreateRDSSnapshotFuncName = "CreateRDSSnapshot"
 	// CreateRDSSnapshotInstanceIDArg provides rds instance ID
 	CreateRDSSnapshotInstanceIDArg = "instanceID"
-	// CreateRDSSnapshotSecurityGroupIDArg provides RDS instance security group ID
-	CreateRDSSnapshotSecurityGroupIDArg = "securityGroupID"
 	// RDSSnapshotID provides RDS snapshot ID
 	CreateRDSSnapshotSnapshotIDArg = "snapshotID"
 )
@@ -82,9 +80,8 @@ func createRDSSnapshot(ctx context.Context, instanceID, sgID, snapshotID string,
 	}
 
 	output := map[string]interface{}{
-		CreateRDSSnapshotSnapshotIDArg:      snapshotID,
-		CreateRDSSnapshotInstanceIDArg:      instanceID,
-		CreateRDSSnapshotSecurityGroupIDArg: sgID,
+		CreateRDSSnapshotSnapshotIDArg: snapshotID,
+		CreateRDSSnapshotInstanceIDArg: instanceID,
 	}
 	return output, nil
 }
@@ -94,9 +91,6 @@ func (crs *createRDSSnapshotFunc) Exec(ctx context.Context, tp param.TemplatePar
 	if err := Arg(args, CreateRDSSnapshotInstanceIDArg, &instanceID); err != nil {
 		return nil, err
 	}
-	if err := Arg(args, CreateRDSSnapshotSecurityGroupIDArg, &sgID); err != nil {
-		return nil, err
-	}
 	if err := Arg(args, CreateRDSSnapshotSnapshotIDArg, &snapshotID); err != nil {
 		return nil, err
 	}
@@ -104,5 +98,5 @@ func (crs *createRDSSnapshotFunc) Exec(ctx context.Context, tp param.TemplatePar
 }
 
 func (*createRDSSnapshotFunc) RequiredArgs() []string {
-	return []string{CreateRDSSnapshotInstanceIDArg, CreateRDSSnapshotSecurityGroupIDArg, CreateRDSSnapshotSnapshotIDArg}
+	return []string{CreateRDSSnapshotInstanceIDArg, CreateRDSSnapshotSnapshotIDArg}
 }

--- a/pkg/function/create_rds_snapshot.go
+++ b/pkg/function/create_rds_snapshot.go
@@ -1,0 +1,112 @@
+// Copyright 2019 The Kanister Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package function
+
+import (
+	"context"
+	"time"
+
+	"github.com/pkg/errors"
+
+	kanister "github.com/kanisterio/kanister/pkg"
+	"github.com/kanisterio/kanister/pkg/aws"
+	"github.com/kanisterio/kanister/pkg/aws/rds"
+	"github.com/kanisterio/kanister/pkg/field"
+	"github.com/kanisterio/kanister/pkg/log"
+	"github.com/kanisterio/kanister/pkg/param"
+)
+
+func init() {
+	_ = kanister.Register(&createRDSSnapshotFunc{})
+}
+
+var (
+	_ kanister.Func = (*createRDSSnapshotFunc)(nil)
+)
+
+const (
+	// CreateVolumeFromSnapshotFuncName gives the name of the function
+	CreateRDSSnapshotFuncName = "CreateRDSSnapshot"
+	// CreateRDSSnapshotInstanceIDArg provides rds instance ID
+	CreateRDSSnapshotInstanceIDArg = "instanceID"
+	// CreateRDSSnapshotSecurityGroupIDArg provides RDS instance security group ID
+	CreateRDSSnapshotSecurityGroupIDArg = "securityGroupID"
+	// RDSSnapshotID provides RDS snapshot ID
+	CreateRDSSnapshotSnapshotIDArg = "snapshotID"
+
+	rdsReadyTimeout = 20 * time.Minute
+)
+
+type createRDSSnapshotFunc struct{}
+
+func (*createRDSSnapshotFunc) Name() string {
+	return CreateRDSSnapshotFuncName
+}
+
+func createRDSSnapshot(ctx context.Context, instanceID, sgID, snapshotID string, profile *param.Profile) (map[string]interface{}, error) {
+	// Validate profile
+	if err := ValidateProfile(profile); err != nil {
+		return nil, errors.Wrapf(err, "Profile Validation failed")
+	}
+
+	awsConfig, region, err := aws.GetConfigFromProfile(ctx, profile)
+	if err != nil {
+		return nil, err
+	}
+	// Create rds client
+	rdsCli, err := rds.NewClient(ctx, awsConfig, region)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create Snapshot
+	log.Print("Creating RDS snapshot", field.M{"SnapshotID": snapshotID})
+	_, err = rdsCli.CreateDBSnapshot(ctx, instanceID, snapshotID)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to create snapshot")
+	}
+	// Wait until snapshot becomes available
+	ctx, cancel := context.WithTimeout(ctx, rdsReadyTimeout)
+	defer cancel()
+	log.Print("Waiting for RDS snapshot to be available", field.M{"SnapshotID": snapshotID})
+	if err := rdsCli.WaitUntilDBSnapshotAvailable(ctx, snapshotID); err != nil {
+		return nil, err
+	}
+
+	output := map[string]interface{}{
+		CreateRDSSnapshotSnapshotIDArg:      snapshotID,
+		CreateRDSSnapshotInstanceIDArg:      instanceID,
+		CreateRDSSnapshotSecurityGroupIDArg: sgID,
+	}
+	return output, nil
+}
+
+func (crs *createRDSSnapshotFunc) Exec(ctx context.Context, tp param.TemplateParams, args map[string]interface{}) (map[string]interface{}, error) {
+	var instanceID, sgID, snapshotID string
+	if err := Arg(args, CreateRDSSnapshotInstanceIDArg, &instanceID); err != nil {
+		return nil, err
+	}
+	if err := Arg(args, CreateRDSSnapshotSecurityGroupIDArg, &sgID); err != nil {
+		return nil, err
+	}
+	if err := Arg(args, CreateRDSSnapshotSnapshotIDArg, &snapshotID); err != nil {
+		return nil, err
+	}
+	return createRDSSnapshot(ctx, instanceID, sgID, snapshotID, tp.Profile)
+}
+
+func (*createRDSSnapshotFunc) RequiredArgs() []string {
+	return []string{CreateRDSSnapshotInstanceIDArg, CreateRDSSnapshotSecurityGroupIDArg, CreateRDSSnapshotSnapshotIDArg}
+}

--- a/pkg/function/create_rds_snapshot.go
+++ b/pkg/function/create_rds_snapshot.go
@@ -17,6 +17,7 @@ package function
 import (
 	"context"
 
+	awssdk "github.com/aws/aws-sdk-go/aws"
 	"github.com/pkg/errors"
 
 	kanister "github.com/kanisterio/kanister/pkg"
@@ -25,6 +26,7 @@ import (
 	"github.com/kanisterio/kanister/pkg/field"
 	"github.com/kanisterio/kanister/pkg/log"
 	"github.com/kanisterio/kanister/pkg/param"
+	"github.com/kanisterio/kanister/pkg/secrets"
 )
 
 func init() {
@@ -58,10 +60,12 @@ func createRDSSnapshot(ctx context.Context, instanceID, sgID, snapshotID string,
 		return nil, errors.Wrapf(err, "Profile Validation failed")
 	}
 
-	awsConfig, region, err := aws.GetConfigFromProfile(ctx, profile)
+	// Get aws config from profile
+	awsConfig, region, err := getAWSConfigFromProfile(ctx, profile)
 	if err != nil {
 		return nil, err
 	}
+
 	// Create rds client
 	rdsCli, err := rds.NewClient(ctx, awsConfig, region)
 	if err != nil {
@@ -104,4 +108,20 @@ func (crs *createRDSSnapshotFunc) Exec(ctx context.Context, tp param.TemplatePar
 
 func (*createRDSSnapshotFunc) RequiredArgs() []string {
 	return []string{CreateRDSSnapshotInstanceIDArg, CreateRDSSnapshotSecurityGroupIDArg, CreateRDSSnapshotSnapshotIDArg}
+}
+
+func getAWSConfigFromProfile(ctx context.Context, profile *param.Profile) (*awssdk.Config, string, error) {
+	// Validate profile secret
+	config := make(map[string]string)
+	if profile.Credential.Type == param.CredentialTypeKeyPair {
+		config[aws.AccessKeyID] = profile.Credential.KeyPair.ID
+		config[aws.SecretAccessKey] = profile.Credential.KeyPair.Secret
+	} else if profile.Credential.Type == param.CredentialTypeSecret {
+		config[aws.AccessKeyID] = string(profile.Credential.Secret.Data[secrets.AWSAccessKeyID])
+		config[aws.SecretAccessKey] = string(profile.Credential.Secret.Data[secrets.AWSSecretAccessKey])
+		config[aws.ConfigRole] = string(profile.Credential.Secret.Data[secrets.ConfigRole])
+		config[aws.SessionToken] = string(profile.Credential.Secret.Data[secrets.AWSSessionToken])
+	}
+	config[aws.ConfigRegion] = profile.Location.Region
+	return aws.GetConfig(ctx, config)
 }

--- a/pkg/function/export_rds_snapshot_location.go
+++ b/pkg/function/export_rds_snapshot_location.go
@@ -1,0 +1,242 @@
+// Copyright 2019 The Kanister Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package function
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/teris-io/shortid"
+
+	kanister "github.com/kanisterio/kanister/pkg"
+	"github.com/kanisterio/kanister/pkg/aws/rds"
+	"github.com/kanisterio/kanister/pkg/field"
+	"github.com/kanisterio/kanister/pkg/kube"
+	"github.com/kanisterio/kanister/pkg/log"
+	"github.com/kanisterio/kanister/pkg/param"
+)
+
+func init() {
+	_ = kanister.Register(&exportRDSSnapshotToLocationFunc{})
+}
+
+var (
+	_ kanister.Func = (*exportRDSSnapshotToLocationFunc)(nil)
+)
+
+const (
+	ExportRDSSnapshotToLocFuncName           = "ExportRDSSnapshotToLocation"
+	ExportRDSSnapshotToLocInstanceIDArg      = "instanceID"
+	ExportRDSSnapshotToLocSecGrpIDArg        = "securityGroupID"
+	ExportRDSSnapshotToLocSnapshotIDArg      = "snapshotID"
+	ExportRDSSnapshotToLocDBUsernameArg      = "username"
+	ExportRDSSnapshotToLocDBPasswordArg      = "password"
+	ExportRDSSnapshotToLocBackupArtPrefixArg = "backupArtifactPrefix"
+	ExportRDSSnapshotToLocDBEngineArg        = "dbengine"
+	ExportRDSSnapshotToLocBackupID           = "backupID"
+
+	PostgrSQLEngine RDSDBEngine = "PostgreSQL"
+
+	BackupAction  RDSAction = "backup"
+	RestoreAction RDSAction = "restore"
+
+	postgresToolsImage = "kanisterio/postgres-kanister-tools:0.23.0"
+)
+
+type exportRDSSnapshotToLocationFunc struct{}
+
+type RDSDBEngine string
+type RDSAction string
+
+func (*exportRDSSnapshotToLocationFunc) Name() string {
+	return ExportRDSSnapshotToLocFuncName
+}
+
+func exportRDSSnapshotToLoc(ctx context.Context, instanceID, sgID, snapshotID, username, password, backupPrefix string, dbEngine RDSDBEngine, profile *param.Profile) (map[string]interface{}, error) {
+	// Validate profilextractDumpFromDBe
+	if err := ValidateProfile(profile); err != nil {
+		return nil, errors.Wrapf(err, "Profile Validation failed")
+	}
+
+	awsConfig, region, err := getAWSConfigFromProfile(ctx, profile)
+	if err != nil {
+		return nil, err
+	}
+	// Create rds client
+	rdsCli, err := rds.NewClient(ctx, awsConfig, region)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create tmp instance from the snapshot
+	randomID, err := shortid.Generate()
+	if err != nil {
+		return nil, err
+	}
+
+	tmpInstanceID := fmt.Sprintf("%s-%s", instanceID, randomID)
+	log.Print("Restore RDS instance from snapshot.", field.M{"SnapshotID": snapshotID, "InstanceID": tmpInstanceID})
+	// TODO: Use RDSRestoreSnapshot function instead
+	_, err = rdsCli.RestoreDBInstanceFromDBSnapshot(ctx, tmpInstanceID, snapshotID, sgID)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to create snapshot")
+	}
+	// Wait until snapshot becomes available
+	log.Print("Waiting for RDS DB instance to be available", field.M{"InstanceID": tmpInstanceID})
+	if err := rdsCli.WaitUntilDBInstanceAvailable(ctx, tmpInstanceID); err != nil {
+		return nil, err
+	}
+
+	// Find host of the instance
+	dbInstance, err := rdsCli.DescribeDBInstances(ctx, tmpInstanceID)
+	if err != nil {
+		return nil, err
+	}
+	dbEndpoint := *dbInstance.DBInstances[0].Endpoint.Address
+
+	// Extract dump from DB
+	output, err := extractAndPushDump(ctx, dbEngine, tmpInstanceID, dbEndpoint, username, password, backupPrefix, profile)
+	if err != nil {
+		return nil, err
+	}
+
+	// Deleting tmp instance
+	log.Print("Delete temporary RDS instance.", field.M{"SnapshotID": snapshotID, "InstanceID": tmpInstanceID})
+	_, err = rdsCli.DeleteDBInstance(ctx, tmpInstanceID)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to delete rds instance")
+	}
+	// Wait until instance is deleted
+	log.Print("Waiting for RDS DB instance to be deleted", field.M{"InstanceID": tmpInstanceID})
+	if err := rdsCli.WaitUntilDBInstanceDeleted(ctx, tmpInstanceID); err != nil {
+		return nil, err
+	}
+
+	// Add output artifacts
+	output[ExportRDSSnapshotToLocSnapshotIDArg] = snapshotID
+	output[ExportRDSSnapshotToLocInstanceIDArg] = instanceID
+	output[ExportRDSSnapshotToLocSecGrpIDArg] = sgID
+
+	return output, nil
+}
+
+func (crs *exportRDSSnapshotToLocationFunc) Exec(ctx context.Context, tp param.TemplateParams, args map[string]interface{}) (map[string]interface{}, error) {
+	var instanceID, sgID, snapshotID, username, password, backupArtifact string
+	var dbEngine RDSDBEngine
+	if err := Arg(args, ExportRDSSnapshotToLocInstanceIDArg, &instanceID); err != nil {
+		return nil, err
+	}
+	if err := Arg(args, ExportRDSSnapshotToLocSecGrpIDArg, &sgID); err != nil {
+		return nil, err
+	}
+	if err := Arg(args, ExportRDSSnapshotToLocSnapshotIDArg, &snapshotID); err != nil {
+		return nil, err
+	}
+	if err := Arg(args, ExportRDSSnapshotToLocDBEngineArg, &dbEngine); err != nil {
+		return nil, err
+	}
+	if err := OptArg(args, ExportRDSSnapshotToLocDBUsernameArg, &username, ""); err != nil {
+		return nil, err
+	}
+	if err := OptArg(args, ExportRDSSnapshotToLocDBPasswordArg, &password, ""); err != nil {
+		return nil, err
+	}
+	if err := OptArg(args, ExportRDSSnapshotToLocBackupArtPrefixArg, &backupArtifact, instanceID); err != nil {
+		return nil, err
+	}
+	return exportRDSSnapshotToLoc(ctx, instanceID, sgID, snapshotID, username, password, backupArtifact, dbEngine, tp.Profile)
+}
+
+func (*exportRDSSnapshotToLocationFunc) RequiredArgs() []string {
+	return []string{ExportRDSSnapshotToLocInstanceIDArg, ExportRDSSnapshotToLocSecGrpIDArg, ExportRDSSnapshotToLocSnapshotIDArg, ExportRDSSnapshotToLocDBEngineArg}
+}
+
+func extractAndPushDump(ctx context.Context, dbEngine RDSDBEngine, instanceID, dbEndpoint, username, password, backupPrefix string, profile *param.Profile) (map[string]interface{}, error) {
+	command, image, err := prepareCommand(dbEngine, BackupAction, instanceID, dbEndpoint, username, password, backupPrefix, profile)
+	if err != nil {
+		return nil, err
+	}
+
+	// Execute kubetask
+	cli, err := kube.NewClient()
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to create Kubernetes client")
+	}
+
+	namespace, err := kube.GetControllerNamespace()
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to get controller namespace")
+	}
+
+	return kubeTask(ctx, cli, namespace, image, command, nil)
+}
+
+func prepareCommand(dbEngine RDSDBEngine, action RDSAction, instanceID, dbEndpoint, username, password, backupPrefix string, profile *param.Profile) ([]string, string, error) {
+	switch dbEngine {
+	case PostgrSQLEngine:
+		switch action {
+		case BackupAction:
+			command, err := postgresBackupCommand(instanceID, dbEndpoint, username, password, backupPrefix, profile)
+			return command, postgresToolsImage, err
+		case RestoreAction:
+			fallthrough
+		default:
+		}
+	default:
+	}
+	return nil, "", errors.New("Invalid RDSDBEngine or RDSAction")
+}
+
+func postgresBackupCommand(instanceID, dbEndpoint, username, password, backupPrefix string, profile *param.Profile) ([]string, error) {
+	profileJson, err := json.Marshal(profile)
+	if err != nil {
+		return nil, err
+	}
+	randomID, err := shortid.Generate()
+	if err != nil {
+		return nil, err
+	}
+	backupID := fmt.Sprintf("backup-%s.tar.gz", randomID)
+	// TODO:
+	// 1. Pass and read creds from K8s Secrets
+	// 2. Find list of dbs using correct postgres go sdks
+	command := []string{
+		"bash",
+		"-o",
+		"errexit",
+		"-o",
+		"pipefail",
+		"-c",
+		fmt.Sprintf(`
+			export PGHOST=%s
+			export PGUSER=%s
+			export PGPASSWORD=%s
+			BACKUP_PREFIX=%s
+			BACKUP_ID=%s
+
+			mkdir /backup
+			restricted=("template0", "rdsadmin")
+			psql -lqt | awk -F "|" '{print $1}' | tr -d " " | sed '/^$/d' |
+			while read db;
+			  do [[ ! ${restricted[@]} =~ ${db} ]] && echo "backing up $db db" && pg_dump $db -C > /backup/$db.sql;
+			done
+			tar -zc backup | kando location push --profile '%s' --path "${BACKUP_PREFIX}/${BACKUP_ID}" -
+			kando output %s ${BACKUP_ID}`,
+			dbEndpoint, username, password, backupPrefix, backupID, profileJson, ExportRDSSnapshotToLocBackupID),
+	}
+	return command, nil
+}

--- a/pkg/function/restore_rds_snapshot.go
+++ b/pkg/function/restore_rds_snapshot.go
@@ -1,0 +1,196 @@
+// Copyright 2019 The Kanister Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package function
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/pkg/errors"
+	"k8s.io/client-go/kubernetes"
+
+	kanister "github.com/kanisterio/kanister/pkg"
+	"github.com/kanisterio/kanister/pkg/aws"
+	"github.com/kanisterio/kanister/pkg/aws/rds"
+	"github.com/kanisterio/kanister/pkg/kube"
+	"github.com/kanisterio/kanister/pkg/param"
+)
+
+func init() {
+	_ = kanister.Register(&restoreRDSSnapshotFunc{})
+}
+
+var (
+	_ kanister.Func = (*restoreRDSSnapshotFunc)(nil)
+)
+
+const (
+	// RestoreRDSSnapshotFuncName will store the name of the function
+	RestoreRDSSnapshotFuncName = "RestoreRDSSnapshot"
+	// RestoreRDSSnapshotDBEngine is type that will store which db we are dealing with
+	RestoreRDSSnapshotDBEngine DBEngine = "dbEngine"
+	// RestoreRDSSnapshotInstanceID is ID of the target instance
+	RestoreRDSSnapshotInstanceID = "instanceID"
+	// RestoreRDSSnapshotBackupArtifactPrefix stores the prefix of backup in object storage
+	RestoreRDSSnapshotBackupArtifactPrefix = "backupArtifactPrefix"
+	// RestoreRDSSnapshotBackupID stores the ID of backup in object storage
+	RestoreRDSSnapshotBackupID = "backupID"
+	// RestoreRDSSnapshotSecurityGroupID stores the securitygroup
+	RestoreRDSSnapshotSecurityGroupID = "securityGroupID"
+	// RestoreRDSSnapshotSnapshotID stores the snapshot ID
+	RestoreRDSSnapshotSnapshotID = "snapshotID"
+	// RestoreRDSSnapshotImage stores the image that will be used to run backup and restore commands
+	RestoreRDSSnapshotImage = "image"
+	// RestoreRDSSnapshotUsername stores username of the database
+	RestoreRDSSnapshotUsername = "username"
+	// RestoreRDSSnapshotPassword stores the password of the database
+	RestoreRDSSnapshotPassword = "password"
+
+	// PostgreSQLEngine stores the postgres appname
+	PostgreSQLEngine DBEngine = "PostgreSQL"
+)
+
+// DBEngine is type for the rds db engines
+type DBEngine string
+
+type restoreRDSSnapshotFunc struct{}
+
+func (*restoreRDSSnapshotFunc) Name() string {
+	return RestoreRDSSnapshotFuncName
+}
+
+func (*restoreRDSSnapshotFunc) RequiredArgs() []string {
+	return []string{RestoreRDSSnapshotSnapshotID, RestoreRDSSnapshotInstanceID, RestoreRDSSnapshotSecurityGroupID, RestoreRDSSnapshotUsername, RestoreRDSSnapshotPassword}
+}
+
+func (*restoreRDSSnapshotFunc) Exec(ctx context.Context, tp param.TemplateParams, args map[string]interface{}) (map[string]interface{}, error) {
+	var instanceID, snapshotID, securityGroupID, backupArtifactPrefix, backupID, image, username, password string
+
+	if err := Arg(args, RestoreRDSSnapshotInstanceID, &instanceID); err != nil {
+		return nil, err
+	}
+
+	if err := OptArg(args, RestoreRDSSnapshotSnapshotID, &snapshotID, ""); err != nil {
+		// snapshot ID is not provided get backupPrefix and backupID
+		if err := Arg(args, RestoreRDSSnapshotBackupArtifactPrefix, &backupArtifactPrefix); err != nil {
+			return nil, err
+		}
+
+		if err := Arg(args, RestoreRDSSnapshotBackupID, &backupID); err != nil {
+			return nil, err
+		}
+
+	}
+
+	if err := Arg(args, RestoreRDSSnapshotSecurityGroupID, &securityGroupID); err != nil {
+		return nil, err
+	}
+
+	if err := OptArg(args, RestoreRDSSnapshotImage, &image, "kanisterio/postgres-kanister-tools:0.22.1"); err != nil {
+		return nil, err
+	}
+
+	if err := Arg(args, RestoreRDSSnapshotUsername, &username); err != nil {
+		return nil, err
+	}
+	if err := Arg(args, RestoreRDSSnapshotPassword, &password); err != nil {
+		return nil, err
+	}
+
+	return restoreRDSSnapshot(ctx, instanceID, snapshotID, securityGroupID, backupArtifactPrefix, backupID, image, username, password, tp.Profile)
+}
+
+func restoreRDSSnapshot(ctx context.Context, instanceID, snapshotID, securityGroupID, backupArtifactPrefix, backupID, image, username, password string, profile *param.Profile) (map[string]interface{}, error) {
+	// Validate profile
+	if err := ValidateProfile(profile); err != nil {
+		return nil, errors.Wrapf(err, "error validating profile")
+	}
+
+	awsConfig, region, err := aws.GetConfigFromProfile(ctx, profile)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error getting awsconfig from profile")
+	}
+
+	// Create rds client
+	rdsCli, err := rds.NewClient(ctx, awsConfig, region)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error getting rds client from awsconfig")
+	}
+
+	// TODO delete the db instance
+
+	if snapshotID != "" {
+		// restore from snapshot
+		_, err := rdsCli.RestoreDBInstanceFromDBSnapshot(ctx, instanceID, snapshotID, securityGroupID)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error restoring database instance from snapshot")
+		}
+
+		return nil, nil
+	}
+
+	// restore from backup
+	var command []string
+	// convert the profile object to string
+	profilejson, err := json.Marshal(profile)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error converting profile object to string")
+	}
+
+	switch RestoreRDSSnapshotDBEngine {
+	case PostgreSQLEngine:
+		command = getPostgreSQLRestoreCommand(instanceID, password, backupArtifactPrefix, backupID, username, string(profilejson))
+	default:
+		return nil, errors.New("provided value of dbEngine is incorrect")
+	}
+
+	return restorePostgreSQLFrom(ctx, image, command)
+}
+
+func getPostgreSQLRestoreCommand(instanceID, password, backupArtifactPrefix, backupID, username, profilejson string) []string {
+	return []string{
+		"bash",
+		"-o",
+		"errexit",
+		"-o",
+		"pipefail",
+		"-c",
+		fmt.Sprintf(`
+		export PGHOST=%s
+		export PGPASSWORD=%s
+		kando location pull --profile '%s' --path "%s" - | gunzip -c -f | psql -q -U "%s"
+		`, instanceID, password, profilejson, fmt.Sprintf("%s/%s", backupArtifactPrefix, backupID), username),
+	}
+}
+
+func restorePostgreSQLFrom(ctx context.Context, image string, command []string) (map[string]interface{}, error) {
+	cfg, err := kube.LoadConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	kubeclient, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error getting kubeclient from kubeconfig")
+	}
+
+	ns, err := kube.GetControllerNamespace()
+	if err != nil {
+		return nil, errors.Wrapf(err, "error getting controller namespace")
+	}
+
+	return kubeTask(ctx, kubeclient, ns, image, command, nil)
+}

--- a/pkg/function/restore_rds_snapshot.go
+++ b/pkg/function/restore_rds_snapshot.go
@@ -65,6 +65,9 @@ const (
 
 	// PostgreSQLEngine stores the postgres appname
 	PostgreSQLEngine RDSDBEngine = "PostgreSQL"
+
+	// PostgresToolsImage is the image that has tools to take backup and restore of rds postgres instance
+	PostgresToolsImage = "kanisterio/postgres-kanister-tools:0.22.1"
 )
 
 // RDSDBEngine is type for the rds db engines
@@ -77,7 +80,8 @@ func (*restoreRDSSnapshotFunc) Name() string {
 }
 
 func (*restoreRDSSnapshotFunc) RequiredArgs() []string {
-	return []string{RestoreRDSSnapshotInstanceID, RestoreRDSSnapshotSecurityGroupID, string(RestoreRDSSnapshotDBEngine)}
+	return []string{RestoreRDSSnapshotInstanceID, RestoreRDSSnapshotSecurityGroupID, string(RestoreRDSSnapshotDBEngine),
+		RestoreRDSSnapshotUsername, RestoreRDSSnapshotPassword}
 }
 
 func (*restoreRDSSnapshotFunc) Exec(ctx context.Context, tp param.TemplateParams, args map[string]interface{}) (map[string]interface{}, error) {
@@ -107,7 +111,7 @@ func (*restoreRDSSnapshotFunc) Exec(ctx context.Context, tp param.TemplateParams
 		return nil, err
 	}
 
-	if err := OptArg(args, RestoreRDSSnapshotImage, &image, "kanisterio/postgres-kanister-tools:0.22.1"); err != nil {
+	if err := OptArg(args, RestoreRDSSnapshotImage, &image, PostgresToolsImage); err != nil {
 		return nil, err
 	}
 
@@ -216,12 +220,13 @@ func getPostgreSQLRestoreCommand(pgHost, password, backupArtifactPrefix, backupI
 		export PGHOST=%s
 		export PGPASSWORD=%s
 		export PGUSER=%s
+
 		if psql -l | grep -Fwq  "postgres"
 		then 
 		DATABASE=postgres
 		elif psql -l | grep -Fwq  "template1"
 		then 
-		DATABASE=tmeplate1
+		DATABASE=template1
 		else
 		echo "either postgres or template1 database should already be there in the database."
 		EXIT 1

--- a/pkg/function/restore_rds_snapshot.go
+++ b/pkg/function/restore_rds_snapshot.go
@@ -75,7 +75,7 @@ func (*restoreRDSSnapshotFunc) Name() string {
 }
 
 func (*restoreRDSSnapshotFunc) RequiredArgs() []string {
-	return []string{RestoreRDSSnapshotInstanceID, RestoreRDSSnapshotSecurityGroupID, RestoreRDSSnapshotDBEngine, RestoreRDSSnapshotUsername, RestoreRDSSnapshotPassword}
+	return []string{RestoreRDSSnapshotInstanceID, RestoreRDSSnapshotSecurityGroupID, RestoreRDSSnapshotDBEngine}
 }
 
 func (*restoreRDSSnapshotFunc) Exec(ctx context.Context, tp param.TemplateParams, args map[string]interface{}) (map[string]interface{}, error) {
@@ -211,6 +211,7 @@ func restoreFromDump(ctx context.Context, image string, command []string) (map[s
 func restoreFromSnapshot(ctx context.Context, rdsCli *rds.RDS, instanceID, snapshotID, sgID string) error {
 	// Delete and recreate RDS instance
 	// TODO: Call DeleteRDSSnapshot function instead
+	log.Print("Deleting existing instance.", field.M{"instanceID": instanceID})
 	_, err := rdsCli.DeleteDBInstance(ctx, instanceID)
 	if err != nil {
 		if aerr, ok := err.(awserr.Error); ok {

--- a/pkg/function/restore_rds_snapshot.go
+++ b/pkg/function/restore_rds_snapshot.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	kanister "github.com/kanisterio/kanister/pkg"
-	"github.com/kanisterio/kanister/pkg/aws"
 	"github.com/kanisterio/kanister/pkg/aws/rds"
 	"github.com/kanisterio/kanister/pkg/field"
 	"github.com/kanisterio/kanister/pkg/kube"
@@ -135,7 +134,7 @@ func restoreRDSSnapshot(ctx context.Context, instanceID, snapshotID, securityGro
 		return nil, errors.Wrapf(err, "error validating profile")
 	}
 
-	awsConfig, region, err := aws.GetConfigFromProfile(ctx, profile)
+	awsConfig, region, err := getAWSConfigFromProfile(ctx, profile)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error getting awsconfig from profile")
 	}
@@ -209,6 +208,8 @@ func restoreRDSSnapshot(ctx context.Context, instanceID, snapshotID, securityGro
 }
 
 func getPostgreSQLRestoreCommand(pgHost, password, backupArtifactPrefix, backupID, username, profilejson, database string) []string {
+	// TODO: use rds dbEngine lib to communicate to the datbase instead of using BASH
+	// TODO: use secrets to read the secrets details don't set as ENV var
 	return []string{
 		"bash",
 		"-o",

--- a/pkg/function/restore_rds_snapshot.go
+++ b/pkg/function/restore_rds_snapshot.go
@@ -149,6 +149,9 @@ func restoreRDSSnapshot(ctx context.Context, instanceID, snapshotID, securityGro
 	}
 	dbEndpoint := *descOp.DBInstances[0].Endpoint.Address
 	command, image, err := prepareCommand(dbEngine, RestoreAction, instanceID, dbEndpoint, username, password, backupArtifactPrefix, backupID, profile)
+	if err != nil {
+		return err
+	}
 	_, err = restoreFromDump(ctx, image, command)
 	return err
 }


### PR DESCRIPTION
## Change Overview

This PR Adda a new Kanister function RestoreRDSSnapshot  that can be used to restore the data either from the rds snapshot or from the dump that is stored in the object storage.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

To test the function please create the blueprint using below manifest 
```
apiVersion: cr.kanister.io/v1alpha1
kind: Blueprint
metadata:
  name: rds-postgres-blueprint
actions:
  restore:
    kind: Namespace
    phases:
    - func: RestoreRDSSnapshot 
      name: restoreSnapshots
      args:
        image: "kanisterio/postgres-kanister-tools:0.23.0"
        instanceID: "<instanceID>"
        securityGroupID:  "<sec-group-id>"
        snapshotID: "<snapshot-id>"
        username: "<username>"
        password: "<password>"
        dbEngine: "PostgreSQL"
```
**Note**
Please make a note that we either have to provide the details of snapshot or the backup details from object storage.

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
