### PR TITLE
Add support for ConfigMap refs in objects

### DIFF
--- a/pkg/param/param.go
+++ b/pkg/param/param.go
@@ -122,8 +122,9 @@ type KeyPair struct {
 
 // Phase represents a Blueprint phase and contains the phase output
 type Phase struct {
-	Secrets map[string]v1.Secret
-	Output  map[string]interface{}
+	ConfigMaps map[string]v1.ConfigMap
+	Secrets    map[string]v1.Secret
+	Output     map[string]interface{}
 }
 
 const (
@@ -133,6 +134,7 @@ const (
 	PVCKind              = "pvc"
 	NamespaceKind        = "namespace"
 	SecretKind           = "secret"
+	ConfigMapKind        = "configmap"
 )
 
 // New function fetches and returns the desired params
@@ -454,8 +456,14 @@ func InitPhaseParams(ctx context.Context, cli kubernetes.Interface, tp *Template
 	if err != nil {
 		return err
 	}
+	cms, err := fetchConfigMaps(ctx, cli, filterByKind(objects, ConfigMapKind))
+	if err != nil {
+		return err
+	}
+
 	tp.Phases[phaseName] = &Phase{
-		Secrets: secrets,
+		Secrets:    secrets,
+		ConfigMaps: cms,
 	}
 	return nil
 }


### PR DESCRIPTION
## Change Overview

Adds support to reference ConfigMaps in phase initialization

## Pull request type

Please check the type of change your PR introduces:
- [x] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
