### PR TITLE
Dump postgres data as INSERT commands in ExportRDSSnapshotToLocation

### DIFF
--- a/pkg/function/export_rds_snapshot_location.go
+++ b/pkg/function/export_rds_snapshot_location.go
@@ -251,7 +251,7 @@ func postgresBackupCommand(dbEndpoint, username, password string, dbList []strin
 			mkdir /backup
 			dblist=( %s )
 			for db in "${dblist[@]}";
-			  do echo "backing up $db db" && pg_dump $db -C > /backup/$db.sql;
+			  do echo "backing up $db db" && pg_dump $db -C --inserts > /backup/$db.sql;
 			done
 			tar -zc backup | kando location push --profile '%s' --path "${BACKUP_PREFIX}/${BACKUP_ID}" -
 			kando output %s ${BACKUP_ID}`,


### PR DESCRIPTION
Signed-off-by: Prasad Ghangal <prasad.ghangal@gmail.com>

## Change Overview

Dump postgres data as INSERT commands instead of COPY in ExportRDSSnapshotToLocation

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

fixes #505 

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [x] :green_heart: E2E
