### PR TITLE
Cap session duration when using AWS role chaining

### DIFF
--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -76,6 +76,12 @@ func GetCredentials(ctx context.Context, config map[string]string) (*credentials
 	if role, ok := config[ConfigRole]; !ok || role == assumedRole {
 		return creds, nil
 	}
+	// When you use role chaining, your new credentials are limited to a maximum duration of one hour
+	// https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html
+	if assumedRole != "" {
+		assumeRoleDuration = 60 * time.Hour
+	}
+
 	// If the caller wants to use a specific role, use the credentials initialized above to assume that
 	// role and return those credentials instead
 	creds, err := awsrole.Switch(ctx, creds, config[ConfigRole], assumeRoleDuration)


### PR DESCRIPTION
## Change Overview

Cap session duration when using AWS role chaining. AWS limits these sessions
to 1 hour.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
