### PR TITLE
Adding a temporary way of overwritting kanister-tools for kan functions

### DIFF
--- a/pkg/function/backup_data_stats.go
+++ b/pkg/function/backup_data_stats.go
@@ -65,7 +65,7 @@ func backupDataStats(ctx context.Context, cli kubernetes.Interface, tp param.Tem
 	options := &kube.PodOptions{
 		Namespace:    namespace,
 		GenerateName: jobPrefix,
-		Image:        kanisterToolsImage,
+		Image:        getKanisterToolsImage(),
 		Command:      []string{"sh", "-c", "tail -f /dev/null"},
 		PodOverride:  podOverride,
 	}

--- a/pkg/function/checkRepository.go
+++ b/pkg/function/checkRepository.go
@@ -49,7 +49,7 @@ func CheckRepository(ctx context.Context, cli kubernetes.Interface, tp param.Tem
 	options := &kube.PodOptions{
 		Namespace:    namespace,
 		GenerateName: jobPrefix,
-		Image:        kanisterToolsImage,
+		Image:        getKanisterToolsImage(),
 		Command:      []string{"sh", "-c", "tail -f /dev/null"},
 		PodOverride:  podOverride,
 	}

--- a/pkg/function/copy_volume_data.go
+++ b/pkg/function/copy_volume_data.go
@@ -33,7 +33,6 @@ import (
 )
 
 const (
-	kanisterToolsImage = "kanisterio/kanister-tools:0.24.0"
 	// CopyVolumeDataFuncName gives the function name
 	CopyVolumeDataFuncName                     = "CopyVolumeData"
 	CopyVolumeDataMountPoint                   = "/mnt/vol_data/%s"
@@ -74,7 +73,7 @@ func copyVolumeData(ctx context.Context, cli kubernetes.Interface, tp param.Temp
 	options := &kube.PodOptions{
 		Namespace:    namespace,
 		GenerateName: CopyVolumeDataJobPrefix,
-		Image:        kanisterToolsImage,
+		Image:        getKanisterToolsImage(),
 		Command:      []string{"sh", "-c", "tail -f /dev/null"},
 		Volumes:      map[string]string{pvc: mountPoint},
 		PodOverride:  podOverride,

--- a/pkg/function/delete_data.go
+++ b/pkg/function/delete_data.go
@@ -69,7 +69,7 @@ func deleteData(ctx context.Context, cli kubernetes.Interface, tp param.Template
 	options := &kube.PodOptions{
 		Namespace:    namespace,
 		GenerateName: jobPrefix,
-		Image:        kanisterToolsImage,
+		Image:        getKanisterToolsImage(),
 		Command:      []string{"sh", "-c", "tail -f /dev/null"},
 		PodOverride:  podOverride,
 	}

--- a/pkg/function/describe_backups.go
+++ b/pkg/function/describe_backups.go
@@ -67,7 +67,7 @@ func describeBackups(ctx context.Context, cli kubernetes.Interface, tp param.Tem
 	options := &kube.PodOptions{
 		Namespace:    namespace,
 		GenerateName: jobPrefix,
-		Image:        kanisterToolsImage,
+		Image:        getKanisterToolsImage(),
 		Command:      []string{"sh", "-c", "tail -f /dev/null"},
 		PodOverride:  podOverride,
 	}

--- a/pkg/function/utils.go
+++ b/pkg/function/utils.go
@@ -3,9 +3,9 @@ package function
 import (
 	"bytes"
 	"context"
+	"os"
 	"path"
 	"strings"
-	"os"
 
 	awssdk "github.com/aws/aws-sdk-go/aws"
 	"github.com/pkg/errors"
@@ -24,9 +24,10 @@ import (
 )
 
 const (
-	FunctionOutputVersion = "version"
-	kanisterToolsImage    = "kanisterio/kanister-tools:0.24.2"
-    kanisterToolsImageEnvName = "KANISTER_TOOLS"
+	// FunctionOutputVersion returns version
+	FunctionOutputVersion     = "version"
+	kanisterToolsImage        = "kanisterio/kanister-tools:0.24.2"
+	kanisterToolsImageEnvName = "KANISTER_TOOLS"
 )
 
 func getKanisterToolsImage() string {

--- a/pkg/function/utils.go
+++ b/pkg/function/utils.go
@@ -5,10 +5,11 @@ import (
 	"context"
 	"path"
 	"strings"
+	"os"
 
 	awssdk "github.com/aws/aws-sdk-go/aws"
 	"github.com/pkg/errors"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
@@ -24,7 +25,16 @@ import (
 
 const (
 	FunctionOutputVersion = "version"
+	kanisterToolsImage    = "kanisterio/kanister-tools:0.24.0"
+    kanisterToolsImageEnvName = "KANISTER_TOOLS"
 )
+
+func getKanisterToolsImage() string {
+	if val, ok := os.LookupEnv(kanisterToolsImageEnvName); ok {
+		return val
+	}
+	return kanisterToolsImage
+}
 
 // ValidateCredentials verifies if the given credentials have appropriate values set
 func ValidateCredentials(creds *param.Credential) error {

--- a/pkg/function/utils.go
+++ b/pkg/function/utils.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	FunctionOutputVersion = "version"
-	kanisterToolsImage    = "kanisterio/kanister-tools:0.24.0"
+	kanisterToolsImage    = "kanisterio/kanister-tools:0.24.2"
     kanisterToolsImageEnvName = "KANISTER_TOOLS"
 )
 


### PR DESCRIPTION
## Change Overview

kanister-tools is hardcoded 
to make things flexible adding a way of specifying kanister-tools image 
via env var

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [x] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
