### PR TITLE
K10 3548 Handle unresponsive nodes when choosing zones on restore

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -393,6 +393,8 @@ k8s.io/apiextensions-apiserver v0.0.0-20190708181606-527eacf2d4b7 h1:iAZwiJOjeCx
 k8s.io/apiextensions-apiserver v0.0.0-20190708181606-527eacf2d4b7/go.mod h1:IxkesAMoaCRoLrPJdZNZUQp9NfZnzqaVzLhb2VEQzXE=
 k8s.io/apimachinery v0.0.0-20190404173353-6a84e37a896d h1:Jmdtdt1ZnoGfWWIIik61Z7nKYgO3J+swQJtPYsP9wHA=
 k8s.io/apimachinery v0.0.0-20190404173353-6a84e37a896d/go.mod h1:ccL7Eh7zubPUSh9A3USN90/OzHNSVN6zxzde07TDCL0=
+k8s.io/apimachinery v0.17.3 h1:f+uZV6rm4/tHE7xXgLyToprg6xWairaClGVkm2t8omg=
+k8s.io/client-go v11.0.0+incompatible h1:LBbX2+lOwY9flffWlJM7f1Ct8V2SRNiMRDFeiwnJo9o=
 k8s.io/client-go v11.0.1-0.20190708175433-62e1c231c5dc+incompatible h1:mgGP6MavlibbFi6hsTgBNV3wIirs8KItSR0R1JVv8UI=
 k8s.io/client-go v11.0.1-0.20190708175433-62e1c231c5dc+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=
 k8s.io/code-generator v0.0.0-20190311093542-50b561225d70/go.mod h1:MYiN+ZJZ9HkETbgVZdWw2AsuAi9PZ4V80cwfuf2axe8=

--- a/pkg/blockstorage/zone/zone.go
+++ b/pkg/blockstorage/zone/zone.go
@@ -229,13 +229,16 @@ func GetReadySchedulableNodes(cli kubernetes.Interface) (*v1.NodeList, error) {
 	ns, err := cli.CoreV1().Nodes().List(metav1.ListOptions{FieldSelector: fields.Set{
 		"spec.unschedulable": "false",
 	}.AsSelector().String()})
+	if err != nil {
+		return nil, err
+	}
 	Filter(ns, func(node v1.Node) bool {
 		return IsNodeSchedulable(&node)
 	})
 	if len(ns.Items) == 0 {
 		return nil, errors.New("There are currently no ready, schedulable nodes in the cluster")
 	}
-	return ns, err
+	return ns, nil
 }
 
 // Filter filters nodes in NodeList in place, removing nodes that do not

--- a/pkg/blockstorage/zone/zone_test.go
+++ b/pkg/blockstorage/zone/zone_test.go
@@ -78,17 +78,73 @@ func (s ZoneSuite) TestNodeZoneAndRegionGCP(c *C) {
 			Name:   "node1",
 			Labels: map[string]string{kubevolume.PVRegionLabelName: "us-west2", kubevolume.PVZoneLabelName: "us-west2-a"},
 		},
+		Status: v1.NodeStatus{
+			Conditions: []v1.NodeCondition{
+				v1.NodeCondition{
+					Status: "True",
+					Type:   "Ready",
+				},
+			},
+		},
 	}
 	node2 := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "node2",
 			Labels: map[string]string{kubevolume.PVRegionLabelName: "us-west2", kubevolume.PVZoneLabelName: "us-west2-b"},
 		},
+		Status: v1.NodeStatus{
+			Conditions: []v1.NodeCondition{
+				v1.NodeCondition{
+					Status: "True",
+					Type:   "Ready",
+				},
+			},
+		},
 	}
 	node3 := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "node3",
 			Labels: map[string]string{kubevolume.PVRegionLabelName: "us-west2", kubevolume.PVZoneLabelName: "us-west2-c"},
+		},
+		Status: v1.NodeStatus{
+			Conditions: []v1.NodeCondition{
+				v1.NodeCondition{
+					Status: "True",
+					Type:   "Ready",
+				},
+			},
+		},
+	}
+	node4 := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node4",
+			Labels: map[string]string{kubevolume.PVRegionLabelName: "us-west2", kubevolume.PVZoneLabelName: "us-west2-c"},
+		},
+		Status: v1.NodeStatus{
+			Conditions: []v1.NodeCondition{
+				v1.NodeCondition{
+					Status: "False",
+					Type:   "Ready",
+				},
+			},
+		},
+	}
+
+	node5 := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node5",
+			Labels: map[string]string{kubevolume.PVRegionLabelName: "us-west2", kubevolume.PVZoneLabelName: "us-west2-c"},
+		},
+		Spec: v1.NodeSpec{
+			Unschedulable: true,
+		},
+		Status: v1.NodeStatus{
+			Conditions: []v1.NodeCondition{
+				v1.NodeCondition{
+					Status: "True",
+					Type:   "Ready",
+				},
+			},
 		},
 	}
 	expectedZone := make(map[string]struct{})
