### PR TITLE
Separate Makefile target to run OpenShift apps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ integration-test: build-dirs
 	@$(MAKE) run CMD='-c "./build/integration-test.sh short"'
 
 openshift-test:
-	@/bin/bash ./build/integration-test.sh oc
+	@/bin/bash ./build/integration-test.sh openshift
 
 golint:
 	@$(MAKE) run CMD='-c "./build/golint.sh"'

--- a/Makefile
+++ b/Makefile
@@ -172,6 +172,9 @@ test: build-dirs
 integration-test: build-dirs
 	@$(MAKE) run CMD='-c "./build/integration-test.sh short"'
 
+openshift-test:
+	@/bin/bash ./build/integration-test.sh oc
+
 golint:
 	@$(MAKE) run CMD='-c "./build/golint.sh"'
 

--- a/build/integration-test.sh
+++ b/build/integration-test.sh
@@ -26,6 +26,8 @@ TEST_TIMEOUT="30m"
 TEST_OPTIONS="-tags=integration -timeout ${TEST_TIMEOUT} -check.suitep ${DOP}"
 # Regex to match apps to run in short mode
 SHORT_APPS="^PostgreSQL|^PITRPostgreSQL|MySQL|Elasticsearch|^MongoDB$"
+# OCAPPS has all the apps that are to be tested against openshift cluster
+OC_APPS="MysqlDBDepConfig|MongoDBDepConfig"
 
 check_dependencies() {
     # Check if minio is already deployed
@@ -47,6 +49,7 @@ Usage: ${0} <app-type>
 Where app-type is one of [short|all]:
   short: Runs e2e integration tests for part of apps
   all: Runs e2e integration tests for all apps
+  oc: Runs e2e integration tests for apps that are to be tetsed against openshift cluster
 OR
   You can also provide regex to match apps you want to run.
 EOM
@@ -61,6 +64,10 @@ case "${1}" in
     short)
         # Run only part of apps
         TEST_APPS=${SHORT_APPS}
+        ;;
+    oc)
+        # Run only openshift apps
+        TEST_APPS=${OC_APPS}
         ;;
     *)
         TEST_APPS=${1}

--- a/build/integration-test.sh
+++ b/build/integration-test.sh
@@ -65,7 +65,7 @@ case "${1}" in
         # Run only part of apps
         TEST_APPS=${SHORT_APPS}
         ;;
-    oc)
+    openshift)
         # Run only openshift apps
         TEST_APPS=${OC_APPS}
         ;;

--- a/build/minishift.sh
+++ b/build/minishift.sh
@@ -31,14 +31,16 @@ start_minishift ()
     tar zxvf ${TMP_DIR}/minishift-${MINISHIFT_VERSION}-linux-amd64.tgz -C ${TMP_DIR}
     cp ${TMP_DIR}/minishift-${MINISHIFT_VERSION}-linux-amd64/minishift ${GOPATH}/bin
     echo 'minishift was downloaded'
-    echo 
+    echo
     echo 'Starting minishift...'
     minishift start --vm-driver=${1}
-    echo 'minishift was started successfully.' 
+    echo 'minishift was started successfully.'
     echo
     echo 'Copying OpenShift client to correct location...'
     cp  ${HOME}/.minishift/cache/oc/v${OC_VERSION}/linux/oc ${GOPATH}/bin
     oc login -u system:admin
+    # https://github.com/minio/minio/issues/6524#issuecomment-451689375
+    oc adm policy add-scc-to-group anyuid system:authenticated
     echo 'Success, you are ready to use minishift.'
 }
 
@@ -46,7 +48,7 @@ start_minishift ()
 stop_minishift ()
 {
     minishift stop
-    echo   
+    echo
     minishift delete -f
     rm -rf ${GOPATH}/bin/minishift
     rm -rf ${GOPATH}/bin/oc
@@ -71,7 +73,7 @@ case "${1}" in
         start_minishift)
             # check if vm-driver was provided or not
             if [ $# -ne 2 ]
-            then 
+            then
                 echo 'Please provide vm driver using vm-driver flag.'
                 exit 1
             fi

--- a/pkg/app/mongodb-deploymentconfig.go
+++ b/pkg/app/mongodb-deploymentconfig.go
@@ -34,7 +34,7 @@ import (
 
 const (
 	mongoDepConfigName        = "mongodb"
-	mongoDepConfigWaitTimeout = 2 * time.Minute
+	mongoDepConfigWaitTimeout = 4 * time.Minute
 )
 
 type MongoDBDepConfig struct {


### PR DESCRIPTION
## Change Overview
We can now run the test for applications that are being deployed on OpenShift clusters, using make target.
We currently have MongoDB and MySQL databases in kanister test that is deployed on OpenShift cluster. If you just want to test those application just run 

```
make openshift-test
```
and the test will run for MySQL and MongoDB application on minishift cluster.

PreReq:
Install minishift using the command 
```
make start-minishift vm-driver=virtualbox
```
and install minio using 
```
make install-minio 
```

## Pull request type

Please check the type of change your PR introduces:
- [x] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan
Just run 
```
 make openshift-test
```
Logs can be found [here](https://gist.github.com/viveksinghggits/dede0b497e28f37e8e696d6178ae1256).

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [x] :green_heart: E2E
