### PR TITLE
Use alpine as the base for elastic image

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -61,8 +61,6 @@ dockers:
   dockerfile: 'examples/helm/kanister/kanister-elasticsearch/image/Dockerfile'
   extra_files:
   - 'examples/helm/kanister/kanister-elasticsearch/image/esdump-setup.sh'
-  build_flag_templates:
-  - "--build-arg=TOOLS_IMAGE=kanisterio/kanister-tools:{{ .Tag }}"
 - binaries:
   - kando
   image_templates:

--- a/examples/helm/kanister/kanister-elasticsearch/image/Dockerfile
+++ b/examples/helm/kanister/kanister-elasticsearch/image/Dockerfile
@@ -1,6 +1,10 @@
-ARG TOOLS_IMAGE
-FROM $TOOLS_IMAGE
-MAINTAINER Supriya Kharade <supriya@kasten.io>
+FROM alpine:3.11.3
 
-ADD --chmod=kanister:kanister examples/helm/kanister/kanister-elasticsearch/image/esdump-setup.sh /esdump-setup.sh
-RUN sync && bash /esdump-setup.sh
+COPY --from=restic/restic:0.9.5 /usr/bin/restic /usr/local/bin/restic
+COPY --from=kanisterio/kopia:alpine-2fb6bc8 /kopia/kopia /usr/local/bin/kopia
+ADD kando /usr/local/bin/
+
+ADD examples/helm/kanister/kanister-elasticsearch/image/esdump-setup.sh /esdump-setup.sh
+RUN chmod +x /esdump-setup.sh && sync && /esdump-setup.sh
+
+CMD [ "/usr/bin/tail", "-f", "/dev/null" ]


### PR DESCRIPTION
## Change Overview

Use alpine as the base for elastic image

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E

```
docker build . -t kanisterio/es-sidecar:0.25.0 --build-arg=TOOLS_IMAGE=kanisterio/kanister-tools:0.25.0
Sending build context to Docker daemon  36.96MB
Step 1/7 : FROM alpine:3.11.3
 ---> e7d92cdc71fe
Step 2/7 : COPY --from=restic/restic:0.9.5 /usr/bin/restic /usr/local/bin/restic
 ---> Using cache
 ---> 8665ac35437d
Step 3/7 : COPY --from=kanisterio/kopia:alpine-2fb6bc8 /kopia/kopia /usr/local/bin/kopia
 ---> Using cache
 ---> a0a7a1971687
Step 4/7 : ADD kando /usr/local/bin/
 ---> Using cache
 ---> 4f9c60533872
Step 5/7 : ADD examples/helm/kanister/kanister-elasticsearch/image/esdump-setup.sh /esdump-setup.sh
 ---> Using cache
 ---> e88bf105190a
Step 6/7 : RUN chmod +x /esdump-setup.sh && sync && /esdump-setup.sh
 ---> Running in d8af5040f538
fetch http://dl-cdn.alpinelinux.org/alpine/v3.11/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.11/community/x86_64/APKINDEX.tar.gz
(1/7) Installing ca-certificates (20191127-r0)
(2/7) Installing c-ares (1.15.0-r0)
(3/7) Installing libgcc (9.2.0-r3)
(4/7) Installing nghttp2-libs (1.40.0-r0)
(5/7) Installing libstdc++ (9.2.0-r3)
(6/7) Installing libuv (1.34.0-r0)
(7/7) Installing nodejs (12.14.0-r0)
Executing busybox-1.31.1-r9.trigger
Executing ca-certificates-20191127-r0.trigger
OK: 36 MiB in 21 packages
(1/1) Installing npm (12.14.0-r0)
Executing busybox-1.31.1-r9.trigger
OK: 64 MiB in 22 packages
npm WARN deprecated bower@1.8.8: We don't recommend using Bower for new projects. Please consider Yarn and Webpack or Parcel. You can read how to migrate legacy project here: https://bower.io/blog/2017/how-to-migrate-away-from-bower/
npm WARN deprecated cross-spawn-async@2.2.5: cross-spawn no longer requires a build toolchain, use it instead
/usr/bin/bower -> /usr/lib/node_modules/bower/bin/bower
/usr/bin/grunt -> /usr/lib/node_modules/grunt-cli/bin/grunt
/usr/bin/npm -> /usr/lib/node_modules/npm/bin/npm-cli.js
/usr/bin/npx -> /usr/lib/node_modules/npm/bin/npx-cli.js
/usr/bin/yo -> /usr/lib/node_modules/yo/lib/cli.js
/usr/bin/yo-complete -> /usr/lib/node_modules/yo/lib/completion/index.js

> core-js@3.6.4 postinstall /usr/lib/node_modules/yo/node_modules/core-js
> node -e "try{require('./postinstall')}catch(e){}"

Thank you for using core-js ( https://github.com/zloirock/core-js ) for polyfilling JavaScript standard library!

The project needs your help! Please consider supporting of core-js on Open Collective or Patreon:
> https://opencollective.com/core-js
> https://www.patreon.com/zloirock

Also, the author of core-js ( https://github.com/zloirock ) is looking for a good job -)


> spawn-sync@1.0.15 postinstall /usr/lib/node_modules/yo/node_modules/spawn-sync
> node postinstall


> yo@3.1.1 postinstall /usr/lib/node_modules/yo
> yodoctor


Yeoman Doctor
Running sanity checks on your system

✔ No .bowerrc file in home directory
✔ Global configuration file is valid
✔ NODE_PATH matches the npm root
✔ No .yo-rc.json file in home directory
✔ Node.js version
✔ npm version
✔ yo version

Everything looks all right!
+ yo@3.1.1
+ express@4.17.1
+ bower@1.8.8
+ grunt-cli@1.3.2
+ npm@6.13.7
added 767 packages from 328 contributors, removed 2 packages, updated 12 packages and moved 1 package in 37.849s
/usr/bin/node
v12.14.0
/usr/bin/npm
6.13.7
/usr/lib
+-- bower@1.8.8
+-- express@4.17.1
+-- grunt-cli@1.3.2
+-- npm@6.13.7
`-- yo@3.1.1

npm WARN deprecated s3signed@0.1.0: This module is no longer maintained. It is provided as is.
/usr/bin/elasticdump -> /usr/lib/node_modules/elasticdump/bin/elasticdump
/usr/bin/multielasticdump -> /usr/lib/node_modules/elasticdump/bin/multielasticdump
+ elasticdump@6.19.0
added 103 packages from 146 contributors in 6.154s
Removing intermediate container d8af5040f538
 ---> cced90bec78f
Step 7/7 : CMD [ "/usr/bin/tail", "-f", "/dev/null" ]
 ---> Running in ef5ad8ae8d89
Removing intermediate container ef5ad8ae8d89
 ---> 0cecfe70d666
[Warning] One or more build-args [TOOLS_IMAGE] were not consumed
Successfully built 0cecfe70d666
Successfully tagged kanisterio/es-sidecar:0.25.0
```
