### PR TITLE
Add resource limits to temporary pods

### DIFF
--- a/pkg/kube/pod.go
+++ b/pkg/kube/pod.go
@@ -22,6 +22,7 @@ import (
 	json "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	sp "k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/client-go/kubernetes"
@@ -42,17 +43,25 @@ type PodOptions struct {
 	PodOverride        crv1alpha1.JSONMap
 }
 
+const defaultContainerName = "container"
+
 // CreatePod creates a pod with a single container based on the specified image
 func CreatePod(ctx context.Context, cli kubernetes.Interface, opts *PodOptions) (*v1.Pod, error) {
 	volumeMounts, podVolumes := createVolumeSpecs(opts.Volumes)
 	defaultSpecs := v1.PodSpec{
 		Containers: []v1.Container{
 			{
-				Name:            "container",
+				Name:            defaultContainerName,
 				Image:           opts.Image,
 				Command:         opts.Command,
 				ImagePullPolicy: v1.PullPolicy(v1.PullAlways),
 				VolumeMounts:    volumeMounts,
+				Resources: v1.ResourceRequirements{
+					Limits: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("100m"),
+						v1.ResourceMemory: resource.MustParse("128Mi"),
+					},
+				},
 			},
 		},
 		// RestartPolicy dictates when the containers of the pod should be restarted.

--- a/pkg/kube/pod_runner_test.go
+++ b/pkg/kube/pod_runner_test.go
@@ -112,7 +112,8 @@ func (s *PodRunnerTestSuite) TestPodRunner_Quota(c *C) {
 			},
 		},
 	}
-	q, err = cli.CoreV1().ResourceQuotas(ns.GetName()).Create(q)
+	_, err = cli.CoreV1().ResourceQuotas(ns.GetName()).Create(q)
+	c.Assert(err, IsNil)
 
 	ctx := context.Background()
 	pr := NewPodRunner(cli, &PodOptions{


### PR DESCRIPTION
## Change Overview

Prior to this change, we would not be able to spin up pods using pod runner if the namespace had a quota set.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [x] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

Prior to this change, the test fails with:
```
[13:17:08]tom@tom-XPS-13-9360: (tmp)~/src/kanister/ go test -v ./pkg/kube -check.v -check.f TestPodRunner_Quota
=== RUN   Test

----------------------------------------------------------------------
FAIL: pod_runner_test.go:87: PodRunnerTestSuite.TestPodRunner_Quota

pod_runner_test.go:126:
    c.Assert(err, IsNil)
... value *errors.withStack = Failed to create pod: Failed to create pod. Namespace: test-podrunner-quota-vbn84, NameFmt: runner-test-quota-: pods "runner-test-quota-7wn8b" is forbidden: failed quota: ns-quota: must specify cpu,memory ("Failed to create pod: Failed to create pod. Namespace: test-podrunner-quota-vbn84, NameFmt: runner-test-quota-: pods \"runner-test-quota-7wn8b\" is forbidden: failed quota: ns-quota: must specify cpu,memory")

OOPS: 0 passed, 1 FAILED
--- FAIL: Test (0.36s)
FAIL
FAIL    github.com/kanisterio/kanister/pkg/kube 0.369s
```

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
