### PR TITLE
Support Scaling DeploymentConfigs

### DIFF
--- a/pkg/function/scale_workload.go
+++ b/pkg/function/scale_workload.go
@@ -61,7 +61,7 @@ func (*scaleWorkloadFunc) Exec(ctx context.Context, tp param.TemplateParams, arg
 
 	cfg, err := kube.LoadConfig()
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "Failed to load Kubernetes config")
 	}
 	cli, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
@@ -75,7 +75,7 @@ func (*scaleWorkloadFunc) Exec(ctx context.Context, tp param.TemplateParams, arg
 	case param.DeploymentConfigKind:
 		osCli, err := osversioned.NewForConfig(cfg)
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrapf(err, "Failed to create OpenShift client")
 		}
 		return nil, kube.ScaleDeploymentConfig(ctx, cli, osCli, namespace, name, replicas)
 	}

--- a/pkg/function/scale_workload.go
+++ b/pkg/function/scale_workload.go
@@ -19,7 +19,9 @@ import (
 	"strconv"
 	"strings"
 
+	osversioned "github.com/openshift/client-go/apps/clientset/versioned"
 	"github.com/pkg/errors"
+	"k8s.io/client-go/kubernetes"
 
 	kanister "github.com/kanisterio/kanister/pkg"
 	"github.com/kanisterio/kanister/pkg/kube"
@@ -57,7 +59,11 @@ func (*scaleWorkloadFunc) Exec(ctx context.Context, tp param.TemplateParams, arg
 		return nil, err
 	}
 
-	cli, err := kube.NewClient()
+	cfg, err := kube.LoadConfig()
+	if err != nil {
+		return nil, err
+	}
+	cli, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed to create Kubernetes client")
 	}
@@ -66,9 +72,14 @@ func (*scaleWorkloadFunc) Exec(ctx context.Context, tp param.TemplateParams, arg
 		return nil, kube.ScaleStatefulSet(ctx, cli, namespace, name, replicas)
 	case param.DeploymentKind:
 		return nil, kube.ScaleDeployment(ctx, cli, namespace, name, replicas)
-	default:
-		return nil, errors.New("Workload type not supported " + kind)
+	case param.DeploymentConfigKind:
+		osCli, err := osversioned.NewForConfig(cfg)
+		if err != nil {
+			return nil, err
+		}
+		return nil, kube.ScaleDeploymentConfig(ctx, cli, osCli, namespace, name, replicas)
 	}
+	return nil, errors.New("Workload type not supported " + kind)
 }
 
 func (*scaleWorkloadFunc) RequiredArgs() []string {
@@ -110,6 +121,10 @@ func getArgs(tp param.TemplateParams, args map[string]interface{}) (namespace, k
 		kind = param.DeploymentKind
 		name = tp.Deployment.Name
 		namespace = tp.Deployment.Namespace
+	case tp.DeploymentConfig != nil:
+		kind = param.DeploymentConfigKind
+		name = tp.DeploymentConfig.Name
+		namespace = tp.DeploymentConfig.Namespace
 	default:
 		if !ArgExists(args, ScaleWorkloadNamespaceArg) || !ArgExists(args, ScaleWorkloadNameArg) || !ArgExists(args, ScaleWorkloadKindArg) {
 			return namespace, kind, name, replicas, errors.New("Workload information not available via defaults or namespace/name/kind parameters")

--- a/pkg/kube/discover.go
+++ b/pkg/kube/discover.go
@@ -1,0 +1,23 @@
+package kube
+
+import (
+	"context"
+
+	"k8s.io/client-go/discovery"
+)
+
+const osAppsGroupName = `apps.openshift.io`
+
+// IsOSAppsGroupAvailable returns true if the openshift apps group is registered in service discovery.
+func IsOSAppsGroupAvailable(ctx context.Context, cli discovery.DiscoveryInterface) (bool, error) {
+	sgs, err := cli.ServerGroups()
+	if err != nil {
+		return false, err
+	}
+	for _, g := range sgs.Groups {
+		if g.Name == osAppsGroupName {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/pkg/kube/workload.go
+++ b/pkg/kube/workload.go
@@ -330,6 +330,19 @@ func ScaleDeployment(ctx context.Context, kubeCli kubernetes.Interface, namespac
 	return WaitOnDeploymentReady(ctx, kubeCli, namespace, name)
 }
 
+func ScaleDeploymentConfig(ctx context.Context, kubeCli kubernetes.Interface, osCli osversioned.Interface, namespace string, name string, replicas int32) error {
+	dc, err := osCli.AppsV1().DeploymentConfigs(namespace).Get(name, metav1.GetOptions{})
+	if err != nil {
+		return errors.Wrapf(err, "Could not get DeploymentConfig{Namespace %s, Name: %s}", namespace, name)
+	}
+	dc.Spec.Replicas = replicas
+	_, err = osCli.AppsV1().DeploymentConfigs(namespace).Update(dc)
+	if err != nil {
+		return errors.Wrapf(err, "Could not update DeploymentConfig{Namespace %s, Name: %s}", namespace, name)
+	}
+	return WaitOnDeploymentConfigReady(ctx, osCli, kubeCli, namespace, name)
+}
+
 // DeploymentVolumes returns the PVCs referenced by this deployment as a [pods spec volume name]->[PVC name] map
 func DeploymentVolumes(cli kubernetes.Interface, d *appsv1.Deployment) (volNameToPvc map[string]string) {
 	volNameToPvc = make(map[string]string)

--- a/pkg/kube/workload_test.go
+++ b/pkg/kube/workload_test.go
@@ -47,7 +47,7 @@ func (s *WorkloadSuite) TestScaleDeploymentConfig(c *C) {
 	dc := newDeploymentConfig()
 	osCli, err := osversioned.NewForConfig(cfg)
 	c.Assert(err, IsNil)
-	dc, err = osCli.Apps().DeploymentConfigs(ns.GetName()).Create(dc)
+	dc, err = osCli.AppsV1().DeploymentConfigs(ns.GetName()).Create(dc)
 	c.Assert(err, IsNil)
 
 	err = ScaleDeploymentConfig(ctx, cli, osCli, dc.GetNamespace(), dc.GetName(), 0)


### PR DESCRIPTION
## Change Overview


## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

```
/go/src/github.com/kanisterio/kanister # go test -v ./pkg/kube -check.v -check.f WorkloadSuite
=== RUN   Test
PASS: workload_test.go:18: WorkloadSuite.TestScaleDeploymentConfig      36.314s
OK: 1 passed
--- PASS: Test (36.31s)
PASS
ok      github.com/kanisterio/kanister/pkg/kube 36.327s
```

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
