### PR TITLE
Support to have OpenShift apps ephemeral or persistent

### DIFF
--- a/pkg/app/mongodb-deploymentconfig.go
+++ b/pkg/app/mongodb-deploymentconfig.go
@@ -38,27 +38,27 @@ const (
 )
 
 type MongoDBDepConfig struct {
-	cli        kubernetes.Interface
-	osCli      osversioned.Interface
-	name       string
-	namespace  string
-	dbTemplate string
-	user       string
-	label      string
-	osClient   openshift.OSClient
-	params     map[string]string
+	cli         kubernetes.Interface
+	osCli       osversioned.Interface
+	name        string
+	namespace   string
+	user        string
+	label       string
+	osClient    openshift.OSClient
+	params      map[string]string
+	storageType storage
 }
 
 func NewMongoDBDepConfig(name string) App {
 	return &MongoDBDepConfig{
-		name:       name,
-		dbTemplate: getOpenShiftDBTemplate(mongoDepConfigName, ephemeralStorage),
-		user:       "admin",
+		name: name,
+		user: "admin",
 		params: map[string]string{
 			"MONGODB_ADMIN_PASSWORD": "secretpassword",
 		},
-		label:    getLabelOfApp(mongoDepConfigName),
-		osClient: openshift.NewOpenShiftClient(),
+		label:       getLabelOfApp(mongoDepConfigName),
+		osClient:    openshift.NewOpenShiftClient(),
+		storageType: ephemeralStorage,
 	}
 }
 
