### PR TITLE
Add stack Trace to error logs

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -6,9 +6,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"time"
 
-	"github.com/luci/go-render/render"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
@@ -42,6 +40,8 @@ const (
 	LoggingServicePortEnv = "LOGGING_SVC_SERVICE_PORT_LOGGING"
 )
 
+const stackTrace = "stackTrace"
+
 type logger struct {
 	level Level
 	ctx   context.Context
@@ -74,81 +74,14 @@ func SetOutput(sink OutputSink) error {
 	}
 }
 
-// OutputFormat sets the output data format.
-type OutputFormat uint8
-
-const (
-	// TextFormat creates a plain text format log entry (not CEE).
-	TextFormat OutputFormat = iota
-	// JSONFormat create a JSON format log entry.
-	JSONFormat
-)
-
-// Used as a filter to expand (render) the contents of the fields
-type renderFormatter struct {
-	formatter logrus.Formatter
-}
-
-// SetFormatter sets the output formatter.
-func SetFormatter(format OutputFormat) {
-	switch format {
-	case TextFormat:
-		log.SetFormatter(&renderFormatter{
-			&logrus.TextFormatter{
-				FullTimestamp:   true,
-				TimestampFormat: time.RFC3339Nano}})
-	case JSONFormat:
-		log.SetFormatter(&logrus.JSONFormatter{TimestampFormat: time.RFC3339Nano})
-	default:
-		panic("not implemented")
-	}
-}
-
-func formatError(err error) (string, string) {
-	if err == nil {
-		return "", ""
-	}
-	msg := fmt.Sprintf("%+v", err)
-	split := strings.SplitAfter(msg, err.Error())
-
-	if len(split) > 1 {
-		return split[0], split[1]
-	}
-	return split[0], ""
-}
-
-func (f *renderFormatter) Format(e *logrus.Entry) ([]byte, error) {
-	if e != nil && len(e.Data) > 0 {
-		cp := *e
-		cp.Buffer = nil
-		data := make(logrus.Fields, len(e.Data))
-
-		// Expand / render the fields in the entry
-		for k, v := range e.Data {
-			switch t := v.(type) {
-			case error:
-				errmsg, stacktrace := formatError(t)
-				data[k] = errmsg
-				data["stackTrace"] = stacktrace
-			case string, fmt.Stringer:
-				data[k] = v
-			default:
-				if k != "time" && k != "field.time" {
-					// Preserve time formatting set in the upstream formatter
-					data[k] = render.Render(v)
-				} else {
-					data[k] = v
-				}
-			}
+func addStackTraceField(e *logrus.Entry, err error) *logrus.Entry {
+	if e != nil && err != nil {
+		split := strings.SplitAfter(fmt.Sprintf("%+v", err), err.Error())
+		if len(split) > 1 && len(split[1]) != 0 {
+			return e.WithField(stackTrace, split[1])
 		}
-		cp.Data = data
-		return f.formatter.Format(&cp)
 	}
-	return f.formatter.Format(e)
-}
-
-func init() {
-	SetFormatter(TextFormat)
+	return e
 }
 
 func Info() Logger {
@@ -184,7 +117,6 @@ func WithError(err error) Logger {
 
 func (l *logger) Print(msg string, fields ...field.M) {
 	logFields := make(logrus.Fields)
-
 	if ctxFields := field.FromContext(l.ctx); ctxFields != nil {
 		for _, cf := range ctxFields.Fields() {
 			logFields[cf.Key()] = cf.Value()
@@ -200,6 +132,7 @@ func (l *logger) Print(msg string, fields ...field.M) {
 	entry := log.WithFields(logFields)
 	if l.err != nil {
 		entry = entry.WithError(l.err)
+		entry = addStackTraceField(entry, l.err)
 	}
 	entry.Logln(logrus.Level(l.level), msg)
 }


### PR DESCRIPTION
## Change Overview

Add stackTrace to error logs

## Pull request type

Please check the type of change your PR introduces:
- [x] :sunflower: Log


Sample output:
```
time="2020-01-08T17:17:04.815055486Z" level=info msg="Failed to execute phase: v1alpha1.Phase{Name:\"myPhase-0\", State:\"pending\", Output:map[string]interface {}(nil)}:" ActionSet=test-actionset-4t89d Phase=myPhase-0 error="Kanister function failed" stackTrace="\ngithub.com/kanisterio/kanister/pkg/testutil.failFunc\n\t/go/src/github.com/kanisterio/kanister/pkg/testutil/func.go:45\ngithub.com/kanisterio/kanister/pkg/testutil.(*mockKanisterFunc).Exec\n\t/go/src/github.com/kanisterio/kanister/pkg/testutil/func.go:106\ngithub.com/kanisterio/kanister/pkg.(*Phase).Exec\n\t/go/src/github.com/kanisterio/kanister/pkg/phase.go:72\ngithub.com/kanisterio/kanister/pkg/controller.(*Controller).runAction.func1\n\t/go/src/github.com/kanisterio/kanister/pkg/controller/controller.go:406\ngopkg.in/tomb%2ev2.(*Tomb).run\n\t/go/pkg/mod/gopkg.in/tomb.v2@v2.0.0-20161208151619-d5d1b5820637/tomb.go:163\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1337"
```