### PR TITLE
Correct the contianer name in BluePrint and Cassandra app

### DIFF
--- a/examples/stable/cassandra/cassandra-blueprint.yaml
+++ b/examples/stable/cassandra/cassandra-blueprint.yaml
@@ -19,7 +19,7 @@ actions:
       args:
         namespace: "{{ .StatefulSet.Namespace }}"
         pods: "{{ range .StatefulSet.Pods }} {{.}}{{end}}"
-        containers: cassandra
+        containers: "{{ .StatefulSet.Name }}"
         command:
           - bash
           - -o
@@ -40,7 +40,7 @@ actions:
       args:
         namespace: "{{ .StatefulSet.Namespace }}"
         pods: "{{ range .StatefulSet.Pods }} {{.}}{{end}}"
-        containers: "cassandra"
+        containers: "{{ .StatefulSet.Name }}"
         command:
           - bash
           - -o
@@ -69,7 +69,7 @@ actions:
       args:
         namespace: "{{ .StatefulSet.Namespace }}"
         pods: "{{ range .StatefulSet.Pods }} {{.}}{{end}}"
-        container: cassandra
+        container: "{{ .StatefulSet.Name }}"
         includePath: "{{ .Phases.getBackupPrefixLocation.Output.localSnapshotPrefixLocation }}"
         backupArtifactPrefix: "{{ .Phases.getBackupPrefixLocation.Output.backupPrefixLocation }}"
     - func: KubeExec
@@ -77,7 +77,7 @@ actions:
       args:
         namespace: "{{ .StatefulSet.Namespace }}"
         pod: "{{ index .StatefulSet.Pods 0}}"
-        containers: "cassandra"
+        containers: "{{ .StatefulSet.Name }}"
         command:
           - bash
           - -o
@@ -122,7 +122,7 @@ actions:
       args:
         namespace: "{{ .StatefulSet.Namespace }}"
         pod: "{{ index .StatefulSet.Pods 0 }}"
-        containers: "cassandra"
+        containers: "{{ .StatefulSet.Name }}"
         command:
           - bash
           - -o

--- a/pkg/app/cassandra.go
+++ b/pkg/app/cassandra.go
@@ -209,7 +209,7 @@ func (cas *CassandraInstance) Reset(ctx context.Context) error {
 }
 
 func (cas *CassandraInstance) execCommand(ctx context.Context, command []string) (string, string, error) {
-	podname, containername, err := kube.GetPodContainerFromStatefulSet(ctx, cas.cli, cas.namespace, "cassandra")
+	podname, containername, err := kube.GetPodContainerFromStatefulSet(ctx, cas.cli, cas.namespace, cas.chart.Release)
 	if err != nil || podname == "" {
 		return "", "", errors.Wrapf(err, "Error getting the pod and container name %s.", cas.name)
 	}


### PR DESCRIPTION
## Change Overview
To run database command for the cassandra database we were getting the pod for the statefulset `cassandra` but that name depends on the helm release name so if we change the helm release name the name of the statefulset will be changed. 
This change handles in the cassandra app as well as cassandra blueprint.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan
Make changes in integraion-test.sh file to have cassandra app then follow below steps to run the test
```
make install-minio
```
and 
```
make integration-test
```
The logs for this test can be found [here](https://gist.github.com/viveksinghggits/7e782ed727a61f7a1585efb755cea107).

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