@@ -81,7 +81,9 @@ func (mongo *MongoDBDepConfig) Init(context.Context) error {
 func (mongo *MongoDBDepConfig) Install(ctx context.Context, namespace string) error {
 	mongo.namespace = namespace
 
-	_, err := mongo.osClient.NewApp(ctx, mongo.namespace, mongo.dbTemplate, nil, mongo.params)
+	dbTemplate := getOpenShiftDBTemplate(mongoDepConfigName, ephemeralStorage)
+
+	_, err := mongo.osClient.NewApp(ctx, mongo.namespace, dbTemplate, nil, mongo.params)
 
 	return errors.Wrapf(err, "Error installing app %s on openshift cluster.", mongo.name)
 }

--- a/pkg/app/mongodb-deploymentconfig.go
+++ b/pkg/app/mongodb-deploymentconfig.go
@@ -49,7 +49,7 @@ type MongoDBDepConfig struct {
 	storageType storage
 }
 
-func NewMongoDBDepConfig(name string) App {
+func NewMongoDBDepConfig(name string, storageType storage) App {
 	return &MongoDBDepConfig{
 		name: name,
 		user: "admin",
@@ -58,7 +58,7 @@ func NewMongoDBDepConfig(name string) App {
 		},
 		label:       getLabelOfApp(mongoDepConfigName),
 		osClient:    openshift.NewOpenShiftClient(),
-		storageType: ephemeralStorage,
+		storageType: storageType,
 	}
 }
 
@@ -81,7 +81,7 @@ func (mongo *MongoDBDepConfig) Init(context.Context) error {
 func (mongo *MongoDBDepConfig) Install(ctx context.Context, namespace string) error {
 	mongo.namespace = namespace
 
-	dbTemplate := getOpenShiftDBTemplate(mongoDepConfigName, ephemeralStorage)
+	dbTemplate := getOpenShiftDBTemplate(mongoDepConfigName, mongo.storageType)
 
 	_, err := mongo.osClient.NewApp(ctx, mongo.namespace, dbTemplate, nil, mongo.params)
 

--- a/pkg/app/mongodb-deploymentconfig.go
+++ b/pkg/app/mongodb-deploymentconfig.go
@@ -34,7 +34,7 @@ import (
 
 const (
 	mongoDepConfigName        = "mongodb"
-	mongoDepConfigWaitTimeout = 4 * time.Minute
+	mongoDepConfigWaitTimeout = 5 * time.Minute
 )
 
 type MongoDBDepConfig struct {
@@ -52,7 +52,7 @@ type MongoDBDepConfig struct {
 func NewMongoDBDepConfig(name string) App {
 	return &MongoDBDepConfig{
 		name:       name,
-		dbTemplate: getOpenShiftDBTemplate(mongoDepConfigName),
+		dbTemplate: getOpenShiftDBTemplate(mongoDepConfigName, ephemeralStorage),
 		user:       "admin",
 		params: map[string]string{
 			"MONGODB_ADMIN_PASSWORD": "secretpassword",

--- a/pkg/app/mysql-deploymentconfig.go
+++ b/pkg/app/mysql-deploymentconfig.go
@@ -44,21 +44,21 @@ const (
 )
 
 type MysqlDepConfig struct {
-	cli        kubernetes.Interface
-	osCli      osversioned.Interface
-	name       string
-	namespace  string
-	dbTemplate string
-	envVar     map[string]string
+	cli         kubernetes.Interface
+	osCli       osversioned.Interface
+	name        string
+	namespace   string
+	envVar      map[string]string
+	storageType storage
 }
 
 func NewMysqlDepConfig(name string) App {
 	return &MysqlDepConfig{
-		name:       name,
-		dbTemplate: getOpenShiftDBTemplate(mysqlDepConfigName, ephemeralStorage),
+		name: name,
 		envVar: map[string]string{
 			"MYSQL_ROOT_PASSWORD": "secretpassword",
 		},
+		storageType: ephemeralStorage,
 	}
 }
 
@@ -81,8 +81,10 @@ func (mdep *MysqlDepConfig) Init(context.Context) error {
 func (mdep *MysqlDepConfig) Install(ctx context.Context, namespace string) error {
 	mdep.namespace = namespace
 
+	dbTemplate := getOpenShiftDBTemplate(mysqlDepConfigName, mdep.storageType)
+
 	oc := openshift.NewOpenShiftClient()
-	_, err := oc.NewApp(ctx, mdep.namespace, mdep.dbTemplate, mdep.envVar, nil)
+	_, err := oc.NewApp(ctx, mdep.namespace, dbTemplate, mdep.envVar, nil)
 	if err != nil {
 		return errors.Wrapf(err, "Error installing app %s on openshift cluster.", mdep.name)
 	}

--- a/pkg/app/mysql-deploymentconfig.go
+++ b/pkg/app/mysql-deploymentconfig.go
@@ -52,13 +52,13 @@ type MysqlDepConfig struct {
 	storageType storage
 }
 
-func NewMysqlDepConfig(name string) App {
+func NewMysqlDepConfig(name string, storageType storage) App {
 	return &MysqlDepConfig{
 		name: name,
 		envVar: map[string]string{
 			"MYSQL_ROOT_PASSWORD": "secretpassword",
 		},
-		storageType: ephemeralStorage,
+		storageType: storageType,
 	}
 }
 

--- a/pkg/app/mysql-deploymentconfig.go
+++ b/pkg/app/mysql-deploymentconfig.go
@@ -36,7 +36,7 @@ import (
 )
 
 const (
-	mysqlDepConfigWaitTimeout = 4 * time.Minute
+	mysqlDepConfigWaitTimeout = 5 * time.Minute
 	mysqlToolPodName          = "mysql-tools-pod"
 	mysqlToolContainerName    = "mysql-tools-container"
 	mysqlToolImage            = "kanisterio/mysql-sidecar:0.26.0"
@@ -55,7 +55,7 @@ type MysqlDepConfig struct {
 func NewMysqlDepConfig(name string) App {
 	return &MysqlDepConfig{
 		name:       name,
-		dbTemplate: getOpenShiftDBTemplate(mysqlDepConfigName),
+		dbTemplate: getOpenShiftDBTemplate(mysqlDepConfigName, ephemeralStorage),
 		envVar: map[string]string{
 			"MYSQL_ROOT_PASSWORD": "secretpassword",
 		},

--- a/pkg/app/postgresql-deploymentconfig.go
+++ b/pkg/app/postgresql-deploymentconfig.go
@@ -36,7 +36,7 @@ import (
 
 const (
 	postgresDepConfigName          = "postgresql"
-	postgreSQLDepConfigWaitTimeout = 2 * time.Minute
+	postgreSQLDepConfigWaitTimeout = 5 * time.Minute
 )
 
 type PostgreSQLDepConfig struct {
@@ -54,7 +54,7 @@ func NewPostgreSQLDepConfig(name string) App {
 	return &PostgreSQLDepConfig{
 		name:           name,
 		opeshiftClient: openshift.NewOpenShiftClient(),
-		dbTemplate:     getOpenShiftDBTemplate(postgresDepConfigName),
+		dbTemplate:     getOpenShiftDBTemplate(postgresDepConfigName, ephemeralStorage),
 		label:          getLabelOfApp(postgresDepConfigName),
 		envVar: map[string]string{
 			"POSTGRESQL_ADMIN_PASSWORD": "secretpassword",

--- a/pkg/app/postgresql-deploymentconfig.go
+++ b/pkg/app/postgresql-deploymentconfig.go
@@ -50,7 +50,7 @@ type PostgreSQLDepConfig struct {
 	storageType    storage
 }
 
-func NewPostgreSQLDepConfig(name string) App {
+func NewPostgreSQLDepConfig(name string, storageType storage) App {
 	return &PostgreSQLDepConfig{
 		name:           name,
 		opeshiftClient: openshift.NewOpenShiftClient(),
@@ -58,7 +58,7 @@ func NewPostgreSQLDepConfig(name string) App {
 		envVar: map[string]string{
 			"POSTGRESQL_ADMIN_PASSWORD": "secretpassword",
 		},
-		storageType: ephemeralStorage,
+		storageType: storageType,
 	}
 }
 

--- a/pkg/app/utils.go
+++ b/pkg/app/utils.go
@@ -22,10 +22,10 @@ import (
 
 const (
 	dbTemplateURI             = "https://raw.githubusercontent.com/openshift/origin/v3.11.0/examples/db-templates/%s-%s-template.json"
-	// PersistentStorage or EphemeralStorage can be used to 
-	// decide which version (either persistent or ephemeral) of
-	// database we are going to install using the dbTemplate. 
+	// PersistentStorage can be used if we want to deploy database with Persistent
 	PersistentStorage storage = "persistent" // nolint:varcheck
+	
+	// EphemeralStorage can be used if we don't want to deploy database with Persistent
 	EphemeralStorage  storage = "ephemeral"
 )
 

--- a/pkg/app/utils.go
+++ b/pkg/app/utils.go
@@ -21,8 +21,12 @@ import (
 )
 
 const (
-	dbTemplateURI = "https://raw.githubusercontent.com/openshift/origin/master/examples/db-templates/%s-persistent-template.json"
+	dbTemplateURI             = "https://raw.githubusercontent.com/openshift/origin/v3.11.0/examples/db-templates/%s-%s-template.json"
+	persistentStorage storage = "persistent"
+	ephemeralStorage  storage = "ephemeral"
 )
+
+type storage string
 
 // appendRandString, appends a random string to the passed string value
 func appendRandString(name string) string {
@@ -32,8 +36,8 @@ func appendRandString(name string) string {
 // getOpenShiftDBTemplate accepts the application name and returns the
 // db template for that application
 // https://github.com/openshift/origin/tree/master/examples/db-templates
-func getOpenShiftDBTemplate(appName string) string {
-	return fmt.Sprintf(dbTemplateURI, appName)
+func getOpenShiftDBTemplate(appName string, storageType storage) string {
+	return fmt.Sprintf(dbTemplateURI, appName, storageType)
 }
 
 // getLabelOfApp returns label of the passed application this label can be

--- a/pkg/app/utils.go
+++ b/pkg/app/utils.go
@@ -21,12 +21,12 @@ import (
 )
 
 const (
-	dbTemplateURI             = "https://raw.githubusercontent.com/openshift/origin/v3.11.0/examples/db-templates/%s-%s-template.json"
+	dbTemplateURI = "https://raw.githubusercontent.com/openshift/origin/v3.11.0/examples/db-templates/%s-%s-template.json"
 	// PersistentStorage can be used if we want to deploy database with Persistent
 	PersistentStorage storage = "persistent" // nolint:varcheck
-	
+
 	// EphemeralStorage can be used if we don't want to deploy database with Persistent
-	EphemeralStorage  storage = "ephemeral"
+	EphemeralStorage storage = "ephemeral"
 )
 
 type storage string

--- a/pkg/app/utils.go
+++ b/pkg/app/utils.go
@@ -21,9 +21,9 @@ import (
 )
 
 const (
-	dbTemplateURI             = "https://raw.githubusercontent.com/openshift/origin/v3.11.0/examples/db-templates/%s-%s-template.json"
-	persistentStorage storage = "persistent"
-	ephemeralStorage  storage = "ephemeral"
+	dbTemplateURI = "https://raw.githubusercontent.com/openshift/origin/v3.11.0/examples/db-templates/%s-%s-template.json"
+	//persistentStorage storage = "persistent"
+	ephemeralStorage storage = "ephemeral"
 )
 
 type storage string

--- a/pkg/app/utils.go
+++ b/pkg/app/utils.go
@@ -21,9 +21,9 @@ import (
 )
 
 const (
-	dbTemplateURI = "https://raw.githubusercontent.com/openshift/origin/v3.11.0/examples/db-templates/%s-%s-template.json"
-	//PersistentStorage storage = "persistent"
-	EphemeralStorage storage = "ephemeral"
+	dbTemplateURI             = "https://raw.githubusercontent.com/openshift/origin/v3.11.0/examples/db-templates/%s-%s-template.json"
+	PersistentStorage storage = "persistent" // nolint:varcheck
+	EphemeralStorage  storage = "ephemeral"
 )
 
 type storage string

--- a/pkg/app/utils.go
+++ b/pkg/app/utils.go
@@ -22,6 +22,9 @@ import (
 
 const (
 	dbTemplateURI             = "https://raw.githubusercontent.com/openshift/origin/v3.11.0/examples/db-templates/%s-%s-template.json"
+	// PersistentStorage or EphemeralStorage can be used to 
+	// decide which version (either persistent or ephemeral) of
+	// database we are going to install using the dbTemplate. 
 	PersistentStorage storage = "persistent" // nolint:varcheck
 	EphemeralStorage  storage = "ephemeral"
 )

--- a/pkg/app/utils.go
+++ b/pkg/app/utils.go
@@ -22,8 +22,8 @@ import (
 
 const (
 	dbTemplateURI = "https://raw.githubusercontent.com/openshift/origin/v3.11.0/examples/db-templates/%s-%s-template.json"
-	//persistentStorage storage = "persistent"
-	ephemeralStorage storage = "ephemeral"
+	//PersistentStorage storage = "persistent"
+	EphemeralStorage storage = "ephemeral"
 )
 
 type storage string

--- a/pkg/testing/integration_register.go
+++ b/pkg/testing/integration_register.go
@@ -197,7 +197,7 @@ var _ = Suite(&MysqlDBDepConfig{
 	IntegrationSuite{
 		name:      "mysqldc",
 		namespace: "mysqldc-test",
-		app:       app.NewMysqlDepConfig("mysqldeploymentconfig"),
+		app:       app.NewMysqlDepConfig("mysqldeploymentconfig", app.EphemeralStorage),
 		bp:        app.NewBlueprint("mysql-dep-config", ""),
 		profile:   newSecretProfile(),
 	},
@@ -212,7 +212,7 @@ var _ = Suite(&MongoDBDepConfig{
 	IntegrationSuite{
 		name:      "mongodb",
 		namespace: "mongodb-test",
-		app:       app.NewMongoDBDepConfig("mongodeploymentconfig"),
+		app:       app.NewMongoDBDepConfig("mongodeploymentconfig", app.EphemeralStorage),
 		bp:        app.NewBlueprint("mongo-dep-config", ""),
 		profile:   newSecretProfile(),
 	},
@@ -227,7 +227,7 @@ var _ = Suite(&PostgreSQLDepConfig{
 	IntegrationSuite{
 		name:      "postgresdepconf",
 		namespace: "postgresdepconf-test",
-		app:       app.NewPostgreSQLDepConfig("postgresdepconf"),
+		app:       app.NewPostgreSQLDepConfig("postgresdepconf", app.EphemeralStorage),
 		bp:        app.NewBlueprint("postgres-dep-config", ""),
 		profile:   newSecretProfile(),
 	},


### PR DESCRIPTION
## Change Overview
In current implementation if we deployed OpenShift apps as part of test, the apps were persistent always this change adds the support to have epehmeral apps as well.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan
Run 
```
make openshift-test
```
to test the things, make sure you have setup a minishift cluster using command 
```
make start-minishift vm-driver=virtualbox
```
Logs of this test can be found [here](https://gist.github.com/viveksinghggits/9817f35c0d78f5b4dd706ba15d04e353)

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
