### PR TITLE
Checking for both types of region/zone labels

### DIFF
--- a/pkg/blockstorage/zone/zone.go
+++ b/pkg/blockstorage/zone/zone.go
@@ -166,7 +166,7 @@ func NodeZonesAndRegion(ctx context.Context, cli kubernetes.Interface) (map[stri
 	for _, n := range ns {
 		zone := kube.GetZoneFromNode(n)
 		// make sure it is not a faultDomain
-		// For Example: all non-zonal cluster nodes in azure get addigned a faultDomain(0/1)
+		// For Example: all non-zonal cluster nodes in azure get assigned a faultDomain(0/1)
 		// for "failure-domain.beta.kubernetes.io/zone" label
 		if len(zone) > 1 {
 			zoneSet[zone] = struct{}{}

--- a/pkg/blockstorage/zone/zone.go
+++ b/pkg/blockstorage/zone/zone.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/kanisterio/kanister/pkg/field"
-	kubevolume "github.com/kanisterio/kanister/pkg/kube/volume"
+	"github.com/kanisterio/kanister/pkg/kube"
 	"github.com/kanisterio/kanister/pkg/log"
 )
 
@@ -164,11 +164,11 @@ func NodeZonesAndRegion(ctx context.Context, cli kubernetes.Interface) (map[stri
 	zoneSet := make(map[string]struct{})
 	regionSet := make(map[string]struct{})
 	for _, n := range ns {
-		zone := kubevolume.GetZoneFromNode(n)
+		zone := kube.GetZoneFromNode(n)
 		if zone != "" {
 			zoneSet[zone] = struct{}{}
 		}
-		region := kubevolume.GetRegionFromNode(n)
+		region := kube.GetRegionFromNode(n)
 		if region != "" {
 			regionSet[region] = struct{}{}
 		}

--- a/pkg/blockstorage/zone/zone_test.go
+++ b/pkg/blockstorage/zone/zone_test.go
@@ -21,7 +21,7 @@ import (
 	"sort"
 	"testing"
 
-	kubevolume "github.com/kanisterio/kanister/pkg/kube/volume"
+	"github.com/kanisterio/kanister/pkg/kube"
 	. "gopkg.in/check.v1"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -41,7 +41,7 @@ func (s ZoneSuite) TestNodeZoneAndRegionGCP(c *C) {
 	node1 := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "node1",
-			Labels: map[string]string{kubevolume.PVRegionLabelName: "us-west2", kubevolume.PVZoneLabelName: "us-west2-a"},
+			Labels: map[string]string{kube.FDRegionLabelName: "us-west2", kube.FDZoneLabelName: "us-west2-a"},
 		},
 		Status: v1.NodeStatus{
 			Conditions: []v1.NodeCondition{
@@ -55,7 +55,7 @@ func (s ZoneSuite) TestNodeZoneAndRegionGCP(c *C) {
 	node2 := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "node2",
-			Labels: map[string]string{kubevolume.PVRegionLabelName: "us-west2", kubevolume.PVZoneLabelName: "us-west2-b"},
+			Labels: map[string]string{kube.FDRegionLabelName: "us-west2", kube.FDZoneLabelName: "us-west2-b"},
 		},
 		Status: v1.NodeStatus{
 			Conditions: []v1.NodeCondition{
@@ -69,7 +69,7 @@ func (s ZoneSuite) TestNodeZoneAndRegionGCP(c *C) {
 	node3 := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "node3",
-			Labels: map[string]string{kubevolume.PVRegionLabelName: "us-west2", kubevolume.PVZoneLabelName: "us-west2-c"},
+			Labels: map[string]string{kube.FDRegionLabelName: "us-west2", kube.FDZoneLabelName: "us-west2-c"},
 		},
 		Status: v1.NodeStatus{
 			Conditions: []v1.NodeCondition{
@@ -84,7 +84,7 @@ func (s ZoneSuite) TestNodeZoneAndRegionGCP(c *C) {
 	node4 := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "node4",
-			Labels: map[string]string{kubevolume.PVRegionLabelName: "us-west2", kubevolume.PVZoneLabelName: "us-west2-c"},
+			Labels: map[string]string{kube.FDRegionLabelName: "us-west2", kube.FDZoneLabelName: "us-west2-c"},
 		},
 		Status: v1.NodeStatus{
 			Conditions: []v1.NodeCondition{
@@ -98,7 +98,7 @@ func (s ZoneSuite) TestNodeZoneAndRegionGCP(c *C) {
 	node5 := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "node5",
-			Labels: map[string]string{kubevolume.PVRegionLabelName: "us-west2", kubevolume.PVZoneLabelName: "us-west2-c"},
+			Labels: map[string]string{kube.FDRegionLabelName: "us-west2", kube.FDZoneLabelName: "us-west2-c"},
 		},
 		Spec: v1.NodeSpec{
 			Unschedulable: true,
@@ -132,7 +132,7 @@ func (s ZoneSuite) TestNodeZoneAndRegionEBS(c *C) {
 	node1 := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "node1",
-			Labels: map[string]string{kubevolume.PVRegionLabelName: "us-west-2", kubevolume.PVZoneLabelName: "us-west-2a"},
+			Labels: map[string]string{kube.FDRegionLabelName: "us-west-2", kube.FDZoneLabelName: "us-west-2a"},
 		},
 		Status: v1.NodeStatus{
 			Conditions: []v1.NodeCondition{
@@ -146,7 +146,7 @@ func (s ZoneSuite) TestNodeZoneAndRegionEBS(c *C) {
 	node2 := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "node2",
-			Labels: map[string]string{kubevolume.PVRegionLabelName: "us-west-2", kubevolume.PVZoneLabelName: "us-west-2b"},
+			Labels: map[string]string{kube.FDRegionLabelName: "us-west-2", kube.FDZoneLabelName: "us-west-2b"},
 		},
 		Status: v1.NodeStatus{
 			Conditions: []v1.NodeCondition{
@@ -160,7 +160,7 @@ func (s ZoneSuite) TestNodeZoneAndRegionEBS(c *C) {
 	node3 := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "node3",
-			Labels: map[string]string{kubevolume.PVRegionLabelName: "us-west-2", kubevolume.PVZoneLabelName: "us-west-2c"},
+			Labels: map[string]string{kube.FDRegionLabelName: "us-west-2", kube.FDZoneLabelName: "us-west-2c"},
 		},
 		Status: v1.NodeStatus{
 			Conditions: []v1.NodeCondition{
@@ -175,7 +175,7 @@ func (s ZoneSuite) TestNodeZoneAndRegionEBS(c *C) {
 	node4 := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "node4",
-			Labels: map[string]string{kubevolume.PVRegionLabelName: "us-west-2", kubevolume.PVZoneLabelName: "us-west-2c"},
+			Labels: map[string]string{kube.FDRegionLabelName: "us-west-2", kube.FDZoneLabelName: "us-west-2c"},
 		},
 		Status: v1.NodeStatus{
 			Conditions: []v1.NodeCondition{
@@ -189,7 +189,7 @@ func (s ZoneSuite) TestNodeZoneAndRegionEBS(c *C) {
 	node5 := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "node5",
-			Labels: map[string]string{kubevolume.PVRegionLabelName: "us-west-2", kubevolume.PVZoneLabelName: "us-west-2c"},
+			Labels: map[string]string{kube.FDRegionLabelName: "us-west-2", kube.FDZoneLabelName: "us-west-2c"},
 		},
 		Spec: v1.NodeSpec{
 			Unschedulable: true,
@@ -223,7 +223,7 @@ func (s ZoneSuite) TestNodeZoneAndRegionAD(c *C) {
 	node1 := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "node1",
-			Labels: map[string]string{kubevolume.PVRegionLabelName: "westus2", kubevolume.PVZoneLabelName: "westus2-1"},
+			Labels: map[string]string{kube.FDRegionLabelName: "westus2", kube.FDZoneLabelName: "westus2-1"},
 		},
 		Status: v1.NodeStatus{
 			Conditions: []v1.NodeCondition{
@@ -237,7 +237,7 @@ func (s ZoneSuite) TestNodeZoneAndRegionAD(c *C) {
 	node2 := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "node2",
-			Labels: map[string]string{kubevolume.PVTopologyRegionLabelName: "westus2", kubevolume.PVTopologyZoneLabelName: "westus2-2"},
+			Labels: map[string]string{kube.TopologyRegionLabelName: "westus2", kube.TopologyZoneLabelName: "westus2-2"},
 		},
 		Status: v1.NodeStatus{
 			Conditions: []v1.NodeCondition{
@@ -251,7 +251,7 @@ func (s ZoneSuite) TestNodeZoneAndRegionAD(c *C) {
 	node3 := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "node3",
-			Labels: map[string]string{kubevolume.PVRegionLabelName: "westus2", kubevolume.PVZoneLabelName: "westus2-3"},
+			Labels: map[string]string{kube.FDRegionLabelName: "westus2", kube.FDZoneLabelName: "westus2-3"},
 		},
 		Status: v1.NodeStatus{
 			Conditions: []v1.NodeCondition{
@@ -266,7 +266,7 @@ func (s ZoneSuite) TestNodeZoneAndRegionAD(c *C) {
 	node4 := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "node4",
-			Labels: map[string]string{kubevolume.PVRegionLabelName: "us-west2", kubevolume.PVZoneLabelName: "us-west2-4"},
+			Labels: map[string]string{kube.FDRegionLabelName: "us-west2", kube.FDZoneLabelName: "us-west2-4"},
 		},
 		Status: v1.NodeStatus{
 			Conditions: []v1.NodeCondition{
@@ -280,7 +280,7 @@ func (s ZoneSuite) TestNodeZoneAndRegionAD(c *C) {
 	node5 := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "node5",
-			Labels: map[string]string{kubevolume.PVRegionLabelName: "us-west2", kubevolume.PVZoneLabelName: "us-west2-5"},
+			Labels: map[string]string{kube.FDRegionLabelName: "us-west2", kube.FDZoneLabelName: "us-west2-5"},
 		},
 		Spec: v1.NodeSpec{
 			Unschedulable: true,
@@ -409,7 +409,7 @@ func (s ZoneSuite) TestFromSourceRegionZone(c *C) {
 	node1 := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "node1",
-			Labels: map[string]string{kubevolume.PVRegionLabelName: "us-west-2", kubevolume.PVZoneLabelName: "us-west-2a"},
+			Labels: map[string]string{kube.FDRegionLabelName: "us-west-2", kube.FDZoneLabelName: "us-west-2a"},
 		},
 		Status: v1.NodeStatus{
 			Conditions: []v1.NodeCondition{
@@ -423,7 +423,7 @@ func (s ZoneSuite) TestFromSourceRegionZone(c *C) {
 	node2 := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "node2",
-			Labels: map[string]string{kubevolume.PVRegionLabelName: "us-west-2", kubevolume.PVZoneLabelName: "us-west-2b"},
+			Labels: map[string]string{kube.FDRegionLabelName: "us-west-2", kube.FDZoneLabelName: "us-west-2b"},
 		},
 		Status: v1.NodeStatus{
 			Conditions: []v1.NodeCondition{
@@ -437,7 +437,7 @@ func (s ZoneSuite) TestFromSourceRegionZone(c *C) {
 	node3 := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "node3",
-			Labels: map[string]string{kubevolume.PVRegionLabelName: "us-west-2", kubevolume.PVZoneLabelName: "us-west-2c"},
+			Labels: map[string]string{kube.FDRegionLabelName: "us-west-2", kube.FDZoneLabelName: "us-west-2c"},
 		},
 		Status: v1.NodeStatus{
 			Conditions: []v1.NodeCondition{
@@ -452,7 +452,7 @@ func (s ZoneSuite) TestFromSourceRegionZone(c *C) {
 	gceNode1 := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "node1",
-			Labels: map[string]string{kubevolume.PVRegionLabelName: "us-west2", kubevolume.PVZoneLabelName: "us-west2-a"},
+			Labels: map[string]string{kube.FDRegionLabelName: "us-west2", kube.FDZoneLabelName: "us-west2-a"},
 		},
 		Status: v1.NodeStatus{
 			Conditions: []v1.NodeCondition{
@@ -467,7 +467,7 @@ func (s ZoneSuite) TestFromSourceRegionZone(c *C) {
 	gceNode2 := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "node2",
-			Labels: map[string]string{kubevolume.PVRegionLabelName: "us-west2", kubevolume.PVZoneLabelName: "us-west2-b"},
+			Labels: map[string]string{kube.FDRegionLabelName: "us-west2", kube.FDZoneLabelName: "us-west2-b"},
 		},
 		Status: v1.NodeStatus{
 			Conditions: []v1.NodeCondition{
@@ -482,7 +482,7 @@ func (s ZoneSuite) TestFromSourceRegionZone(c *C) {
 	gceNode3 := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "node3",
-			Labels: map[string]string{kubevolume.PVRegionLabelName: "us-west2", kubevolume.PVZoneLabelName: "us-west2-c"},
+			Labels: map[string]string{kube.FDRegionLabelName: "us-west2", kube.FDZoneLabelName: "us-west2-c"},
 		},
 		Status: v1.NodeStatus{
 			Conditions: []v1.NodeCondition{
@@ -497,7 +497,7 @@ func (s ZoneSuite) TestFromSourceRegionZone(c *C) {
 	noZonesNode := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "noZoneNode",
-			Labels: map[string]string{kubevolume.PVRegionLabelName: "us-east2", kubevolume.PVZoneLabelName: "us-east2-c"},
+			Labels: map[string]string{kube.FDRegionLabelName: "us-east2", kube.FDZoneLabelName: "us-east2-c"},
 		},
 		Status: v1.NodeStatus{
 			Conditions: []v1.NodeCondition{
@@ -653,7 +653,7 @@ func (s ZoneSuite) TestGetReadySchedulableNodes(c *C) {
 	node1 := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "node1",
-			Labels: map[string]string{kubevolume.PVRegionLabelName: "westus2", kubevolume.PVZoneLabelName: "westus2-1"},
+			Labels: map[string]string{kube.FDRegionLabelName: "westus2", kube.FDZoneLabelName: "westus2-1"},
 		},
 		Status: v1.NodeStatus{
 			Conditions: []v1.NodeCondition{
@@ -667,7 +667,7 @@ func (s ZoneSuite) TestGetReadySchedulableNodes(c *C) {
 	node2 := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "node2",
-			Labels: map[string]string{kubevolume.PVRegionLabelName: "westus2", kubevolume.PVZoneLabelName: "westus2-2"},
+			Labels: map[string]string{kube.FDRegionLabelName: "westus2", kube.FDZoneLabelName: "westus2-2"},
 		},
 		Spec: v1.NodeSpec{
 			Unschedulable: true,
@@ -684,7 +684,7 @@ func (s ZoneSuite) TestGetReadySchedulableNodes(c *C) {
 	node3 := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "node3",
-			Labels: map[string]string{kubevolume.PVRegionLabelName: "westus2", kubevolume.PVZoneLabelName: "westus2-3"},
+			Labels: map[string]string{kube.FDRegionLabelName: "westus2", kube.FDZoneLabelName: "westus2-3"},
 		},
 		Status: v1.NodeStatus{
 			Conditions: []v1.NodeCondition{

--- a/pkg/function/create_volume_snapshot.go
+++ b/pkg/function/create_volume_snapshot.go
@@ -34,7 +34,6 @@ import (
 	"github.com/kanisterio/kanister/pkg/blockstorage/awsebs"
 	"github.com/kanisterio/kanister/pkg/blockstorage/getter"
 	"github.com/kanisterio/kanister/pkg/kube"
-	kubevolume "github.com/kanisterio/kanister/pkg/kube/volume"
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/secrets"
 )
@@ -202,7 +201,7 @@ func getPVCInfo(ctx context.Context, kubeCli kubernetes.Interface, namespace str
 			return nil, errors.Wrap(err, "Profile validation failed")
 		}
 		// Get Region from PV label or EC2 metadata
-		if pvRegion, ok := pvLabels[kubevolume.PVRegionLabelName]; ok {
+		if pvRegion := kube.GetRegionFromLabels(pvLabels); pvRegion != "" {
 			region = pvRegion
 		} else {
 			region, err = awsebs.GetRegionFromEC2Metadata()
@@ -210,7 +209,7 @@ func getPVCInfo(ctx context.Context, kubeCli kubernetes.Interface, namespace str
 				return nil, err
 			}
 		}
-		if pvZone, ok := pvLabels[kubevolume.PVZoneLabelName]; ok {
+		if pvZone := kube.GetZoneFromLabels(pvLabels); pvZone != "" {
 			config := getConfig(tp.Profile, blockstorage.TypeEBS)
 			config[awsconfig.ConfigRegion] = region
 			provider, err = getter.Get(blockstorage.TypeEBS, config)
@@ -227,7 +226,7 @@ func getPVCInfo(ctx context.Context, kubeCli kubernetes.Interface, namespace str
 		if err = ValidateLocationForBlockstorage(tp.Profile, blockstorage.TypeGPD); err != nil {
 			return nil, errors.Wrap(err, "Profile validation failed")
 		}
-		if pvZone, ok := pvLabels[kubevolume.PVZoneLabelName]; ok {
+		if pvZone := kube.GetZoneFromLabels(pvLabels); pvZone != "" {
 			config := getConfig(tp.Profile, blockstorage.TypeGPD)
 			provider, err = getter.Get(blockstorage.TypeGPD, config)
 			if err != nil {

--- a/pkg/function/create_volume_snapshot_test.go
+++ b/pkg/function/create_volume_snapshot_test.go
@@ -25,7 +25,7 @@ import (
 
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	"github.com/kanisterio/kanister/pkg/blockstorage"
-	kubevolume "github.com/kanisterio/kanister/pkg/kube/volume"
+	kube "github.com/kanisterio/kanister/pkg/kube"
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/testutil/mockblockstorage"
 )
@@ -67,8 +67,8 @@ func (s *CreateVolumeSnapshotTestSuite) TestGetPVCInfo(c *C) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "pv-test-1",
 				Labels: map[string]string{
-					kubevolume.PVZoneLabelName:   "us-west-2a",
-					kubevolume.PVRegionLabelName: "us-west-2",
+					kube.FDZoneLabelName:   "us-west-2a",
+					kube.FDRegionLabelName: "us-west-2",
 				},
 			},
 			Spec: v1.PersistentVolumeSpec{
@@ -119,7 +119,7 @@ func (s *CreateVolumeSnapshotTestSuite) TestGetPVCInfo(c *C) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "pv-test-3",
 				Labels: map[string]string{
-					kubevolume.PVZoneLabelName: "us-west-2a",
+					kube.FDZoneLabelName: "us-west-2a",
 				},
 			},
 			Spec: v1.PersistentVolumeSpec{

--- a/pkg/kube/utils.go
+++ b/pkg/kube/utils.go
@@ -110,13 +110,12 @@ func GetZoneFromPV(pv v1.PersistentVolume) string {
 }
 
 func GetZoneFromLabels(labels map[string]string) string {
-	var zone string
 	if v, ok := labels[FDZoneLabelName]; ok {
-		zone = v
+		return v
 	} else if v, ok := labels[TopologyZoneLabelName]; ok {
-		zone = v
+		return v
 	}
-	return zone
+	return ""
 }
 
 func GetRegionFromNode(node v1.Node) string {
@@ -128,11 +127,10 @@ func GetRegionFromPV(pv v1.PersistentVolume) string {
 }
 
 func GetRegionFromLabels(labels map[string]string) string {
-	var region string
 	if v, ok := labels[FDRegionLabelName]; ok {
-		region = v
+		return v
 	} else if v, ok := labels[TopologyRegionLabelName]; ok {
-		region = v
+		return v
 	}
-	return region
+	return ""
 }

--- a/pkg/kube/utils.go
+++ b/pkg/kube/utils.go
@@ -19,7 +19,19 @@ import (
 	"fmt"
 
 	osversioned "github.com/openshift/client-go/apps/clientset/versioned"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	// FDZoneLabelName is a known k8s label. used to specify volume zone
+	FDZoneLabelName = "failure-domain.beta.kubernetes.io/zone"
+	// TopologyZoneLabelName is a known k8s label. used to specify volume zone for kubernetes 1.17 onwards
+	TopologyZoneLabelName = "topology.kubernetes.io/zone"
+	// FDRegionLabelName is a known k8s label
+	FDRegionLabelName = "failure-domain.beta.kubernetes.io/region"
+	// TopologyRegionLabelName is a known k8s label. used to specify volume region for kubernetes 1.17 onwards
+	TopologyRegionLabelName = "topology.kubernetes.io/region"
 )
 
 // GetPodContainerFromDeployment returns a pod and container running the deployment
@@ -82,4 +94,40 @@ func GetPodContainerFromStatefulSet(ctx context.Context, cli kubernetes.Interfac
 		return podName, containerName, fmt.Errorf("Unable to find containers in pod %s/%s", namespace, podName)
 	}
 	return podName, container[0].Name, nil
+}
+
+func GetZoneFromNode(node v1.Node) string {
+	return GetZoneFromLabels(node.Labels)
+}
+
+func GetZoneFromPV(pv v1.PersistentVolume) string {
+	return GetZoneFromLabels(pv.Labels)
+}
+
+func GetZoneFromLabels(labels map[string]string) string {
+	var zone string
+	if v, ok := labels[FDZoneLabelName]; ok {
+		zone = v
+	} else if v, ok := labels[TopologyZoneLabelName]; ok {
+		zone = v
+	}
+	return zone
+}
+
+func GetRegionFromNode(node v1.Node) string {
+	return GetRegionFromLabels(node.Labels)
+}
+
+func GetRegionFromPV(pv v1.PersistentVolume) string {
+	return GetRegionFromLabels(pv.Labels)
+}
+
+func GetRegionFromLabels(labels map[string]string) string {
+	var region string
+	if v, ok := labels[FDRegionLabelName]; ok {
+		region = v
+	} else if v, ok := labels[TopologyRegionLabelName]; ok {
+		region = v
+	}
+	return region
 }

--- a/pkg/kube/utils.go
+++ b/pkg/kube/utils.go
@@ -96,6 +96,11 @@ func GetPodContainerFromStatefulSet(ctx context.Context, cli kubernetes.Interfac
 	return podName, container[0].Name, nil
 }
 
+// Following functions get the regions and zones from
+// labels on Nodes and Persistent Volumes
+// As of kubernetes 1.17 the "failure.domain" annotation
+// has been deprecated in favor of the "topology" annotation
+
 func GetZoneFromNode(node v1.Node) string {
 	return GetZoneFromLabels(node.Labels)
 }


### PR DESCRIPTION
## Change Overview

In kubernetes 1.17 they are deprecating the "failure-domain..." labels and moving towards "topology..."
This change is checks for both labels when deriving the zone and the region.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
