### PR TITLE
Update postgresql-wale blueprint to refer the secret as an "Object"

### DIFF
--- a/examples/stable/postgresql-wale/postgresql-blueprint.yaml
+++ b/examples/stable/postgresql-wale/postgresql-blueprint.yaml
@@ -10,11 +10,14 @@ actions:
         keyValue:
           prefix: 'postgres-backups/{{ .StatefulSet.Name }}'
           path: 'postgres-backups/{{ .StatefulSet.Name }}/{{ toDate "2006-01-02T15:04:05.999999999Z07:00" .Time  | date "2006-01-02T15-04-05" }}/manifest.txt'
-    secretNames:
-    - postgresql
     phases:
     - func: KubeExec
       name: baseBackup
+      objects:
+        postgresqlSecret:
+          kind: Secret
+          name: '{{ .StatefulSet.Name }}'
+          namespace: '{{ .StatefulSet.Namespace }}'
       args:
         namespace: "{{ .StatefulSet.Namespace }}"
         pod: "{{ index .StatefulSet.Pods 0 }}"
@@ -85,7 +88,7 @@ actions:
             set -o xtrace
 
             # Create and push a base-backup to the object store.
-            PGPASSWORD="{{ index .Secrets.postgresql.Data "postgresql-password" | toString }}" envdir "${env_dir}" wal-e backup-push "${PGDATA}"
+            PGPASSWORD="{{ index .Phases.baseBackup.Secrets.postgresqlSecret.Data "postgresql-password" | toString }}" envdir "${env_dir}" wal-e backup-push "${PGDATA}"
             backup_name=$(envdir "${env_dir}" wal-e backup-list | tail -n +2 | sort -k2 | tail -n 1 | awk '{print $1}')
 
             # Create a manifest that references the backup we created and the current timeline.


### PR DESCRIPTION
## Change Overview
In postgresql blueprint we are referring the secret with name "postgresql" viz.:
```
secretNames:
- postgresql 
```
I have updated the blueprint to refer the  secret as an Object viz:
```
      objects:
        postgresqlSecret:
          kind: Secret
          name: '{{ .StatefulSet.Name }}'
          namespace: '{{ .StatefulSet.Namespace }}'
```

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [x] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #561 

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [x] :green_heart: E2E
