### PR TITLE
Kanister app's helm release name should be genereated

### DIFF
--- a/pkg/app/cassandra.go
+++ b/pkg/app/cassandra.go
@@ -51,7 +51,7 @@ func NewCassandraInstance(name string) App {
 	return &CassandraInstance{
 		name: name,
 		chart: helm.ChartInfo{
-			Release:  AppendRandString(name),
+			Release:  appendRandString(name),
 			RepoURL:  helm.IncubatorRepoURL,
 			Chart:    "cassandra",
 			RepoName: helm.IncubatorRepoName,

--- a/pkg/app/couchbase.go
+++ b/pkg/app/couchbase.go
@@ -53,14 +53,14 @@ func NewCouchbaseDB(name string) App {
 	return &CouchbaseDB{
 		name: name,
 		operatorChart: helm.ChartInfo{
-			Release:  fmt.Sprintf("%s-operator", name),
+			Release:  AppendRandString(fmt.Sprintf("%s-operator", name)),
 			RepoName: helm.CouchbaseRepoName,
 			RepoURL:  helm.CouchbaseRepoURL,
 			Chart:    "couchbase-operator",
 			Version:  "0.1.2",
 		},
 		clusterChart: helm.ChartInfo{
-			Release: name,
+			Release: AppendRandString(name),
 			Chart:   "couchbase-cluster",
 			Version: "0.1.2",
 			Values: map[string]string{

--- a/pkg/app/couchbase.go
+++ b/pkg/app/couchbase.go
@@ -53,14 +53,14 @@ func NewCouchbaseDB(name string) App {
 	return &CouchbaseDB{
 		name: name,
 		operatorChart: helm.ChartInfo{
-			Release:  AppendRandString(fmt.Sprintf("%s-operator", name)),
+			Release:  appendRandString(fmt.Sprintf("%s-operator", name)),
 			RepoName: helm.CouchbaseRepoName,
 			RepoURL:  helm.CouchbaseRepoURL,
 			Chart:    "couchbase-operator",
 			Version:  "0.1.2",
 		},
 		clusterChart: helm.ChartInfo{
-			Release: AppendRandString(name),
+			Release: appendRandString(name),
 			Chart:   "couchbase-cluster",
 			Version: "0.1.2",
 			Values: map[string]string{

--- a/pkg/app/elasticsearch.go
+++ b/pkg/app/elasticsearch.go
@@ -60,7 +60,7 @@ func NewElasticsearchInstance(name string) App {
 		namespace: "es-test",
 		indexname: "testindex",
 		chart: helm.ChartInfo{
-			Release:  name,
+			Release:  AppendRandString(name),
 			RepoURL:  helm.ElasticRepoURL,
 			Chart:    "elasticsearch",
 			RepoName: helm.ElasticRepoName,
@@ -98,11 +98,11 @@ func (esi *ElasticsearchInstance) Install(ctx context.Context, namespace string)
 		return err
 	}
 
-	err = cli.Install(ctx, fmt.Sprintf("%s/%s", esi.chart.RepoName, esi.chart.Chart), esi.chart.Version, esi.name, esi.namespace, esi.chart.Values)
+	err = cli.Install(ctx, fmt.Sprintf("%s/%s", esi.chart.RepoName, esi.chart.Chart), esi.chart.Version, esi.chart.Release, esi.namespace, esi.chart.Values)
 	if err != nil {
 		return err
 	}
-	log.Print("Application was installed succcessfully.", field.M{"app": esi.name})
+	log.Print("Application was installed successfully.", field.M{"app": esi.name})
 	return nil
 }
 
@@ -135,7 +135,7 @@ func (esi *ElasticsearchInstance) Uninstall(ctx context.Context) error {
 	}
 
 	log.Print("UnInstalling the application using helm.", field.M{"app": esi.name})
-	err = cli.Uninstall(ctx, esi.name, esi.namespace)
+	err = cli.Uninstall(ctx, esi.chart.Release, esi.namespace)
 	if err != nil {
 		return errors.Wrapf(err, "Error uninstalling the application %s", esi.name)
 	}

--- a/pkg/app/elasticsearch.go
+++ b/pkg/app/elasticsearch.go
@@ -60,7 +60,7 @@ func NewElasticsearchInstance(name string) App {
 		namespace: "es-test",
 		indexname: "testindex",
 		chart: helm.ChartInfo{
-			Release:  AppendRandString(name),
+			Release:  appendRandString(name),
 			RepoURL:  helm.ElasticRepoURL,
 			Chart:    "elasticsearch",
 			RepoName: helm.ElasticRepoName,

--- a/pkg/app/foundationdb.go
+++ b/pkg/app/foundationdb.go
@@ -56,8 +56,8 @@ type FoundationDB struct {
 func NewFoundationDB(name string) App {
 	return &FoundationDB{
 		name:           name,
-		oprReleaseName: "fdb-operator",
-		fdbReleaseName: "fdb-instance",
+		oprReleaseName: AppendRandString("fdb-operator"),
+		fdbReleaseName: AppendRandString("fdb-instance"),
 	}
 }
 

--- a/pkg/app/foundationdb.go
+++ b/pkg/app/foundationdb.go
@@ -56,8 +56,8 @@ type FoundationDB struct {
 func NewFoundationDB(name string) App {
 	return &FoundationDB{
 		name:           name,
-		oprReleaseName: AppendRandString("fdb-operator"),
-		fdbReleaseName: AppendRandString("fdb-instance"),
+		oprReleaseName: appendRandString("fdb-operator"),
+		fdbReleaseName: appendRandString("fdb-instance"),
 	}
 }
 

--- a/pkg/app/mongodb.go
+++ b/pkg/app/mongodb.go
@@ -54,7 +54,7 @@ func NewMongoDB(name string) App {
 		username: "root",
 		name:     name,
 		chart: helm.ChartInfo{
-			Release:  AppendRandString(name),
+			Release:  appendRandString(name),
 			RepoURL:  helm.StableRepoURL,
 			Chart:    "mongodb",
 			RepoName: helm.StableRepoName,

--- a/pkg/app/mysql.go
+++ b/pkg/app/mysql.go
@@ -44,7 +44,7 @@ func NewMysqlDB(name string) App {
 	return &MysqlDB{
 		name: name,
 		chart: helm.ChartInfo{
-			Release:  AppendRandString(name),
+			Release:  appendRandString(name),
 			RepoURL:  helm.StableRepoURL,
 			Chart:    "mysql",
 			RepoName: helm.StableRepoName,

--- a/pkg/app/mysql.go
+++ b/pkg/app/mysql.go
@@ -44,7 +44,7 @@ func NewMysqlDB(name string) App {
 	return &MysqlDB{
 		name: name,
 		chart: helm.ChartInfo{
-			Release:  name,
+			Release:  AppendRandString(name),
 			RepoURL:  helm.StableRepoURL,
 			Chart:    "mysql",
 			RepoName: helm.StableRepoName,
@@ -97,7 +97,7 @@ func (mdb *MysqlDB) IsReady(ctx context.Context) (bool, error) {
 	log.Print("Waiting for the mysql instance to be ready.", field.M{"app": mdb.name})
 	ctx, cancel := context.WithTimeout(ctx, mysqlWaitTimeout)
 	defer cancel()
-	err := kube.WaitOnDeploymentReady(ctx, mdb.cli, mdb.namespace, mdb.name)
+	err := kube.WaitOnDeploymentReady(ctx, mdb.cli, mdb.namespace, mdb.chart.Release)
 	if err != nil {
 		return false, err
 	}
@@ -109,7 +109,7 @@ func (mdb *MysqlDB) IsReady(ctx context.Context) (bool, error) {
 func (mdb *MysqlDB) Object() crv1alpha1.ObjectReference {
 	return crv1alpha1.ObjectReference{
 		Kind:      "deployment",
-		Name:      mdb.name,
+		Name:      mdb.chart.Release,
 		Namespace: mdb.namespace,
 	}
 }
@@ -119,7 +119,7 @@ func (mdb *MysqlDB) Uninstall(ctx context.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to create helm client")
 	}
-	err = cli.Uninstall(ctx, mdb.name, mdb.namespace)
+	err = cli.Uninstall(ctx, mdb.chart.Release, mdb.namespace)
 	if err != nil {
 		log.WithError(err).Print("Failed to uninstall app, you will have to uninstall it manually.", field.M{"app": mdb.name})
 		return err
@@ -202,14 +202,14 @@ func (mdb *MysqlDB) Secrets() map[string]crv1alpha1.ObjectReference {
 	return map[string]crv1alpha1.ObjectReference{
 		"mysql": crv1alpha1.ObjectReference{
 			Kind:      "Secret",
-			Name:      mdb.name,
+			Name:      mdb.chart.Release,
 			Namespace: mdb.namespace,
 		},
 	}
 }
 
 func (mdb *MysqlDB) execCommand(ctx context.Context, command []string) (string, string, error) {
-	podname, containername, err := kube.GetPodContainerFromDeployment(ctx, mdb.cli, mdb.namespace, mdb.name)
+	podname, containername, err := kube.GetPodContainerFromDeployment(ctx, mdb.cli, mdb.namespace, mdb.chart.Release)
 	if err != nil || podname == "" {
 		return "", "", errors.Wrapf(err, "Error  getting pod and containername %s.", mdb.name)
 	}

--- a/pkg/app/postgresql.go
+++ b/pkg/app/postgresql.go
@@ -44,7 +44,7 @@ func NewPostgresDB(name string) App {
 	return &PostgresDB{
 		name: name,
 		chart: helm.ChartInfo{
-			Release:  name,
+			Release:  AppendRandString(name),
 			RepoName: helm.StableRepoName,
 			RepoURL:  helm.StableRepoURL,
 			Chart:    "postgresql",

--- a/pkg/app/postgresql.go
+++ b/pkg/app/postgresql.go
@@ -44,7 +44,7 @@ func NewPostgresDB(name string) App {
 	return &PostgresDB{
 		name: name,
 		chart: helm.ChartInfo{
-			Release:  AppendRandString(name),
+			Release:  appendRandString(name),
 			RepoName: helm.StableRepoName,
 			RepoURL:  helm.StableRepoURL,
 			Chart:    "postgresql",

--- a/pkg/app/utils.go
+++ b/pkg/app/utils.go
@@ -20,7 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 )
 
-// AppendRandString, appends a random string to the passed string value
-func AppendRandString(name string) string {
+// appendRandString, appends a random string to the passed string value
+func appendRandString(name string) string {
 	return fmt.Sprintf("%s-%s", name, rand.String(5))
 }

--- a/pkg/app/utils.go
+++ b/pkg/app/utils.go
@@ -1,0 +1,26 @@
+// Copyright 2019 The Kanister Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/util/rand"
+)
+
+// AppendRandString, appends a random string to the passed string value
+func AppendRandString(name string) string {
+	return fmt.Sprintf("%s-%s", name, rand.String(5))
+}

--- a/pkg/blueprint/blueprint.go
+++ b/pkg/blueprint/blueprint.go
@@ -25,8 +25,10 @@ package blueprint
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 
+	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/yaml"
 
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
@@ -44,5 +46,11 @@ func ReadFromFile(path string) (*crv1alpha1.Blueprint, error) {
 	if err := dec.Decode(&bp); err != nil {
 		return nil, err
 	}
+
+	// set the name to a dynamically generated value
+	// so that the name wont conflict with the same application
+	// installed as part of k10
+	bp.ObjectMeta.Name = fmt.Sprintf("%s-%s", bp.ObjectMeta.Name, rand.String(5))
+
 	return &bp, err
 }


### PR DESCRIPTION
## Change Overview

In current kanister test suite the applications that are being installed through the helm, the name is being passed from test suite to app and if there is another helm application installed with same name, we will have problems.
This PR addresses that problem, and now the BluePrint name and the helm app name is being generated dynamically.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan
To test changes please run 
```
make integration_test 
```
for the application that you want to test. 

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
