### PR TITLE
Add MongoDB in Kanister app that will be deployed on OpenShift cluster

### DIFF
--- a/build/integration-test.sh
+++ b/build/integration-test.sh
@@ -25,7 +25,7 @@ TEST_TIMEOUT="30m"
 # Set default options
 TEST_OPTIONS="-tags=integration -timeout ${TEST_TIMEOUT} -check.suitep ${DOP}"
 # Regex to match apps to run in short mode
-SHORT_APPS="^PostgreSQL|^PITRPostgreSQL|MySQL|Elasticsearch|MongoDB"
+SHORT_APPS="^PostgreSQL|^PITRPostgreSQL|MySQL|Elasticsearch|^MongoDB$"
 
 check_dependencies() {
     # Check if minio is already deployed

--- a/pkg/app/mongodb-deploymentconfig.go
+++ b/pkg/app/mongodb-deploymentconfig.go
@@ -46,6 +46,7 @@ type MongoDBDepConfig struct {
 	envVar     map[string]string
 	user       string
 	label      string
+	osClient   openshift.OSClient
 }
 
 func NewMongoDBDepConfig(name string) App {
@@ -56,7 +57,8 @@ func NewMongoDBDepConfig(name string) App {
 		envVar: map[string]string{
 			"MONGODB_ADMIN_PASSWORD": "secretpassword",
 		},
-		label: getLabelOfApp(mongoDepConfigName),
+		label:    getLabelOfApp(mongoDepConfigName),
+		osClient: openshift.NewOpenShiftClient(),
 	}
 }
 
@@ -79,8 +81,7 @@ func (mongo *MongoDBDepConfig) Init(context.Context) error {
 func (mongo *MongoDBDepConfig) Install(ctx context.Context, namespace string) error {
 	mongo.namespace = namespace
 
-	oc := openshift.NewOpenShiftClient()
-	_, err := oc.NewApp(ctx, mongo.namespace, mongo.dbTemplate, mongo.envVar)
+	_, err := mongo.osClient.NewApp(ctx, mongo.namespace, mongo.dbTemplate, mongo.envVar)
 
 	return errors.Wrapf(err, "Error installing app %s on openshift cluster.", mongo.name)
 }
@@ -108,8 +109,7 @@ func (mongo *MongoDBDepConfig) Object() crv1alpha1.ObjectReference {
 }
 
 func (mongo *MongoDBDepConfig) Uninstall(ctx context.Context) error {
-	oc := openshift.NewOpenShiftClient()
-	_, err := oc.DeleteApp(ctx, mongo.namespace, mongo.label)
+	_, err := mongo.osClient.DeleteApp(ctx, mongo.namespace, mongo.label)
 	return err
 }
 

--- a/pkg/app/mongodb-deploymentconfig.go
+++ b/pkg/app/mongodb-deploymentconfig.go
@@ -1,0 +1,238 @@
+// Copyright 2019 The Kanister Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/google/uuid"
+	osversioned "github.com/openshift/client-go/apps/clientset/versioned"
+	"github.com/pkg/errors"
+	"k8s.io/client-go/kubernetes"
+
+	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
+	"github.com/kanisterio/kanister/pkg/field"
+	"github.com/kanisterio/kanister/pkg/kube"
+	"github.com/kanisterio/kanister/pkg/log"
+	"github.com/kanisterio/kanister/pkg/openshift"
+)
+
+const (
+	mongoDepConfigName        = "mongodb"
+	mongoDepConfigWaitTimeout = 2 * time.Minute
+	mongoToolPodName          = "mongo-tools-pod"
+	mongoToolContainerName    = "mongo-tools-container"
+	mongoToolImage            = "kanisterio/mongo-sidecar:0.26.0"
+)
+
+type MongoDBDepConfig struct {
+	cli        kubernetes.Interface
+	osCli      osversioned.Interface
+	name       string
+	namespace  string
+	dbTemplate string
+	envVar     map[string]string
+	user       string
+}
+
+func NewMongoDBDepConfig(name string) App {
+	return &MongoDBDepConfig{
+		name:       name,
+		dbTemplate: getOpenShiftDBTemplate(mongoDepConfigName),
+		user:       "admin",
+		envVar: map[string]string{
+			"MONGODB_ADMIN_PASSWORD": "secretpassword",
+		},
+	}
+}
+
+func (mongo *MongoDBDepConfig) Init(context.Context) error {
+	cfg, err := kube.LoadConfig()
+	if err != nil {
+		return err
+	}
+
+	mongo.cli, err = kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return err
+	}
+
+	mongo.osCli, err = osversioned.NewForConfig(cfg)
+
+	return err
+}
+
+func (mongo *MongoDBDepConfig) Install(ctx context.Context, namespace string) error {
+	mongo.namespace = namespace
+
+	oc := openshift.NewOpenShiftClient()
+	_, err := oc.NewApp(ctx, mongo.namespace, mongo.dbTemplate, mongo.envVar)
+	if err != nil {
+		return errors.Wrapf(err, "Error installing app %s on openshift cluster.", mongo.name)
+	}
+
+	return nil
+}
+
+// func (mongo *MongoDBDepConfig) createMongoSecret(context.Context) error {
+
+// 	mongoSecret := &v1.Secret{
+// 		TypeMeta: metav1.TypeMeta{
+// 			Kind:       "Pod",
+// 			APIVersion: "v1",
+// 		},
+// 		ObjectMeta: metav1.ObjectMeta{
+// 			Name:      mongo.name,
+// 			Namespace: mongo.namespace,
+// 		},
+// 		Data: map[string][]byte{
+// 			"mongodb-root-password": []byte(mongo.envVar["MONGODB_ADMIN_PASSWORD"]),
+// 		},
+// 	}
+
+// 	_, err := mongo.cli.CoreV1().Secrets(mongo.namespace).Create(mongoSecret)
+
+// 	return errors.Wrapf(err, "Error creating secret for %s app.", mongo.name)
+// }
+
+// func (mongo *MongoDBDepConfig) createMongoToolsPod(ctx context.Context) error {
+// 	mongoPod := &v1.Pod{
+// 		TypeMeta: metav1.TypeMeta{
+// 			Kind:       "Pod",
+// 			APIVersion: "v1",
+// 		},
+// 		ObjectMeta: metav1.ObjectMeta{
+// 			Name: mongoToolPodName,
+// 		},
+// 		Spec: v1.PodSpec{
+// 			Containers: []v1.Container{
+// 				v1.Container{
+// 					Name:      mongoToolContainerName,
+// 					Image:     mongoToolImage,
+// 					Resources: v1.ResourceRequirements{},
+// 					Env: []v1.EnvVar{
+// 						v1.EnvVar{
+// 							Name: "MONGODB_ROOT_PASSWORD",
+// 							ValueFrom: &v1.EnvVarSource{
+// 								SecretKeyRef: &v1.SecretKeySelector{
+// 									LocalObjectReference: v1.LocalObjectReference{Name: mongo.name},
+// 									Key:                  "mongodb-root-password",
+// 								},
+// 							},
+// 						},
+// 					},
+// 				},
+// 			},
+// 		},
+// 	}
+
+// 	_, err := mongo.cli.CoreV1().Pods(mongo.namespace).Create(mongoPod)
+
+// 	return errors.Wrapf(err, "Error creating %s tools pod", mongo.name)
+// }
+
+func (mongo *MongoDBDepConfig) IsReady(ctx context.Context) (bool, error) {
+	log.Info().Print("Waiting for application to be ready.", field.M{"app": mongo.name})
+	ctx, cancel := context.WithTimeout(ctx, mongoDepConfigWaitTimeout)
+	defer cancel()
+
+	err := kube.WaitOnDeploymentConfigReady(ctx, mongo.osCli, mongo.cli, mongo.namespace, mongoDepConfigName)
+	if err != nil {
+		return false, err
+	}
+
+	log.Print("Application is ready", field.M{"application": mongo.name})
+	return true, nil
+}
+
+func (mongo *MongoDBDepConfig) Object() crv1alpha1.ObjectReference {
+	return crv1alpha1.ObjectReference{
+		Kind:      "deploymentconfig",
+		Name:      mongoDepConfigName,
+		Namespace: mongo.namespace,
+	}
+}
+
+func (mongo *MongoDBDepConfig) Uninstall(context.Context) error {
+	return nil
+}
+
+func (mongo *MongoDBDepConfig) Ping(ctx context.Context) error {
+	log.Print("Pinging the application", field.M{"app": mongo.name})
+
+	pingCMD := []string{"sh", "-c", fmt.Sprintf("mongo admin --authenticationDatabase admin -u %s -p $MONGODB_ADMIN_PASSWORD --quiet --eval \"rs.slaveOk(); db\"", mongo.user)}
+	_, stderr, err := mongo.execCommand(ctx, pingCMD)
+	if err != nil {
+		return errors.Wrapf(err, "Error while Pinging the database %s, %s", stderr, err)
+	}
+	log.Print("Ping to the application was successful.")
+	return nil
+}
+
+func (mongo *MongoDBDepConfig) Insert(ctx context.Context) error {
+
+	log.Print("Inserting documents into collection.", field.M{"app": mongo.name})
+	insertCMD := []string{"sh", "-c", fmt.Sprintf("mongo admin --authenticationDatabase admin -u %s -p $MONGODB_ADMIN_PASSWORD --quiet --eval \"db.restaurants.insert({'_id': '%s','name' : 'Tom', 'cuisine' : 'Hawaiian', 'id' : '8675309'})\"", mongo.user, uuid.New())}
+	_, stderr, err := mongo.execCommand(ctx, insertCMD)
+	if err != nil {
+		return errors.Wrapf(err, "Error %s while inserting data data into mongodb collection.", stderr)
+	}
+
+	log.Print("Insertion of documents into collection was successful.", field.M{"app": mongo.name})
+	return nil
+}
+
+func (mongo *MongoDBDepConfig) Count(ctx context.Context) (int, error) {
+	log.Print("Counting documents of collection.", field.M{"app": mongo.name})
+	countCMD := []string{"sh", "-c", fmt.Sprintf("mongo admin --authenticationDatabase admin -u %s -p $MONGODB_ADMIN_PASSWORD --quiet --eval \"rs.slaveOk(); db.restaurants.count()\"", mongo.user)}
+	stdout, stderr, err := mongo.execCommand(ctx, countCMD)
+	if err != nil {
+		return 0, errors.Wrapf(err, "Error %s while counting the data in mongodb collection.", stderr)
+	}
+
+	count, err := strconv.Atoi(stdout)
+	if err != nil {
+		return 0, err
+	}
+
+	log.Print("Count that we are returning from count method is.", field.M{"app": "mongodb", "count": count})
+	return count, nil
+}
+
+func (mongo *MongoDBDepConfig) Reset(ctx context.Context) error {
+	log.Print("Resetting the application.", field.M{"app": mongo.name})
+	// delete all the entries from the restaurants dummy collection
+	// we are not deleting the database because we are dealing with admin database here
+	// and deletion admin database is prohibited
+	deleteDBCMD := []string{"sh", "-c", fmt.Sprintf("mongo admin --authenticationDatabase admin -u %s -p $MONGODB_ADMIN_PASSWORD --quiet --eval \"rs.slaveOk(); db.restaurants.drop()\"", mongo.user)}
+	stdout, stderr, err := mongo.execCommand(ctx, deleteDBCMD)
+	return errors.Wrapf(err, "Error %s, resetting the mongodb application. stdout is %s", stderr, stdout)
+}
+
+func (mongo *MongoDBDepConfig) execCommand(ctx context.Context, command []string) (string, string, error) {
+	podName, containerName, err := kube.GetPodContainerFromDeploymentConfig(ctx, mongo.osCli, mongo.cli, mongo.namespace, mongoDepConfigName)
+	if err != nil {
+		return "", "", err
+	}
+	stdout, stderr, err := kube.Exec(mongo.cli, mongo.namespace, podName, containerName, command, nil)
+	log.Print("Executing the command in pod and contianer", field.M{"pod": podName, "container": containerName, "cmd": command})
+	if err != nil {
+		return stdout, stderr, errors.Wrapf(err, "Error executing command in the pod")
+	}
+	return stdout, stderr, err
+}

