### PR TITLE
[Docs] Correct the function name in KubeExecAll example

### DIFF
--- a/docs/functions.rst
+++ b/docs/functions.rst
@@ -91,7 +91,7 @@ Example:
 .. code-block:: yaml
   :linenos:
 
-  - func: KubeExec
+  - func: KubeExecAll
     name: examplePhase
     args:
       namespace: "{{ .Deployment.Namespace }}"


### PR DESCRIPTION
## Change Overview

There was a typo in the example of `KubeExecAll` function in the docs. This change fixes that.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [x] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan
NA

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
