### PR TITLE
Add PostgreSQL DeploymentConfig in Kanister test suite

### DIFF
--- a/build/integration-test.sh
+++ b/build/integration-test.sh
@@ -27,7 +27,7 @@ TEST_OPTIONS="-tags=integration -timeout ${TEST_TIMEOUT} -check.suitep ${DOP}"
 # Regex to match apps to run in short mode
 SHORT_APPS="^PostgreSQL$|^PITRPostgreSQL|MySQL|Elasticsearch|^MongoDB$"
 # OCAPPS has all the apps that are to be tested against openshift cluster
-OC_APPS="MysqlDBDepConfig|MongoDBDepConfig"
+OC_APPS="MysqlDBDepConfig|MongoDBDepConfig|PostgreSQLDepConfig"
 
 check_dependencies() {
     # Check if minio is already deployed

--- a/build/integration-test.sh
+++ b/build/integration-test.sh
@@ -25,7 +25,7 @@ TEST_TIMEOUT="30m"
 # Set default options
 TEST_OPTIONS="-tags=integration -timeout ${TEST_TIMEOUT} -check.suitep ${DOP}"
 # Regex to match apps to run in short mode
-SHORT_APPS="^PostgreSQL|^PITRPostgreSQL|MySQL|Elasticsearch|^MongoDB$"
+SHORT_APPS="^PostgreSQL$|^PITRPostgreSQL|MySQL|Elasticsearch|^MongoDB$"
 # OCAPPS has all the apps that are to be tested against openshift cluster
 OC_APPS="MysqlDBDepConfig|MongoDBDepConfig"
 

--- a/pkg/app/mongodb-deploymentconfig.go
+++ b/pkg/app/mongodb-deploymentconfig.go
@@ -43,7 +43,6 @@ type MongoDBDepConfig struct {
 	name       string
 	namespace  string
 	dbTemplate string
-	envVar     map[string]string
 	user       string
 	label      string
 	osClient   openshift.OSClient
@@ -82,7 +81,7 @@ func (mongo *MongoDBDepConfig) Init(context.Context) error {
 func (mongo *MongoDBDepConfig) Install(ctx context.Context, namespace string) error {
 	mongo.namespace = namespace
 
-	_, err := mongo.osClient.NewApp(ctx, mongo.namespace, mongo.dbTemplate, mongo.envVar, mongo.params)
+	_, err := mongo.osClient.NewApp(ctx, mongo.namespace, mongo.dbTemplate, nil, mongo.params)
 
 	return errors.Wrapf(err, "Error installing app %s on openshift cluster.", mongo.name)
 }

--- a/pkg/app/mongodb-deploymentconfig.go
+++ b/pkg/app/mongodb-deploymentconfig.go
@@ -47,6 +47,7 @@ type MongoDBDepConfig struct {
 	user       string
 	label      string
 	osClient   openshift.OSClient
+	params     map[string]string
 }
 
 func NewMongoDBDepConfig(name string) App {
@@ -54,7 +55,7 @@ func NewMongoDBDepConfig(name string) App {
 		name:       name,
 		dbTemplate: getOpenShiftDBTemplate(mongoDepConfigName),
 		user:       "admin",
-		envVar: map[string]string{
+		params: map[string]string{
 			"MONGODB_ADMIN_PASSWORD": "secretpassword",
 		},
 		label:    getLabelOfApp(mongoDepConfigName),
@@ -81,7 +82,7 @@ func (mongo *MongoDBDepConfig) Init(context.Context) error {
 func (mongo *MongoDBDepConfig) Install(ctx context.Context, namespace string) error {
 	mongo.namespace = namespace
 
-	_, err := mongo.osClient.NewApp(ctx, mongo.namespace, mongo.dbTemplate, mongo.envVar)
+	_, err := mongo.osClient.NewApp(ctx, mongo.namespace, mongo.dbTemplate, mongo.envVar, mongo.params)
 
 	return errors.Wrapf(err, "Error installing app %s on openshift cluster.", mongo.name)
 }

--- a/pkg/app/mysql-deploymentconfig.go
+++ b/pkg/app/mysql-deploymentconfig.go
@@ -50,6 +50,7 @@ type MysqlDepConfig struct {
 	namespace  string
 	dbTemplate string
 	envVar     map[string]string
+	params     map[string]string
 }
 
 func NewMysqlDepConfig(name string) App {
@@ -82,7 +83,7 @@ func (mdep *MysqlDepConfig) Install(ctx context.Context, namespace string) error
 	mdep.namespace = namespace
 
 	oc := openshift.NewOpenShiftClient()
-	_, err := oc.NewApp(ctx, mdep.namespace, mdep.dbTemplate, mdep.envVar)
+	_, err := oc.NewApp(ctx, mdep.namespace, mdep.dbTemplate, mdep.envVar, mdep.params)
 	if err != nil {
 		return errors.Wrapf(err, "Error installing app %s on openshift cluster.", mdep.name)
 	}
@@ -102,7 +103,7 @@ func (mdep *MysqlDepConfig) Install(ctx context.Context, namespace string) error
 func (mdep *MysqlDepConfig) createMySQLSecret(ctx context.Context) error {
 	mysqlSecret := &v1.Secret{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       "Pod",
+			Kind:       "Secret",
 			APIVersion: "v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/app/mysql-deploymentconfig.go
+++ b/pkg/app/mysql-deploymentconfig.go
@@ -36,7 +36,7 @@ import (
 )
 
 const (
-	mysqlDepConfigWaitTimeout = 2 * time.Minute
+	mysqlDepConfigWaitTimeout = 4 * time.Minute
 	mysqlToolPodName          = "mysql-tools-pod"
 	mysqlToolContainerName    = "mysql-tools-container"
 	mysqlToolImage            = "kanisterio/mysql-sidecar:0.26.0"
@@ -50,7 +50,6 @@ type MysqlDepConfig struct {
 	namespace  string
 	dbTemplate string
 	envVar     map[string]string
-	params     map[string]string
 }
 
 func NewMysqlDepConfig(name string) App {
@@ -83,7 +82,7 @@ func (mdep *MysqlDepConfig) Install(ctx context.Context, namespace string) error
 	mdep.namespace = namespace
 
 	oc := openshift.NewOpenShiftClient()
-	_, err := oc.NewApp(ctx, mdep.namespace, mdep.dbTemplate, mdep.envVar, mdep.params)
+	_, err := oc.NewApp(ctx, mdep.namespace, mdep.dbTemplate, mdep.envVar, nil)
 	if err != nil {
 		return errors.Wrapf(err, "Error installing app %s on openshift cluster.", mdep.name)
 	}

--- a/pkg/app/postgresql-deploymentconfig.go
+++ b/pkg/app/postgresql-deploymentconfig.go
@@ -1,0 +1,117 @@
+// Copyright 2019 The Kanister Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import (
+	"context"
+	"time"
+
+	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
+	osversioned "github.com/openshift/client-go/apps/clientset/versioned"
+	"github.com/pkg/errors"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/kanisterio/kanister/pkg/field"
+	"github.com/kanisterio/kanister/pkg/kube"
+	"github.com/kanisterio/kanister/pkg/log"
+	"github.com/kanisterio/kanister/pkg/openshift"
+)
+
+const (
+	postgresDepConfigName          = "postgresql"
+	postgreSQLDepConfigWaitTimeout = 2 * time.Minute
+)
+
+type PostgreSQLDepConfig struct {
+	name           string
+	cli            kubernetes.Interface
+	osCli          osversioned.Interface
+	namespace      string
+	opeshiftClient openshift.OSClient
+	dbTemplate     string
+}
+
+func NewPostgreSQLDepConfig(name string) App {
+	return &PostgreSQLDepConfig{
+		name:           name,
+		opeshiftClient: openshift.NewOpenShiftClient(),
+		dbTemplate:     getOpenShiftDBTemplate(postgresDepConfigName),
+	}
+}
+
+func (pgres *PostgreSQLDepConfig) Init(ctx context.Context) error {
+	cfg, err := kube.LoadConfig()
+	if err != nil {
+		return err
+	}
+	pgres.cli, err = kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return err
+	}
+
+	pgres.osCli, err = osversioned.NewForConfig(cfg)
+
+	return err
+}
+
+func (pgres *PostgreSQLDepConfig) Install(ctx context.Context, namespace string) error {
+	pgres.namespace = namespace
+
+	_, err := pgres.opeshiftClient.NewApp(ctx, pgres.namespace, pgres.dbTemplate, nil)
+
+	return errors.Wrap(err, "Error while installing the application.")
+}
+
+func (pgres *PostgreSQLDepConfig) IsReady(ctx context.Context) (bool, error) {
+	log.Print("Waiting for application to be ready.", field.M{"app": pgres.name})
+	ctx, cancel := context.WithTimeout(ctx, postgreSQLDepConfigWaitTimeout)
+	defer cancel()
+
+	err := kube.WaitOnDeploymentConfigReady(ctx, pgres.osCli, pgres.cli, pgres.namespace, postgresDepConfigName)
+	if err != nil {
+		return false, errors.Wrapf(err, "Error %s waiting for application to be ready.", pgres.name)
+	}
+
+	log.Print("Application is ready", field.M{"app": pgres.name})
+	return false, nil
+}
+
+func (pgres *PostgreSQLDepConfig) Object() crv1alpha1.ObjectReference {
+	return crv1alpha1.ObjectReference{
+		Kind:      "deploymentconfig",
+		Name:      postgresDepConfigName,
+		Namespace: pgres.namespace,
+	}
+}
+
+func (pgres *PostgreSQLDepConfig) Uninstall(context.Context) error {
+	return nil
+}
+
+func (pgres *PostgreSQLDepConfig) Ping(context.Context) error {
+	return nil
+}
+
+func (pgres *PostgreSQLDepConfig) Insert(ctx context.Context) error {
+	return nil
+}
+
+func (pgres *PostgreSQLDepConfig) Count(context.Context) (int, error) {
+	return 0, nil
+}
+
+func (pgres *PostgreSQLDepConfig) Reset(context.Context) error {
+	return nil
+}

--- a/pkg/app/postgresql-deploymentconfig.go
+++ b/pkg/app/postgresql-deploymentconfig.go
@@ -16,11 +16,16 @@ package app
 
 import (
 	"context"
+	"fmt"
+	"strconv"
+	"strings"
 	"time"
 
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	osversioned "github.com/openshift/client-go/apps/clientset/versioned"
 	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/kanisterio/kanister/pkg/field"
@@ -42,6 +47,8 @@ type PostgreSQLDepConfig struct {
 	opeshiftClient openshift.OSClient
 	dbTemplate     string
 	label          string
+	params         map[string]string
+	envVar         map[string]string
 }
 
 func NewPostgreSQLDepConfig(name string) App {
@@ -49,6 +56,10 @@ func NewPostgreSQLDepConfig(name string) App {
 		name:           name,
 		opeshiftClient: openshift.NewOpenShiftClient(),
 		dbTemplate:     getOpenShiftDBTemplate(postgresDepConfigName),
+		label:          getLabelOfApp(postgresDepConfigName),
+		envVar: map[string]string{
+			"POSTGRESQL_ADMIN_PASSWORD": "secretpassword",
+		},
 	}
 }
 
@@ -70,9 +81,34 @@ func (pgres *PostgreSQLDepConfig) Init(ctx context.Context) error {
 func (pgres *PostgreSQLDepConfig) Install(ctx context.Context, namespace string) error {
 	pgres.namespace = namespace
 
-	_, err := pgres.opeshiftClient.NewApp(ctx, pgres.namespace, pgres.dbTemplate, nil)
+	_, err := pgres.opeshiftClient.NewApp(ctx, pgres.namespace, pgres.dbTemplate, pgres.envVar, pgres.params)
+	if err != nil {
+		return errors.Wrapf(err, "Error installing application %s on openshift cluster", pgres.name)
+	}
+	// The secret that get created after installation doesnt have the creds that are mentioned in the
+	// POSTGRESQL_ADMIN_PASSWORD above, we are creating another secret that will have this detail
 
-	return errors.Wrap(err, "Error while installing the application.")
+	return pgres.createPostgreSQLSecret(ctx)
+}
+
+func (pgres *PostgreSQLDepConfig) createPostgreSQLSecret(ctx context.Context) error {
+	postgreSQLSecret := &v1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-%s", postgresDepConfigName, pgres.namespace),
+			Namespace: pgres.namespace,
+		},
+		Data: map[string][]byte{
+			"postgresql_admin_password": []byte(pgres.envVar["POSTGRESQL_ADMIN_PASSWORD"]),
+		},
+	}
+
+	_, err := pgres.cli.CoreV1().Secrets(pgres.namespace).Create(postgreSQLSecret)
+
+	return errors.Wrapf(err, "Error creating secret for mysqldepconf app.")
 }
 
 func (pgres *PostgreSQLDepConfig) IsReady(ctx context.Context) (bool, error) {
@@ -86,7 +122,7 @@ func (pgres *PostgreSQLDepConfig) IsReady(ctx context.Context) (bool, error) {
 	}
 
 	log.Print("Application is ready", field.M{"app": pgres.name})
-	return false, nil
+	return true, nil
 }
 
 func (pgres *PostgreSQLDepConfig) Object() crv1alpha1.ObjectReference {
@@ -97,22 +133,79 @@ func (pgres *PostgreSQLDepConfig) Object() crv1alpha1.ObjectReference {
 	}
 }
 
-func (pgres *PostgreSQLDepConfig) Uninstall(context.Context) error {
-	return nil
+func (pgres *PostgreSQLDepConfig) Uninstall(ctx context.Context) error {
+	_, err := pgres.opeshiftClient.DeleteApp(ctx, pgres.namespace, pgres.label)
+	return err
 }
 
-func (pgres *PostgreSQLDepConfig) Ping(context.Context) error {
+func (pgres *PostgreSQLDepConfig) Ping(ctx context.Context) error {
+	cmd := "pg_isready -U 'postgres' -h 127.0.0.1 -p 5432"
+	_, stderr, err := pgres.execCommand(ctx, []string{"sh", "-c", cmd})
+	if err != nil {
+		return errors.Wrapf(err, "Failed to ping postgresql deployment config DB. %s", stderr)
+	}
+	log.Info().Print("Connected to database.", field.M{"app": pgres.name})
 	return nil
 }
 
 func (pgres *PostgreSQLDepConfig) Insert(ctx context.Context) error {
+	cmd := fmt.Sprintf("psql -d test -c \"INSERT INTO COMPANY (NAME,AGE,CREATED_AT) VALUES ('foo', 32, now());\"")
+	_, stderr, err := pgres.execCommand(ctx, []string{"sh", "-c", cmd})
+	if err != nil {
+		return errors.Wrapf(err, "Failed to create db in postgresql deployment config. %s", stderr)
+	}
+	log.Info().Print("Inserted a row in test db.", field.M{"app": pgres.name})
 	return nil
 }
 
-func (pgres *PostgreSQLDepConfig) Count(context.Context) (int, error) {
-	return 0, nil
+func (pgres *PostgreSQLDepConfig) Count(ctx context.Context) (int, error) {
+	cmd := "psql -d test -c 'SELECT COUNT(*) FROM company;'"
+	stdout, stderr, err := pgres.execCommand(ctx, []string{"sh", "-c", cmd})
+	if err != nil {
+		return 0, errors.Wrapf(err, "Failed to count db entries in postgresql deployment config. %s ", stderr)
+	}
+
+	out := strings.Fields(stdout)
+	if len(out) < 4 {
+		return 0, fmt.Errorf("Unknown response for count query")
+	}
+	count, err := strconv.Atoi(out[2])
+	if err != nil {
+		return 0, errors.Wrapf(err, "Failed to count db entries in postgresql deployment config. %s ", stderr)
+	}
+	log.Info().Print("Counting rows in test db.", field.M{"app": pgres.name, "count": count})
+	return count, nil
 }
 
-func (pgres *PostgreSQLDepConfig) Reset(context.Context) error {
+func (pgres *PostgreSQLDepConfig) Reset(ctx context.Context) error {
+	cmd := "psql -c 'DROP DATABASE IF EXISTS test;'"
+	_, stderr, err := pgres.execCommand(ctx, []string{"sh", "-c", cmd})
+	if err != nil {
+		return errors.Wrapf(err, "Failed to drop db from postgresql deployment config. %s ", stderr)
+	}
+
+	// Create database
+	cmd = "psql -c 'CREATE DATABASE test;'"
+	_, stderr, err = pgres.execCommand(ctx, []string{"sh", "-c", cmd})
+	if err != nil {
+		return errors.Wrapf(err, "Failed to create db in postgresql deployment config %s ", stderr)
+	}
+
+	// Create table
+	cmd = "psql -d test -c 'CREATE TABLE COMPANY(ID SERIAL PRIMARY KEY NOT NULL, NAME TEXT NOT NULL, AGE INT NOT NULL, CREATED_AT TIMESTAMP);'"
+	_, stderr, err = pgres.execCommand(ctx, []string{"sh", "-c", cmd})
+	if err != nil {
+		return errors.Wrapf(err, "Failed to create table in postgresql deployment config %s ", stderr)
+	}
+	log.Info().Print("Database reset successful!", field.M{"app": pgres.name})
 	return nil
+}
+
+func (pgres *PostgreSQLDepConfig) execCommand(ctx context.Context, command []string) (string, string, error) {
+	// Get pod and container name
+	pod, container, err := kube.GetPodContainerFromDeploymentConfig(ctx, pgres.osCli, pgres.cli, pgres.namespace, postgresDepConfigName)
+	if err != nil {
+		return "", "", err
+	}
+	return kube.Exec(pgres.cli, pgres.namespace, pod, container, command, nil)
 }

--- a/pkg/app/postgresql-deploymentconfig.go
+++ b/pkg/app/postgresql-deploymentconfig.go
@@ -21,13 +21,13 @@ import (
 	"strings"
 	"time"
 
-	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	osversioned "github.com/openshift/client-go/apps/clientset/versioned"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
+	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	"github.com/kanisterio/kanister/pkg/field"
 	"github.com/kanisterio/kanister/pkg/kube"
 	"github.com/kanisterio/kanister/pkg/log"
@@ -47,7 +47,6 @@ type PostgreSQLDepConfig struct {
 	opeshiftClient openshift.OSClient
 	dbTemplate     string
 	label          string
-	params         map[string]string
 	envVar         map[string]string
 }
 
@@ -81,7 +80,7 @@ func (pgres *PostgreSQLDepConfig) Init(ctx context.Context) error {
 func (pgres *PostgreSQLDepConfig) Install(ctx context.Context, namespace string) error {
 	pgres.namespace = namespace
 
-	_, err := pgres.opeshiftClient.NewApp(ctx, pgres.namespace, pgres.dbTemplate, pgres.envVar, pgres.params)
+	_, err := pgres.opeshiftClient.NewApp(ctx, pgres.namespace, pgres.dbTemplate, pgres.envVar, nil)
 	if err != nil {
 		return errors.Wrapf(err, "Error installing application %s on openshift cluster", pgres.name)
 	}

--- a/pkg/app/postgresql-deploymentconfig.go
+++ b/pkg/app/postgresql-deploymentconfig.go
@@ -41,6 +41,7 @@ type PostgreSQLDepConfig struct {
 	namespace      string
 	opeshiftClient openshift.OSClient
 	dbTemplate     string
+	label          string
 }
 
 func NewPostgreSQLDepConfig(name string) App {

--- a/pkg/blueprint/blueprints/postgres-dep-config-blueprint.yaml
+++ b/pkg/blueprint/blueprints/postgres-dep-config-blueprint.yaml
@@ -1,0 +1,84 @@
+apiVersion: cr.kanister.io/v1alpha1
+kind: Blueprint
+metadata:
+  name: postgres-bp
+actions:
+  backup:
+    kind: DeploymentConfig
+    outputArtifacts:
+      cloudObject:
+        keyValue:
+          backupLocation: "{{ .Phases.pgDump.Output.backupLocation }}"
+    phases:
+    - func: KubeTask
+      name: pgDump
+      objects:
+        pgSecret:
+          kind: Secret
+          name: '{{ .DeploymentConfig.Name }}-{{ .DeploymentConfig.Namespace }}'
+          namespace: '{{ .DeploymentConfig.Namespace }}'
+      args:
+        image: kanisterio/postgres-kanister-tools:0.26.0
+        namespace: '{{ .DeploymentConfig.Namespace }}'
+        command:
+        - bash
+        - -o
+        - errexit
+        - -o
+        - pipefail
+        - -c
+        - |
+          export PGHOST='{{ .DeploymentConfig.Name }}.{{ .DeploymentConfig.Namespace }}.svc.cluster.local'
+          export PGUSER='postgres'
+          export PGPASSWORD='{{ index .Phases.pgDump.Secrets.pgSecret.Data "postgresql_admin_password" | toString }}'
+          BACKUP_LOCATION=pg_backups/{{ .DeploymentConfig.Namespace }}/{{ .DeploymentConfig.Name }}/{{ toDate "2006-01-02T15:04:05.999999999Z07:00" .Time | date "2006-01-02T15:04:05Z07:00" }}/backup.sql.gz
+          pg_dumpall --clean -U $PGUSER | gzip -c | kando location push --profile '{{ toJson .Profile }}' --path "${BACKUP_LOCATION}" -
+          kando output backupLocation "${BACKUP_LOCATION}"
+  restore:
+    kind: DeploymentConfig
+    inputArtifactNames:
+    - cloudObject
+    phases:
+    - func: KubeTask
+      name: pgRestore
+      objects:
+        pgSecret:
+          kind: Secret
+          name: '{{ .DeploymentConfig.Name }}-{{ .DeploymentConfig.Namespace }}'
+          namespace: '{{ .DeploymentConfig.Namespace }}'
+      args:
+        image: kanisterio/postgres-kanister-tools:0.26.0
+        namespace: '{{ .DeploymentConfig.Namespace }}'
+        command:
+        - bash
+        - -o
+        - errexit
+        - -o
+        - pipefail
+        - -c
+        - |
+          export PGHOST='{{ .DeploymentConfig.Name }}.{{ .DeploymentConfig.Namespace }}.svc.cluster.local'
+          export PGUSER='postgres'
+          export PGPASSWORD='{{ index .Phases.pgRestore.Secrets.pgSecret.Data "postgresql_admin_password" | toString }}'
+          BACKUP_LOCATION={{ .ArtifactsIn.cloudObject.KeyValue.backupLocation }}
+          kando location pull --profile '{{ toJson .Profile }}' --path "${BACKUP_LOCATION}" - | gunzip -c -f | psql -q -U "${PGUSER}"
+  delete:
+    kind: DeploymentConfig
+    inputArtifactNames:
+      - cloudObject
+    phases:
+    - func: KubeTask
+      name: deleteDump
+      args:
+        image: kanisterio/postgres-kanister-tools:0.26.0
+        namespace: "{{ .DeploymentConfig.Namespace }}"
+        command:
+          - bash
+          - -o
+          - errexit
+          - -o
+          - pipefail
+          - -c
+          - |
+            kando location delete --profile '{{ toJson .Profile }}' --path '{{ .ArtifactsIn.cloudObject.KeyValue.backupLocation }}'
+

--- a/pkg/openshift/oc.go
+++ b/pkg/openshift/oc.go
@@ -35,13 +35,20 @@ func (oc OpenShiftClient) CreateNamespace(ctx context.Context, namespace string)
 
 // NewApp install a new application in the openshift
 // cluster using ``oc new-app`` command
-func (oc OpenShiftClient) NewApp(ctx context.Context, namespace, dpTemplate string, envVar map[string]string) (string, error) {
-	var formedVars []string
+func (oc OpenShiftClient) NewApp(ctx context.Context, namespace, dpTemplate string, envVar, params map[string]string) (string, error) {
+	var formedVars, formedParams []string
 	for k, v := range envVar {
-		formedVars = append(formedVars, "-p", fmt.Sprintf("%s=%s", k, v))
+		formedVars = append(formedVars, "-e", fmt.Sprintf("%s=%s", k, v))
 	}
 
+	for k, v := range params {
+		formedParams = append(formedParams, "-p", fmt.Sprintf("%s=%s", k, v))
+	}
+
+	// append env variables in the command
 	command := append([]string{"new-app", "-n", namespace, dpTemplate}, formedVars...)
+	// append parameters in the command
+	command = append(command, formedParams...)
 	return helm.RunCmdWithTimeout(ctx, "oc", command)
 }
 

--- a/pkg/openshift/openshift.go
+++ b/pkg/openshift/openshift.go
@@ -24,7 +24,7 @@ type OSClient interface {
 
 	// NewApp installs new app in the openshift clsuter
 	// similar to oc new-app ...
-	NewApp(ctx context.Context, namespace, osAppImage string, envVar map[string]string) (string, error)
+	NewApp(ctx context.Context, namespace, dpTemplate string, envVar, params map[string]string) (string, error)
 
 	// DeleteApp delete an app from the openshift cluster
 	// similar to oc delete all -n <ns> -l <label>

--- a/pkg/testing/integration_register.go
+++ b/pkg/testing/integration_register.go
@@ -217,3 +217,18 @@ var _ = Suite(&MongoDBDepConfig{
 		profile:   newSecretProfile(),
 	},
 })
+
+// PostgreSQL deployed on openshift cluster
+type PostgreSQLDepConfig struct {
+	IntegrationSuite
+}
+
+var _ = Suite(&PostgreSQLDepConfig{
+	IntegrationSuite{
+		name:      "postgresdepconf",
+		namespace: "postgresdepconf-test",
+		app:       app.NewPostgreSQLDepConfig("postgresdepconf"),
+		bp:        app.NewBlueprint("postgres-dep-config"),
+		profile:   newSecretProfile(),
+	},
+})


### PR DESCRIPTION
## Change Overview

1. Add PostgreSQL dep config in Kanister test suite
2. Add params in oc.NewApp, so that we can pass parameter as well
3. Refactor mongo and mysql dep conf accordingly


## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan
To test the changes, please start the minishift cluster on you local machine, to do that first change the `Makefile` to `DOCKER_BUILD ?= "false"` and then start the minishift cluster using below command 
```
make start-minishift vm-driver=virtualbox
```
Once the cluster is up and running you will have to make the changes in the `integration-test.sh` file to only run the DeploymentConfig application by changing the variable `SHORT_APPS` to
`SHORT_APPS="PostgreSQLDepConfig|MongoDBDepConfig|MysqlDBDepConfig"`
and run 
```
make integration-test
```
Logs of the above test can be found [here](https://gist.github.com/viveksinghggits/72561f7849d897bce75173db63468b9a).


- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
