### PR TITLE
K10-3548-1 Using levenshtein distance to sanitize nodes

### DIFF
--- a/pkg/blockstorage/zone/sanitize_zones.go
+++ b/pkg/blockstorage/zone/sanitize_zones.go
@@ -1,0 +1,139 @@
+// Copyright 2020 The Kanister Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Parts of this code are derived from https://github.com/agnivade/levenshtein
+// which carries the following license
+
+// The MIT License (MIT)
+// Copyright (c) 2015 Agniva De Sarker
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package zone
+
+import (
+	"sort"
+	"unicode/utf8"
+
+	"github.com/kanisterio/kanister/pkg/field"
+	"github.com/kanisterio/kanister/pkg/log"
+)
+
+func sanitizeAvailableZones(availableZones map[string]struct{}, validZoneNames []string) map[string]struct{} {
+	sanitizedZones := map[string]struct{}{}
+	for zone := range availableZones {
+		if isZoneNameValid(zone, validZoneNames) {
+			sanitizedZones[zone] = struct{}{}
+		} else {
+			closestMatch := levenshteinMatch(zone, validZoneNames)
+			log.Debug().Print("Exact match not found for available zone, using closest match",
+				field.M{"availableZone": zone, "closestMatch": closestMatch})
+			sanitizedZones[closestMatch] = struct{}{}
+		}
+	}
+	return sanitizedZones
+}
+
+func isZoneNameValid(zone string, validZones []string) bool {
+	for _, z := range validZones {
+		if zone == z {
+			return true
+		}
+	}
+	return false
+}
+
+func levenshteinMatch(input string, options []string) string {
+	sort.Slice(options, func(i, j int) bool {
+		return computeDistance(input, options[i]) < computeDistance(input, options[j])
+	})
+	return options[0]
+}
+
+// ComputeDistance computes the levenshtein distance between the two
+// strings passed as an argument. The return value is the levenshtein distance
+func computeDistance(a, b string) int {
+	if len(a) == 0 {
+		return utf8.RuneCountInString(b)
+	}
+
+	if len(b) == 0 {
+		return utf8.RuneCountInString(a)
+	}
+
+	if a == b {
+		return 0
+	}
+
+	// We need to convert to []rune if the strings are non-ASCII.
+	// This could be avoided by using utf8.RuneCountInString
+	// and then doing some juggling with rune indices,
+	// but leads to far more bounds checks. It is a reasonable trade-off.
+	s1 := []rune(a)
+	s2 := []rune(b)
+
+	// swap to save some memory O(min(a,b)) instead of O(a)
+	if len(s1) > len(s2) {
+		s1, s2 = s2, s1
+	}
+	lenS1 := len(s1)
+	lenS2 := len(s2)
+
+	// init the row
+	x := make([]uint16, lenS1+1)
+	// we start from 1 because index 0 is already 0.
+	for i := 1; i < len(x); i++ {
+		x[i] = uint16(i)
+	}
+
+	// make a dummy bounds check to prevent the 2 bounds check down below.
+	// The one inside the loop is particularly costly.
+	_ = x[lenS1]
+	// fill in the rest
+	for i := 1; i <= lenS2; i++ {
+		prev := uint16(i)
+		var current uint16
+		for j := 1; j <= lenS1; j++ {
+			if s2[i-1] == s1[j-1] {
+				current = x[j-1] // match
+			} else {
+				current = min(min(x[j-1]+1, prev+1), x[j]+1)
+			}
+			x[j-1] = prev
+			prev = current
+		}
+		x[lenS1] = prev
+	}
+	return int(x[lenS1])
+}
+
+func min(a, b uint16) uint16 {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/pkg/blockstorage/zone/sanitize_zones_test.go
+++ b/pkg/blockstorage/zone/sanitize_zones_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The Kanister Authors.
+// Copyright 2020 The Kanister Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/blockstorage/zone/sanitize_zones_test.go
+++ b/pkg/blockstorage/zone/sanitize_zones_test.go
@@ -1,0 +1,115 @@
+// Copyright 2019 The Kanister Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package zone
+
+import (
+	. "gopkg.in/check.v1"
+)
+
+type SanitizeZoneSuite struct{}
+
+var _ = Suite(&SanitizeZoneSuite{})
+
+func (s SanitizeZoneSuite) TestSanitizeZones(c *C) {
+	for _, tc := range []struct {
+		availableZones map[string]struct{}
+		validZoneNames []string
+		out            map[string]struct{}
+	}{
+		{
+			availableZones: map[string]struct{}{
+				"us-west1-a": {},
+				"us-west1-b": {},
+				"us-west1-c": {},
+			},
+			validZoneNames: []string{
+				"us-west1-a",
+				"us-west1-b",
+				"us-west1-c",
+			},
+			out: map[string]struct{}{
+				"us-west1-a": {},
+				"us-west1-b": {},
+				"us-west1-c": {},
+			},
+		},
+		{
+			availableZones: map[string]struct{}{
+				"us-west1-a": {},
+				"us-west1-b": {},
+				"us-west1-c": {},
+			},
+			validZoneNames: []string{
+				"us-west1a",
+				"us-west1b",
+				"us-west1c",
+			},
+			out: map[string]struct{}{
+				"us-west1a": {},
+				"us-west1b": {},
+				"us-west1c": {},
+			},
+		},
+		{
+			availableZones: map[string]struct{}{
+				"us-west1-a": {},
+				"us-west1-b": {},
+				"us-west1-c": {},
+			},
+			validZoneNames: []string{
+				"us-west1a",
+				"us-west1b",
+				"us-west1c",
+				"us-west1d",
+			},
+			out: map[string]struct{}{
+				"us-west1a": {},
+				"us-west1b": {},
+				"us-west1c": {},
+			},
+		},
+		{
+			availableZones: map[string]struct{}{
+				"us-west1-a": {},
+				"us-west1-b": {},
+				"us-west1-c": {},
+			},
+			validZoneNames: []string{
+				"us-west1",
+				"us-west2",
+			},
+			out: map[string]struct{}{
+				"us-west1": {},
+			},
+		},
+		{
+			availableZones: map[string]struct{}{
+				"us-west1-a": {},
+				"us-west1-b": {},
+				"us-west1-c": {},
+			},
+			validZoneNames: []string{
+				"east",
+				"west",
+			},
+			out: map[string]struct{}{
+				"west": {},
+			},
+		},
+	} {
+		out := sanitizeAvailableZones(tc.availableZones, tc.validZoneNames)
+		c.Assert(out, DeepEquals, tc.out)
+	}
+}


### PR DESCRIPTION
## Change Overview

This PR takes a list of node names and sanitizes it against a list of valid node names.
For each input node name it calculates the levenshtein distance and picks the best match out of the valid node names.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [x] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
