### PR TITLE
Add way to install minishift using Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,9 +35,12 @@ VERSION := $(shell git describe --tags --always --dirty)
 PWD := $$(pwd)
 
 # Whether to build inside a containerized build environment
-DOCKER_BUILD ?= "true"
+DOCKER_BUILD ?= "false"
 
 DOCKER_CONFIG ?= "$(HOME)/.docker"
+
+# Mention the vm-driver that should be used to install OpenShift
+VM_DRIVER ?= "virtualbox"
 
 ###
 ### These variables should not need tweaking.
@@ -265,6 +268,12 @@ install-minio:
 
 uninstall-minio:
 	@$(MAKE) run CMD='-c "./build/minio.sh uninstall_minio"'
+
+install-minishift:
+	@/bin/bash ./build/minishift.sh install_minishift $(VM_DRIVER)
+
+uninstall-minishift:
+	@$(MAKE) run CMD='-c "./build/minishift.sh uninstall_minishift"'
 
 stop-kind:
 	@$(MAKE) run CMD='-c "./build/local_kubernetes.sh stop_localkube"'

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ DOCKER_BUILD ?= "false"
 DOCKER_CONFIG ?= "$(HOME)/.docker"
 
 # Mention the vm-driver that should be used to install OpenShift
-VM_DRIVER ?= "virtualbox"
+vm-driver ?= "virtualbox"
 
 ###
 ### These variables should not need tweaking.
@@ -270,10 +270,10 @@ uninstall-minio:
 	@$(MAKE) run CMD='-c "./build/minio.sh uninstall_minio"'
 
 install-minishift:
-	@/bin/bash ./build/minishift.sh install_minishift $(VM_DRIVER)
+	@/bin/bash ./build/minishift.sh install_minishift $(vm-driver)
 
 uninstall-minishift:
-	@$(MAKE) run CMD='-c "./build/minishift.sh uninstall_minishift"'
+	@/bin/bash ./build/minishift.sh uninstall_minishift
 
 stop-kind:
 	@$(MAKE) run CMD='-c "./build/local_kubernetes.sh stop_localkube"'

--- a/build/minishift.sh
+++ b/build/minishift.sh
@@ -17,34 +17,38 @@
 set -o errexit
 set -o nounset
 
+TMP_DIR=/tmp/minishift
+
 install_minishift ()
 {
     echo 'Started Deploying minishift...'
+    echo
     echo 'Downloading minishift...'
-    mkdir -p /tmp/minishift/bin
-    wget https://github.com/minishift/minishift/releases/download/v1.34.2/minishift-1.34.2-linux-amd64.tgz  -P /tmp/minishift/
-    tar zxvf /tmp/minishift/minishift-1.34.2-linux-amd64.tgz -C /tmp/minishift/bin
-    #cp /tmp/minishift/minishift-1.34.2-linux-amd64/minishift /usr/local/bin/
-    export PATH=/tmp/minishift/bin:$PATH
+    mkdir -p ${TMP_DIR}
+    wget https://github.com/minishift/minishift/releases/download/v1.34.2/minishift-1.34.2-linux-amd64.tgz  -P ${TMP_DIR}
+    tar zxvf ${TMP_DIR}/minishift-1.34.2-linux-amd64.tgz -C ${TMP_DIR}
+    cp ${TMP_DIR}/minishift-1.34.2-linux-amd64/minishift ${GOPATH}/bin
     echo 'minishift was downloaded'
     echo 
     echo 'Starting minishift...'
     minishift start --vm-driver=${1}
     echo 'minishift was started successfully.' 
     echo
-    echo 'Setting path variable...'
-    eval $(minishift oc-env)
+    echo 'Copying OpenShift client to correct location...'
+    cp  /home/user/.minishift/cache/oc/v3.11.0/linux/oc ${GOPATH}/bin
     echo 'Success, you are ready to use minishift.'
 }
 
 
 uninstall_minishift ()
 {
-    echo 'Stopping minishift...'
     minishift stop
-    echo
-    echo 'Deleting minishift...'
+    echo   
     minishift delete -f
+    rm -rf ${GOPATH}/bin/minishift
+    rm -rf ${GOPATH}/bin/oc
+    rm -rf ${TMP_DIR}
+    echo 'minishift was deleted successfully.'
 }
 
 [ ${#@} -gt 0 ] || usage

--- a/build/minishift.sh
+++ b/build/minishift.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# Copyright 2019 The Kanister Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+
+install_minishift ()
+{
+    echo 'Started Deploying minishift...'
+    echo 'Downloading minishift...'
+    mkdir -p /tmp/minishift/bin
+    wget https://github.com/minishift/minishift/releases/download/v1.34.2/minishift-1.34.2-linux-amd64.tgz  -P /tmp/minishift/
+    tar zxvf /tmp/minishift/minishift-1.34.2-linux-amd64.tgz -C /tmp/minishift/bin
+    #cp /tmp/minishift/minishift-1.34.2-linux-amd64/minishift /usr/local/bin/
+    export PATH=/tmp/minishift/bin:$PATH
+    echo 'minishift was downloaded'
+    echo 
+    echo 'Starting minishift...'
+    minishift start --vm-driver=${1}
+    echo 'minishift was started successfully.' 
+    echo
+    echo 'Setting path variable...'
+    eval $(minishift oc-env)
+    echo 'Success, you are ready to use minishift.'
+}
+
+
+uninstall_minishift ()
+{
+    echo 'Stopping minishift...'
+    minishift stop
+    echo
+    echo 'Deleting minishift...'
+    minishift delete -f
+}
+
+[ ${#@} -gt 0 ] || usage
+case "${1}" in
+        # Alphabetically sorted
+        install_minishift)
+            time -p install_minishift "${2}"
+            ;;
+        uninstall_minishift)
+            time -p uninstall_minishift
+            ;;
+        *)
+            usage
+            exit 1
+esac


### PR DESCRIPTION
## Change Overview
After this change we will be able to install `minishift` using `make` command.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan
Run below command to install the `minishift` cluster 
```
make install-minishift
```
above command will setup an `OpenShift` cluster using `virtualbox` `vm-driver` you can provide any other vm-driver using below command
```
make install-minishift vm-driver=kvm
```

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
