### PR TITLE
Removing a different base image for ARCHs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,18 +51,6 @@ SRC_DIRS := cmd pkg # directories which hold app source (not vendored)
 ALL_ARCH := amd64 arm arm64 ppc64le
 
 # Set default base image dynamically for each arch
-ifeq ($(ARCH),amd64)
-    BASEIMAGE?=alpine
-endif
-ifeq ($(ARCH),arm)
-    BASEIMAGE?=armel/busybox
-endif
-ifeq ($(ARCH),arm64)
-    BASEIMAGE?=aarch64/busybox
-endif
-ifeq ($(ARCH),ppc64le)
-    BASEIMAGE?=ppc64le/busybox
-endif
 
 IMAGE_NAME := $(BIN)
 
@@ -131,7 +119,6 @@ container: .container-$(DOTFILE_IMAGE) container-name
 	@/bin/bash -c "                   \
 		BIN=$(BIN)                    \
 		ARCH=$(ARCH)                  \
-		BASEIMAGE=$(BASEIMAGE)        \
 		IMAGE=$(IMAGE)                \
 		VERSION=$(VERSION)            \
 		SOURCE_BIN=bin/$(ARCH)/$(BIN) \

--- a/build/package.sh
+++ b/build/package.sh
@@ -28,9 +28,6 @@ if [ -z "${ARCH:-""}" ]; then
     echo "ARCH must be set"
     exit 1
 fi
-if [ -n "${BASEIMAGE:-""}" ]; then
-    baseimagearg="--build-arg base_image=${BASEIMAGE}"
-fi
 if [ -z "${IMAGE:-""}" ]; then
     echo "IMAGE must be set"
     exit 1


### PR DESCRIPTION
## Change Overview

after switching to UBI dockerFile has dependencies on UBI images
and non-ubi won't work.

the good news ubi-8 supports: `AMD64` `ARM64` `PPC64LE` `S390X`
https://access.redhat.com/containers/#/registry.access.redhat.com/ubi8-minimal


## Pull request type

Please check the type of change your PR introduces:
- [x] :bug: Bugfix

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
