### PR TITLE
Revert "Upgrade kanister build image to v0.0.8"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ IMAGE_NAME := $(BIN)
 
 IMAGE := $(REGISTRY)/$(IMAGE_NAME)
 
-BUILD_IMAGE ?= kanisterio/build:v0.0.8
+BUILD_IMAGE ?= kanisterio/build:v0.0.7
 DOCS_BUILD_IMAGE ?= kanisterio/docker-sphinx
 
 DOCS_RELEASE_BUCKET ?= s3://docs.kanister.io


### PR DESCRIPTION
Reverts kanisterio/kanister#602

@SupriyaKasten the image has to be built from PR - https://github.com/kanisterio/kanister/pull/597
I am assuming you have built the image from `master`
```
$ docker run --rm kanisterio/build:v0.0.8 kind version
v0.5.1
```
That's why its still using older dependencies. 