@@ -100,6 +156,10 @@ func (s ZoneSuite) TestNodeZoneAndRegionGCP(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(reflect.DeepEqual(z, expectedZone), Equals, true)
 	c.Assert(r, Equals, "us-west2")
+
+	cli = fake.NewSimpleClientset(node4, node5)
+	_, _, err = NodeZonesAndRegion(ctx, cli)
+	c.Assert(err, NotNil)
 }
 
 func (s ZoneSuite) TestNodeZoneAndRegionEBS(c *C) {
@@ -109,11 +169,27 @@ func (s ZoneSuite) TestNodeZoneAndRegionEBS(c *C) {
 			Name:   "node1",
 			Labels: map[string]string{kubevolume.PVRegionLabelName: "us-west-2", kubevolume.PVZoneLabelName: "us-west-2a"},
 		},
+		Status: v1.NodeStatus{
+			Conditions: []v1.NodeCondition{
+				v1.NodeCondition{
+					Status: "True",
+					Type:   "Ready",
+				},
+			},
+		},
 	}
 	node2 := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "node2",
 			Labels: map[string]string{kubevolume.PVRegionLabelName: "us-west-2", kubevolume.PVZoneLabelName: "us-west-2b"},
+		},
+		Status: v1.NodeStatus{
+			Conditions: []v1.NodeCondition{
+				v1.NodeCondition{
+					Status: "True",
+					Type:   "Ready",
+				},
+			},
 		},
 	}
 	node3 := &v1.Node{
@@ -121,7 +197,49 @@ func (s ZoneSuite) TestNodeZoneAndRegionEBS(c *C) {
 			Name:   "node3",
 			Labels: map[string]string{kubevolume.PVRegionLabelName: "us-west-2", kubevolume.PVZoneLabelName: "us-west-2c"},
 		},
+		Status: v1.NodeStatus{
+			Conditions: []v1.NodeCondition{
+				v1.NodeCondition{
+					Status: "True",
+					Type:   "Ready",
+				},
+			},
+		},
 	}
+
+	node4 := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node4",
+			Labels: map[string]string{kubevolume.PVRegionLabelName: "us-west-2", kubevolume.PVZoneLabelName: "us-west-2c"},
+		},
+		Status: v1.NodeStatus{
+			Conditions: []v1.NodeCondition{
+				v1.NodeCondition{
+					Status: "False",
+					Type:   "Ready",
+				},
+			},
+		},
+	}
+
+	node5 := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node5",
+			Labels: map[string]string{kubevolume.PVRegionLabelName: "us-west-2", kubevolume.PVZoneLabelName: "us-west-2c"},
+		},
+		Spec: v1.NodeSpec{
+			Unschedulable: true,
+		},
+		Status: v1.NodeStatus{
+			Conditions: []v1.NodeCondition{
+				v1.NodeCondition{
+					Status: "True",
+					Type:   "Ready",
+				},
+			},
+		},
+	}
+
 	expectedZone := make(map[string]struct{})
 	expectedZone["us-west-2a"] = struct{}{}
 	expectedZone["us-west-2b"] = struct{}{}
@@ -131,4 +249,8 @@ func (s ZoneSuite) TestNodeZoneAndRegionEBS(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(reflect.DeepEqual(z, expectedZone), Equals, true)
 	c.Assert(r, Equals, "us-west-2")
+
+	cli = fake.NewSimpleClientset(node4, node5)
+	_, _, err = NodeZonesAndRegion(ctx, cli)
+	c.Assert(err, NotNil)
 }


### PR DESCRIPTION
## Change Overview

Adding checks on available nodes to make sure they are ready and are schedulable before selecting a zone.

## Pull request type

Please check the type of change your PR introduces:
- [x] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #K10-3548, K10-3515

https://kasten.atlassian.net/browse/K10-3548
https://kasten.atlassian.net/browse/K10-3515

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ x] :muscle: Manual
- [ x] :zap: Unit test
- [ ] :green_heart: E2E