--- a/pkg/app/mongodb-deploymentconfig.go
+++ b/pkg/app/mongodb-deploymentconfig.go
@@ -126,7 +126,6 @@ func (mongo *MongoDBDepConfig) Ping(ctx context.Context) error {
 }
 
 func (mongo *MongoDBDepConfig) Insert(ctx context.Context) error {
-
 	log.Print("Inserting documents into collection.", field.M{"app": mongo.name})
 	insertCMD := []string{"sh", "-c", fmt.Sprintf("mongo admin --authenticationDatabase admin -u %s -p $MONGODB_ADMIN_PASSWORD --quiet --eval \"db.restaurants.insert({'_id': '%s','name' : 'Tom', 'cuisine' : 'Hawaiian', 'id' : '8675309'})\"", mongo.user, uuid.New())}
 	_, stderr, err := mongo.execCommand(ctx, insertCMD)

--- a/pkg/app/mysql-deploymentconfig.go
+++ b/pkg/app/mysql-deploymentconfig.go
@@ -120,8 +120,6 @@ func (mdep *MysqlDepConfig) createMySQLSecret(ctx context.Context) error {
 }
 
 // createMySQLToolsPod creates a pod that will be use to run command into mysql instance
-// we had to do this because, the secret to login to mysql instance doesnt get created
-// when we deploy mysql using deploymentConfig on openshift cluster.
 func (mdep *MysqlDepConfig) createMySQLToolsPod(ctx context.Context) error {
 	mysqlToolPod := &v1.Pod{
 		TypeMeta: metav1.TypeMeta{
@@ -292,13 +290,3 @@ func (mdep *MysqlDepConfig) execCommand(ctx context.Context, command []string) (
 	}
 	return stdout, stderr, err
 }
-<<<<<<< HEAD
-=======
-
-// getDepConfName returns the name of the deployment config that is running the mysql instance
-// it gets generated on the openshift image that we have provided thats why we are getting the
-// name from app image
-// func (mdep *MysqlDepConfig) getDepConfName(ctx context.Context) string {
-// 	return strings.Split(mdep.osAppImage, "/")[1]
-// }
->>>>>>> Add another way to install databases on openshift cluster

--- a/pkg/app/mysql-deploymentconfig.go
+++ b/pkg/app/mysql-deploymentconfig.go
@@ -120,6 +120,8 @@ func (mdep *MysqlDepConfig) createMySQLSecret(ctx context.Context) error {
 }
 
 // createMySQLToolsPod creates a pod that will be use to run command into mysql instance
+// we had to do this because, the secret to login to mysql instance doesnt get created
+// when we deploy mysql using deploymentConfig on openshift cluster.
 func (mdep *MysqlDepConfig) createMySQLToolsPod(ctx context.Context) error {
 	mysqlToolPod := &v1.Pod{
 		TypeMeta: metav1.TypeMeta{
@@ -290,3 +292,13 @@ func (mdep *MysqlDepConfig) execCommand(ctx context.Context, command []string) (
 	}
 	return stdout, stderr, err
 }
+<<<<<<< HEAD
+=======
+
+// getDepConfName returns the name of the deployment config that is running the mysql instance
+// it gets generated on the openshift image that we have provided thats why we are getting the
+// name from app image
+// func (mdep *MysqlDepConfig) getDepConfName(ctx context.Context) string {
+// 	return strings.Split(mdep.osAppImage, "/")[1]
+// }
+>>>>>>> Add another way to install databases on openshift cluster

--- a/pkg/app/utils.go
+++ b/pkg/app/utils.go
@@ -35,3 +35,9 @@ func appendRandString(name string) string {
 func getOpenShiftDBTemplate(appName string) string {
 	return fmt.Sprintf(dbTemplateURI, appName)
 }
+
+// getLabelOfApp returns label of the passed application this label can be
+// used to delete all the resources that were created while deploying this application
+func getLabelOfApp(appName string) string {
+	return fmt.Sprintf("app=%s-persistent", appName)
+}

--- a/pkg/blueprint/blueprints/mongo-dep-config-blueprint.yaml
+++ b/pkg/blueprint/blueprints/mongo-dep-config-blueprint.yaml
@@ -11,7 +11,7 @@ actions:
           path: '/mongodb-replicaset-backups/{{ .DeploymentConfig.Name }}/{{ toDate "2006-01-02T15:04:05.999999999Z07:00" .Time  | date "2006-01-02T15-04-05" }}/rs_backup.gz'
     phases:
     - func: KubeTask
-      name: takeConsistentBackup
+      name: mongoDump
       objects:
         mongosecret:
           kind: Secret
@@ -29,7 +29,7 @@ actions:
           - -c
           - |
             host="{{ .DeploymentConfig.Name }}.{{ .DeploymentConfig.Namespace }}.svc.cluster.local"
-            dbPassword='{{ index .Phases.takeConsistentBackup.Secrets.mongosecret.Data "database-admin-password" | toString }}'
+            dbPassword='{{ index .Phases.mongoDump.Secrets.mongosecret.Data "database-admin-password" | toString }}'
             dump_cmd="mongodump --gzip --archive --host ${host} -u admin -p ${dbPassword}"
             echo $dump_cmd
             ${dump_cmd} | kando location push --profile '{{ toJson .Profile }}' --path '/mongodb-replicaset-backups/{{ .DeploymentConfig.Name }}/{{ toDate "2006-01-02T15:04:05.999999999Z07:00" .Time  | date "2006-01-02T15-04-05" }}/rs_backup.gz' -

--- a/pkg/blueprint/blueprints/mongo-dep-config-blueprint.yaml
+++ b/pkg/blueprint/blueprints/mongo-dep-config-blueprint.yaml
@@ -1,0 +1,82 @@
+apiVersion: cr.kanister.io/v1alpha1
+kind: Blueprint
+metadata:
+  name: mongodb-blueprint
+actions:
+  backup:
+    type: DeploymentConfig
+    outputArtifacts:
+      cloudObject:
+        keyValue:
+          path: '/mongodb-replicaset-backups/{{ .DeploymentConfig.Name }}/{{ toDate "2006-01-02T15:04:05.999999999Z07:00" .Time  | date "2006-01-02T15-04-05" }}/rs_backup.gz'
+    phases:
+    - func: KubeTask
+      name: takeConsistentBackup
+      objects:
+        mongosecret:
+          kind: Secret
+          name: "{{ .DeploymentConfig.Name }}"
+          namespace: "{{ .DeploymentConfig.Namespace }}"
+      args:
+        namespace: "{{ .DeploymentConfig.Namespace }}"
+        image: kanisterio/mongodb:0.26.0
+        command:
+          - bash
+          - -o
+          - errexit
+          - -o
+          - pipefail
+          - -c
+          - |
+            host="{{ .DeploymentConfig.Name }}.{{ .DeploymentConfig.Namespace }}.svc.cluster.local"
+            dbPassword='{{ index .Phases.takeConsistentBackup.Secrets.mongosecret.Data "database-admin-password" | toString }}'
+            dump_cmd="mongodump --gzip --archive --host ${host} -u admin -p ${dbPassword}"
+            echo $dump_cmd
+            ${dump_cmd} | kando location push --profile '{{ toJson .Profile }}' --path '/mongodb-replicaset-backups/{{ .DeploymentConfig.Name }}/{{ toDate "2006-01-02T15:04:05.999999999Z07:00" .Time  | date "2006-01-02T15-04-05" }}/rs_backup.gz' -
+  restore:
+    type: DeploymentConfig
+    inputArtifactNames:
+      - cloudObject
+    phases:
+    - func: KubeTask
+      name: pullFromBlobStore
+      objects:
+        mongosecret:
+          kind: Secret
+          name: "{{ .DeploymentConfig.Name }}"
+          namespace: "{{ .DeploymentConfig.Namespace }}"
+      args:
+        namespace: "{{ .DeploymentConfig.Namespace }}"
+        image: kanisterio/mongodb:0.26.0
+        command:
+          - bash
+          - -o
+          - errexit
+          - -o
+          - pipefail
+          - -c
+          - |
+            host="{{ .DeploymentConfig.Name }}.{{ .DeploymentConfig.Namespace }}.svc.cluster.local"
+            dbPassword='{{ index .Phases.pullFromBlobStore.Secrets.mongosecret.Data "database-admin-password" | toString }}'
+            restore_cmd="mongorestore --gzip --archive --drop --host ${host} -u admin -p ${dbPassword}"
+            kando location pull --profile '{{ toJson .Profile }}' --path '{{ .ArtifactsIn.cloudObject.KeyValue.path }}' - | ${restore_cmd}
+  delete:
+    type: DeploymentConfig
+    inputArtifactNames:
+      - cloudObject
+    phases:
+    - func: KubeTask
+      name: deleteFromBlobStore
+      args:
+        namespace: "{{ .DeploymentConfig.Namespace }}"
+        image: kanisterio/mongodb:0.26.0
+        command:
+          - bash
+          - -o
+          - errexit
+          - -o
+          - pipefail
+          - -c
+          - |
+            s3_path="{{ .ArtifactsIn.cloudObject.KeyValue.path }}"
+            kando location delete --profile '{{ toJson .Profile }}' --path ${s3_path}

--- a/pkg/openshift/oc.go
+++ b/pkg/openshift/oc.go
@@ -35,7 +35,7 @@ func (oc OpenShiftClient) CreateNamespace(ctx context.Context, namespace string)
 
 // NewApp install a new application in the openshift
 // cluster using ``oc new-app`` command
-func (oc OpenShiftClient) NewApp(ctx context.Context, namespace, osAppImage string, envVar map[string]string) (string, error) {
+func (oc OpenShiftClient) NewApp(ctx context.Context, namespace, dpTemplate string, envVar map[string]string) (string, error) {
 	var formedVars []string
 	for k, v := range envVar {
 		formedVars = append(formedVars, "-p", fmt.Sprintf("%s=%s", k, v))

--- a/pkg/openshift/oc.go
+++ b/pkg/openshift/oc.go
@@ -42,7 +42,13 @@ func (oc OpenShiftClient) NewApp(ctx context.Context, namespace, dpTemplate stri
 	}
 
 	command := append([]string{"new-app", "-n", namespace, dpTemplate}, formedVars...)
-	out, err := helm.RunCmdWithTimeout(ctx, "oc", command)
+	return helm.RunCmdWithTimeout(ctx, "oc", command)
+}
 
-	return out, err
+// DeleteApp deletes an application that is deployed on OpenShift cluster
+// oc delete all -n <ns-name> -l <label>
+// openshift adds a specific label to all the resources, while deploying an application
+func (oc OpenShiftClient) DeleteApp(ctx context.Context, namespace, label string) (string, error) {
+	delCommand := []string{"delete", "all", "-n", namespace, "-l", label}
+	return helm.RunCmdWithTimeout(ctx, "oc", delCommand)
 }

--- a/pkg/openshift/oc.go
+++ b/pkg/openshift/oc.go
@@ -35,7 +35,7 @@ func (oc OpenShiftClient) CreateNamespace(ctx context.Context, namespace string)
 
 // NewApp install a new application in the openshift
 // cluster using ``oc new-app`` command
-func (oc OpenShiftClient) NewApp(ctx context.Context, namespace, dpTemplate string, envVar map[string]string) (string, error) {
+func (oc OpenShiftClient) NewApp(ctx context.Context, namespace, osAppImage string, envVar map[string]string) (string, error) {
 	var formedVars []string
 	for k, v := range envVar {
 		formedVars = append(formedVars, "-p", fmt.Sprintf("%s=%s", k, v))

--- a/pkg/openshift/openshift.go
+++ b/pkg/openshift/openshift.go
@@ -25,4 +25,8 @@ type OSClient interface {
 	// NewApp installs new app in the openshift clsuter
 	// similar to oc new-app ...
 	NewApp(ctx context.Context, namespace, osAppImage string, envVar map[string]string) (string, error)
+
+	// DeleteApp delete an app from the openshift cluster
+	// similar to oc delete all -n <ns> -l <label>
+	DeleteApp(ctx context.Context, namespace, label string) (string, error)
 }

--- a/pkg/testing/integration_register.go
+++ b/pkg/testing/integration_register.go
@@ -202,3 +202,18 @@ var _ = Suite(&MysqlDBDepConfig{
 		profile:   newSecretProfile(),
 	},
 })
+
+// MongoDB deployed on openshift cluster
+type MongoDBDepConfig struct {
+	IntegrationSuite
+}
+
+var _ = Suite(&MongoDBDepConfig{
+	IntegrationSuite{
+		name:      "mongodb",
+		namespace: "mongodb-test",
+		app:       app.NewMongoDBDepConfig("mongodeploymentconfig"),
+		bp:        app.NewBlueprint("mongo-dep-config"),
+		profile:   newSecretProfile(),
+	},
+})


### PR DESCRIPTION
## Change Overview
This PR adds MongoDB application in Kanister test suite that will be deployed on OpenShift cluster.

## Pull request type

Please check the type of change your PR introduces:
- [x] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan
Start a minishift cluster on your host

```
make start-minishift vm-driver=virtualbox
```
Make the changes in `integration_register.go` and `integration_register.sh` to run the test only for the applications that are going to be deployed on the open shift cluster.
Run below command to start the test

```
make integration-test
```



- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
