### PR TITLE
Make deployment config kanister level resource 

### DIFF
--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -3,7 +3,7 @@
 Template Parameters
 *******************
 
-Template Parameters are use to render templates in Blueprints. A ``TemplateParam``
+Template Parameters are used to render templates in Blueprints. A ``TemplateParam``
 struct is constructed based on fields in an ActionSet.
 
 The TemplateParam struct is defined as:

--- a/go.mod
+++ b/go.mod
@@ -52,8 +52,8 @@ require (
 	github.com/lib/pq v1.2.0
 	github.com/luci/go-render v0.0.0-20160219211803-9a04cc21af0f
 	github.com/mitchellh/mapstructure v0.0.0-20180220230111-00c29f56e238
-	github.com/openshift/api v3.9.0+incompatible
-	github.com/openshift/client-go v3.9.0+incompatible
+	github.com/openshift/api v0.0.0-20190402135445-d2f01e7b77a6
+	github.com/openshift/client-go v0.0.0-20190402163854-7cc0953bbbb7
 	github.com/pborman/uuid v1.2.0 // indirect
 	github.com/pkg/errors v0.8.0
 	github.com/renier/xmlrpc v0.0.0-20170708154548-ce4a1a486c03 // indirect

--- a/go.mod
+++ b/go.mod
@@ -52,6 +52,8 @@ require (
 	github.com/lib/pq v1.2.0
 	github.com/luci/go-render v0.0.0-20160219211803-9a04cc21af0f
 	github.com/mitchellh/mapstructure v0.0.0-20180220230111-00c29f56e238
+	github.com/openshift/api v3.9.0+incompatible
+	github.com/openshift/client-go v3.9.0+incompatible
 	github.com/pborman/uuid v1.2.0 // indirect
 	github.com/pkg/errors v0.8.0
 	github.com/renier/xmlrpc v0.0.0-20170708154548-ce4a1a486c03 // indirect

--- a/go.sum
+++ b/go.sum
@@ -187,6 +187,7 @@ github.com/kubernetes-csi/external-snapshotter v1.1.0 h1:godlw8BSOac5TMGH2rVPJrm
 github.com/kubernetes-csi/external-snapshotter v1.1.0/go.mod h1:oYfxnsuh48V1UDYORl77YQxQbbdokNy7D73phuFpksY=
 github.com/lib/pq v1.2.0 h1:LXpIM/LZ5xGFhOpXAQUIMM1HdyqzVYM13zNdjCEEcA0=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
+github.com/luci/go-render v0.0.0-20160219211803-9a04cc21af0f h1:WVPqVsbUsrzAebTEgWRAZMdDOfkFx06iyhbIoyMgtkE=
 github.com/luci/go-render v0.0.0-20160219211803-9a04cc21af0f/go.mod h1:aS446i8akEg0DAtNKTVYpNpLPMc0SzsZ0RtGhjl0uFM=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
@@ -216,6 +217,7 @@ github.com/openshift/api v3.9.0+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9Pn
 github.com/openshift/client-go v3.9.0+incompatible h1:13k3Ok0B7TA2hA3bQW2aFqn6y04JaJWdk7ITTyg+Ek0=
 github.com/openshift/client-go v3.9.0+incompatible/go.mod h1:6rzn+JTr7+WYS2E1TExP4gByoABxMznR6y2SnUIkmxk=
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
+github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
@@ -253,6 +255,7 @@ github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoH
 github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/vmware/govmomi v0.21.1-0.20191008161538-40aebf13ba45 h1:zpQBW+l4uPQTfTOxedN5GEcSONhabbCf3X+5+P/H4Jk=
 github.com/vmware/govmomi v0.21.1-0.20191008161538-40aebf13ba45/go.mod h1:zbnFoBQ9GIjs2RVETy8CNEpb+L+Lwkjs3XZUL0B3/m0=
 github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728/go.mod h1:x9oS4Wk2s2u4tS29nEaDLdzvuHdB19CvSGJjPgkZJNk=
 go.opencensus.io v0.20.1 h1:pMEjRZ1M4ebWGikflH7nQpV6+Zr88KBMA2XJD3sbijw=

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,7 @@ github.com/Azure/go-autorest/autorest/date v0.2.0 h1:yW+Zlqf26583pE43KhfnhFcdmSW
 github.com/Azure/go-autorest/autorest/date v0.2.0/go.mod h1:vcORJHLJEh643/Ioh9+vPmf1Ij9AEBM5FuBIXLmIy0g=
 github.com/Azure/go-autorest/autorest/mocks v0.1.0/go.mod h1:OTyCOPRA2IgIlWxVYxBee2F5Gr4kF2zd2J5cFRaIDN0=
 github.com/Azure/go-autorest/autorest/mocks v0.2.0/go.mod h1:OTyCOPRA2IgIlWxVYxBee2F5Gr4kF2zd2J5cFRaIDN0=
+github.com/Azure/go-autorest/autorest/mocks v0.3.0 h1:qJumjCaCudz+OcqE9/XtEPfvtOjOmKaui4EOpFI6zZc=
 github.com/Azure/go-autorest/autorest/mocks v0.3.0/go.mod h1:a8FDP3DYzQ4RYfVAxAN3SVSiiO77gL2j2ronKKP0syM=
 github.com/Azure/go-autorest/autorest/to v0.2.0/go.mod h1:GunWKJp1AEqgMaGLV+iocmRAJWqST1wQYhyyjXJ3SJc=
 github.com/Azure/go-autorest/autorest/to v0.3.0 h1:zebkZaadz7+wIQYgC7GXaz3Wb28yKYfVkkBKwc38VF8=
@@ -74,6 +75,7 @@ github.com/aws/aws-sdk-go v1.26.8/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/census-instrumentation/opencensus-proto v0.2.0 h1:LzQXZOgg4CQfE6bFvXGM30YZL1WW/M337pXml+GrcZ4=
 github.com/census-instrumentation/opencensus-proto v0.2.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
+github.com/cheekybits/is v0.0.0-20150225183255-68e9c0620927 h1:SKI1/fuSdodxmNNyVBR8d7X/HuLnRpvvFO0AgyQk764=
 github.com/cheekybits/is v0.0.0-20150225183255-68e9c0620927/go.mod h1:h/aW8ynjgkuj+NQRlZcDbAbM1ORAbXjXX77sX7T289U=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -138,6 +140,7 @@ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v1.0.0 h1:A8PeW59pxE9IoFRqBp37U+mSNaQoZ46F1f0f863XSXw=
@@ -212,8 +215,12 @@ github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
+github.com/openshift/api v0.0.0-20190402135445-d2f01e7b77a6 h1:SYi9lNozXRC7vIHfNxGPkxV0jHywz9X5PooRAaC90nI=
+github.com/openshift/api v0.0.0-20190402135445-d2f01e7b77a6/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
 github.com/openshift/api v3.9.0+incompatible h1:fJ/KsefYuZAjmrr3+5U9yZIZbTOpVkDDLDLFresAeYs=
 github.com/openshift/api v3.9.0+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
+github.com/openshift/client-go v0.0.0-20190402163854-7cc0953bbbb7 h1:YxC8399EDGhV1iOUd7y5cv6cgRBmtJmk3AsGMtZszu8=
+github.com/openshift/client-go v0.0.0-20190402163854-7cc0953bbbb7/go.mod h1:6rzn+JTr7+WYS2E1TExP4gByoABxMznR6y2SnUIkmxk=
 github.com/openshift/client-go v3.9.0+incompatible h1:13k3Ok0B7TA2hA3bQW2aFqn6y04JaJWdk7ITTyg+Ek0=
 github.com/openshift/client-go v3.9.0+incompatible/go.mod h1:6rzn+JTr7+WYS2E1TExP4gByoABxMznR6y2SnUIkmxk=
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
@@ -223,6 +230,7 @@ github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829/go.mod h1:p2iRAGwDERtqlqzRXnrOVns+ignqQo//hLXqYxZYVNs=
@@ -254,6 +262,7 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/vmware/govmomi v0.21.1-0.20191008161538-40aebf13ba45 h1:zpQBW+l4uPQTfTOxedN5GEcSONhabbCf3X+5+P/H4Jk=
 github.com/vmware/govmomi v0.21.1-0.20191008161538-40aebf13ba45/go.mod h1:zbnFoBQ9GIjs2RVETy8CNEpb+L+Lwkjs3XZUL0B3/m0=
@@ -371,6 +380,7 @@ honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 k8s.io/api v0.0.0-20190708174958-539a33f6e817 h1:V6YPTc5fSnwv7EBjx6es9VyAki/6bqK4M3ECA6WwfBk=
 k8s.io/api v0.0.0-20190708174958-539a33f6e817/go.mod h1:iuAfoD4hCxJ8Onx9kaTIt30j7jUFS00AXQi6QMi99vA=
+k8s.io/api v0.17.1 h1:i46MidoDOE9tvQ0TTEYggf3ka/pziP1+tHI/GFVeJao=
 k8s.io/apiextensions-apiserver v0.0.0-20190708181606-527eacf2d4b7 h1:iAZwiJOjeCxGicPs5bDPLNP9DVZHCQp91gKIeLBIKlk=
 k8s.io/apiextensions-apiserver v0.0.0-20190708181606-527eacf2d4b7/go.mod h1:IxkesAMoaCRoLrPJdZNZUQp9NfZnzqaVzLhb2VEQzXE=
 k8s.io/apimachinery v0.0.0-20190404173353-6a84e37a896d h1:Jmdtdt1ZnoGfWWIIik61Z7nKYgO3J+swQJtPYsP9wHA=

--- a/go.sum
+++ b/go.sum
@@ -127,6 +127,7 @@ github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.2.0 h1:xU6/SpYbvkNYiptHJYEDRseDLvYE7wSqhYYNy0QSUzI=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
+github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6 h1:ZgQEtGgCBiWRM39fZuwSd1LwSqqSW0hOdXCYYDX0R3I=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -210,6 +211,10 @@ github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
+github.com/openshift/api v3.9.0+incompatible h1:fJ/KsefYuZAjmrr3+5U9yZIZbTOpVkDDLDLFresAeYs=
+github.com/openshift/api v3.9.0+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
+github.com/openshift/client-go v3.9.0+incompatible h1:13k3Ok0B7TA2hA3bQW2aFqn6y04JaJWdk7ITTyg+Ek0=
+github.com/openshift/client-go v3.9.0+incompatible/go.mod h1:6rzn+JTr7+WYS2E1TExP4gByoABxMznR6y2SnUIkmxk=
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=

--- a/pkg/function/e2e_volume_snapshot_test.go
+++ b/pkg/function/e2e_volume_snapshot_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/resource"
 	"github.com/kanisterio/kanister/pkg/testutil"
+	osversioned "github.com/openshift/client-go/apps/clientset/versioned"
 )
 
 const (
@@ -48,6 +49,7 @@ const (
 type VolumeSnapshotTestSuite struct {
 	cli       kubernetes.Interface
 	crCli     versioned.Interface
+	osCli     osversioned.Interface
 	namespace string
 	tp        *param.TemplateParams
 }
@@ -61,6 +63,8 @@ func (s *VolumeSnapshotTestSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 	crCli, err := versioned.NewForConfig(config)
 	c.Assert(err, IsNil)
+	osCli, err := osversioned.NewForConfig(config)
+	c.Assert(err, IsNil)
 
 	// Make sure the CRD's exist.
 	err = resource.CreateCustomResources(context.Background(), config)
@@ -68,6 +72,7 @@ func (s *VolumeSnapshotTestSuite) SetUpTest(c *C) {
 
 	s.cli = cli
 	s.crCli = crCli
+	s.osCli = osCli
 
 	ns := testutil.NewTestNamespace()
 
@@ -112,7 +117,7 @@ func (s *VolumeSnapshotTestSuite) SetUpTest(c *C) {
 		},
 	}
 
-	tp, err := param.New(ctx, s.cli, fake.NewSimpleDynamicClient(k8sscheme.Scheme, ss), s.crCli, as)
+	tp, err := param.New(ctx, s.cli, fake.NewSimpleDynamicClient(k8sscheme.Scheme, ss), s.crCli, s.osCli, as)
 	c.Assert(err, IsNil)
 	s.tp = tp
 }

--- a/pkg/function/kube_exec_all_test.go
+++ b/pkg/function/kube_exec_all_test.go
@@ -32,11 +32,13 @@ import (
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/resource"
 	"github.com/kanisterio/kanister/pkg/testutil"
+	osversioned "github.com/openshift/client-go/apps/clientset/versioned"
 )
 
 type KubeExecAllTest struct {
 	crCli     versioned.Interface
 	cli       kubernetes.Interface
+	osCli     osversioned.Interface
 	namespace string
 }
 
@@ -49,6 +51,8 @@ func (s *KubeExecAllTest) SetUpSuite(c *C) {
 	c.Assert(err, IsNil)
 	crCli, err := versioned.NewForConfig(config)
 	c.Assert(err, IsNil)
+	osCli, err := osversioned.NewForConfig(config)
+	c.Assert(err, IsNil)
 
 	// Make sure the CRD's exist.
 	err = resource.CreateCustomResources(context.Background(), config)
@@ -56,6 +60,7 @@ func (s *KubeExecAllTest) SetUpSuite(c *C) {
 
 	s.cli = cli
 	s.crCli = crCli
+	s.osCli = osCli
 
 	ns := &v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -124,7 +129,7 @@ func (s *KubeExecAllTest) TestKubeExecAllDeployment(c *C) {
 			Namespace: s.namespace,
 		},
 	}
-	tp, err := param.New(ctx, s.cli, fake.NewSimpleDynamicClient(k8sscheme.Scheme, d), s.crCli, as)
+	tp, err := param.New(ctx, s.cli, fake.NewSimpleDynamicClient(k8sscheme.Scheme, d), s.crCli, s.osCli, as)
 	c.Assert(err, IsNil)
 
 	action := "echo"
@@ -158,7 +163,7 @@ func (s *KubeExecAllTest) TestKubeExecAllStatefulSet(c *C) {
 			Namespace: s.namespace,
 		},
 	}
-	tp, err := param.New(ctx, s.cli, fake.NewSimpleDynamicClient(k8sscheme.Scheme, ss), s.crCli, as)
+	tp, err := param.New(ctx, s.cli, fake.NewSimpleDynamicClient(k8sscheme.Scheme, ss), s.crCli, s.osCli, as)
 	c.Assert(err, IsNil)
 
 	action := "echo"

--- a/pkg/function/kube_exec_test.go
+++ b/pkg/function/kube_exec_test.go
@@ -33,11 +33,13 @@ import (
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/resource"
 	"github.com/kanisterio/kanister/pkg/testutil"
+	osversioned "github.com/openshift/client-go/apps/clientset/versioned"
 )
 
 type KubeExecTest struct {
 	cli       kubernetes.Interface
 	crCli     versioned.Interface
+	osCli     osversioned.Interface
 	namespace string
 }
 
@@ -50,6 +52,8 @@ func (s *KubeExecTest) SetUpSuite(c *C) {
 	c.Assert(err, IsNil)
 	crCli, err := versioned.NewForConfig(config)
 	c.Assert(err, IsNil)
+	osCli, err := osversioned.NewForConfig(config)
+	c.Assert(err, IsNil)
 
 	// Make sure the CRD's exist.
 	err = resource.CreateCustomResources(context.Background(), config)
@@ -57,6 +61,7 @@ func (s *KubeExecTest) SetUpSuite(c *C) {
 
 	s.cli = cli
 	s.crCli = crCli
+	s.osCli = osCli
 
 	ns := &v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -153,7 +158,7 @@ func (s *KubeExecTest) TestKubeExec(c *C) {
 			Namespace: s.namespace,
 		},
 	}
-	tp, err := param.New(ctx, s.cli, fake.NewSimpleDynamicClient(k8sscheme.Scheme, ss), s.crCli, as)
+	tp, err := param.New(ctx, s.cli, fake.NewSimpleDynamicClient(k8sscheme.Scheme, ss), s.crCli, s.osCli, as)
 	c.Assert(err, IsNil)
 
 	action := "echo"

--- a/pkg/function/scale_test.go
+++ b/pkg/function/scale_test.go
@@ -32,11 +32,13 @@ import (
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/resource"
 	"github.com/kanisterio/kanister/pkg/testutil"
+	osversioned "github.com/openshift/client-go/apps/clientset/versioned"
 )
 
 type ScaleSuite struct {
 	cli       kubernetes.Interface
 	crCli     versioned.Interface
+	osCli     osversioned.Interface
 	namespace string
 }
 
@@ -49,9 +51,12 @@ func (s *ScaleSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 	crCli, err := versioned.NewForConfig(config)
 	c.Assert(err, IsNil)
+	osCli, err := osversioned.NewForConfig(config)
+	c.Assert(err, IsNil)
 
 	s.cli = cli
 	s.crCli = crCli
+	s.osCli = osCli
 
 	err = resource.CreateCustomResources(context.Background(), config)
 	c.Assert(err, IsNil)
@@ -156,7 +161,7 @@ func (s *ScaleSuite) TestScaleDeployment(c *C) {
 		},
 	}
 	for _, action := range []string{"scaleUp", "echoHello", "scaleDown"} {
-		tp, err := param.New(ctx, s.cli, fake.NewSimpleDynamicClient(k8sscheme.Scheme, d), s.crCli, as)
+		tp, err := param.New(ctx, s.cli, fake.NewSimpleDynamicClient(k8sscheme.Scheme, d), s.crCli, s.osCli, as)
 		c.Assert(err, IsNil)
 		bp := newScaleBlueprint(kind)
 		phases, err := kanister.GetPhases(*bp, action, kanister.DefaultVersion, *tp)
@@ -205,7 +210,7 @@ func (s *ScaleSuite) TestScaleStatefulSet(c *C) {
 	}
 
 	for _, action := range []string{"scaleUp", "echoHello", "scaleDown"} {
-		tp, err := param.New(ctx, s.cli, fake.NewSimpleDynamicClient(k8sscheme.Scheme, ss), s.crCli, as)
+		tp, err := param.New(ctx, s.cli, fake.NewSimpleDynamicClient(k8sscheme.Scheme, ss), s.crCli, s.osCli, as)
 		c.Assert(err, IsNil)
 		bp := newScaleBlueprint(kind)
 		phases, err := kanister.GetPhases(*bp, action, kanister.DefaultVersion, *tp)

--- a/pkg/kanctl/actionset.go
+++ b/pkg/kanctl/actionset.go
@@ -33,6 +33,7 @@ import (
 	"github.com/kanisterio/kanister/pkg/client/clientset/versioned"
 	"github.com/kanisterio/kanister/pkg/kube"
 	"github.com/kanisterio/kanister/pkg/param"
+	osversioned "github.com/openshift/client-go/apps/clientset/versioned"
 )
 
 const (
@@ -45,6 +46,7 @@ const (
 	pvcFlagName              = "pvc"
 	secretsFlagName          = "secrets"
 	statefulSetFlagName      = "statefulset"
+	deploymentConfigFlagName = "deploymentconfig"
 	sourceFlagName           = "from"
 	selectorFlagName         = "selector"
 	selectorKindFlag         = "kind"
@@ -86,6 +88,7 @@ func newActionSetCmd() *cobra.Command {
 	cmd.Flags().StringSliceP(pvcFlagName, "v", []string{}, "pvc for the action set, comma separated namespace/name pairs (eg: --pvc namespace1/name1,namespace2/name2)")
 	cmd.Flags().StringSliceP(secretsFlagName, "s", []string{}, "secrets for the action set, comma separated ref=namespace/name pairs (eg: --secrets ref1=namespace1/name1,ref2=namespace2/name2)")
 	cmd.Flags().StringSliceP(statefulSetFlagName, "t", []string{}, "statefulset for the action set, comma separated namespace/name pairs (eg: --statefulset namespace1/name1,namespace2/name2)")
+	cmd.Flags().StringSliceP(deploymentConfigFlagName, "D", []string{}, "deploymentconfig for action set, comma separated namespace/name pairs (e.g. --deploymentconfig namespace1/name1,namespace2/name2). Will ideally be used on openshift clusters.")
 	cmd.Flags().StringP(selectorFlagName, "l", "", "k8s selector for objects")
 	cmd.Flags().StringP(selectorKindFlag, "k", "all", "resource kind to apply selector on. Used along with the selector specified using --selector/-l")
 	cmd.Flags().String(selectorNamespaceFlag, "", "namespace to apply selector on. Used along with the selector specified using --selector/-l")
@@ -95,11 +98,11 @@ func newActionSetCmd() *cobra.Command {
 }
 
 func initializeAndPerform(cmd *cobra.Command, args []string) error {
-	cli, crCli, err := initializeClients()
+	cli, crCli, osCli, err := initializeClients()
 	if err != nil {
 		return err
 	}
-	params, err := extractPerformParams(cmd, args, cli)
+	params, err := extractPerformParams(cmd, args, cli, osCli)
 	if err != nil {
 		return err
 	}
@@ -107,7 +110,7 @@ func initializeAndPerform(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 	valFlag, _ := cmd.Flags().GetBool(skipValidationFlag)
 	if !valFlag {
-		err = verifyParams(ctx, params, cli, crCli)
+		err = verifyParams(ctx, params, cli, crCli, osCli)
 		if err != nil {
 			return err
 		}
@@ -250,7 +253,7 @@ func printActionSet(as *crv1alpha1.ActionSet) error {
 	return nil
 }
 
-func extractPerformParams(cmd *cobra.Command, args []string, cli kubernetes.Interface) (*PerformParams, error) {
+func extractPerformParams(cmd *cobra.Command, args []string, cli kubernetes.Interface, osCli osversioned.Interface) (*PerformParams, error) {
 	if len(args) != 0 {
 		return nil, newArgsLengthError("expected 0 arguments. got %#v", args)
 	}
@@ -270,7 +273,7 @@ func extractPerformParams(cmd *cobra.Command, args []string, cli kubernetes.Inte
 	if err != nil {
 		return nil, err
 	}
-	objects, err := parseObjects(cmd, cli)
+	objects, err := parseObjects(cmd, cli, osCli)
 	if err != nil {
 		return nil, err
 	}
@@ -333,17 +336,19 @@ func parseSecrets(cmd *cobra.Command) (map[string]crv1alpha1.ObjectReference, er
 	return secrets, nil
 }
 
-func parseObjects(cmd *cobra.Command, cli kubernetes.Interface) ([]crv1alpha1.ObjectReference, error) {
+func parseObjects(cmd *cobra.Command, cli kubernetes.Interface, osCli osversioned.Interface) ([]crv1alpha1.ObjectReference, error) {
 	var objects []crv1alpha1.ObjectReference
 	objs := make(map[string][]string)
 
 	deployments, _ := cmd.Flags().GetStringSlice(deploymentFlagName)
 	statefulSets, _ := cmd.Flags().GetStringSlice(statefulSetFlagName)
+	deploymetConfig, _ := cmd.Flags().GetStringSlice(deploymentConfigFlagName)
 	pvcs, _ := cmd.Flags().GetStringSlice(pvcFlagName)
 	namespaces, _ := cmd.Flags().GetStringSlice(namespaceTargetsFlagName)
 
 	objs[param.DeploymentKind] = deployments
 	objs[param.StatefulSetKind] = statefulSets
+	objs[param.DeploymentConfigKind] = deploymetConfig
 	objs[param.PVCKind] = pvcs
 	objs[param.NamespaceKind] = namespaces
 
@@ -370,7 +375,7 @@ func parseObjects(cmd *cobra.Command, cli kubernetes.Interface) ([]crv1alpha1.Ob
 		}
 		kind, _ := cmd.Flags().GetString(selectorKindFlag)
 		sns, _ := cmd.Flags().GetString(selectorNamespaceFlag)
-		fromSelector, err := parseObjectsFromSelector(selector.String(), kind, sns, cli, parsed)
+		fromSelector, err := parseObjectsFromSelector(selector.String(), kind, sns, cli, osCli, parsed)
 		if err != nil {
 			return nil, err
 		}
@@ -397,6 +402,8 @@ func parseObjectsFromCmd(objs map[string][]string, parsed map[string]bool) ([]cr
 				objects = append(objects, crv1alpha1.ObjectReference{Kind: param.DeploymentKind, Namespace: namespace, Name: name})
 			case param.StatefulSetKind:
 				objects = append(objects, crv1alpha1.ObjectReference{Kind: param.StatefulSetKind, Namespace: namespace, Name: name})
+			case param.DeploymentConfigKind:
+				objects = append(objects, crv1alpha1.ObjectReference{Kind: param.DeploymentConfigKind, Namespace: namespace, Name: name})
 			case param.PVCKind:
 				objects = append(objects, crv1alpha1.ObjectReference{Kind: param.PVCKind, Namespace: namespace, Name: name})
 			case param.NamespaceKind:
@@ -437,7 +444,7 @@ func parseGenericObjectReference(s string) (crv1alpha1.ObjectReference, error) {
 	}, nil
 }
 
-func parseObjectsFromSelector(selector, kind, sns string, cli kubernetes.Interface, parsed map[string]bool) ([]crv1alpha1.ObjectReference, error) {
+func parseObjectsFromSelector(selector, kind, sns string, cli kubernetes.Interface, osCli osversioned.Interface, parsed map[string]bool) ([]crv1alpha1.ObjectReference, error) {
 	var objects []crv1alpha1.ObjectReference
 	appendObj := func(kind, namespace, name string) {
 		r := fmt.Sprintf("%s=%s/%s", kind, namespace, name)
@@ -456,6 +463,19 @@ func parseObjectsFromSelector(selector, kind, sns string, cli kubernetes.Interfa
 		}
 		for _, d := range dpts.Items {
 			appendObj(param.DeploymentKind, d.Namespace, d.Name)
+		}
+		if kind != "all" {
+			break
+		}
+		fallthrough
+	case param.DeploymentConfigKind:
+		// use open shift SDK to get the deployment config resource
+		dcs, err := osCli.AppsV1().DeploymentConfigs(sns).List(metav1.ListOptions{LabelSelector: selector})
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to get deploymentconfig using select '%s' in namespaces '%s'", selector, sns)
+		}
+		for _, d := range dcs.Items {
+			appendObj(param.DeploymentConfigKind, d.Namespace, d.Name)
 		}
 		if kind != "all" {
 			break
@@ -567,7 +587,7 @@ func parseName(k string, r string) (namespace, name string, err error) {
 	return m[1], m[2], nil
 }
 
-func verifyParams(ctx context.Context, p *PerformParams, cli kubernetes.Interface, crCli versioned.Interface) error {
+func verifyParams(ctx context.Context, p *PerformParams, cli kubernetes.Interface, crCli versioned.Interface, osCli osversioned.Interface) error {
 	const notFoundTmpl = "Please make sure '%s' with name '%s' exists in namespace '%s'"
 	msgs := make(chan error)
 	wg := sync.WaitGroup{}
@@ -605,6 +625,9 @@ func verifyParams(ctx context.Context, p *PerformParams, cli kubernetes.Interfac
 				_, err = cli.AppsV1().Deployments(obj.Namespace).Get(obj.Name, metav1.GetOptions{})
 			case param.StatefulSetKind:
 				_, err = cli.AppsV1().StatefulSets(obj.Namespace).Get(obj.Name, metav1.GetOptions{})
+			case param.DeploymentConfigKind:
+				// use open shift client to get the deployment config resource
+				_, err = osCli.AppsV1().DeploymentConfigs(obj.Namespace).Get(obj.Name, metav1.GetOptions{})
 			case param.PVCKind:
 				_, err = cli.CoreV1().PersistentVolumeClaims(obj.Namespace).Get(obj.Name, metav1.GetOptions{})
 			case param.NamespaceKind:

--- a/pkg/kanctl/profile.go
+++ b/pkg/kanctl/profile.go
@@ -26,7 +26,7 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/oauth2/google"
 	compute "google.golang.org/api/compute/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sYAML "k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/kubernetes"
@@ -154,7 +154,7 @@ func createNewProfile(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 	skipValidation, _ := cmd.Flags().GetBool(skipValidationFlag)
 	dryRun, _ := cmd.Flags().GetBool(dryRunFlag)
-	cli, crCli, err := initializeClients()
+	cli, crCli, _, err := initializeClients()
 	if err != nil {
 		return err
 	}
@@ -369,7 +369,7 @@ func createProfile(ctx context.Context, profile *v1alpha1.Profile, crCli version
 
 func performProfileValidation(p *validateParams) error {
 	ctx := context.Background()
-	cli, crCli, err := initializeClients()
+	cli, crCli, _, err := initializeClients()
 	if err != nil {
 		return errors.Wrap(err, "could not initialize clients for validation")
 	}

--- a/pkg/param/param.go
+++ b/pkg/param/param.go
@@ -175,7 +175,7 @@ func New(ctx context.Context, cli kubernetes.Interface, dynCli dynamic.Interface
 			return nil, err
 		}
 		tp.DeploymentConfig = dcp
-		gvr = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "deploymentconfig"}
+		gvr = schema.GroupVersionResource{Group: "apps.openshift.io", Version: "v1", Resource: "deploymentconfigs"}
 	case DeploymentKind:
 		dp, err := fetchDeploymentParams(ctx, cli, as.Object.Namespace, as.Object.Name)
 		if err != nil {

--- a/pkg/param/param.go
+++ b/pkg/param/param.go
@@ -30,25 +30,37 @@ import (
 	"github.com/kanisterio/kanister/pkg/client/clientset/versioned"
 	"github.com/kanisterio/kanister/pkg/kube"
 	"github.com/kanisterio/kanister/pkg/secrets"
+	osversioned "github.com/openshift/client-go/apps/clientset/versioned"
 )
 
 const timeFormat = time.RFC3339Nano
 
 // TemplateParams are the values that will change between separate runs of Phases.
 type TemplateParams struct {
-	StatefulSet *StatefulSetParams
-	Deployment  *DeploymentParams
-	PVC         *PVCParams
-	Namespace   *NamespaceParams
-	ArtifactsIn map[string]crv1alpha1.Artifact
-	ConfigMaps  map[string]v1.ConfigMap
-	Secrets     map[string]v1.Secret
-	Time        string
-	Profile     *Profile
-	Options     map[string]string
-	Object      map[string]interface{}
-	Phases      map[string]*Phase
-	PodOverride crv1alpha1.JSONMap
+	StatefulSet      *StatefulSetParams
+	DeploymentConfig *DeploymentConfigParams
+	Deployment       *DeploymentParams
+	PVC              *PVCParams
+	Namespace        *NamespaceParams
+	ArtifactsIn      map[string]crv1alpha1.Artifact
+	ConfigMaps       map[string]v1.ConfigMap
+	Secrets          map[string]v1.Secret
+	Time             string
+	Profile          *Profile
+	Options          map[string]string
+	Object           map[string]interface{}
+	Phases           map[string]*Phase
+	PodOverride      crv1alpha1.JSONMap
+}
+
+// DeploymentConfigParams are params for deploymentconfig, will be used if working on open shift cluster
+// https://docs.openshift.com/container-platform/4.1/applications/deployments/what-deployments-are.html
+type DeploymentConfigParams struct {
+	Name                   string
+	Namespace              string
+	Pods                   []string
+	Containers             [][]string
+	PersistentVolumeClaims map[string]map[string]string
 }
 
 // StatefulSetParams are params for stateful sets.
@@ -115,15 +127,16 @@ type Phase struct {
 }
 
 const (
-	DeploymentKind  = "deployment"
-	StatefulSetKind = "statefulset"
-	PVCKind         = "pvc"
-	NamespaceKind   = "namespace"
-	SecretKind      = "secret"
+	DeploymentKind       = "deployment"
+	StatefulSetKind      = "statefulset"
+	DeploymentConfigKind = "deploymentconfig"
+	PVCKind              = "pvc"
+	NamespaceKind        = "namespace"
+	SecretKind           = "secret"
 )
 
 // New function fetches and returns the desired params
-func New(ctx context.Context, cli kubernetes.Interface, dynCli dynamic.Interface, crCli versioned.Interface, as crv1alpha1.ActionSpec) (*TemplateParams, error) {
+func New(ctx context.Context, cli kubernetes.Interface, dynCli dynamic.Interface, crCli versioned.Interface, osCli osversioned.Interface, as crv1alpha1.ActionSpec) (*TemplateParams, error) {
 	secrets, err := fetchSecrets(ctx, cli, as.Secrets)
 	if err != nil {
 		return nil, err
@@ -156,6 +169,13 @@ func New(ctx context.Context, cli kubernetes.Interface, dynCli dynamic.Interface
 		}
 		tp.StatefulSet = ssp
 		gvr = schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "statefulsets"}
+	case DeploymentConfigKind:
+		dcp, err := fetchDeploymentConfigParams(ctx, cli, osCli, as.Object.Namespace, as.Object.Name)
+		if err != nil {
+			return nil, err
+		}
+		tp.DeploymentConfig = dcp
+		gvr = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "deploymentconfig"}
 	case DeploymentKind:
 		dp, err := fetchDeploymentParams(ctx, cli, as.Object.Namespace, as.Object.Name)
 		if err != nil {
@@ -320,6 +340,38 @@ func fetchStatefulSetParams(ctx context.Context, cli kubernetes.Interface, names
 		}
 	}
 	return ssp, nil
+}
+
+func fetchDeploymentConfigParams(ctx context.Context, cli kubernetes.Interface, osCli osversioned.Interface, namespace, name string) (*DeploymentConfigParams, error) {
+	// we will have to have another OpenShift cli to get the deployment config resource
+	// because deploymentconfig is not standard kubernetes resource.
+	dc, err := osCli.AppsV1().DeploymentConfigs(namespace).Get(name, metav1.GetOptions{})
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	dcp := &DeploymentConfigParams{
+		Name:                   name,
+		Namespace:              namespace,
+		Pods:                   []string{},
+		Containers:             [][]string{},
+		PersistentVolumeClaims: make(map[string]map[string]string),
+	}
+
+	pods, _, err := kube.FetchPods(cli, namespace, dc.UID)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, p := range pods {
+		dcp.Pods = append(dcp.Pods, p.Name)
+		dcp.Containers = append(dcp.Containers, containerNames(p))
+		if pvcToMountPath := volumes(p, kube.DeploymentConfigVolumes(osCli, dc, &p)); len(pvcToMountPath) > 0 {
+			dcp.PersistentVolumeClaims[p.Name] = pvcToMountPath
+		}
+	}
+
+	return dcp, nil
 }
 
 func fetchDeploymentParams(ctx context.Context, cli kubernetes.Interface, namespace, name string) (*DeploymentParams, error) {

--- a/pkg/param/param_test.go
+++ b/pkg/param/param_test.go
@@ -39,6 +39,7 @@ import (
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	crfake "github.com/kanisterio/kanister/pkg/client/clientset/versioned/fake"
 	"github.com/kanisterio/kanister/pkg/kube"
+	osfake "github.com/openshift/client-go/apps/clientset/versioned/fake"
 )
 
 // Hook up gocheck into the "go test" runner.
@@ -323,6 +324,8 @@ func (s *ParamsSuite) testNewTemplateParams(ctx context.Context, c *C, dynCli dy
 	_, err = s.cli.CoreV1().Secrets(s.namespace).Get("secret-name", metav1.GetOptions{})
 	c.Assert(err, IsNil)
 
+	osCli := osfake.NewSimpleClientset()
+
 	crCli := crfake.NewSimpleClientset()
 	_, err = crCli.CrV1alpha1().Profiles(s.namespace).Create(prof)
 	c.Assert(err, IsNil)
@@ -372,7 +375,7 @@ func (s *ParamsSuite) testNewTemplateParams(ctx context.Context, c *C, dynCli dy
 	artsTpl["kindArtifact"] = crv1alpha1.Artifact{KeyValue: map[string]string{"my-key": template}}
 	artsTpl["objectNameArtifact"] = crv1alpha1.Artifact{KeyValue: map[string]string{"my-key": unstructuredTemplate}}
 
-	tp, err := New(ctx, s.cli, dynCli, crCli, as)
+	tp, err := New(ctx, s.cli, dynCli, crCli, osCli, as)
 	c.Assert(err, IsNil)
 	c.Assert(tp.ConfigMaps["myCM"].Data, DeepEquals, map[string]string{"someKey": "some-value"})
 	c.Assert(tp.Options, DeepEquals, map[string]string{"podName": "some-pod"})
@@ -509,8 +512,10 @@ func (s *ParamsSuite) TestProfile(c *C) {
 	_, err = crCli.CrV1alpha1().Profiles(s.namespace).Get("", metav1.GetOptions{})
 	c.Assert(err, IsNil)
 
+	osCli := osfake.NewSimpleClientset()
+
 	ctx := context.Background()
-	tp, err := New(ctx, cli, dynCli, crCli, as.Spec.Actions[0])
+	tp, err := New(ctx, cli, dynCli, crCli, osCli, as.Spec.Actions[0])
 	c.Assert(err, IsNil)
 	c.Assert(tp.Profile, NotNil)
 	c.Assert(tp.Profile, DeepEquals, &Profile{
@@ -566,6 +571,7 @@ func (s *ParamsSuite) TestPhaseParams(c *C) {
 	c.Assert(err, IsNil)
 	dynCli := s.getDynamicClient(c, pvc)
 	crCli := crfake.NewSimpleClientset()
+	osCli := osfake.NewSimpleClientset()
 	_, err = crCli.CrV1alpha1().Profiles(s.namespace).Create(prof)
 	c.Assert(err, IsNil)
 	_, err = crCli.CrV1alpha1().Profiles(s.namespace).Get("profName", metav1.GetOptions{})
@@ -587,7 +593,7 @@ func (s *ParamsSuite) TestPhaseParams(c *C) {
 			},
 		},
 	}
-	tp, err := New(ctx, s.cli, dynCli, crCli, as)
+	tp, err := New(ctx, s.cli, dynCli, crCli, osCli, as)
 	c.Assert(err, IsNil)
 	c.Assert(tp.Phases, IsNil)
 	err = InitPhaseParams(ctx, s.cli, tp, "backup", nil)

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -63,6 +63,8 @@ func actionSpec(s crv1alpha1.ActionSpec) error {
 		fallthrough
 	case param.PVCKind:
 		fallthrough
+	case param.DeploymentConfigKind:
+		fallthrough
 	case param.NamespaceKind:
 		// Known types
 	default:


### PR DESCRIPTION
## Change Overview

This change makes DeploymentConfig kanister level resource. [DeploymentConfig](https://docs.openshift.com/container-platform/4.1/applications/deployments/what-deployments-are.html#deployments-and-deploymentconfigs_what-deployments-are) will usually be used on the openshift clusters.

**Note**
So the main issue that we suspect we would get is OpenShift client not getting initialised if we are running the controller on non OpenShift cluster, but when checked even if we run the controller on the normal Kubernetes cluster below code does't break
```
osClient, err := osversioned.NewForConfig(c.config)
if err != nil {
	return errors.Wrap(err, "failed to get a openshift client")
}
```
and once we have osClient we are just passing around and only using it if the Kanister resource we are dealing with is DeploymentConfig.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #501 

## Test Plan

I will update after adding this into integration test.

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E


**Note**
I have marked this as WIP because I still have not checked that introducing/initializing the openshift client doesnt break in Kubernetes clusters.