### PR TITLE
Avoid using operation timeout while executing WaitForPodReady func

### DIFF
--- a/pkg/blockstorage/zone/zone.go
+++ b/pkg/blockstorage/zone/zone.go
@@ -204,9 +204,9 @@ func GetReadySchedulableNodes(cli kubernetes.Interface) ([]v1.Node, error) {
 	var l []v1.Node
 	for _, node := range ns.Items {
 		switch {
-		case !isNodeReady(&node):
+		case !kube.IsNodeReady(&node):
 			notReady++
-		case !isNodeSchedulable(&node):
+		case !kube.IsNodeSchedulable(&node):
 			unschedulable++
 		default:
 			l = append(l, node)
@@ -217,31 +217,6 @@ func GetReadySchedulableNodes(cli kubernetes.Interface) ([]v1.Node, error) {
 		return nil, errors.New("There are currently no ready, schedulable nodes in the cluster")
 	}
 	return l, nil
-}
-
-// isNodeSchedulable returns true if:
-// 1) doesn't have "unschedulable" field set
-// 2) it also returns true from IsNodeReady
-// Derived from "k8s.io/kubernetes/test/e2e/framework/node"
-func isNodeSchedulable(node *v1.Node) bool {
-	if node == nil {
-		return false
-	}
-	return !node.Spec.Unschedulable
-}
-
-// isNodeReady returns true if:
-// 1) it's Ready condition is set to true
-// Derived from "k8s.io/kubernetes/test/e2e/framework/node"
-func isNodeReady(node *v1.Node) bool {
-	for _, cond := range node.Status.Conditions {
-		if cond.Type == v1.NodeReady {
-			if cond.Status == v1.ConditionTrue {
-				return true
-			}
-		}
-	}
-	return false
 }
 
 // SanitizeAvailableZones validates and updates a map of zones against a list of valid zone names

--- a/pkg/kube/pod.go
+++ b/pkg/kube/pod.go
@@ -205,7 +205,6 @@ func checkPVCAndPVStatus(vol v1.Volume, p *v1.Pod, cli kubernetes.Interface, nam
 		if pv.Status.Phase == v1.VolumeFailed {
 			return errors.Errorf("PV %s associated with PVC %s has status: %s message: %s reason: %s namespace: %s", pvName, pvcName, v1.VolumeFailed, pv.Status.Message, pv.Status.Reason, namespace)
 		}
-
 	} else if pvc.Status.Phase == v1.ClaimLost {
 		return errors.Errorf("PVC %s assoicated with pod %s has status: %s", pvcName, p.Name, v1.ClaimLost)
 	}

--- a/pkg/kube/pod.go
+++ b/pkg/kube/pod.go
@@ -174,7 +174,7 @@ func checkPVCAndPVStatus(p *v1.Pod, cli kubernetes.Interface, namespace string) 
 					return errors.Wrapf(err, "Failed to get PV %s, namespace: %s", pvName, namespace)
 				}
 				if pv.Status.Phase == v1.VolumeFailed {
-					return errors.Errorf("PV %s associated with pvc %s has status: %s message: %s reason: %s namespace: %s", pvName, pvcName, v1.VolumeFailed, pv.Status.Message, pv.Status.Reason, namespace)
+					return errors.Errorf("PV %s associated with PVC %s has status: %s message: %s reason: %s namespace: %s", pvName, pvcName, v1.VolumeFailed, pv.Status.Message, pv.Status.Reason, namespace)
 				}
 			} else if pvc.Status.Phase == v1.ClaimLost {
 				return errors.Errorf("PVC %s assoicated with pod %s has status: %s", pvcName, p.Name, v1.ClaimLost)

--- a/pkg/kube/pod.go
+++ b/pkg/kube/pod.go
@@ -128,15 +128,8 @@ func WaitForPodReady(ctx context.Context, cli kubernetes.Interface, namespace, n
 		}
 
 		// check if nodes are up and available
-		n := strings.Split(p.Spec.NodeName, "/")
-		if n[0] != "" {
-			node, err := cli.CoreV1().Nodes().Get(n[0], metav1.GetOptions{})
-			if err != nil {
-				return false, errors.Wrapf(err, "Failed to get node %s", n[0])
-			}
-			if !IsNodeReady(node) || !IsNodeSchedulable(node) {
-				return false, errors.Errorf("Node %s is currently not ready/schedulable", n[0])
-			}
+		if err := checkNodesStatus(p, cli); err != nil {
+			return false, err
 		}
 
 		// check for memory or resource issues
@@ -153,7 +146,21 @@ func WaitForPodReady(ctx context.Context, cli kubernetes.Interface, namespace, n
 
 		return p.Status.Phase != v1.PodPending && p.Status.Phase != "", nil
 	})
-	return errors.Wrapf(err, "Pod did not transition into running state. Namespace:%s, Name:%s", namespace, name)
+	return errors.Wrapf(err, "Pod did not transition into running state. Timeout:%v  Namespace:%s, Name:%s", podReadyWaitTimeout, namespace, name)
+}
+
+func checkNodesStatus(p *v1.Pod, cli kubernetes.Interface) error {
+	n := strings.Split(p.Spec.NodeName, "/")
+	if n[0] != "" {
+		node, err := cli.CoreV1().Nodes().Get(n[0], metav1.GetOptions{})
+		if err != nil {
+			return errors.Wrapf(err, "Failed to get node %s", n[0])
+		}
+		if !IsNodeReady(node) || !IsNodeSchedulable(node) {
+			return errors.Errorf("Node %s is currently not ready/schedulable", n[0])
+		}
+	}
+	return nil
 }
 
 func checkPVCAndPVStatus(p *v1.Pod, cli kubernetes.Interface, namespace string) error {

--- a/pkg/kube/pod.go
+++ b/pkg/kube/pod.go
@@ -174,7 +174,7 @@ func checkPVCAndPVStatus(p *v1.Pod, cli kubernetes.Interface, namespace string) 
 					return errors.Wrapf(err, "Failed to get PV %s, namespace: %s", pvName, namespace)
 				}
 				if pv.Status.Phase == v1.VolumeFailed {
-					return errors.Errorf("PV %s associated with pvc %s has status: %s message: %s reason:%s namespace:%s", pvName, pvcName, v1.VolumeFailed, pv.Status.Message, pv.Status.Reason, namespace)
+					return errors.Errorf("PV %s associated with pvc %s has status: %s message: %s reason: %s namespace: %s", pvName, pvcName, v1.VolumeFailed, pv.Status.Message, pv.Status.Reason, namespace)
 				}
 			} else if pvc.Status.Phase == v1.ClaimLost {
 				return errors.Errorf("PVC %s assoicated with pod %s has status: %s", pvcName, p.Name, v1.ClaimLost)

--- a/pkg/kube/pod.go
+++ b/pkg/kube/pod.go
@@ -178,11 +178,10 @@ func checkPVCAndPVStatus(p *v1.Pod, cli kubernetes.Interface, namespace string) 
 					pvName := pvc.Spec.VolumeName
 					if pvName != "" {
 						pv, err := cli.CoreV1().PersistentVolumes().Get(pvName, metav1.GetOptions{})
-						if err == nil {
-							if pv.Status.Phase == v1.VolumeFailed {
-								return errors.Errorf("PV %s associated with PVC %s has status: %s message: %s reason: %s namespace: %s", pvName, pvcName, v1.VolumeFailed, pv.Status.Message, pv.Status.Reason, namespace)
-							}
+						if err == nil && pv.Status.Phase == v1.VolumeFailed {
+							return errors.Errorf("PV %s associated with PVC %s has status: %s message: %s reason: %s namespace: %s", pvName, pvcName, v1.VolumeFailed, pv.Status.Message, pv.Status.Reason, namespace)
 						}
+
 					}
 				} else if pvc.Status.Phase == v1.ClaimLost {
 					return errors.Errorf("PVC %s assoicated with pod %s has status: %s", pvcName, p.Name, v1.ClaimLost)

--- a/pkg/kube/pod.go
+++ b/pkg/kube/pod.go
@@ -163,28 +163,30 @@ func checkNodesStatus(p *v1.Pod, cli kubernetes.Interface) error {
 	return nil
 }
 
+// checkPVCAndPVStatus does the following:
+// 1. if PVC is present then check the status of PVC
+// 	1.1 if PVC is pending then check if the PV status is VolumeFailed return error if so. if not then wait for timeout.
+// 2. if PVC not present then wait for timeout
 func checkPVCAndPVStatus(p *v1.Pod, cli kubernetes.Interface, namespace string) error {
 	for _, vol := range p.Spec.Volumes {
 		if vol.VolumeSource.PersistentVolumeClaim != nil {
 			pvcName := vol.VolumeSource.PersistentVolumeClaim.ClaimName
 			pvc, err := cli.CoreV1().PersistentVolumeClaims(namespace).Get(pvcName, metav1.GetOptions{})
-			if err != nil {
-				return errors.Wrapf(err, "Failed to get PVC %s", pvcName)
-			}
-			if pvc.Status.Phase == v1.ClaimPending {
-				pvName := pvc.Spec.VolumeName
-				if pvName == "" {
-					return errors.Errorf("PVC %s in namespace %s not bound", pvcName, namespace)
+			// if err != nil then wait for timeout, since sometimes in case of statefulsets,they trigger creation of a volume
+			if err == nil {
+				if pvc.Status.Phase == v1.ClaimPending {
+					pvName := pvc.Spec.VolumeName
+					if pvName != "" {
+						pv, err := cli.CoreV1().PersistentVolumes().Get(pvName, metav1.GetOptions{})
+						if err == nil {
+							if pv.Status.Phase == v1.VolumeFailed {
+								return errors.Errorf("PV %s associated with PVC %s has status: %s message: %s reason: %s namespace: %s", pvName, pvcName, v1.VolumeFailed, pv.Status.Message, pv.Status.Reason, namespace)
+							}
+						}
+					}
+				} else if pvc.Status.Phase == v1.ClaimLost {
+					return errors.Errorf("PVC %s assoicated with pod %s has status: %s", pvcName, p.Name, v1.ClaimLost)
 				}
-				pv, err := cli.CoreV1().PersistentVolumes().Get(pvName, metav1.GetOptions{})
-				if err != nil {
-					return errors.Wrapf(err, "Failed to get PV %s, namespace: %s", pvName, namespace)
-				}
-				if pv.Status.Phase == v1.VolumeFailed {
-					return errors.Errorf("PV %s associated with PVC %s has status: %s message: %s reason: %s namespace: %s", pvName, pvcName, v1.VolumeFailed, pv.Status.Message, pv.Status.Reason, namespace)
-				}
-			} else if pvc.Status.Phase == v1.ClaimLost {
-				return errors.Errorf("PVC %s assoicated with pod %s has status: %s", pvcName, p.Name, v1.ClaimLost)
 			}
 		}
 	}

--- a/pkg/kube/pod.go
+++ b/pkg/kube/pod.go
@@ -34,7 +34,7 @@ import (
 )
 
 // podReadyWaitTimeout is the time to wait for pod to be ready
-const podReadyWaitTimeout = 5 * time.Minute // Q: Is 5 minutes sufficient?
+const podReadyWaitTimeout = 5 * time.Minute
 
 // PodOptions specifies options for `CreatePod`
 type PodOptions struct {

--- a/pkg/kube/pod.go
+++ b/pkg/kube/pod.go
@@ -162,7 +162,7 @@ func checkPVCAndPVStatus(p *v1.Pod, cli kubernetes.Interface, namespace string) 
 			pvcName := vol.VolumeSource.PersistentVolumeClaim.ClaimName
 			pvc, err := cli.CoreV1().PersistentVolumeClaims(namespace).Get(pvcName, metav1.GetOptions{})
 			if err != nil {
-				return errors.Wrapf(err, "Failed to get pvc %s", pvcName)
+				return errors.Wrapf(err, "Failed to get PVC %s", pvcName)
 			}
 			if pvc.Status.Phase == v1.ClaimPending {
 				pvName := pvc.Spec.VolumeName

--- a/pkg/kube/pod.go
+++ b/pkg/kube/pod.go
@@ -182,6 +182,7 @@ func getVolStatus(p *v1.Pod, cli kubernetes.Interface, namespace string) error {
 // 2. if PVC not present then wait for timeout
 func checkPVCAndPVStatus(vol v1.Volume, p *v1.Pod, cli kubernetes.Interface, namespace string) error {
 	if vol.VolumeSource.PersistentVolumeClaim == nil {
+		// wait for timeout
 		return nil
 	}
 	pvcName := vol.VolumeSource.PersistentVolumeClaim.ClaimName
@@ -192,16 +193,19 @@ func checkPVCAndPVStatus(vol v1.Volume, p *v1.Pod, cli kubernetes.Interface, nam
 	}
 	if pvc.Status.Phase == v1.ClaimPending {
 		pvName := pvc.Spec.VolumeName
-		if pvName != "" {
-			pv, err := cli.CoreV1().PersistentVolumes().Get(pvName, metav1.GetOptions{})
-			if err != nil {
-				// wait for timeout
-				return nil
-			}
-			if pv.Status.Phase == v1.VolumeFailed {
-				return errors.Errorf("PV %s associated with PVC %s has status: %s message: %s reason: %s namespace: %s", pvName, pvcName, v1.VolumeFailed, pv.Status.Message, pv.Status.Reason, namespace)
-			}
+		if pvName == "" {
+			// wait for timeout
+			return nil
 		}
+		pv, err := cli.CoreV1().PersistentVolumes().Get(pvName, metav1.GetOptions{})
+		if err != nil {
+			// wait for timeout
+			return nil
+		}
+		if pv.Status.Phase == v1.VolumeFailed {
+			return errors.Errorf("PV %s associated with PVC %s has status: %s message: %s reason: %s namespace: %s", pvName, pvcName, v1.VolumeFailed, pv.Status.Message, pv.Status.Reason, namespace)
+		}
+
 	} else if pvc.Status.Phase == v1.ClaimLost {
 		return errors.Errorf("PVC %s assoicated with pod %s has status: %s", pvcName, p.Name, v1.ClaimLost)
 	}

--- a/pkg/kube/pod.go
+++ b/pkg/kube/pod.go
@@ -177,7 +177,7 @@ func checkPVCAndPVStatus(p *v1.Pod, cli kubernetes.Interface, namespace string) 
 					return errors.Errorf("PV %s associated with pvc %s has status: %s message: %s reason:%s namespace:%s", pvName, pvcName, v1.VolumeFailed, pv.Status.Message, pv.Status.Reason, namespace)
 				}
 			} else if pvc.Status.Phase == v1.ClaimLost {
-				return errors.Errorf("PVC %s assoicated with pod %s has status: %s", pvcName, name, v1.ClaimLost)
+				return errors.Errorf("PVC %s assoicated with pod %s has status: %s", pvcName, p.Name, v1.ClaimLost)
 			}
 		}
 	}

--- a/pkg/kube/pod.go
+++ b/pkg/kube/pod.go
@@ -134,7 +134,7 @@ func WaitForPodReady(ctx context.Context, cli kubernetes.Interface, namespace, n
 			if err != nil {
 				return false, errors.Wrapf(err, "Failed to get node %s", n[0])
 			}
-			if !IsNodeReady(&node) || !IsNodeSchedulable(&node) {
+			if !IsNodeReady(node) || !IsNodeSchedulable(node) {
 				return false, errors.Errorf("Node %s is currently not ready/schedulable", n[0])
 			}
 		}

--- a/pkg/kube/pod.go
+++ b/pkg/kube/pod.go
@@ -181,7 +181,6 @@ func checkPVCAndPVStatus(p *v1.Pod, cli kubernetes.Interface, namespace string) 
 						if err == nil && pv.Status.Phase == v1.VolumeFailed {
 							return errors.Errorf("PV %s associated with PVC %s has status: %s message: %s reason: %s namespace: %s", pvName, pvcName, v1.VolumeFailed, pv.Status.Message, pv.Status.Reason, namespace)
 						}
-
 					}
 				} else if pvc.Status.Phase == v1.ClaimLost {
 					return errors.Errorf("PVC %s assoicated with pod %s has status: %s", pvcName, p.Name, v1.ClaimLost)

--- a/pkg/kube/pod_test.go
+++ b/pkg/kube/pod_test.go
@@ -77,6 +77,8 @@ func (s *PodSuite) TestPod(c *C) {
 
 func (s *PodSuite) TestPodWithVolumes(c *C) {
 	cli := fake.NewSimpleClientset()
+	_, err1 := cli.CoreV1().PersistentVolumeClaims(s.namespace).Get("fake-pvc", metav1.GetOptions{})
+	c.Assert(err1, IsNil)
 	pvc := &v1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "pvc-test",

--- a/pkg/kube/pod_test.go
+++ b/pkg/kube/pod_test.go
@@ -86,8 +86,8 @@ func (s *PodSuite) TestPod(c *C) {
 	// get controller's SA
 	sa, err := GetControllerServiceAccount(fake.NewSimpleClientset())
 	c.Assert(err, IsNil)
- 
-  ctx := context.Background()
+
+	ctx := context.Background()
 	podOptions := []*PodOptions{
 		{
 			Namespace:    s.namespace,

--- a/pkg/kube/pod_test.go
+++ b/pkg/kube/pod_test.go
@@ -97,7 +97,7 @@ func (s *PodSuite) TestPodWithVolumes(c *C) {
 		Volumes:      vols,
 	})
 	c.Assert(err, IsNil)
-	c.Assert(WaitForPodReady(ctx, s.cli, s.namespace, pod.Name), IsNil)
+	c.Assert(WaitForPodReady(ctx, cli, s.namespace, pod.Name), IsNil)
 	c.Assert(pod.Spec.Volumes, HasLen, 1)
 	c.Assert(pod.Spec.Volumes[0].VolumeSource.PersistentVolumeClaim.ClaimName, Equals, "pvc-test")
 	c.Assert(pod.Spec.Containers[0].VolumeMounts[0].MountPath, Equals, "/mnt/data1")

--- a/pkg/kube/pod_test.go
+++ b/pkg/kube/pod_test.go
@@ -77,8 +77,6 @@ func (s *PodSuite) TestPod(c *C) {
 
 func (s *PodSuite) TestPodWithVolumes(c *C) {
 	cli := fake.NewSimpleClientset()
-	_, err1 := cli.CoreV1().PersistentVolumeClaims(s.namespace).Get("fake-pvc", metav1.GetOptions{})
-	c.Assert(err1, IsNil)
 	pvc := &v1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "pvc-test",

--- a/pkg/kube/utils.go
+++ b/pkg/kube/utils.go
@@ -148,10 +148,8 @@ func IsNodeSchedulable(node *v1.Node) bool {
 // Derived from "k8s.io/kubernetes/test/e2e/framework/node"
 func IsNodeReady(node *v1.Node) bool {
 	for _, cond := range node.Status.Conditions {
-		if cond.Type == v1.NodeReady {
-			if cond.Status == v1.ConditionTrue {
-				return true
-			}
+		if cond.Type == v1.NodeReady && cond.Status == v1.ConditionTrue {
+			return true
 		}
 	}
 	return false

--- a/pkg/kube/utils.go
+++ b/pkg/kube/utils.go
@@ -134,3 +134,28 @@ func GetRegionFromLabels(labels map[string]string) string {
 	}
 	return ""
 }
+
+// IsNodeSchedulable returns true if:
+// 1) doesn't have "unschedulable" field set
+// 2) it also returns true from IsNodeReady
+// Derived from "k8s.io/kubernetes/test/e2e/framework/node"
+func IsNodeSchedulable(node *v1.Node) bool {
+	if node == nil {
+		return false
+	}
+	return !node.Spec.Unschedulable
+}
+
+// IsNodeReady returns true if:
+// 1) it's Ready condition is set to true
+// Derived from "k8s.io/kubernetes/test/e2e/framework/node"
+func IsNodeReady(node *v1.Node) bool {
+	for _, cond := range node.Status.Conditions {
+		if cond.Type == v1.NodeReady {
+			if cond.Status == v1.ConditionTrue {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/pkg/kube/utils.go
+++ b/pkg/kube/utils.go
@@ -135,9 +135,7 @@ func GetRegionFromLabels(labels map[string]string) string {
 	return ""
 }
 
-// IsNodeSchedulable returns true if:
-// 1) doesn't have "unschedulable" field set
-// 2) it also returns true from IsNodeReady
+// IsNodeSchedulable returns true if it doesn't have "unschedulable" field set
 // Derived from "k8s.io/kubernetes/test/e2e/framework/node"
 func IsNodeSchedulable(node *v1.Node) bool {
 	if node == nil {
@@ -146,8 +144,7 @@ func IsNodeSchedulable(node *v1.Node) bool {
 	return !node.Spec.Unschedulable
 }
 
-// IsNodeReady returns true if:
-// 1) it's Ready condition is set to true
+// IsNodeReady returns true if it's Ready condition is set to true
 // Derived from "k8s.io/kubernetes/test/e2e/framework/node"
 func IsNodeReady(node *v1.Node) bool {
 	for _, cond := range node.Status.Conditions {


### PR DESCRIPTION
## Change Overview

Avoid using operation timeout while executing WaitForPodReady func

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [x] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
