### PR TITLE
Add serviceAccount if namespace arg is same as controller ns

### DIFF
--- a/pkg/function/kube_task.go
+++ b/pkg/function/kube_task.go
@@ -55,11 +55,15 @@ func (*kubeTaskFunc) Name() string {
 func kubeTask(ctx context.Context, cli kubernetes.Interface, namespace, image string, command []string, podOverride crv1alpha1.JSONMap) (map[string]interface{}, error) {
 	var serviceAccount string
 	var err error
+
+	controllerNs, err := kube.GetControllerNamespace()
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to get controller namespace")
+	}
 	if namespace == "" {
-		namespace, err = kube.GetControllerNamespace()
-		if err != nil {
-			return nil, errors.Wrapf(err, "Failed to get controller namespace")
-		}
+		namespace = controllerNs
+	}
+	if namespace == controllerNs {
 		serviceAccount, err = kube.GetControllerServiceAccount(cli)
 		if err != nil {
 			return nil, errors.Wrap(err, "Failed to get Controller Service Account")

--- a/pkg/kube/podinfo.go
+++ b/pkg/kube/podinfo.go
@@ -25,14 +25,14 @@ import (
 
 const (
 	nsFile        = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
-	podNSEnvVar   = "POD_NAMESPACE"
-	podSAEnvVar   = "POD_SERVICE_ACCOUNT"
+	PodNSEnvVar   = "POD_NAMESPACE"
+	PodSAEnvVar   = "POD_SERVICE_ACCOUNT"
 	podNameEnvVar = "POD_NAME"
 )
 
 //GetControllerNamespace returns controller namespace
 func GetControllerNamespace() (string, error) {
-	if ns, ok := os.LookupEnv(podNSEnvVar); ok {
+	if ns, ok := os.LookupEnv(PodNSEnvVar); ok {
 		return ns, nil
 	}
 
@@ -46,7 +46,7 @@ func GetControllerNamespace() (string, error) {
 
 //GetControllerServiceAccount returns controller ServiceAccount
 func GetControllerServiceAccount(k8sclient kubernetes.Interface) (string, error) {
-	if ns, ok := os.LookupEnv(podSAEnvVar); ok {
+	if ns, ok := os.LookupEnv(PodSAEnvVar); ok {
 		return ns, nil
 	}
 	ns, err := GetControllerNamespace()

--- a/pkg/kube/podinfo_test.go
+++ b/pkg/kube/podinfo_test.go
@@ -31,11 +31,11 @@ const testPodName = "test-pod-name"
 const testPodSA = "test-pod-sa"
 
 func (s *PodInfoSuite) TestGetControllerNamespaceFromEnv(c *C) {
-	os.Setenv(podNSEnvVar, testPodNamespace)
+	os.Setenv(PodNSEnvVar, testPodNamespace)
 	ns, err := GetControllerNamespace()
 	c.Assert(err, IsNil)
 	c.Assert(ns, Equals, testPodNamespace)
-	os.Unsetenv(podNSEnvVar)
+	os.Unsetenv(PodNSEnvVar)
 }
 
 func (s *PodInfoSuite) TestGetControllerNamespaceFromFile(c *C) {
@@ -67,7 +67,7 @@ func (s *PodInfoSuite) TestGetControllerPodNameFromSystem(c *C) {
 }
 
 func (s *PodInfoSuite) TestGetControllerServiceAccountFromEnv(c *C) {
-	os.Setenv(podSAEnvVar, testPodSA)
+	os.Setenv(PodSAEnvVar, testPodSA)
 	saName, err := GetControllerServiceAccount(fake.NewSimpleClientset())
 	c.Assert(err, IsNil)
 	c.Assert(saName, Equals, testPodSA)

--- a/pkg/testing/integration_test.go
+++ b/pkg/testing/integration_test.go
@@ -17,6 +17,7 @@ package testing
 
 import (
 	"context"
+	"os"
 	"time"
 
 	"github.com/pkg/errors"
@@ -42,6 +43,7 @@ import (
 const (
 	// appWaitTimeout decides the time we are going to wait for app to be ready
 	appWaitTimeout = 3 * time.Minute
+	controllerSA   = "default"
 )
 
 type secretProfile struct {
@@ -119,6 +121,10 @@ func (s *IntegrationSuite) TestRun(c *C) {
 	// Create namespace
 	err = createNamespace(s.cli, s.namespace)
 	c.Assert(err, IsNil)
+
+	// Set Controller namespace and service account
+	os.Setenv(kube.PodNSEnvVar, s.namespace)
+	os.Setenv(kube.PodSAEnvVar, controllerSA)
 
 	// Create profile
 	if s.profile == nil {


### PR DESCRIPTION
Signed-off-by: Prasad Ghangal <prasad.ghangal@gmail.com>

## Change Overview

Add Kanister serviceAccount to Pod while executing KubeTask function is namespace arg is same as controller namespace

<!-- Insert PR description-->

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
