### PR TITLE
replacing depricated API with newer one for mysql helm chart

### DIFF
--- a/examples/helm/kanister/kanister-mysql/templates/deployment.yaml
+++ b/examples/helm/kanister/kanister-mysql/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "mysql.fullname" . }}


### PR DESCRIPTION
## Change Overview

Deployment extensions/v1beta1 is depricated since 1.16

## Pull request type

Please check the type of change your PR introduces:
- [x] :bug: Bugfix

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
```
helm install examples/helm/kanister/kanister-mysql/ --dry-run --debug

---
# Source: kanister-mysql/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: named-porcupine-kanister-mysql
  labels:
    app: named-porcupine-kanister-mysql
    chart: "kanister-mysql-0.26.0"
    release: "named-porcupine"
    heritage: "Tiller"
  annotations:

```
