### PR TITLE
WIP: Use dynamic client to create volume snapshots

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,6 @@ require (
 	github.com/jpillora/backoff v0.0.0-20170918002102-8eab2debe79d
 	github.com/json-iterator/go v1.1.9
 	github.com/kelseyhightower/envconfig v1.4.0 // indirect
-	github.com/kubernetes-csi/external-snapshotter v1.1.0
 	github.com/lib/pq v1.2.0
 	github.com/luci/go-render v0.0.0-20160219211803-9a04cc21af0f
 	github.com/mitchellh/mapstructure v0.0.0-20180220230111-00c29f56e238

--- a/go.sum
+++ b/go.sum
@@ -89,6 +89,7 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumC
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dimchansky/utfbom v1.1.0 h1:FcM3g+nofKgUteL8dm/UpdRXNC9KmADgTpLKsu0TRo4=
 github.com/dimchansky/utfbom v1.1.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQvIirEdv+8=
+github.com/dnaeon/go-vcr v1.0.1 h1:r8L/HqC0Hje5AXMu1ooW8oyQyOFv4GxqpL0nRP7SLLY=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
 github.com/docker/spdystream v0.0.0-20181023171402-6480d4af844c h1:ZfSZ3P3BedhKGUhzj7BQlPSU4OvT6tfOKe3DVHzOA7s=
 github.com/docker/spdystream v0.0.0-20181023171402-6480d4af844c/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
@@ -189,8 +190,6 @@ github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFB
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/kubernetes-csi/external-snapshotter v1.1.0 h1:godlw8BSOac5TMGH2rVPJrmllek3y8wuqd9JsJHgulw=
-github.com/kubernetes-csi/external-snapshotter v1.1.0/go.mod h1:oYfxnsuh48V1UDYORl77YQxQbbdokNy7D73phuFpksY=
 github.com/lib/pq v1.2.0 h1:LXpIM/LZ5xGFhOpXAQUIMM1HdyqzVYM13zNdjCEEcA0=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/luci/go-render v0.0.0-20160219211803-9a04cc21af0f h1:WVPqVsbUsrzAebTEgWRAZMdDOfkFx06iyhbIoyMgtkE=
@@ -269,6 +268,7 @@ github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365/go.mod h1:a8OnRci
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/vmware/govmomi v0.21.1-0.20191008161538-40aebf13ba45 h1:zpQBW+l4uPQTfTOxedN5GEcSONhabbCf3X+5+P/H4Jk=
 github.com/vmware/govmomi v0.21.1-0.20191008161538-40aebf13ba45/go.mod h1:zbnFoBQ9GIjs2RVETy8CNEpb+L+Lwkjs3XZUL0B3/m0=

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -15,7 +15,6 @@
 package kube
 
 import (
-	snapshot "github.com/kubernetes-csi/external-snapshotter/pkg/client/clientset/versioned"
 	"github.com/pkg/errors"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes" // Load the GCP plugin - required to authenticate against
@@ -60,21 +59,6 @@ func NewClient() (kubernetes.Interface, error) {
 
 	// creates the clientset
 	clientset, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return nil, err
-	}
-	return clientset, nil
-}
-
-// NewClientSnapshot returns a VolumeSnapshot client configured by the Kanister environment.
-func NewSnapshotClient() (snapshot.Interface, error) {
-	config, err := LoadConfig()
-	if err != nil {
-		return nil, err
-	}
-
-	// creates the clientset
-	clientset, err := snapshot.NewForConfig(config)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -17,6 +17,7 @@ package kube
 import (
 	snapshot "github.com/kubernetes-csi/external-snapshotter/pkg/client/clientset/versioned"
 	"github.com/pkg/errors"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes" // Load the GCP plugin - required to authenticate against
 	// GKE clusters
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
@@ -74,6 +75,21 @@ func NewSnapshotClient() (snapshot.Interface, error) {
 
 	// creates the clientset
 	clientset, err := snapshot.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	return clientset, nil
+}
+
+// NewDynamicClient returns a Dynamic client configured by the Kanister environment.
+func NewDynamicClient() (dynamic.Interface, error) {
+	config, err := LoadConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	// creates the clientset
+	clientset, err := dynamic.NewForConfig(config)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kube/snapshot/snapshot.go
+++ b/pkg/kube/snapshot/snapshot.go
@@ -16,6 +16,8 @@ package snapshot
 
 import (
 	"context"
+
+	"github.com/kanisterio/kanister/pkg/kube/snapshot/apis/v1alpha1"
 )
 
 type Snapshotter interface {
@@ -31,7 +33,7 @@ type Snapshotter interface {
 	//
 	// 'name' is the name of the VolumeSnapshot that will be returned.
 	// 'namespace' is the namespace of the VolumeSnapshot that will be returned.
-	Get(ctx context.Context, name, namespace string) (*VolumeSnapshot, error)
+	Get(ctx context.Context, name, namespace string) (*v1alpha1.VolumeSnapshot, error)
 	// Delete will delete the VolumeSnapshot and returns any error as a result.
 	//
 	// 'name' is the name of the VolumeSnapshot that will be deleted.
@@ -69,22 +71,4 @@ type Source struct {
 	Driver                  string
 	RestoreSize             *int64
 	VolumeSnapshotClassName string
-}
-
-// VolumeSnapshot contains Snapshot metadata
-type VolumeSnapshot struct {
-	metav1.ObjectMeta `json:"metadata"`
-	Spec              SnapshotSpec   `json:"spec"`
-	Status            SnapshotStatus `json:"status"`
-}
-
-type SnapshotSpec struct {
-	SnapshotContentName string `json:"snapshotContentName"`
-}
-
-type SnapshotStatus struct {
-	CreationTime *metav1.Time         `json:"creationTime"`
-	RestoreSize  *resource.Quantity   `json:"restoreSize"`
-	ReadyToUse   bool                 `json:"readyToUse"`
-	Error        *storage.VolumeError `json:"error"`
 }

--- a/pkg/kube/snapshot/snapshot.go
+++ b/pkg/kube/snapshot/snapshot.go
@@ -16,125 +16,51 @@ package snapshot
 
 import (
 	"context"
-
-	snapshot "github.com/kubernetes-csi/external-snapshotter/pkg/apis/volumesnapshot/v1alpha1"
-	snapshotclient "github.com/kubernetes-csi/external-snapshotter/pkg/client/clientset/versioned"
-	"github.com/pkg/errors"
-	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	k8errors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/uuid"
-	"k8s.io/client-go/kubernetes"
-
-	"github.com/kanisterio/kanister/pkg/poll"
 )
 
-const (
-	snapshotKind = "VolumeSnapshot"
-	pvcKind      = "PersistentVolumeClaim"
-)
-
-// Create creates a VolumeSnapshot and returns it or any error happened meanwhile.
-//
-// 'name' is the name of the VolumeSnapshot.
-// 'namespace' is namespace of the PVC. VolumeSnapshot will be crated in the same namespace.
-// 'volumeName' is the name of the PVC of which we will take snapshot. It must be in the same namespace 'ns'.
-// 'waitForReady' will block the caller until the snapshot status is 'ReadyToUse'.
-// or 'ctx.Done()' is signalled. Otherwise it will return immediately after the snapshot is cut.
-func Create(ctx context.Context, kubeCli kubernetes.Interface, snapCli snapshotclient.Interface, name, namespace, volumeName string, snapshotClass *string, waitForReady bool) error {
-	if _, err := kubeCli.CoreV1().PersistentVolumeClaims(namespace).Get(volumeName, metav1.GetOptions{}); err != nil {
-		if k8errors.IsNotFound(err) {
-			return errors.Errorf("Failed to find PVC %s, Namespace %s", volumeName, namespace)
-		}
-		return errors.Errorf("Failed to query PVC %s, Namespace %s: %v", volumeName, namespace, err)
-	}
-
-	snap := &snapshot.VolumeSnapshot{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
-		Spec: snapshot.VolumeSnapshotSpec{
-			Source: &corev1.TypedLocalObjectReference{
-				Kind: pvcKind,
-				Name: volumeName,
-			},
-			VolumeSnapshotClassName: snapshotClass,
-		},
-	}
-
-	_, err := snapCli.VolumesnapshotV1alpha1().VolumeSnapshots(namespace).Create(snap)
-	if err != nil {
-		return err
-	}
-
-	if !waitForReady {
-		return nil
-	}
-
-	err = WaitOnReadyToUse(ctx, snapCli, name, namespace)
-	if err != nil {
-		return err
-	}
-
-	_, err = Get(ctx, snapCli, name, namespace)
-	return err
-}
-
-// Get will return the VolumeSnapshot in the namespace 'namespace' with given 'name'.
-//
-// 'name' is the name of the VolumeSnapshot that will be returned.
-// 'namespace' is the namespace of the VolumeSnapshot that will be returned.
-func Get(ctx context.Context, snapCli snapshotclient.Interface, name, namespace string) (*snapshot.VolumeSnapshot, error) {
-	return snapCli.VolumesnapshotV1alpha1().VolumeSnapshots(namespace).Get(name, metav1.GetOptions{})
-}
-
-// Delete will delete the VolumeSnapshot and returns any error as a result.
-//
-// 'name' is the name of the VolumeSnapshot that will be deleted.
-// 'namespace' is the namespace of the VolumeSnapshot that will be deleted.
-func Delete(ctx context.Context, snapCli snapshotclient.Interface, name, namespace string) error {
-	if err := snapCli.VolumesnapshotV1alpha1().VolumeSnapshots(namespace).Delete(name, &metav1.DeleteOptions{}); !apierrors.IsNotFound(err) {
-		return err
-	}
-	// If the Snapshot does not exist, that's an acceptable error and we ignore it
-	return nil
-}
-
-// Clone will clone the VolumeSnapshot to namespace 'cloneNamespace'.
-// Underlying VolumeSnapshotContent will be cloned with a different name.
-//
-// 'name' is the name of the VolumeSnapshot that will be cloned.
-// 'namespace' is the namespace of the VolumeSnapshot that will be cloned.
-// 'cloneName' is name of the clone.
-// 'cloneNamespace' is the namespace where the clone will be created.
-// 'waitForReady' will make the function blocks until the clone's status is ready to use.
-func Clone(ctx context.Context, snapCli snapshotclient.Interface, name, namespace, cloneName, cloneNamespace string, waitForReady bool) error {
-	snap, err := Get(ctx, snapCli, name, namespace)
-	if err != nil {
-		return err
-	}
-	if !snap.Status.ReadyToUse {
-		return errors.Errorf("Original snapshot is not ready, VolumeSnapshot: %s, Namespace: %s", cloneName, cloneNamespace)
-	}
-	if snap.Spec.SnapshotContentName == "" {
-		return errors.Errorf("Original snapshot does not have content, VolumeSnapshot: %s, Namespace: %s", cloneName, cloneNamespace)
-	}
-
-	_, err = Get(ctx, snapCli, cloneName, cloneNamespace)
-	if err == nil {
-		return errors.Errorf("Target snapshot already exists in target namespace, Volumesnapshot: %s, Namespace: %s", cloneName, cloneNamespace)
-	}
-	if !k8errors.IsNotFound(err) {
-		return errors.Errorf("Failed to query target Volumesnapshot: %s, Namespace: %s: %v", cloneName, cloneNamespace, err)
-	}
-
-	src, err := GetSource(ctx, snapCli, name, namespace)
-	if err != nil {
-		return errors.Errorf("Failed to get source")
-	}
-	return CreateFromSource(ctx, snapCli, src, cloneName, cloneNamespace, waitForReady)
+type Snapshotter interface {
+	// Create creates a VolumeSnapshot and returns it or any error happened meanwhile.
+	//
+	// 'name' is the name of the VolumeSnapshot.
+	// 'namespace' is namespace of the PVC. VolumeSnapshot will be crated in the same namespace.
+	// 'volumeName' is the name of the PVC of which we will take snapshot. It must be in the same namespace 'ns'.
+	// 'waitForReady' will block the caller until the snapshot status is 'ReadyToUse'.
+	// or 'ctx.Done()' is signalled. Otherwise it will return immediately after the snapshot is cut.
+	Create(ctx context.Context, name, namespace, volumeName string, snapshotClass *string, waitForReady bool) error
+	// Get will return the VolumeSnapshot in the namespace 'namespace' with given 'name'.
+	//
+	// 'name' is the name of the VolumeSnapshot that will be returned.
+	// 'namespace' is the namespace of the VolumeSnapshot that will be returned.
+	Get(ctx context.Context, name, namespace string) (*VolumeSnapshot, error)
+	// Delete will delete the VolumeSnapshot and returns any error as a result.
+	//
+	// 'name' is the name of the VolumeSnapshot that will be deleted.
+	// 'namespace' is the namespace of the VolumeSnapshot that will be deleted.
+	Delete(ctx context.Context, name, namespace string) error
+	// Clone will clone the VolumeSnapshot to namespace 'cloneNamespace'.
+	// Underlying VolumeSnapshotContent will be cloned with a different name.
+	//
+	// 'name' is the name of the VolumeSnapshot that will be cloned.
+	// 'namespace' is the namespace of the VolumeSnapshot that will be cloned.
+	// 'cloneName' is name of the clone.
+	// 'cloneNamespace' is the namespace where the clone will be created.
+	// 'waitForReady' will make the function blocks until the clone's status is ready to use.
+	Clone(ctx context.Context, name, namespace, cloneName, cloneNamespace string, waitForReady bool) error
+	// GetSource will return the CSI source that backs the volume snapshot.
+	//
+	// 'snapshotName' is the name of the Volumesnapshot.
+	// 'namespace' is the namespace of the Volumesnapshot.
+	GetSource(ctx context.Context, snapshotName, namespace string) (*Source, error)
+	// CreateFromSource will create a 'Volumesnapshot' and 'VolumesnaphotContent' pair for the underlying snapshot source.
+	//
+	// 'source' contains information about CSI snapshot.
+	// 'snapshotName' is the name of the snapshot that will be created.
+	// 'namespace' is the namespace of the snapshot.
+	// 'waitForReady' blocks the caller until snapshot is ready to use or context is cancelled.
+	CreateFromSource(ctx context.Context, source *Source, snapshotName, namespace string, waitForReady bool) error
+	// WaitOnReadyToUse will block until the Volumesnapshot in namespace 'namespace' with name 'snapshotName'
+	// has status 'ReadyToUse' or 'ctx.Done()' is signalled.
+	WaitOnReadyToUse(ctx context.Context, snapshotName, namespace string) error
 }
 
 // Source represents the CSI source of the Volumesnapshot.
@@ -142,112 +68,23 @@ type Source struct {
 	Handle                  string
 	Driver                  string
 	RestoreSize             *int64
-	VolumeSnapshotClassName *string
+	VolumeSnapshotClassName string
 }
 
-// GetSource will return the CSI source that backs the volume snapshot.
-//
-// 'snapshotName' is the name of the Volumesnapshot.
-// 'namespace' is the namespace of the Volumesnapshot.
-func GetSource(ctx context.Context, snapCli snapshotclient.Interface, snapshotName, namespace string) (*Source, error) {
-	snap, err := Get(ctx, snapCli, snapshotName, namespace)
-	if err != nil {
-		return nil, errors.Errorf("Failed to get snapshot, VolumeSnapshot: %s, Error: %v", snapshotName, err)
-	}
-	cont, err := getContent(ctx, snapCli, snap.Spec.SnapshotContentName)
-	if err != nil {
-		return nil, errors.Errorf("Failed to get snapshot content, VolumeSnapshot: %s, VolumeSnapshotContent: %s, Error: %v", snapshotName, snap.Spec.SnapshotContentName, err)
-	}
-	src := &Source{
-		Handle:                  cont.Spec.CSI.SnapshotHandle,
-		Driver:                  cont.Spec.CSI.Driver,
-		RestoreSize:             cont.Spec.CSI.RestoreSize,
-		VolumeSnapshotClassName: cont.Spec.VolumeSnapshotClassName,
-	}
-	return src, nil
+// VolumeSnapshot contains Snapshot metadata
+type VolumeSnapshot struct {
+	metav1.ObjectMeta `json:"metadata"`
+	Spec              SnapshotSpec   `json:"spec"`
+	Status            SnapshotStatus `json:"status"`
 }
 
-// CreateFromSource will create a 'Volumesnapshot' and 'VolumesnaphotContent' pair for the underlying snapshot source.
-//
-// 'source' contains information about CSI snapshot.
-// 'snapshotName' is the name of the snapshot that will be created.
-// 'namespace' is the namespace of the snapshot.
-// 'waitForReady' blocks the caller until snapshot is ready to use or context is cancelled.
-func CreateFromSource(ctx context.Context, snapCli snapshotclient.Interface, source *Source, snapshotName, namespace string, waitForReady bool) error {
-	deletionPolicy, err := getDeletionPolicyFromClass(snapCli, *source.VolumeSnapshotClassName)
-	if err != nil {
-		return errors.Wrap(err, "Failed to get DeletionPolicy from VolumeSnapshotClass")
-	}
-	contentName := snapshotName + "-content-" + string(uuid.NewUUID())
-	content := &snapshot.VolumeSnapshotContent{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: contentName,
-		},
-		Spec: snapshot.VolumeSnapshotContentSpec{
-			VolumeSnapshotSource: snapshot.VolumeSnapshotSource{
-				CSI: &snapshot.CSIVolumeSnapshotSource{
-					Driver:         source.Driver,
-					SnapshotHandle: source.Handle,
-				},
-			},
-			VolumeSnapshotRef: &corev1.ObjectReference{
-				Kind:      snapshotKind,
-				Namespace: namespace,
-				Name:      snapshotName,
-			},
-			VolumeSnapshotClassName: source.VolumeSnapshotClassName,
-			DeletionPolicy:          deletionPolicy,
-		},
-	}
-	snap := &snapshot.VolumeSnapshot{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: snapshotName,
-		},
-		Spec: snapshot.VolumeSnapshotSpec{
-			SnapshotContentName:     content.Name,
-			VolumeSnapshotClassName: content.Spec.VolumeSnapshotClassName,
-		},
-	}
-
-	content, err = snapCli.VolumesnapshotV1alpha1().VolumeSnapshotContents().Create(content)
-	if err != nil {
-		return errors.Errorf("Failed to create content, VolumesnapshotContent: %s, Error: %v", content.Name, err)
-	}
-	snap, err = snapCli.VolumesnapshotV1alpha1().VolumeSnapshots(namespace).Create(snap)
-	if err != nil {
-		return errors.Errorf("Failed to create content, Volumesnapshot: %s, Error: %v", snap.Name, err)
-	}
-	if !waitForReady {
-		return nil
-	}
-
-	return WaitOnReadyToUse(ctx, snapCli, snap.Name, snap.Namespace)
+type SnapshotSpec struct {
+	SnapshotContentName string `json:"snapshotContentName"`
 }
 
-// WaitOnReadyToUse will block until the Volumesnapshot in namespace 'namespace' with name 'snapshotName'
-// has status 'ReadyToUse' or 'ctx.Done()' is signalled.
-func WaitOnReadyToUse(ctx context.Context, snapCli snapshotclient.Interface, snapshotName, namespace string) error {
-	return poll.Wait(ctx, func(context.Context) (bool, error) {
-		snap, err := snapCli.VolumesnapshotV1alpha1().VolumeSnapshots(namespace).Get(snapshotName, metav1.GetOptions{})
-		if err != nil {
-			return false, err
-		}
-		// Error can be set while waiting for creation
-		if snap.Status.Error != nil {
-			return false, errors.New(snap.Status.Error.Message)
-		}
-		return (snap.Status.ReadyToUse && snap.Status.CreationTime != nil), nil
-	})
-}
-
-func getContent(ctx context.Context, snapCli snapshotclient.Interface, contentName string) (*snapshot.VolumeSnapshotContent, error) {
-	return snapCli.VolumesnapshotV1alpha1().VolumeSnapshotContents().Get(contentName, metav1.GetOptions{})
-}
-
-func getDeletionPolicyFromClass(snapCli snapshotclient.Interface, snapClassName string) (*snapshot.DeletionPolicy, error) {
-	vsc, err := snapCli.VolumesnapshotV1alpha1().VolumeSnapshotClasses().Get(snapClassName, metav1.GetOptions{})
-	if err != nil {
-		return nil, errors.Wrapf(err, "Failed to find VolumeSnapshotClass: %s", snapClassName)
-	}
-	return vsc.DeletionPolicy, nil
+type SnapshotStatus struct {
+	CreationTime *metav1.Time         `json:"creationTime"`
+	RestoreSize  *resource.Quantity   `json:"restoreSize"`
+	ReadyToUse   bool                 `json:"readyToUse"`
+	Error        *storage.VolumeError `json:"error"`
 }

--- a/pkg/kube/snapshot/snapshot_alpha.go
+++ b/pkg/kube/snapshot/snapshot_alpha.go
@@ -1,0 +1,352 @@
+// Copyright 2019 The Kanister Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package snapshot
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	storage "k8s.io/api/storage/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	k8errors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/kanisterio/kanister/pkg/poll"
+)
+
+const (
+	pvcKind = "PersistentVolumeClaim"
+
+	snapshotVersionAlpha = "v1alpha1"
+	snapshotGroup        = "snapshot.storage.k8s.io"
+
+	volSnapClassResource   = "volumesnapshotclasses"
+	volSnapClassKind       = "VolumeSnapshotClass"
+	volSnapResource        = "volumesnapshots"
+	volSnapKind            = "VolumeSnapshot"
+	volSnapContentResource = "volumesnapshotcontents"
+	volSnapContentKind     = "VolumeSnapshotContent"
+)
+
+var (
+	// VolSnapGVR specifies GVR schema for VolumeSnapshots
+	VolSnapGVR = schema.GroupVersionResource{Group: snapshotGroup, Version: snapshotVersionAlpha, Resource: volSnapResource}
+	// VolSnapClassGVR specifies GVR schema for VolumeSnapshotClasses
+	VolSnapClassGVR = schema.GroupVersionResource{Group: snapshotGroup, Version: snapshotVersionAlpha, Resource: volSnapClassResource}
+	// VolSnapContentGVR specifies GVR schema for VolumeSnapshotContents
+	VolSnapContentGVR = schema.GroupVersionResource{Group: snapshotGroup, Version: snapshotVersionAlpha, Resource: volSnapContentResource}
+)
+
+type VolumeSnapshotContent struct {
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Spec              VolumeSnapshotContentSpec `json:"spec"`
+}
+
+type VolumeSnapshotSource struct {
+	CSI CSIVolumeSnapshotSource
+}
+
+type VolumeSnapshotContentSpec struct {
+	VolumeSnapshotSource
+	VolumeSnapshotClassName string `json:"snapshotClassName"`
+	DeletionPolicy          string `json:"deletionPolicy"`
+}
+
+type CSIVolumeSnapshotSource struct {
+	Driver         string `json:"driver"`
+	SnapshotHandle string `json:"snapshotHandle"`
+	CreationTime   int64  `json:"creationTime"`
+	RestoreSize    int64  `json:"restoreSize"`
+}
+
+type VolumeSnapshotClass struct {
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Snapshotter       string `json:"snapshotter"`
+	DeletionPolicy    string `json:"deletionPolicy"`
+}
+
+type SnapshotAlpha struct {
+	dynCli  dynamic.Interface
+	kubeCli kubernetes.Interface
+}
+
+func NewSnapshotAlpha(dynCli dynamic.Interface, kubeCli kubernetes.Interface) Snapshotter {
+	return &SnapshotAlpha{
+		dynCli:  dynCli,
+		kubeCli: kubeCli,
+	}
+}
+
+// Create creates a VolumeSnapshot and returns it or any error happened meanwhile.
+func (sna *SnapshotAlpha) Create(ctx context.Context, name, namespace, volumeName string, snapshotClass *string, waitForReady bool) error {
+	if _, err := sna.kubeCli.CoreV1().PersistentVolumeClaims(namespace).Get(volumeName, metav1.GetOptions{}); err != nil {
+		if k8errors.IsNotFound(err) {
+			return errors.Errorf("Failed to find PVC %s, Namespace %s", volumeName, namespace)
+		}
+		return errors.Errorf("Failed to query PVC %s, Namespace %s: %v", volumeName, namespace, err)
+	}
+
+	err := sna.createVolumeSnapshot(name, namespace, corev1.ObjectReference{Kind: pvcKind, Name: volumeName}, *snapshotClass)
+	if err != nil {
+		return err
+	}
+
+	if !waitForReady {
+		return nil
+	}
+
+	err = sna.WaitOnReadyToUse(ctx, name, namespace)
+	if err != nil {
+		return err
+	}
+
+	_, err = sna.Get(ctx, name, namespace)
+	return err
+}
+
+// Get will return the VolumeSnapshot in the namespace 'namespace' with given 'name'.
+func (sna *SnapshotAlpha) Get(ctx context.Context, name, namespace string) (*VolumeSnapshot, error) {
+	us, err := sna.dynCli.Resource(VolSnapGVR).Namespace(namespace).Get(name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	vs := &VolumeSnapshot{}
+	err = transformUnstructured(us, vs)
+	return vs, err
+}
+
+// Delete will delete the VolumeSnapshot and returns any error as a result.
+func (sna *SnapshotAlpha) Delete(ctx context.Context, name, namespace string) error {
+	if err := sna.dynCli.Resource(VolSnapGVR).Namespace(namespace).Delete(name, &metav1.DeleteOptions{}); !apierrors.IsNotFound(err) {
+		return err
+	}
+
+	// If the Snapshot does not exist, that's an acceptable error and we ignore it
+	return nil
+}
+
+// Clone will clone the VolumeSnapshot to namespace 'cloneNamespace'.
+// Underlying VolumeSnapshotContent will be cloned with a different name.
+func (sna *SnapshotAlpha) Clone(ctx context.Context, name, namespace, cloneName, cloneNamespace string, waitForReady bool) error {
+	snap, err := sna.Get(ctx, name, namespace)
+	if err != nil {
+		return err
+	}
+	if !snap.Status.ReadyToUse {
+		return errors.Errorf("Original snapshot is not ready, VolumeSnapshot: %s, Namespace: %s", cloneName, cloneNamespace)
+	}
+	if snap.Spec.SnapshotContentName == "" {
+		return errors.Errorf("Original snapshot does not have content, VolumeSnapshot: %s, Namespace: %s", cloneName, cloneNamespace)
+	}
+
+	_, err = sna.Get(ctx, cloneName, cloneNamespace)
+	if err == nil {
+		return errors.Errorf("Target snapshot already exists in target namespace, Volumesnapshot: %s, Namespace: %s", cloneName, cloneNamespace)
+	}
+	if !k8errors.IsNotFound(err) {
+		return errors.Errorf("Failed to query target Volumesnapshot: %s, Namespace: %s: %v", cloneName, cloneNamespace, err)
+	}
+
+	src, err := sna.GetSource(ctx, name, namespace)
+	if err != nil {
+		return errors.Errorf("Failed to get source")
+	}
+	return sna.CreateFromSource(ctx, src, cloneName, cloneNamespace, waitForReady)
+}
+
+// GetSource will return the CSI source that backs the volume snapshot.
+func (sna *SnapshotAlpha) GetSource(ctx context.Context, snapshotName, namespace string) (*Source, error) {
+	snap, err := sna.Get(ctx, snapshotName, namespace)
+	if err != nil {
+		return nil, errors.Errorf("Failed to get snapshot, VolumeSnapshot: %s, Error: %v", snapshotName, err)
+	}
+	cont, err := sna.getContent(ctx, snap.Spec.SnapshotContentName)
+	if err != nil {
+		return nil, errors.Errorf("Failed to get snapshot content, VolumeSnapshot: %s, VolumeSnapshotContent: %s, Error: %v", snapshotName, snap.Spec.SnapshotContentName, err)
+	}
+	src := &Source{
+		Handle:                  cont.Spec.CSI.SnapshotHandle,
+		Driver:                  cont.Spec.CSI.Driver,
+		RestoreSize:             &cont.Spec.CSI.RestoreSize,
+		VolumeSnapshotClassName: cont.Spec.VolumeSnapshotClassName,
+	}
+	return src, nil
+}
+
+// CreateFromSource will create a 'Volumesnapshot' and 'VolumesnaphotContent' pair for the underlying snapshot source.
+func (sna *SnapshotAlpha) CreateFromSource(ctx context.Context, source *Source, snapshotName, namespace string, waitForReady bool) error {
+	deletionPolicy, err := sna.getDeletionPolicyFromClass(source.VolumeSnapshotClassName)
+	if err != nil {
+		return errors.Wrap(err, "Failed to get DeletionPolicy from VolumeSnapshotClass")
+	}
+	contentName := snapshotName + "-content-" + string(uuid.NewUUID())
+
+	content := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": fmt.Sprintf("%s/%s", snapshotGroup, snapshotVersionAlpha),
+			"kind":       volSnapContentKind,
+			"metadata": map[string]interface{}{
+				"name": contentName,
+			},
+			"spec": map[string]interface{}{
+				"volumeSnapshotSource": map[string]interface{}{
+					"csiVolumeSnapshotSource": map[string]interface{}{
+						"driver":         source.Driver,
+						"snapshotHandle": source.Handle,
+					},
+				},
+				"volumeSnapshotRef": map[string]interface{}{
+					"kind":      volSnapKind,
+					"name":      snapshotName,
+					"namespace": snapshotName,
+				},
+				"snapshotClassName": source.VolumeSnapshotClassName,
+				"deletionPolicy":    deletionPolicy,
+			},
+		},
+	}
+
+	snap := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": fmt.Sprintf("%s/%s", snapshotGroup, snapshotVersionAlpha),
+			"kind":       volSnapKind,
+			"metadata": map[string]interface{}{
+				"name": snapshotName,
+			},
+			"spec": map[string]interface{}{
+				"snapshotContentName": content.GetName(),
+				"snapshotClassName":   source.VolumeSnapshotClassName,
+			},
+		},
+	}
+
+	//content, err = snapCli.VolumesnapshotV1alpha1().VolumeSnapshotContents().Create(content)
+	_, err = sna.dynCli.Resource(VolSnapContentGVR).Namespace("").Create(content, metav1.CreateOptions{})
+	if err != nil {
+		return errors.Errorf("Failed to create content, VolumesnapshotContent: %s, Error: %v", content.GetName(), err)
+	}
+	//snap, err = snapCli.VolumesnapshotV1alpha1().VolumeSnapshots(namespace).Create(snap)
+	_, err = sna.dynCli.Resource(VolSnapGVR).Namespace(namespace).Create(snap, metav1.CreateOptions{})
+	if err != nil {
+		return errors.Errorf("Failed to create content, Volumesnapshot: %s, Error: %v", snap.GetName(), err)
+	}
+	if !waitForReady {
+		return nil
+	}
+
+	return sna.WaitOnReadyToUse(ctx, snap.GetName(), snap.GetNamespace())
+}
+
+// WaitOnReadyToUse will block until the Volumesnapshot in namespace 'namespace' with name 'snapshotName'
+// has status 'ReadyToUse' or 'ctx.Done()' is signalled.
+func (sna *SnapshotAlpha) WaitOnReadyToUse(ctx context.Context, snapshotName, namespace string) error {
+	return poll.Wait(ctx, func(context.Context) (bool, error) {
+		us, err := sna.dynCli.Resource(VolSnapGVR).Namespace(namespace).Get(snapshotName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		ss, err := json.Marshal(us.Object)
+		if err != nil {
+			return false, err
+		}
+		vs := VolumeSnapshot{}
+		err = json.Unmarshal(ss, &vs)
+		if err != nil {
+			return false, err
+		}
+		// Error can be set while waiting for creation
+		if vs.Status.Error != nil {
+			return false, errors.New(vs.Status.Error.Message)
+		}
+		return (vs.Status.ReadyToUse && vs.Status.CreationTime != nil), nil
+	})
+}
+
+func (sna *SnapshotAlpha) getContent(ctx context.Context, contentName string) (*VolumeSnapshotContent, error) {
+	us, err := sna.dynCli.Resource(VolSnapContentGVR).Namespace("").Get(contentName, metav1.GetOptions{})
+	ss, err := json.Marshal(us.Object)
+	if err != nil {
+		return nil, err
+	}
+	vsc := VolumeSnapshotContent{}
+	err = json.Unmarshal(ss, &vsc)
+	if err != nil {
+		return nil, err
+	}
+	return &vsc, nil
+}
+
+func (sna *SnapshotAlpha) getDeletionPolicyFromClass(snapClassName string) (string, error) {
+	us, err := sna.dynCli.Resource(VolSnapClassGVR).Namespace("").Get(snapClassName, metav1.GetOptions{})
+	if err != nil {
+		return "", errors.Wrapf(err, "Failed to find VolumeSnapshotClass: %s", snapClassName)
+	}
+	vsc := VolumeSnapshotClass{}
+	st, err := json.Marshal(us.Object)
+	if err != nil {
+		return "", err
+	}
+	err = json.Unmarshal(st, &vsc)
+	if err != nil {
+		return "", err
+	}
+	return vsc.DeletionPolicy, nil
+}
+
+func (sna *SnapshotAlpha) createVolumeSnapshot(name, namespace string, pvcObjectRef corev1.ObjectReference, snapClassName string) error {
+	snap := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": fmt.Sprintf("%s/%s", snapshotGroup, snapshotVersionAlpha),
+			"kind":       volSnapKind,
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"spec": map[string]interface{}{
+				"source": map[string]interface{}{
+					"kind":      pvcObjectRef.Kind,
+					"name":      pvcObjectRef.Name,
+					"namespace": pvcObjectRef.Namespace,
+				},
+				"snapshotClassName": snapClassName,
+			},
+		},
+	}
+
+	_, err := sna.dynCli.Resource(VolSnapGVR).Namespace(namespace).Create(snap, metav1.CreateOptions{})
+	return err
+}
+
+func transformUnstructured(u *unstructured.Unstructured, object interface{}) error {
+	b, err := json.Marshal(u.Object)
+	if err != nil {
+		return errors.Errorf("Failed to Marshal unstructured object: %v", err)
+	}
+	err = json.Unmarshal(b, object)
+	if err != nil {
+		return errors.Errorf("Failed to Unmarshal unstructured object: %v", err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Change Overview

Use dynamic client to create volume snapshots
Remove external-snapshotter dep from snapshot pkg
New interface `Snapshotter` to perform snapshot operations
Remove  external-snapshotter dep from kube/volume package

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
