### PR TITLE
Fix incorrect AssumeRole duration value

### DIFF
--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -73,7 +73,7 @@ func GetCredentials(ctx context.Context, config map[string]string) (*credentials
 		return nil, errors.New("AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY required to initialize AWS credentials")
 	}
 	// If the caller didn't want to assume a different role, we're done
-	if role, ok := config[ConfigRole]; !ok || role == assumedRole {
+	if config[ConfigRole] == "" || config[ConfigRole] == assumedRole {
 		return creds, nil
 	}
 	// When you use role chaining, your new credentials are limited to a maximum duration of one hour

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -79,7 +79,7 @@ func GetCredentials(ctx context.Context, config map[string]string) (*credentials
 	// When you use role chaining, your new credentials are limited to a maximum duration of one hour
 	// https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html
 	if assumedRole != "" {
-		assumeRoleDuration = 60 * time.Hour
+		assumeRoleDuration = 60 * time.Minute
 	}
 
 	// If the caller wants to use a specific role, use the credentials initialized above to assume that


### PR DESCRIPTION
## Change Overview

Fix incorrect duration used for role assumption API.

Also harden the role check to handle the case where the caller 
might have set the config map key with an empty value

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
