### PR TITLE
Use bash instead of sh while connecting DBs

### DIFF
--- a/pkg/app/mongodb-deploymentconfig.go
+++ b/pkg/app/mongodb-deploymentconfig.go
@@ -116,7 +116,7 @@ func (mongo *MongoDBDepConfig) Uninstall(ctx context.Context) error {
 func (mongo *MongoDBDepConfig) Ping(ctx context.Context) error {
 	log.Print("Pinging the application", field.M{"app": mongo.name})
 
-	pingCMD := []string{"sh", "-c", fmt.Sprintf("mongo admin --authenticationDatabase admin -u %s -p $MONGODB_ADMIN_PASSWORD --quiet --eval \"rs.slaveOk(); db\"", mongo.user)}
+	pingCMD := []string{"bash", "-c", fmt.Sprintf("mongo admin --authenticationDatabase admin -u %s -p $MONGODB_ADMIN_PASSWORD --quiet --eval \"rs.slaveOk(); db\"", mongo.user)}
 	_, stderr, err := mongo.execCommand(ctx, pingCMD)
 	if err != nil {
 		return errors.Wrapf(err, "Error while Pinging the database %s, %s", stderr, err)
@@ -127,7 +127,7 @@ func (mongo *MongoDBDepConfig) Ping(ctx context.Context) error {
 
 func (mongo *MongoDBDepConfig) Insert(ctx context.Context) error {
 	log.Print("Inserting documents into collection.", field.M{"app": mongo.name})
-	insertCMD := []string{"sh", "-c", fmt.Sprintf("mongo admin --authenticationDatabase admin -u %s -p $MONGODB_ADMIN_PASSWORD --quiet --eval \"db.restaurants.insert({'_id': '%s','name' : 'Tom', 'cuisine' : 'Hawaiian', 'id' : '8675309'})\"", mongo.user, uuid.New())}
+	insertCMD := []string{"bash", "-c", fmt.Sprintf("mongo admin --authenticationDatabase admin -u %s -p $MONGODB_ADMIN_PASSWORD --quiet --eval \"db.restaurants.insert({'_id': '%s','name' : 'Tom', 'cuisine' : 'Hawaiian', 'id' : '8675309'})\"", mongo.user, uuid.New())}
 	_, stderr, err := mongo.execCommand(ctx, insertCMD)
 	if err != nil {
 		return errors.Wrapf(err, "Error %s while inserting data data into mongodb collection.", stderr)
@@ -139,7 +139,7 @@ func (mongo *MongoDBDepConfig) Insert(ctx context.Context) error {
 
 func (mongo *MongoDBDepConfig) Count(ctx context.Context) (int, error) {
 	log.Print("Counting documents of collection.", field.M{"app": mongo.name})
-	countCMD := []string{"sh", "-c", fmt.Sprintf("mongo admin --authenticationDatabase admin -u %s -p $MONGODB_ADMIN_PASSWORD --quiet --eval \"rs.slaveOk(); db.restaurants.count()\"", mongo.user)}
+	countCMD := []string{"bash", "-c", fmt.Sprintf("mongo admin --authenticationDatabase admin -u %s -p $MONGODB_ADMIN_PASSWORD --quiet --eval \"rs.slaveOk(); db.restaurants.count()\"", mongo.user)}
 	stdout, stderr, err := mongo.execCommand(ctx, countCMD)
 	if err != nil {
 		return 0, errors.Wrapf(err, "Error %s while counting the data in mongodb collection.", stderr)
@@ -159,7 +159,7 @@ func (mongo *MongoDBDepConfig) Reset(ctx context.Context) error {
 	// delete all the entries from the restaurants dummy collection
 	// we are not deleting the database because we are dealing with admin database here
 	// and deletion admin database is prohibited
-	deleteDBCMD := []string{"sh", "-c", fmt.Sprintf("mongo admin --authenticationDatabase admin -u %s -p $MONGODB_ADMIN_PASSWORD --quiet --eval \"rs.slaveOk(); db.restaurants.drop()\"", mongo.user)}
+	deleteDBCMD := []string{"bash", "-c", fmt.Sprintf("mongo admin --authenticationDatabase admin -u %s -p $MONGODB_ADMIN_PASSWORD --quiet --eval \"rs.slaveOk(); db.restaurants.drop()\"", mongo.user)}
 	stdout, stderr, err := mongo.execCommand(ctx, deleteDBCMD)
 	return errors.Wrapf(err, "Error %s, resetting the mongodb application. stdout is %s", stderr, stdout)
 }

--- a/pkg/app/postgresql-deploymentconfig.go
+++ b/pkg/app/postgresql-deploymentconfig.go
@@ -139,7 +139,7 @@ func (pgres *PostgreSQLDepConfig) Uninstall(ctx context.Context) error {
 
 func (pgres *PostgreSQLDepConfig) Ping(ctx context.Context) error {
 	cmd := "pg_isready -U 'postgres' -h 127.0.0.1 -p 5432"
-	_, stderr, err := pgres.execCommand(ctx, []string{"sh", "-c", cmd})
+	_, stderr, err := pgres.execCommand(ctx, []string{"bash", "-c", cmd})
 	if err != nil {
 		return errors.Wrapf(err, "Failed to ping postgresql deployment config DB. %s", stderr)
 	}
@@ -149,7 +149,7 @@ func (pgres *PostgreSQLDepConfig) Ping(ctx context.Context) error {
 
 func (pgres *PostgreSQLDepConfig) Insert(ctx context.Context) error {
 	cmd := fmt.Sprintf("psql -d test -c \"INSERT INTO COMPANY (NAME,AGE,CREATED_AT) VALUES ('foo', 32, now());\"")
-	_, stderr, err := pgres.execCommand(ctx, []string{"sh", "-c", cmd})
+	_, stderr, err := pgres.execCommand(ctx, []string{"bash", "-c", cmd})
 	if err != nil {
 		return errors.Wrapf(err, "Failed to create db in postgresql deployment config. %s", stderr)
 	}
@@ -159,7 +159,7 @@ func (pgres *PostgreSQLDepConfig) Insert(ctx context.Context) error {
 
 func (pgres *PostgreSQLDepConfig) Count(ctx context.Context) (int, error) {
 	cmd := "psql -d test -c 'SELECT COUNT(*) FROM company;'"
-	stdout, stderr, err := pgres.execCommand(ctx, []string{"sh", "-c", cmd})
+	stdout, stderr, err := pgres.execCommand(ctx, []string{"bash", "-c", cmd})
 	if err != nil {
 		return 0, errors.Wrapf(err, "Failed to count db entries in postgresql deployment config. %s ", stderr)
 	}
@@ -178,21 +178,21 @@ func (pgres *PostgreSQLDepConfig) Count(ctx context.Context) (int, error) {
 
 func (pgres *PostgreSQLDepConfig) Reset(ctx context.Context) error {
 	cmd := "psql -c 'DROP DATABASE IF EXISTS test;'"
-	_, stderr, err := pgres.execCommand(ctx, []string{"sh", "-c", cmd})
+	_, stderr, err := pgres.execCommand(ctx, []string{"bash", "-c", cmd})
 	if err != nil {
 		return errors.Wrapf(err, "Failed to drop db from postgresql deployment config. %s ", stderr)
 	}
 
 	// Create database
 	cmd = "psql -c 'CREATE DATABASE test;'"
-	_, stderr, err = pgres.execCommand(ctx, []string{"sh", "-c", cmd})
+	_, stderr, err = pgres.execCommand(ctx, []string{"bash", "-c", cmd})
 	if err != nil {
 		return errors.Wrapf(err, "Failed to create db in postgresql deployment config %s ", stderr)
 	}
 
 	// Create table
 	cmd = "psql -d test -c 'CREATE TABLE COMPANY(ID SERIAL PRIMARY KEY NOT NULL, NAME TEXT NOT NULL, AGE INT NOT NULL, CREATED_AT TIMESTAMP);'"
-	_, stderr, err = pgres.execCommand(ctx, []string{"sh", "-c", cmd})
+	_, stderr, err = pgres.execCommand(ctx, []string{"bash", "-c", cmd})
 	if err != nil {
 		return errors.Wrapf(err, "Failed to create table in postgresql deployment config %s ", stderr)
 	}


### PR DESCRIPTION
## Change Overview

We had a weird issue where we were not able to run database util command for ex mongo using the command format 
```
kubectl exec -it -n <ns> <podname> -- sh -c mongo
```
we decided to use `bash` instead of `sh`, this PR has that change.
And now the commands that will be run are
```
kubectl exec -it -n <ns> <podname> -- bash -c mongo
```

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

```
make start-minishift vm-driver=virtualbox
make install-minio 
make openshift-test
```

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
