### PR TITLE
Avoid adding faultDomain to ZoneSet

### DIFF
--- a/pkg/blockstorage/zone/zone.go
+++ b/pkg/blockstorage/zone/zone.go
@@ -165,7 +165,10 @@ func NodeZonesAndRegion(ctx context.Context, cli kubernetes.Interface) (map[stri
 	regionSet := make(map[string]struct{})
 	for _, n := range ns {
 		zone := kubevolume.GetZoneFromNode(n)
-		if zone != "" {
+		// make sure it is not a faultDomain
+		// For Example: all non-zonal cluster nodes in azure get addigned a faultDomain(0/1)
+		// for "failure-domain.beta.kubernetes.io/zone" label
+		if len(zone) > 1 {
 			zoneSet[zone] = struct{}{}
 		}
 		region := kubevolume.GetRegionFromNode(n)

--- a/pkg/blockstorage/zone/zone_test.go
+++ b/pkg/blockstorage/zone/zone_test.go
@@ -262,10 +262,25 @@ func (s ZoneSuite) TestNodeZoneAndRegionAD(c *C) {
 			},
 		},
 	}
-	// error nodes
+	// non-zonal node (FaultDomain)
 	node4 := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "node4",
+			Labels: map[string]string{kubevolume.PVRegionLabelName: "westus", kubevolume.PVZoneLabelName: "0"},
+		},
+		Status: v1.NodeStatus{
+			Conditions: []v1.NodeCondition{
+				v1.NodeCondition{
+					Status: "True",
+					Type:   "Ready",
+				},
+			},
+		},
+	}
+	// error nodes
+	node5 := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node5",
 			Labels: map[string]string{kubevolume.PVRegionLabelName: "us-west2", kubevolume.PVZoneLabelName: "us-west2-4"},
 		},
 		Status: v1.NodeStatus{
@@ -277,9 +292,9 @@ func (s ZoneSuite) TestNodeZoneAndRegionAD(c *C) {
 			},
 		},
 	}
-	node5 := &v1.Node{
+	node6 := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   "node5",
+			Name:   "node6",
 			Labels: map[string]string{kubevolume.PVRegionLabelName: "us-west2", kubevolume.PVZoneLabelName: "us-west2-5"},
 		},
 		Spec: v1.NodeSpec{
@@ -305,8 +320,14 @@ func (s ZoneSuite) TestNodeZoneAndRegionAD(c *C) {
 	c.Assert(reflect.DeepEqual(z, expectedZone), Equals, true)
 	c.Assert(r, Equals, "westus2")
 
+	// non-zonal cluster test
+	cli = fake.NewSimpleClientset(node4)
+	z, r, err = NodeZonesAndRegion(ctx, cli)
+	c.Assert(err, IsNil)
+	c.Assert(len(z) == 0, Equals, true)
+
 	// error case
-	cli = fake.NewSimpleClientset(node4, node5)
+	cli = fake.NewSimpleClientset(node5, node6)
 	_, _, err = NodeZonesAndRegion(ctx, cli)
 	c.Assert(err, NotNil)
 }

--- a/pkg/blockstorage/zone/zone_test.go
+++ b/pkg/blockstorage/zone/zone_test.go
@@ -325,6 +325,7 @@ func (s ZoneSuite) TestNodeZoneAndRegionAD(c *C) {
 	z, r, err = NodeZonesAndRegion(ctx, cli)
 	c.Assert(err, IsNil)
 	c.Assert(len(z) == 0, Equals, true)
+	c.Assert(r, Equals, "westus")
 
 	// error case
 	cli = fake.NewSimpleClientset(node5, node6)


### PR DESCRIPTION
## Change Overview

Avoid adding faultDomain to ZoneSet
Since we can deploy non-zonal Azure clusters, the nodes get assigned faultDomain(0/1) to their zone labels and we want to avoid adding that to ZoneSet . 

## Pull request type

Please check the type of change your PR introduces:
- [x] :bug: Bugfix



