### PR TITLE
Add another way to install databases on openshift cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -277,4 +277,3 @@ stop-minishift:
 
 stop-kind:
 	@$(MAKE) run CMD='-c "./build/local_kubernetes.sh stop_localkube"'
-

--- a/pkg/app/mysql-deploymentconfig.go
+++ b/pkg/app/mysql-deploymentconfig.go
@@ -36,10 +36,11 @@ import (
 )
 
 const (
-	mysqlDepConfigWaitTimeout = 1 * time.Minute
+	mysqlDepConfigWaitTimeout = 2 * time.Minute
 	mysqlToolPodName          = "mysql-tools-pod"
 	mysqlToolContainerName    = "mysql-tools-container"
 	mysqlToolImage            = "kanisterio/mysql-sidecar:0.26.0"
+	mysqlDepConfigName        = "mysql"
 )
 
 type MysqlDepConfig struct {
@@ -47,14 +48,14 @@ type MysqlDepConfig struct {
 	osCli      osversioned.Interface
 	name       string
 	namespace  string
-	osAppImage string
+	dbTemplate string
 	envVar     map[string]string
 }
 
 func NewMysqlDepConfig(name string) App {
 	return &MysqlDepConfig{
 		name:       name,
-		osAppImage: "openshift/mysql-56-centos7",
+		dbTemplate: fmt.Sprintf("https://raw.githubusercontent.com/openshift/origin/master/examples/db-templates/%s-persistent-template.json", mysqlDepConfigName),
 		envVar: map[string]string{
 			"MYSQL_ROOT_PASSWORD": "secretpassword",
 		},
@@ -81,7 +82,7 @@ func (mdep *MysqlDepConfig) Install(ctx context.Context, namespace string) error
 	mdep.namespace = namespace
 
 	oc := openshift.NewOpenShiftClient()
-	_, err := oc.NewApp(ctx, mdep.namespace, mdep.osAppImage, mdep.envVar)
+	_, err := oc.NewApp(ctx, mdep.namespace, mdep.dbTemplate, mdep.envVar)
 	if err != nil {
 		return errors.Wrapf(err, "Error installing app %s on openshift cluster.", mdep.name)
 	}
@@ -116,6 +117,8 @@ func (mdep *MysqlDepConfig) createMySQLSecret(ctx context.Context) error {
 }
 
 // createMySQLToolsPod creates a pod that will be use to run command into mysql instance
+// we had to do this because, the secret to login to mysql instance doesnt get created
+// when we deploy mysql using deploymentConfig on openshift cluster.
 func (mdep *MysqlDepConfig) createMySQLToolsPod(ctx context.Context) error {
 	mysqlToolPod := &v1.Pod{
 		TypeMeta: metav1.TypeMeta{
@@ -157,7 +160,7 @@ func (mdep *MysqlDepConfig) IsReady(ctx context.Context) (bool, error) {
 	ctx, cancel := context.WithTimeout(ctx, mysqlDepConfigWaitTimeout)
 	defer cancel()
 
-	err := kube.WaitOnDeploymentConfigReady(ctx, mdep.osCli, mdep.cli, mdep.namespace, mdep.getDepConfName(ctx))
+	err := kube.WaitOnDeploymentConfigReady(ctx, mdep.osCli, mdep.cli, mdep.namespace, mysqlDepConfigName)
 	if err != nil {
 		return false, err
 	}
@@ -180,7 +183,7 @@ func (mdep *MysqlDepConfig) IsReady(ctx context.Context) (bool, error) {
 func (mdep *MysqlDepConfig) Object() crv1alpha1.ObjectReference {
 	return crv1alpha1.ObjectReference{
 		Kind:      "deploymentconfig",
-		Name:      mdep.getDepConfName(context.Background()),
+		Name:      mysqlDepConfigName,
 		Namespace: mdep.namespace,
 	}
 }
@@ -197,13 +200,13 @@ func (mdep *MysqlDepConfig) Uninstall(ctx context.Context) error {
 		return errors.Wrapf(err, fmt.Sprintf("Error deleting secret %s from namespace %s while uninstalling appliation %s.", mdep.name, mdep.namespace, mdep.name))
 	}
 	// deleting deployment config that is running the mysql instance
-	return mdep.osCli.AppsV1().DeploymentConfigs(mdep.namespace).Delete(mdep.getDepConfName(ctx), &metav1.DeleteOptions{})
+	return mdep.osCli.AppsV1().DeploymentConfigs(mdep.namespace).Delete(mysqlDepConfigName, &metav1.DeleteOptions{})
 }
 
 func (mdep *MysqlDepConfig) Ping(ctx context.Context) error {
 	log.Print("Pinging the application", field.M{"app": mdep.name})
 
-	pingCMD := []string{"sh", "-c", fmt.Sprintf("mysql -u root --password=$MYSQL_ROOT_PASSWORD -h %s -e 'show databases;'", mdep.getDepConfName(ctx))}
+	pingCMD := []string{"sh", "-c", fmt.Sprintf("mysql -u root --password=$MYSQL_ROOT_PASSWORD -h %s -e 'show databases;'", mysqlDepConfigName)}
 	_, stderr, err := mdep.execCommand(ctx, pingCMD)
 	if err != nil {
 		return errors.Wrapf(err, "Error while Pinging the database %s, %s", stderr, err)
@@ -215,7 +218,7 @@ func (mdep *MysqlDepConfig) Ping(ctx context.Context) error {
 func (mdep *MysqlDepConfig) Insert(ctx context.Context) error {
 	log.Print("Inserting some records in  mysql instance.", field.M{"app": mdep.name})
 
-	insertRecordCMD := []string{"sh", "-c", fmt.Sprintf("mysql -u root --password=$MYSQL_ROOT_PASSWORD -h %s -e 'use testdb; INSERT INTO pets VALUES (\"Puffball\",\"Diane\",\"hamster\",\"f\",\"1999-03-30\",NULL); '", mdep.getDepConfName(ctx))}
+	insertRecordCMD := []string{"sh", "-c", fmt.Sprintf("mysql -u root --password=$MYSQL_ROOT_PASSWORD -h %s -e 'use testdb; INSERT INTO pets VALUES (\"Puffball\",\"Diane\",\"hamster\",\"f\",\"1999-03-30\",NULL); '", mysqlDepConfigName)}
 	_, stderr, err := mdep.execCommand(ctx, insertRecordCMD)
 	if err != nil {
 		return errors.Wrapf(err, "Error while inserting the data into msyql deployment config database: %s", stderr)
@@ -228,7 +231,7 @@ func (mdep *MysqlDepConfig) Insert(ctx context.Context) error {
 func (mdep *MysqlDepConfig) Count(ctx context.Context) (int, error) {
 	log.Print("Counting the records from the mysql instance.", field.M{"app": mdep.name})
 
-	selectRowsCMD := []string{"sh", "-c", fmt.Sprintf("mysql -u root --password=$MYSQL_ROOT_PASSWORD -h %s -e 'use testdb; select count(*) from pets; '", mdep.getDepConfName(ctx))}
+	selectRowsCMD := []string{"sh", "-c", fmt.Sprintf("mysql -u root --password=$MYSQL_ROOT_PASSWORD -h %s -e 'use testdb; select count(*) from pets; '", mysqlDepConfigName)}
 	stdout, stderr, err := mdep.execCommand(ctx, selectRowsCMD)
 	if err != nil {
 		return 0, errors.Wrapf(err, "Error while counting the data of the database: %s", stderr)
@@ -248,14 +251,14 @@ func (mdep *MysqlDepConfig) Reset(ctx context.Context) error {
 	log.Print("Resetting the mysql instance.", field.M{"app": "mysql"})
 
 	// delete all the data from the table
-	deleteCMD := []string{"sh", "-c", fmt.Sprintf("mysql -u root --password=$MYSQL_ROOT_PASSWORD -h %s -e 'DROP DATABASE IF EXISTS testdb'", mdep.getDepConfName(ctx))}
+	deleteCMD := []string{"sh", "-c", fmt.Sprintf("mysql -u root --password=$MYSQL_ROOT_PASSWORD -h %s -e 'DROP DATABASE IF EXISTS testdb'", mysqlDepConfigName)}
 	_, stderr, err := mdep.execCommand(ctx, deleteCMD)
 	if err != nil {
 		return errors.Wrapf(err, "Error while dropping the mysql table: %s", stderr)
 	}
 
 	// create the database and a pets dummy table
-	createCMD := []string{"sh", "-c", fmt.Sprintf("mysql -u root --password=$MYSQL_ROOT_PASSWORD -h %s -e 'create database testdb; use testdb;  CREATE TABLE pets (name VARCHAR(20), owner VARCHAR(20), species VARCHAR(20), sex CHAR(1), birth DATE, death DATE);'", mdep.getDepConfName(ctx))}
+	createCMD := []string{"sh", "-c", fmt.Sprintf("mysql -u root --password=$MYSQL_ROOT_PASSWORD -h %s -e 'create database testdb; use testdb;  CREATE TABLE pets (name VARCHAR(20), owner VARCHAR(20), species VARCHAR(20), sex CHAR(1), birth DATE, death DATE);'", mysqlDepConfigName)}
 	_, stderr, err = mdep.execCommand(ctx, createCMD)
 	if err != nil {
 		return errors.Wrapf(err, "Error while creating the mysql table: %s", stderr)
@@ -290,6 +293,6 @@ func (mdep *MysqlDepConfig) execCommand(ctx context.Context, command []string) (
 // getDepConfName returns the name of the deployment config that is running the mysql instance
 // it gets generated on the openshift image that we have provided thats why we are getting the
 // name from app image
-func (mdep *MysqlDepConfig) getDepConfName(ctx context.Context) string {
-	return strings.Split(mdep.osAppImage, "/")[1]
-}
+// func (mdep *MysqlDepConfig) getDepConfName(ctx context.Context) string {
+// 	return strings.Split(mdep.osAppImage, "/")[1]
+// }

--- a/pkg/app/utils.go
+++ b/pkg/app/utils.go
@@ -24,3 +24,10 @@ import (
 func appendRandString(name string) string {
 	return fmt.Sprintf("%s-%s", name, rand.String(5))
 }
+
+// getOpenShiftDBTemplate accepts the application name and returns the
+// db template for that application
+// https://github.com/openshift/origin/tree/master/examples/db-templates
+func getOpenShiftDBTemplate(appName string) string {
+	return fmt.Sprintf("https://raw.githubusercontent.com/openshift/origin/master/examples/db-templates/%s-persistent-template.json", appName)
+}

--- a/pkg/app/utils.go
+++ b/pkg/app/utils.go
@@ -20,6 +20,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 )
 
+const (
+	dbTemplateURI = "https://raw.githubusercontent.com/openshift/origin/master/examples/db-templates/%s-persistent-template.json"
+)
+
 // appendRandString, appends a random string to the passed string value
 func appendRandString(name string) string {
 	return fmt.Sprintf("%s-%s", name, rand.String(5))
@@ -29,5 +33,5 @@ func appendRandString(name string) string {
 // db template for that application
 // https://github.com/openshift/origin/tree/master/examples/db-templates
 func getOpenShiftDBTemplate(appName string) string {
-	return fmt.Sprintf("https://raw.githubusercontent.com/openshift/origin/master/examples/db-templates/%s-persistent-template.json", appName)
+	return fmt.Sprintf(dbTemplateURI, appName)
 }

--- a/pkg/openshift/oc.go
+++ b/pkg/openshift/oc.go
@@ -35,13 +35,13 @@ func (oc OpenShiftClient) CreateNamespace(ctx context.Context, namespace string)
 
 // NewApp install a new application in the openshift
 // cluster using ``oc new-app`` command
-func (oc OpenShiftClient) NewApp(ctx context.Context, namespace, osAppImage string, envVar map[string]string) (string, error) {
+func (oc OpenShiftClient) NewApp(ctx context.Context, namespace, dpTemplate string, envVar map[string]string) (string, error) {
 	var formedVars []string
 	for k, v := range envVar {
 		formedVars = append(formedVars, "-p", fmt.Sprintf("%s=%s", k, v))
 	}
 
-	command := append([]string{"new-app", "-n", namespace, osAppImage}, formedVars...)
+	command := append([]string{"new-app", "-n", namespace, "-f", dpTemplate}, formedVars...)
 	out, err := helm.RunCmdWithTimeout(ctx, "oc", command)
 
 	return out, err

--- a/pkg/openshift/oc.go
+++ b/pkg/openshift/oc.go
@@ -33,10 +33,12 @@ func (oc OpenShiftClient) CreateNamespace(ctx context.Context, namespace string)
 	return helm.RunCmdWithTimeout(ctx, "oc", command)
 }
 
+// NewApp install a new application in the openshift
+// cluster using ``oc new-app`` command
 func (oc OpenShiftClient) NewApp(ctx context.Context, namespace, osAppImage string, envVar map[string]string) (string, error) {
 	var formedVars []string
 	for k, v := range envVar {
-		formedVars = append(formedVars, "-e", fmt.Sprintf("%s=%s", k, v))
+		formedVars = append(formedVars, "-p", fmt.Sprintf("%s=%s", k, v))
 	}
 
 	command := append([]string{"new-app", "-n", namespace, osAppImage}, formedVars...)

--- a/pkg/openshift/oc.go
+++ b/pkg/openshift/oc.go
@@ -41,7 +41,7 @@ func (oc OpenShiftClient) NewApp(ctx context.Context, namespace, dpTemplate stri
 		formedVars = append(formedVars, "-p", fmt.Sprintf("%s=%s", k, v))
 	}
 
-	command := append([]string{"new-app", "-n", namespace, "-f", dpTemplate}, formedVars...)
+	command := append([]string{"new-app", "-n", namespace, dpTemplate}, formedVars...)
 	out, err := helm.RunCmdWithTimeout(ctx, "oc", command)
 
 	return out, err


### PR DESCRIPTION
## Change Overview

Openshift team [suggested](https://github.com/openshift/origin/tree/master/examples/db-templates) some standard ways to install database on openshift cluster. This PR implements that way to and have respective change in the mysql app that we deployed on the openshift cluster.

https://github.com/openshift/origin/tree/master/examples/db-templates

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

You will first have to setup minishift cluster using 
```
make start-minishift vm-driver=<driver>
```
after that run 
```
# make sure to run only the apps that are to be deployed on openshift cluster
make integration-test
```

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
