### PR TITLE
Fixing MySQL-sidecar example docker file

### DIFF
--- a/examples/helm/kanister/kanister-mysql/image/Dockerfile
+++ b/examples/helm/kanister/kanister-mysql/image/Dockerfile
@@ -1,4 +1,9 @@
 ARG TOOLS_IMAGE
+FROM registry.access.redhat.com/ubi8/ubi:8.1 as builder
+RUN dnf install -y https://dev.mysql.com/get/mysql80-community-release-el8-1.noarch.rpm
+RUN dnf install -y mysql-community-client
+
 FROM $TOOLS_IMAGE
-RUN apk -v --update add --no-cache mysql-client && \
-    rm -f /var/cache/apk/*
+
+COPY --from=builder --chown=kanister:kanister /usr/lib64/mysql /usr/lib64/
+COPY --from=builder --chown=kanister:kanister /usr/bin/mysql* /usr/bin/


### PR DESCRIPTION
## Change Overview

kanister tools were switched form alpine to UBI 
and ubi base is using microdnf 
adding MySQL client is tricky now
using ubi8 full image as a builder 
then coping binaries into sidecar image

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

```
docker build --build-arg TOOLS_IMAGE=kanisterio/kanister-tools:test-ubi goreleaserdocker004554421/ -t test-mysql-side
Sending build context to Docker daemon  36.96MB
Step 1/7 : ARG TOOLS_IMAGE
Step 2/7 : FROM registry.access.redhat.com/ubi8/ubi:8.1 as builder
 ---> 096cae65a207
Step 3/7 : RUN dnf install -y https://dev.mysql.com/get/mysql80-community-release-el8-1.noarch.rpm
 ---> Using cache
 ---> 14481d3118ed
Step 4/7 : RUN dnf install -y mysql-community-client
 ---> Using cache
 ---> 5d3d59f110f2
Step 5/7 : FROM $TOOLS_IMAGE
 ---> 4ad2eca2f7a4
Step 6/7 : COPY --from=builder --chown=kanister:kanister /usr/lib64/mysql /usr/lib64/
 ---> 183130248867
Step 7/7 : COPY --from=builder --chown=kanister:kanister /usr/bin/mysql* /usr/bin/
 ---> 3ca27d893e46
Successfully built 3ca27d893e46
Successfully tagged test-mysql-side:latest

docker run -ti --rm test-mysql-side:latest mysql --version
mysql  Ver 8.0.19 for Linux on x86_64 (MySQL Community Server - GPL)
docker run -ti --rm test-mysql-side:latest mysqldump --version
mysqldump  Ver 8.0.19 for Linux on x86_64 (MySQL Community Server - GPL)

```

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
