### PR TITLE
Use dynamic client to create volume snapshots

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,6 @@ require (
 	github.com/jpillora/backoff v0.0.0-20170918002102-8eab2debe79d
 	github.com/json-iterator/go v1.1.9
 	github.com/kelseyhightower/envconfig v1.4.0 // indirect
-	github.com/kubernetes-csi/external-snapshotter v1.1.0
 	github.com/lib/pq v1.2.0
 	github.com/luci/go-render v0.0.0-20160219211803-9a04cc21af0f
 	github.com/mitchellh/mapstructure v0.0.0-20180220230111-00c29f56e238

--- a/go.sum
+++ b/go.sum
@@ -89,6 +89,7 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumC
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dimchansky/utfbom v1.1.0 h1:FcM3g+nofKgUteL8dm/UpdRXNC9KmADgTpLKsu0TRo4=
 github.com/dimchansky/utfbom v1.1.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQvIirEdv+8=
+github.com/dnaeon/go-vcr v1.0.1 h1:r8L/HqC0Hje5AXMu1ooW8oyQyOFv4GxqpL0nRP7SLLY=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
 github.com/docker/spdystream v0.0.0-20181023171402-6480d4af844c h1:ZfSZ3P3BedhKGUhzj7BQlPSU4OvT6tfOKe3DVHzOA7s=
 github.com/docker/spdystream v0.0.0-20181023171402-6480d4af844c/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
@@ -189,8 +190,6 @@ github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFB
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/kubernetes-csi/external-snapshotter v1.1.0 h1:godlw8BSOac5TMGH2rVPJrmllek3y8wuqd9JsJHgulw=
-github.com/kubernetes-csi/external-snapshotter v1.1.0/go.mod h1:oYfxnsuh48V1UDYORl77YQxQbbdokNy7D73phuFpksY=
 github.com/lib/pq v1.2.0 h1:LXpIM/LZ5xGFhOpXAQUIMM1HdyqzVYM13zNdjCEEcA0=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/luci/go-render v0.0.0-20160219211803-9a04cc21af0f h1:WVPqVsbUsrzAebTEgWRAZMdDOfkFx06iyhbIoyMgtkE=
@@ -269,6 +268,7 @@ github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365/go.mod h1:a8OnRci
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/vmware/govmomi v0.21.1-0.20191008161538-40aebf13ba45 h1:zpQBW+l4uPQTfTOxedN5GEcSONhabbCf3X+5+P/H4Jk=
 github.com/vmware/govmomi v0.21.1-0.20191008161538-40aebf13ba45/go.mod h1:zbnFoBQ9GIjs2RVETy8CNEpb+L+Lwkjs3XZUL0B3/m0=

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -15,7 +15,6 @@
 package kube
 
 import (
-	snapshot "github.com/kubernetes-csi/external-snapshotter/pkg/client/clientset/versioned"
 	"github.com/pkg/errors"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes" // Load the GCP plugin - required to authenticate against
@@ -60,21 +59,6 @@ func NewClient() (kubernetes.Interface, error) {
 
 	// creates the clientset
 	clientset, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return nil, err
-	}
-	return clientset, nil
-}
-
-// NewClientSnapshot returns a VolumeSnapshot client configured by the Kanister environment.
-func NewSnapshotClient() (snapshot.Interface, error) {
-	config, err := LoadConfig()
-	if err != nil {
-		return nil, err
-	}
-
-	// creates the clientset
-	clientset, err := snapshot.NewForConfig(config)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -17,6 +17,7 @@ package kube
 import (
 	snapshot "github.com/kubernetes-csi/external-snapshotter/pkg/client/clientset/versioned"
 	"github.com/pkg/errors"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes" // Load the GCP plugin - required to authenticate against
 	// GKE clusters
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
@@ -74,6 +75,21 @@ func NewSnapshotClient() (snapshot.Interface, error) {
 
 	// creates the clientset
 	clientset, err := snapshot.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	return clientset, nil
+}
+
+// NewDynamicClient returns a Dynamic client configured by the Kanister environment.
+func NewDynamicClient() (dynamic.Interface, error) {
+	config, err := LoadConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	// creates the clientset
+	clientset, err := dynamic.NewForConfig(config)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kube/snapshot/apis/v1alpha1/types.go
+++ b/pkg/kube/snapshot/apis/v1alpha1/types.go
@@ -1,4 +1,6 @@
 /*
+Copyright 2020 The Kanister Authors.
+
 Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/kube/snapshot/apis/v1alpha1/types.go
+++ b/pkg/kube/snapshot/apis/v1alpha1/types.go
@@ -30,6 +30,9 @@ const (
 	VolumeSnapshotResourcePlural = "volumesnapshots"
 	// VolumeSnapshotClassResourcePlural is "volumesnapshotclasses"
 	VolumeSnapshotClassResourcePlural = "volumesnapshotclasses"
+
+	GroupName = "snapshot.storage.k8s.io"
+	Version   = "v1alpha1"
 )
 
 // VolumeSnapshot is a user's request for taking a snapshot. Upon successful creation of the actual

--- a/pkg/kube/snapshot/apis/v1alpha1/types.go
+++ b/pkg/kube/snapshot/apis/v1alpha1/types.go
@@ -1,0 +1,204 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	core_v1 "k8s.io/api/core/v1"
+	storage "k8s.io/api/storage/v1beta1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// VolumeSnapshotContentResourcePlural is "volumesnapshotcontents"
+	VolumeSnapshotContentResourcePlural = "volumesnapshotcontents"
+	// VolumeSnapshotResourcePlural is "volumesnapshots"
+	VolumeSnapshotResourcePlural = "volumesnapshots"
+	// VolumeSnapshotClassResourcePlural is "volumesnapshotclasses"
+	VolumeSnapshotClassResourcePlural = "volumesnapshotclasses"
+)
+
+// VolumeSnapshot is a user's request for taking a snapshot. Upon successful creation of the actual
+// snapshot by the volume provider it is bound to the corresponding VolumeSnapshotContent.
+// Only the VolumeSnapshot object is accessible to the user in the namespace.
+type VolumeSnapshot struct {
+	metav1.TypeMeta `json:",inline"`
+	// Standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+
+	// Spec defines the desired characteristics of a snapshot requested by a user.
+	Spec VolumeSnapshotSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
+
+	// Status represents the latest observed state of the snapshot
+	Status VolumeSnapshotStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
+}
+
+// VolumeSnapshotList is a list of VolumeSnapshot objects
+type VolumeSnapshotList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+
+	// Items is the list of VolumeSnapshots
+	Items []VolumeSnapshot `json:"items" protobuf:"bytes,2,rep,name=items"`
+}
+
+// VolumeSnapshotSpec describes the common attributes of a volume snapshot
+type VolumeSnapshotSpec struct {
+	// Source has the information about where the snapshot is created from.
+	// In Alpha version, only PersistentVolumeClaim is supported as the source.
+	// If not specified, user can create VolumeSnapshotContent and bind it with VolumeSnapshot manually.
+	Source *core_v1.TypedLocalObjectReference `json:"source" protobuf:"bytes,1,opt,name=source"`
+
+	// SnapshotContentName binds the VolumeSnapshot object with the VolumeSnapshotContent
+	SnapshotContentName string `json:"snapshotContentName" protobuf:"bytes,2,opt,name=snapshotContentName"`
+
+	// Name of the VolumeSnapshotClass used by the VolumeSnapshot. If not specified, a default snapshot class will
+	// be used if it is available.
+	VolumeSnapshotClassName string `json:"snapshotClassName" protobuf:"bytes,3,opt,name=snapshotClassName"`
+}
+
+// VolumeSnapshotStatus is the status of the VolumeSnapshot
+type VolumeSnapshotStatus struct {
+	// CreationTime is the time the snapshot was successfully created. If it is set,
+	// it means the snapshot was created; Otherwise the snapshot was not created.
+	CreationTime *metav1.Time `json:"creationTime" protobuf:"bytes,1,opt,name=creationTime"`
+
+	// When restoring volume from the snapshot, the volume size should be equal to or
+	// larger than the RestoreSize if it is specified. If RestoreSize is set to nil, it means
+	// that the storage plugin does not have this information available.
+	RestoreSize *resource.Quantity `json:"restoreSize" protobuf:"bytes,2,opt,name=restoreSize"`
+
+	// ReadyToUse is set to true only if the snapshot is ready to use (e.g., finish uploading if
+	// there is an uploading phase) and also VolumeSnapshot and its VolumeSnapshotContent
+	// bind correctly with each other. If any of the above condition is not true, ReadyToUse is
+	// set to false
+	ReadyToUse bool `json:"readyToUse" protobuf:"varint,3,opt,name=readyToUse"`
+
+	// The last error encountered during create snapshot operation, if any.
+	// This field must only be set by the entity completing the create snapshot
+	// operation, i.e. the external-snapshotter.
+	Error *storage.VolumeError `json:"error,omitempty" protobuf:"bytes,4,opt,name=error,casttype=VolumeError"`
+}
+
+// VolumeSnapshotClass describes the parameters used by storage system when
+// provisioning VolumeSnapshots from PVCs.
+// The name of a VolumeSnapshotClass object is significant, and is how users can request a particular class.
+type VolumeSnapshotClass struct {
+	metav1.TypeMeta `json:",inline"`
+	// Standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+
+	// Snapshotter is the driver expected to handle this VolumeSnapshotClass.
+	Snapshotter string `json:"snapshotter" protobuf:"bytes,2,opt,name=snapshotter"`
+
+	// Parameters holds parameters for the snapshotter.
+	// These values are opaque to the system and are passed directly
+	// to the snapshotter.
+	Parameters map[string]string `json:"parameters,omitempty" protobuf:"bytes,3,rep,name=parameters"`
+
+	// Optional: what happens to a snapshot content when released from its snapshot.
+	// The default policy is Delete if not specified.
+	DeletionPolicy string `json:"deletionPolicy,omitempty" protobuf:"bytes,4,opt,name=deletionPolicy"`
+}
+
+// VolumeSnapshotClassList is a collection of snapshot classes.
+type VolumeSnapshotClassList struct {
+	metav1.TypeMeta `json:",inline"`
+	// Standard list metadata
+	// More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+
+	// Items is the list of VolumeSnapshotClasses
+	Items []VolumeSnapshotClass `json:"items" protobuf:"bytes,2,rep,name=items"`
+}
+
+// VolumeSnapshotContent represents the actual "on-disk" snapshot object
+type VolumeSnapshotContent struct {
+	metav1.TypeMeta `json:",inline"`
+	// Standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+
+	// Spec represents the desired state of the snapshot content
+	Spec VolumeSnapshotContentSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
+}
+
+// VolumeSnapshotContentList is a list of VolumeSnapshotContent objects
+type VolumeSnapshotContentList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+
+	// Items is the list of VolumeSnapshotContents
+	Items []VolumeSnapshotContent `json:"items" protobuf:"bytes,2,rep,name=items"`
+}
+
+// VolumeSnapshotContentSpec is the spec of the volume snapshot content
+type VolumeSnapshotContentSpec struct {
+	// Source represents the location and type of the volume snapshot
+	VolumeSnapshotSource `json:",inline" protobuf:"bytes,1,opt,name=volumeSnapshotSource"`
+
+	// VolumeSnapshotRef is part of bi-directional binding between VolumeSnapshot
+	// and VolumeSnapshotContent. It becomes non-nil when bound.
+	VolumeSnapshotRef *core_v1.ObjectReference `json:"volumeSnapshotRef" protobuf:"bytes,2,opt,name=volumeSnapshotRef"`
+
+	// PersistentVolumeRef represents the PersistentVolume that the snapshot has been
+	// taken from. It becomes non-nil when VolumeSnapshot and VolumeSnapshotContent are bound.
+	PersistentVolumeRef *core_v1.ObjectReference `json:"persistentVolumeRef" protobuf:"bytes,3,opt,name=persistentVolumeRef"`
+
+	// Name of the VolumeSnapshotClass used by the VolumeSnapshot. If not specified, a default snapshot class will
+	// be used if it is available.
+	VolumeSnapshotClassName string `json:"snapshotClassName" protobuf:"bytes,4,opt,name=snapshotClassName"`
+
+	// Optional: what happens to a snapshot content when released from its snapshot. It will be set to Delete by default
+	// if not specified
+	DeletionPolicy string `json:"deletionPolicy" protobuf:"bytes,5,opt,name=deletionPolicy"`
+}
+
+// VolumeSnapshotSource represents the actual location and type of the snapshot. Only one of its members may be specified.
+type VolumeSnapshotSource struct {
+	// CSI (Container Storage Interface) represents storage that handled by an external CSI Volume Driver (Alpha feature).
+	CSI *CSIVolumeSnapshotSource `json:"csiVolumeSnapshotSource,omitempty"`
+}
+
+// CSIVolumeSnapshotSource represents the source from CSI volume snapshot
+type CSIVolumeSnapshotSource struct {
+	// Driver is the name of the driver to use for this snapshot.
+	// This MUST be the same name returned by the CSI GetPluginName() call for
+	// that driver.
+	// Required.
+	Driver string `json:"driver" protobuf:"bytes,1,opt,name=driver"`
+
+	// SnapshotHandle is the unique snapshot id returned by the CSI volume
+	// plugin’s CreateSnapshot to refer to the snapshot on all subsequent calls.
+	// Required.
+	SnapshotHandle string `json:"snapshotHandle" protobuf:"bytes,2,opt,name=snapshotHandle"`
+
+	// Timestamp when the point-in-time snapshot is taken on the storage
+	// system. This timestamp will be generated by the CSI volume driver after
+	// the snapshot is cut. The format of this field should be a Unix nanoseconds
+	// time encoded as an int64. On Unix, the command `date +%s%N` returns
+	// the  current time in nanoseconds since 1970-01-01 00:00:00 UTC.
+	// This field is required in the CSI spec but optional here to support static binding.
+	CreationTime *int64 `json:"creationTime,omitempty" protobuf:"varint,3,opt,name=creationTime"`
+
+	// When restoring volume from the snapshot, the volume size should be equal to or
+	// larger than the RestoreSize if it is specified. If RestoreSize is set to nil, it means
+	// that the storage plugin does not have this information available.
+	RestoreSize *int64 `json:"restoreSize,omitempty" protobuf:"bytes,4,opt,name=restoreSize"`
+}

--- a/pkg/kube/snapshot/snapshot.go
+++ b/pkg/kube/snapshot/snapshot.go
@@ -34,10 +34,10 @@ type Snapshotter interface {
 	//
 	// 'name' is the name of the VolumeSnapshot.
 	// 'namespace' is namespace of the PVC. VolumeSnapshot will be crated in the same namespace.
-	// 'volumeName' is the name of the PVC of which we will take snapshot. It must be in the same namespace 'ns'.
+	// 'pvcName' is the name of the PVC of which we will take snapshot. It must be in the same namespace 'ns'.
 	// 'waitForReady' will block the caller until the snapshot status is 'ReadyToUse'.
 	// or 'ctx.Done()' is signalled. Otherwise it will return immediately after the snapshot is cut.
-	Create(ctx context.Context, name, namespace, volumeName string, snapshotClass *string, waitForReady bool) error
+	Create(ctx context.Context, name, namespace, pvcName string, snapshotClass *string, waitForReady bool) error
 	// Get will return the VolumeSnapshot in the namespace 'namespace' with given 'name'.
 	//
 	// 'name' is the name of the VolumeSnapshot that will be returned.

--- a/pkg/kube/snapshot/snapshot.go
+++ b/pkg/kube/snapshot/snapshot.go
@@ -24,6 +24,12 @@ import (
 )
 
 type Snapshotter interface {
+	// GetVolumeSnapshotClass returns VolumeSnapshotClass name which is annotated with given key.
+	//
+	// 'annotationKey' is the annotation key which has to be present on VolumeSnapshotClass.
+	// 'annotationValue' is the value for annotationKey in VolumeSnapshotClass spec.
+	// This returns error if no VolumeSnapshotClass found.
+	GetVolumeSnapshotClass(annotationKey, annotationValue string) (string, error)
 	// Create creates a VolumeSnapshot and returns it or any error happened meanwhile.
 	//
 	// 'name' is the name of the VolumeSnapshot.

--- a/pkg/kube/snapshot/snapshot.go
+++ b/pkg/kube/snapshot/snapshot.go
@@ -16,6 +16,11 @@ package snapshot
 
 import (
 	"context"
+
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/kanisterio/kanister/pkg/kube/snapshot/apis/v1alpha1"
 )
 
 type Snapshotter interface {
@@ -31,7 +36,7 @@ type Snapshotter interface {
 	//
 	// 'name' is the name of the VolumeSnapshot that will be returned.
 	// 'namespace' is the namespace of the VolumeSnapshot that will be returned.
-	Get(ctx context.Context, name, namespace string) (*VolumeSnapshot, error)
+	Get(ctx context.Context, name, namespace string) (*v1alpha1.VolumeSnapshot, error)
 	// Delete will delete the VolumeSnapshot and returns any error as a result.
 	//
 	// 'name' is the name of the VolumeSnapshot that will be deleted.
@@ -71,20 +76,10 @@ type Source struct {
 	VolumeSnapshotClassName string
 }
 
-// VolumeSnapshot contains Snapshot metadata
-type VolumeSnapshot struct {
-	metav1.ObjectMeta `json:"metadata"`
-	Spec              SnapshotSpec   `json:"spec"`
-	Status            SnapshotStatus `json:"status"`
-}
-
-type SnapshotSpec struct {
-	SnapshotContentName string `json:"snapshotContentName"`
-}
-
-type SnapshotStatus struct {
-	CreationTime *metav1.Time         `json:"creationTime"`
-	RestoreSize  *resource.Quantity   `json:"restoreSize"`
-	ReadyToUse   bool                 `json:"readyToUse"`
-	Error        *storage.VolumeError `json:"error"`
+// NewSnapshotter creates and return new Snapshotter object
+func NewSnapshotter(kubeCli kubernetes.Interface, dynCli dynamic.Interface) Snapshotter {
+	return &SnapshotAlpha{
+		kubeCli: kubeCli,
+		dynCli:  dynCli,
+	}
 }

--- a/pkg/kube/snapshot/snapshot.go
+++ b/pkg/kube/snapshot/snapshot.go
@@ -16,125 +16,51 @@ package snapshot
 
 import (
 	"context"
-
-	snapshot "github.com/kubernetes-csi/external-snapshotter/pkg/apis/volumesnapshot/v1alpha1"
-	snapshotclient "github.com/kubernetes-csi/external-snapshotter/pkg/client/clientset/versioned"
-	"github.com/pkg/errors"
-	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	k8errors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/uuid"
-	"k8s.io/client-go/kubernetes"
-
-	"github.com/kanisterio/kanister/pkg/poll"
 )
 
-const (
-	snapshotKind = "VolumeSnapshot"
-	pvcKind      = "PersistentVolumeClaim"
-)
-
-// Create creates a VolumeSnapshot and returns it or any error happened meanwhile.
-//
-// 'name' is the name of the VolumeSnapshot.
-// 'namespace' is namespace of the PVC. VolumeSnapshot will be crated in the same namespace.
-// 'volumeName' is the name of the PVC of which we will take snapshot. It must be in the same namespace 'ns'.
-// 'waitForReady' will block the caller until the snapshot status is 'ReadyToUse'.
-// or 'ctx.Done()' is signalled. Otherwise it will return immediately after the snapshot is cut.
-func Create(ctx context.Context, kubeCli kubernetes.Interface, snapCli snapshotclient.Interface, name, namespace, volumeName string, snapshotClass *string, waitForReady bool) error {
-	if _, err := kubeCli.CoreV1().PersistentVolumeClaims(namespace).Get(volumeName, metav1.GetOptions{}); err != nil {
-		if k8errors.IsNotFound(err) {
-			return errors.Errorf("Failed to find PVC %s, Namespace %s", volumeName, namespace)
-		}
-		return errors.Errorf("Failed to query PVC %s, Namespace %s: %v", volumeName, namespace, err)
-	}
-
-	snap := &snapshot.VolumeSnapshot{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
-		Spec: snapshot.VolumeSnapshotSpec{
-			Source: &corev1.TypedLocalObjectReference{
-				Kind: pvcKind,
-				Name: volumeName,
-			},
-			VolumeSnapshotClassName: snapshotClass,
-		},
-	}
-
-	_, err := snapCli.VolumesnapshotV1alpha1().VolumeSnapshots(namespace).Create(snap)
-	if err != nil {
-		return err
-	}
-
-	if !waitForReady {
-		return nil
-	}
-
-	err = WaitOnReadyToUse(ctx, snapCli, name, namespace)
-	if err != nil {
-		return err
-	}
-
-	_, err = Get(ctx, snapCli, name, namespace)
-	return err
-}
-
-// Get will return the VolumeSnapshot in the namespace 'namespace' with given 'name'.
-//
-// 'name' is the name of the VolumeSnapshot that will be returned.
-// 'namespace' is the namespace of the VolumeSnapshot that will be returned.
-func Get(ctx context.Context, snapCli snapshotclient.Interface, name, namespace string) (*snapshot.VolumeSnapshot, error) {
-	return snapCli.VolumesnapshotV1alpha1().VolumeSnapshots(namespace).Get(name, metav1.GetOptions{})
-}
-
-// Delete will delete the VolumeSnapshot and returns any error as a result.
-//
-// 'name' is the name of the VolumeSnapshot that will be deleted.
-// 'namespace' is the namespace of the VolumeSnapshot that will be deleted.
-func Delete(ctx context.Context, snapCli snapshotclient.Interface, name, namespace string) error {
-	if err := snapCli.VolumesnapshotV1alpha1().VolumeSnapshots(namespace).Delete(name, &metav1.DeleteOptions{}); !apierrors.IsNotFound(err) {
-		return err
-	}
-	// If the Snapshot does not exist, that's an acceptable error and we ignore it
-	return nil
-}
-
-// Clone will clone the VolumeSnapshot to namespace 'cloneNamespace'.
-// Underlying VolumeSnapshotContent will be cloned with a different name.
-//
-// 'name' is the name of the VolumeSnapshot that will be cloned.
-// 'namespace' is the namespace of the VolumeSnapshot that will be cloned.
-// 'cloneName' is name of the clone.
-// 'cloneNamespace' is the namespace where the clone will be created.
-// 'waitForReady' will make the function blocks until the clone's status is ready to use.
-func Clone(ctx context.Context, snapCli snapshotclient.Interface, name, namespace, cloneName, cloneNamespace string, waitForReady bool) error {
-	snap, err := Get(ctx, snapCli, name, namespace)
-	if err != nil {
-		return err
-	}
-	if !snap.Status.ReadyToUse {
-		return errors.Errorf("Original snapshot is not ready, VolumeSnapshot: %s, Namespace: %s", cloneName, cloneNamespace)
-	}
-	if snap.Spec.SnapshotContentName == "" {
-		return errors.Errorf("Original snapshot does not have content, VolumeSnapshot: %s, Namespace: %s", cloneName, cloneNamespace)
-	}
-
-	_, err = Get(ctx, snapCli, cloneName, cloneNamespace)
-	if err == nil {
-		return errors.Errorf("Target snapshot already exists in target namespace, Volumesnapshot: %s, Namespace: %s", cloneName, cloneNamespace)
-	}
-	if !k8errors.IsNotFound(err) {
-		return errors.Errorf("Failed to query target Volumesnapshot: %s, Namespace: %s: %v", cloneName, cloneNamespace, err)
-	}
-
-	src, err := GetSource(ctx, snapCli, name, namespace)
-	if err != nil {
-		return errors.Errorf("Failed to get source")
-	}
-	return CreateFromSource(ctx, snapCli, src, cloneName, cloneNamespace, waitForReady)
+type Snapshotter interface {
+	// Create creates a VolumeSnapshot and returns it or any error happened meanwhile.
+	//
+	// 'name' is the name of the VolumeSnapshot.
+	// 'namespace' is namespace of the PVC. VolumeSnapshot will be crated in the same namespace.
+	// 'volumeName' is the name of the PVC of which we will take snapshot. It must be in the same namespace 'ns'.
+	// 'waitForReady' will block the caller until the snapshot status is 'ReadyToUse'.
+	// or 'ctx.Done()' is signalled. Otherwise it will return immediately after the snapshot is cut.
+	Create(ctx context.Context, name, namespace, volumeName string, snapshotClass *string, waitForReady bool) error
+	// Get will return the VolumeSnapshot in the namespace 'namespace' with given 'name'.
+	//
+	// 'name' is the name of the VolumeSnapshot that will be returned.
+	// 'namespace' is the namespace of the VolumeSnapshot that will be returned.
+	Get(ctx context.Context, name, namespace string) (*VolumeSnapshot, error)
+	// Delete will delete the VolumeSnapshot and returns any error as a result.
+	//
+	// 'name' is the name of the VolumeSnapshot that will be deleted.
+	// 'namespace' is the namespace of the VolumeSnapshot that will be deleted.
+	Delete(ctx context.Context, name, namespace string) error
+	// Clone will clone the VolumeSnapshot to namespace 'cloneNamespace'.
+	// Underlying VolumeSnapshotContent will be cloned with a different name.
+	//
+	// 'name' is the name of the VolumeSnapshot that will be cloned.
+	// 'namespace' is the namespace of the VolumeSnapshot that will be cloned.
+	// 'cloneName' is name of the clone.
+	// 'cloneNamespace' is the namespace where the clone will be created.
+	// 'waitForReady' will make the function blocks until the clone's status is ready to use.
+	Clone(ctx context.Context, name, namespace, cloneName, cloneNamespace string, waitForReady bool) error
+	// GetSource will return the CSI source that backs the volume snapshot.
+	//
+	// 'snapshotName' is the name of the Volumesnapshot.
+	// 'namespace' is the namespace of the Volumesnapshot.
+	GetSource(ctx context.Context, snapshotName, namespace string) (*Source, error)
+	// CreateFromSource will create a 'Volumesnapshot' and 'VolumesnaphotContent' pair for the underlying snapshot source.
+	//
+	// 'source' contains information about CSI snapshot.
+	// 'snapshotName' is the name of the snapshot that will be created.
+	// 'namespace' is the namespace of the snapshot.
+	// 'waitForReady' blocks the caller until snapshot is ready to use or context is cancelled.
+	CreateFromSource(ctx context.Context, source *Source, snapshotName, namespace string, waitForReady bool) error
+	// WaitOnReadyToUse will block until the Volumesnapshot in namespace 'namespace' with name 'snapshotName'
+	// has status 'ReadyToUse' or 'ctx.Done()' is signalled.
+	WaitOnReadyToUse(ctx context.Context, snapshotName, namespace string) error
 }
 
 // Source represents the CSI source of the Volumesnapshot.
@@ -142,112 +68,23 @@ type Source struct {
 	Handle                  string
 	Driver                  string
 	RestoreSize             *int64
-	VolumeSnapshotClassName *string
+	VolumeSnapshotClassName string
 }
 
-// GetSource will return the CSI source that backs the volume snapshot.
-//
-// 'snapshotName' is the name of the Volumesnapshot.
-// 'namespace' is the namespace of the Volumesnapshot.
-func GetSource(ctx context.Context, snapCli snapshotclient.Interface, snapshotName, namespace string) (*Source, error) {
-	snap, err := Get(ctx, snapCli, snapshotName, namespace)
-	if err != nil {
-		return nil, errors.Errorf("Failed to get snapshot, VolumeSnapshot: %s, Error: %v", snapshotName, err)
-	}
-	cont, err := getContent(ctx, snapCli, snap.Spec.SnapshotContentName)
-	if err != nil {
-		return nil, errors.Errorf("Failed to get snapshot content, VolumeSnapshot: %s, VolumeSnapshotContent: %s, Error: %v", snapshotName, snap.Spec.SnapshotContentName, err)
-	}
-	src := &Source{
-		Handle:                  cont.Spec.CSI.SnapshotHandle,
-		Driver:                  cont.Spec.CSI.Driver,
-		RestoreSize:             cont.Spec.CSI.RestoreSize,
-		VolumeSnapshotClassName: cont.Spec.VolumeSnapshotClassName,
-	}
-	return src, nil
+// VolumeSnapshot contains Snapshot metadata
+type VolumeSnapshot struct {
+	metav1.ObjectMeta `json:"metadata"`
+	Spec              SnapshotSpec   `json:"spec"`
+	Status            SnapshotStatus `json:"status"`
 }
 
-// CreateFromSource will create a 'Volumesnapshot' and 'VolumesnaphotContent' pair for the underlying snapshot source.
-//
-// 'source' contains information about CSI snapshot.
-// 'snapshotName' is the name of the snapshot that will be created.
-// 'namespace' is the namespace of the snapshot.
-// 'waitForReady' blocks the caller until snapshot is ready to use or context is cancelled.
-func CreateFromSource(ctx context.Context, snapCli snapshotclient.Interface, source *Source, snapshotName, namespace string, waitForReady bool) error {
-	deletionPolicy, err := getDeletionPolicyFromClass(snapCli, *source.VolumeSnapshotClassName)
-	if err != nil {
-		return errors.Wrap(err, "Failed to get DeletionPolicy from VolumeSnapshotClass")
-	}
-	contentName := snapshotName + "-content-" + string(uuid.NewUUID())
-	content := &snapshot.VolumeSnapshotContent{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: contentName,
-		},
-		Spec: snapshot.VolumeSnapshotContentSpec{
-			VolumeSnapshotSource: snapshot.VolumeSnapshotSource{
-				CSI: &snapshot.CSIVolumeSnapshotSource{
-					Driver:         source.Driver,
-					SnapshotHandle: source.Handle,
-				},
-			},
-			VolumeSnapshotRef: &corev1.ObjectReference{
-				Kind:      snapshotKind,
-				Namespace: namespace,
-				Name:      snapshotName,
-			},
-			VolumeSnapshotClassName: source.VolumeSnapshotClassName,
-			DeletionPolicy:          deletionPolicy,
-		},
-	}
-	snap := &snapshot.VolumeSnapshot{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: snapshotName,
-		},
-		Spec: snapshot.VolumeSnapshotSpec{
-			SnapshotContentName:     content.Name,
-			VolumeSnapshotClassName: content.Spec.VolumeSnapshotClassName,
-		},
-	}
-
-	content, err = snapCli.VolumesnapshotV1alpha1().VolumeSnapshotContents().Create(content)
-	if err != nil {
-		return errors.Errorf("Failed to create content, VolumesnapshotContent: %s, Error: %v", content.Name, err)
-	}
-	snap, err = snapCli.VolumesnapshotV1alpha1().VolumeSnapshots(namespace).Create(snap)
-	if err != nil {
-		return errors.Errorf("Failed to create content, Volumesnapshot: %s, Error: %v", snap.Name, err)
-	}
-	if !waitForReady {
-		return nil
-	}
-
-	return WaitOnReadyToUse(ctx, snapCli, snap.Name, snap.Namespace)
+type SnapshotSpec struct {
+	SnapshotContentName string `json:"snapshotContentName"`
 }
 
-// WaitOnReadyToUse will block until the Volumesnapshot in namespace 'namespace' with name 'snapshotName'
-// has status 'ReadyToUse' or 'ctx.Done()' is signalled.
-func WaitOnReadyToUse(ctx context.Context, snapCli snapshotclient.Interface, snapshotName, namespace string) error {
-	return poll.Wait(ctx, func(context.Context) (bool, error) {
-		snap, err := snapCli.VolumesnapshotV1alpha1().VolumeSnapshots(namespace).Get(snapshotName, metav1.GetOptions{})
-		if err != nil {
-			return false, err
-		}
-		// Error can be set while waiting for creation
-		if snap.Status.Error != nil {
-			return false, errors.New(snap.Status.Error.Message)
-		}
-		return (snap.Status.ReadyToUse && snap.Status.CreationTime != nil), nil
-	})
-}
-
-func getContent(ctx context.Context, snapCli snapshotclient.Interface, contentName string) (*snapshot.VolumeSnapshotContent, error) {
-	return snapCli.VolumesnapshotV1alpha1().VolumeSnapshotContents().Get(contentName, metav1.GetOptions{})
-}
-
-func getDeletionPolicyFromClass(snapCli snapshotclient.Interface, snapClassName string) (*snapshot.DeletionPolicy, error) {
-	vsc, err := snapCli.VolumesnapshotV1alpha1().VolumeSnapshotClasses().Get(snapClassName, metav1.GetOptions{})
-	if err != nil {
-		return nil, errors.Wrapf(err, "Failed to find VolumeSnapshotClass: %s", snapClassName)
-	}
-	return vsc.DeletionPolicy, nil
+type SnapshotStatus struct {
+	CreationTime *metav1.Time         `json:"creationTime"`
+	RestoreSize  *resource.Quantity   `json:"restoreSize"`
+	ReadyToUse   bool                 `json:"readyToUse"`
+	Error        *storage.VolumeError `json:"error"`
 }

--- a/pkg/kube/snapshot/snapshot_alpha.go
+++ b/pkg/kube/snapshot/snapshot_alpha.go
@@ -84,7 +84,7 @@ func (sna *SnapshotAlpha) Create(ctx context.Context, name, namespace, pvcName s
 		return errors.Errorf("Failed to query PVC %s, Namespace %s: %v", pvcName, namespace, err)
 	}
 
-	err := sna.createVolumeSnapshot(name, namespace, corev1.ObjectReference{Kind: pvcKind, Name: pvcName}, *snapshotClass)
+	err := sna.createVolumeSnapshot(name, namespace, corev1.ObjectReference{Kind: pvcKind, Name: pvcName, Namespace: namespace}, *snapshotClass)
 	if err != nil {
 		return err
 	}

--- a/pkg/kube/snapshot/snapshot_alpha.go
+++ b/pkg/kube/snapshot/snapshot_alpha.go
@@ -194,7 +194,7 @@ func (sna *SnapshotAlpha) CreateFromSource(ctx context.Context, source *Source, 
 				"volumeSnapshotRef": map[string]interface{}{
 					"kind":      VolSnapKind,
 					"name":      snapshotName,
-					"namespace": snapshotName,
+					"namespace": namespace,
 				},
 				"snapshotClassName": source.VolumeSnapshotClassName,
 				"deletionPolicy":    deletionPolicy,

--- a/pkg/kube/snapshot/snapshot_alpha.go
+++ b/pkg/kube/snapshot/snapshot_alpha.go
@@ -37,26 +37,19 @@ import (
 const (
 	pvcKind = "PersistentVolumeClaim"
 
-	VersionAlpha = "v1alpha1"
-	Group        = "snapshot.storage.k8s.io"
-
 	// Snapshot resource Kinds
 	VolSnapClassKind   = "VolumeSnapshotClass"
 	VolSnapKind        = "VolumeSnapshot"
 	VolSnapContentKind = "VolumeSnapshotContent"
-
-	volSnapClassResource   = "volumesnapshotclasses"
-	volSnapResource        = "volumesnapshots"
-	volSnapContentResource = "volumesnapshotcontents"
 )
 
 var (
 	// VolSnapGVR specifies GVR schema for VolumeSnapshots
-	VolSnapGVR = schema.GroupVersionResource{Group: Group, Version: VersionAlpha, Resource: volSnapResource}
+	VolSnapGVR = schema.GroupVersionResource{Group: v1alpha1.GroupName, Version: v1alpha1.Version, Resource: v1alpha1.VolumeSnapshotResourcePlural}
 	// VolSnapClassGVR specifies GVR schema for VolumeSnapshotClasses
-	VolSnapClassGVR = schema.GroupVersionResource{Group: Group, Version: VersionAlpha, Resource: volSnapClassResource}
+	VolSnapClassGVR = schema.GroupVersionResource{Group: v1alpha1.GroupName, Version: v1alpha1.Version, Resource: v1alpha1.VolumeSnapshotClassResourcePlural}
 	// VolSnapContentGVR specifies GVR schema for VolumeSnapshotContents
-	VolSnapContentGVR = schema.GroupVersionResource{Group: Group, Version: VersionAlpha, Resource: volSnapContentResource}
+	VolSnapContentGVR = schema.GroupVersionResource{Group: v1alpha1.GroupName, Version: v1alpha1.Version, Resource: v1alpha1.VolumeSnapshotContentResourcePlural}
 )
 
 type SnapshotAlpha struct {
@@ -188,7 +181,7 @@ func (sna *SnapshotAlpha) CreateFromSource(ctx context.Context, source *Source, 
 
 	content := &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": fmt.Sprintf("%s/%s", Group, VersionAlpha),
+			"apiVersion": fmt.Sprintf("%s/%s", v1alpha1.GroupName, v1alpha1.Version),
 			"kind":       VolSnapContentKind,
 			"metadata": map[string]interface{}{
 				"name": contentName,
@@ -211,7 +204,7 @@ func (sna *SnapshotAlpha) CreateFromSource(ctx context.Context, source *Source, 
 
 	snap := &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": fmt.Sprintf("%s/%s", Group, VersionAlpha),
+			"apiVersion": fmt.Sprintf("%s/%s", v1alpha1.GroupName, v1alpha1.Version),
 			"kind":       VolSnapKind,
 			"metadata": map[string]interface{}{
 				"name": snapshotName,
@@ -289,7 +282,7 @@ func (sna *SnapshotAlpha) getDeletionPolicyFromClass(snapClassName string) (stri
 func (sna *SnapshotAlpha) createVolumeSnapshot(name, namespace string, pvcObjectRef corev1.ObjectReference, snapClassName string) error {
 	snap := &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": fmt.Sprintf("%s/%s", Group, VersionAlpha),
+			"apiVersion": fmt.Sprintf("%s/%s", v1alpha1.GroupName, v1alpha1.Version),
 			"kind":       VolSnapKind,
 			"metadata": map[string]interface{}{
 				"name":      name,

--- a/pkg/kube/snapshot/snapshot_alpha.go
+++ b/pkg/kube/snapshot/snapshot_alpha.go
@@ -1,0 +1,352 @@
+// Copyright 2019 The Kanister Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package snapshot
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	storage "k8s.io/api/storage/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	k8errors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/kanisterio/kanister/pkg/poll"
+)
+
+const (
+	pvcKind = "PersistentVolumeClaim"
+
+	snapshotVersionAlpha = "v1alpha1"
+	snapshotGroup        = "snapshot.storage.k8s.io"
+
+	volSnapClassResource   = "volumesnapshotclasses"
+	volSnapClassKind       = "VolumeSnapshotClass"
+	volSnapResource        = "volumesnapshots"
+	volSnapKind            = "VolumeSnapshot"
+	volSnapContentResource = "volumesnapshotcontents"
+	volSnapContentKind     = "VolumeSnapshotContent"
+)
+
+var (
+	// VolSnapGVR specifies GVR schema for VolumeSnapshots
+	VolSnapGVR = schema.GroupVersionResource{Group: snapshotGroup, Version: snapshotVersionAlpha, Resource: volSnapResource}
+	// VolSnapClassGVR specifies GVR schema for VolumeSnapshotClasses
+	VolSnapClassGVR = schema.GroupVersionResource{Group: snapshotGroup, Version: snapshotVersionAlpha, Resource: volSnapClassResource}
+	// VolSnapContentGVR specifies GVR schema for VolumeSnapshotContents
+	VolSnapContentGVR = schema.GroupVersionResource{Group: snapshotGroup, Version: snapshotVersionAlpha, Resource: volSnapContentResource}
+)
+
+type VolumeSnapshotContent struct {
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Spec              VolumeSnapshotContentSpec `json:"spec"`
+}
+
+type VolumeSnapshotSource struct {
+	CSI CSIVolumeSnapshotSource
+}
+
+type VolumeSnapshotContentSpec struct {
+	VolumeSnapshotSource
+	VolumeSnapshotClassName string `json:"snapshotClassName"`
+	DeletionPolicy          string `json:"deletionPolicy"`
+}
+
+type CSIVolumeSnapshotSource struct {
+	Driver         string `json:"driver"`
+	SnapshotHandle string `json:"snapshotHandle"`
+	CreationTime   int64  `json:"creationTime"`
+	RestoreSize    int64  `json:"restoreSize"`
+}
+
+type VolumeSnapshotClass struct {
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Snapshotter       string `json:"snapshotter"`
+	DeletionPolicy    string `json:"deletionPolicy"`
+}
+
+type SnapshotAlpha struct {
+	dynCli  dynamic.Interface
+	kubeCli kubernetes.Interface
+}
+
+func NewSnapshotAlpha(dynCli dynamic.Interface, kubeCli kubernetes.Interface) Snapshotter {
+	return &SnapshotAlpha{
+		dynCli:  dynCli,
+		kubeCli: kubeCli,
+	}
+}
+
+// Create creates a VolumeSnapshot and returns it or any error happened meanwhile.
+func (sna *SnapshotAlpha) Create(ctx context.Context, name, namespace, volumeName string, snapshotClass *string, waitForReady bool) error {
+	if _, err := sna.kubeCli.CoreV1().PersistentVolumeClaims(namespace).Get(volumeName, metav1.GetOptions{}); err != nil {
+		if k8errors.IsNotFound(err) {
+			return errors.Errorf("Failed to find PVC %s, Namespace %s", volumeName, namespace)
+		}
+		return errors.Errorf("Failed to query PVC %s, Namespace %s: %v", volumeName, namespace, err)
+	}
+
+	err := sna.createVolumeSnapshot(name, namespace, corev1.ObjectReference{Kind: pvcKind, Name: volumeName}, *snapshotClass)
+	if err != nil {
+		return err
+	}
+
+	if !waitForReady {
+		return nil
+	}
+
+	err = sna.WaitOnReadyToUse(ctx, name, namespace)
+	if err != nil {
+		return err
+	}
+
+	_, err = sna.Get(ctx, name, namespace)
+	return err
+}
+
+// Get will return the VolumeSnapshot in the namespace 'namespace' with given 'name'.
+func (sna *SnapshotAlpha) Get(ctx context.Context, name, namespace string) (*VolumeSnapshot, error) {
+	us, err := sna.dynCli.Resource(VolSnapGVR).Namespace(namespace).Get(name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	vs := &VolumeSnapshot{}
+	err = transformUnstructured(us, vs)
+	return vs, err
+}
+
+// Delete will delete the VolumeSnapshot and returns any error as a result.
+func (sna *SnapshotAlpha) Delete(ctx context.Context, name, namespace string) error {
+	if err := sna.dynCli.Resource(VolSnapGVR).Namespace(namespace).Delete(name, &metav1.DeleteOptions{}); !apierrors.IsNotFound(err) {
+		return err
+	}
+
+	// If the Snapshot does not exist, that's an acceptable error and we ignore it
+	return nil
+}
+
+// Clone will clone the VolumeSnapshot to namespace 'cloneNamespace'.
+// Underlying VolumeSnapshotContent will be cloned with a different name.
+func (sna *SnapshotAlpha) Clone(ctx context.Context, name, namespace, cloneName, cloneNamespace string, waitForReady bool) error {
+	snap, err := sna.Get(ctx, name, namespace)
+	if err != nil {
+		return err
+	}
+	if !snap.Status.ReadyToUse {
+		return errors.Errorf("Original snapshot is not ready, VolumeSnapshot: %s, Namespace: %s", cloneName, cloneNamespace)
+	}
+	if snap.Spec.SnapshotContentName == "" {
+		return errors.Errorf("Original snapshot does not have content, VolumeSnapshot: %s, Namespace: %s", cloneName, cloneNamespace)
+	}
+
+	_, err = sna.Get(ctx, cloneName, cloneNamespace)
+	if err == nil {
+		return errors.Errorf("Target snapshot already exists in target namespace, Volumesnapshot: %s, Namespace: %s", cloneName, cloneNamespace)
+	}
+	if !k8errors.IsNotFound(err) {
+		return errors.Errorf("Failed to query target Volumesnapshot: %s, Namespace: %s: %v", cloneName, cloneNamespace, err)
+	}
+
+	src, err := sna.GetSource(ctx, name, namespace)
+	if err != nil {
+		return errors.Errorf("Failed to get source")
+	}
+	return sna.CreateFromSource(ctx, src, cloneName, cloneNamespace, waitForReady)
+}
+
+// GetSource will return the CSI source that backs the volume snapshot.
+func (sna *SnapshotAlpha) GetSource(ctx context.Context, snapshotName, namespace string) (*Source, error) {
+	snap, err := sna.Get(ctx, snapshotName, namespace)
+	if err != nil {
+		return nil, errors.Errorf("Failed to get snapshot, VolumeSnapshot: %s, Error: %v", snapshotName, err)
+	}
+	cont, err := sna.getContent(ctx, snap.Spec.SnapshotContentName)
+	if err != nil {
+		return nil, errors.Errorf("Failed to get snapshot content, VolumeSnapshot: %s, VolumeSnapshotContent: %s, Error: %v", snapshotName, snap.Spec.SnapshotContentName, err)
+	}
+	src := &Source{
+		Handle:                  cont.Spec.CSI.SnapshotHandle,
+		Driver:                  cont.Spec.CSI.Driver,
+		RestoreSize:             &cont.Spec.CSI.RestoreSize,
+		VolumeSnapshotClassName: cont.Spec.VolumeSnapshotClassName,
+	}
+	return src, nil
+}
+
+// CreateFromSource will create a 'Volumesnapshot' and 'VolumesnaphotContent' pair for the underlying snapshot source.
+func (sna *SnapshotAlpha) CreateFromSource(ctx context.Context, source *Source, snapshotName, namespace string, waitForReady bool) error {
+	deletionPolicy, err := sna.getDeletionPolicyFromClass(source.VolumeSnapshotClassName)
+	if err != nil {
+		return errors.Wrap(err, "Failed to get DeletionPolicy from VolumeSnapshotClass")
+	}
+	contentName := snapshotName + "-content-" + string(uuid.NewUUID())
+
+	content := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": fmt.Sprintf("%s/%s", snapshotGroup, snapshotVersionAlpha),
+			"kind":       volSnapContentKind,
+			"metadata": map[string]interface{}{
+				"name": contentName,
+			},
+			"spec": map[string]interface{}{
+				"volumeSnapshotSource": map[string]interface{}{
+					"csiVolumeSnapshotSource": map[string]interface{}{
+						"driver":         source.Driver,
+						"snapshotHandle": source.Handle,
+					},
+				},
+				"volumeSnapshotRef": map[string]interface{}{
+					"kind":      volSnapKind,
+					"name":      snapshotName,
+					"namespace": snapshotName,
+				},
+				"snapshotClassName": source.VolumeSnapshotClassName,
+				"deletionPolicy":    deletionPolicy,
+			},
+		},
+	}
+
+	snap := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": fmt.Sprintf("%s/%s", snapshotGroup, snapshotVersionAlpha),
+			"kind":       volSnapKind,
+			"metadata": map[string]interface{}{
+				"name": snapshotName,
+			},
+			"spec": map[string]interface{}{
+				"snapshotContentName": content.GetName(),
+				"snapshotClassName":   source.VolumeSnapshotClassName,
+			},
+		},
+	}
+
+	//content, err = snapCli.VolumesnapshotV1alpha1().VolumeSnapshotContents().Create(content)
+	_, err = sna.dynCli.Resource(VolSnapContentGVR).Namespace("").Create(content, metav1.CreateOptions{})
+	if err != nil {
+		return errors.Errorf("Failed to create content, VolumesnapshotContent: %s, Error: %v", content.GetName(), err)
+	}
+	//snap, err = snapCli.VolumesnapshotV1alpha1().VolumeSnapshots(namespace).Create(snap)
+	_, err = sna.dynCli.Resource(VolSnapGVR).Namespace(namespace).Create(snap, metav1.CreateOptions{})
+	if err != nil {
+		return errors.Errorf("Failed to create content, Volumesnapshot: %s, Error: %v", snap.GetName(), err)
+	}
+	if !waitForReady {
+		return nil
+	}
+
+	return sna.WaitOnReadyToUse(ctx, snap.GetName(), snap.GetNamespace())
+}
+
+// WaitOnReadyToUse will block until the Volumesnapshot in namespace 'namespace' with name 'snapshotName'
+// has status 'ReadyToUse' or 'ctx.Done()' is signalled.
+func (sna *SnapshotAlpha) WaitOnReadyToUse(ctx context.Context, snapshotName, namespace string) error {
+	return poll.Wait(ctx, func(context.Context) (bool, error) {
+		us, err := sna.dynCli.Resource(VolSnapGVR).Namespace(namespace).Get(snapshotName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		ss, err := json.Marshal(us.Object)
+		if err != nil {
+			return false, err
+		}
+		vs := VolumeSnapshot{}
+		err = json.Unmarshal(ss, &vs)
+		if err != nil {
+			return false, err
+		}
+		// Error can be set while waiting for creation
+		if vs.Status.Error != nil {
+			return false, errors.New(vs.Status.Error.Message)
+		}
+		return (vs.Status.ReadyToUse && vs.Status.CreationTime != nil), nil
+	})
+}
+
+func (sna *SnapshotAlpha) getContent(ctx context.Context, contentName string) (*VolumeSnapshotContent, error) {
+	us, err := sna.dynCli.Resource(VolSnapContentGVR).Namespace("").Get(contentName, metav1.GetOptions{})
+	ss, err := json.Marshal(us.Object)
+	if err != nil {
+		return nil, err
+	}
+	vsc := VolumeSnapshotContent{}
+	err = json.Unmarshal(ss, &vsc)
+	if err != nil {
+		return nil, err
+	}
+	return &vsc, nil
+}
+
+func (sna *SnapshotAlpha) getDeletionPolicyFromClass(snapClassName string) (string, error) {
+	us, err := sna.dynCli.Resource(VolSnapClassGVR).Namespace("").Get(snapClassName, metav1.GetOptions{})
+	if err != nil {
+		return "", errors.Wrapf(err, "Failed to find VolumeSnapshotClass: %s", snapClassName)
+	}
+	vsc := VolumeSnapshotClass{}
+	st, err := json.Marshal(us.Object)
+	if err != nil {
+		return "", err
+	}
+	err = json.Unmarshal(st, &vsc)
+	if err != nil {
+		return "", err
+	}
+	return vsc.DeletionPolicy, nil
+}
+
+func (sna *SnapshotAlpha) createVolumeSnapshot(name, namespace string, pvcObjectRef corev1.ObjectReference, snapClassName string) error {
+	snap := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": fmt.Sprintf("%s/%s", snapshotGroup, snapshotVersionAlpha),
+			"kind":       volSnapKind,
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"spec": map[string]interface{}{
+				"source": map[string]interface{}{
+					"kind":      pvcObjectRef.Kind,
+					"name":      pvcObjectRef.Name,
+					"namespace": pvcObjectRef.Namespace,
+				},
+				"snapshotClassName": snapClassName,
+			},
+		},
+	}
+
+	_, err := sna.dynCli.Resource(VolSnapGVR).Namespace(namespace).Create(snap, metav1.CreateOptions{})
+	return err
+}
+
+func transformUnstructured(u *unstructured.Unstructured, object interface{}) error {
+	b, err := json.Marshal(u.Object)
+	if err != nil {
+		return errors.Errorf("Failed to Marshal unstructured object: %v", err)
+	}
+	err = json.Unmarshal(b, object)
+	if err != nil {
+		return errors.Errorf("Failed to Unmarshal unstructured object: %v", err)
+	}
+	return nil
+}

--- a/pkg/kube/snapshot/snapshot_alpha.go
+++ b/pkg/kube/snapshot/snapshot_alpha.go
@@ -21,10 +21,8 @@ import (
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
-	storage "k8s.io/api/storage/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	k8errors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -32,70 +30,38 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 
+	"github.com/kanisterio/kanister/pkg/kube/snapshot/apis/v1alpha1"
 	"github.com/kanisterio/kanister/pkg/poll"
 )
 
 const (
 	pvcKind = "PersistentVolumeClaim"
 
-	snapshotVersionAlpha = "v1alpha1"
-	snapshotGroup        = "snapshot.storage.k8s.io"
+	VersionAlpha = "v1alpha1"
+	Group        = "snapshot.storage.k8s.io"
+
+	// Snapshot resource Kinds
+	VolSnapClassKind   = "VolumeSnapshotClass"
+	VolSnapKind        = "VolumeSnapshot"
+	VolSnapContentKind = "VolumeSnapshotContent"
 
 	volSnapClassResource   = "volumesnapshotclasses"
-	volSnapClassKind       = "VolumeSnapshotClass"
 	volSnapResource        = "volumesnapshots"
-	volSnapKind            = "VolumeSnapshot"
 	volSnapContentResource = "volumesnapshotcontents"
-	volSnapContentKind     = "VolumeSnapshotContent"
 )
 
 var (
 	// VolSnapGVR specifies GVR schema for VolumeSnapshots
-	VolSnapGVR = schema.GroupVersionResource{Group: snapshotGroup, Version: snapshotVersionAlpha, Resource: volSnapResource}
+	VolSnapGVR = schema.GroupVersionResource{Group: Group, Version: VersionAlpha, Resource: volSnapResource}
 	// VolSnapClassGVR specifies GVR schema for VolumeSnapshotClasses
-	VolSnapClassGVR = schema.GroupVersionResource{Group: snapshotGroup, Version: snapshotVersionAlpha, Resource: volSnapClassResource}
+	VolSnapClassGVR = schema.GroupVersionResource{Group: Group, Version: VersionAlpha, Resource: volSnapClassResource}
 	// VolSnapContentGVR specifies GVR schema for VolumeSnapshotContents
-	VolSnapContentGVR = schema.GroupVersionResource{Group: snapshotGroup, Version: snapshotVersionAlpha, Resource: volSnapContentResource}
+	VolSnapContentGVR = schema.GroupVersionResource{Group: Group, Version: VersionAlpha, Resource: volSnapContentResource}
 )
 
-type VolumeSnapshotContent struct {
-	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              VolumeSnapshotContentSpec `json:"spec"`
-}
-
-type VolumeSnapshotSource struct {
-	CSI CSIVolumeSnapshotSource
-}
-
-type VolumeSnapshotContentSpec struct {
-	VolumeSnapshotSource
-	VolumeSnapshotClassName string `json:"snapshotClassName"`
-	DeletionPolicy          string `json:"deletionPolicy"`
-}
-
-type CSIVolumeSnapshotSource struct {
-	Driver         string `json:"driver"`
-	SnapshotHandle string `json:"snapshotHandle"`
-	CreationTime   int64  `json:"creationTime"`
-	RestoreSize    int64  `json:"restoreSize"`
-}
-
-type VolumeSnapshotClass struct {
-	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Snapshotter       string `json:"snapshotter"`
-	DeletionPolicy    string `json:"deletionPolicy"`
-}
-
 type SnapshotAlpha struct {
-	dynCli  dynamic.Interface
 	kubeCli kubernetes.Interface
-}
-
-func NewSnapshotAlpha(dynCli dynamic.Interface, kubeCli kubernetes.Interface) Snapshotter {
-	return &SnapshotAlpha{
-		dynCli:  dynCli,
-		kubeCli: kubeCli,
-	}
+	dynCli  dynamic.Interface
 }
 
 // Create creates a VolumeSnapshot and returns it or any error happened meanwhile.
@@ -126,14 +92,14 @@ func (sna *SnapshotAlpha) Create(ctx context.Context, name, namespace, volumeNam
 }
 
 // Get will return the VolumeSnapshot in the namespace 'namespace' with given 'name'.
-func (sna *SnapshotAlpha) Get(ctx context.Context, name, namespace string) (*VolumeSnapshot, error) {
+func (sna *SnapshotAlpha) Get(ctx context.Context, name, namespace string) (*v1alpha1.VolumeSnapshot, error) {
 	us, err := sna.dynCli.Resource(VolSnapGVR).Namespace(namespace).Get(name, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
 
-	vs := &VolumeSnapshot{}
-	err = transformUnstructured(us, vs)
+	vs := &v1alpha1.VolumeSnapshot{}
+	err = TransformUnstructured(us, vs)
 	return vs, err
 }
 
@@ -189,7 +155,7 @@ func (sna *SnapshotAlpha) GetSource(ctx context.Context, snapshotName, namespace
 	src := &Source{
 		Handle:                  cont.Spec.CSI.SnapshotHandle,
 		Driver:                  cont.Spec.CSI.Driver,
-		RestoreSize:             &cont.Spec.CSI.RestoreSize,
+		RestoreSize:             cont.Spec.CSI.RestoreSize,
 		VolumeSnapshotClassName: cont.Spec.VolumeSnapshotClassName,
 	}
 	return src, nil
@@ -205,20 +171,18 @@ func (sna *SnapshotAlpha) CreateFromSource(ctx context.Context, source *Source, 
 
 	content := &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": fmt.Sprintf("%s/%s", snapshotGroup, snapshotVersionAlpha),
-			"kind":       volSnapContentKind,
+			"apiVersion": fmt.Sprintf("%s/%s", Group, VersionAlpha),
+			"kind":       VolSnapContentKind,
 			"metadata": map[string]interface{}{
 				"name": contentName,
 			},
 			"spec": map[string]interface{}{
-				"volumeSnapshotSource": map[string]interface{}{
-					"csiVolumeSnapshotSource": map[string]interface{}{
-						"driver":         source.Driver,
-						"snapshotHandle": source.Handle,
-					},
+				"csiVolumeSnapshotSource": map[string]interface{}{
+					"driver":         source.Driver,
+					"snapshotHandle": source.Handle,
 				},
 				"volumeSnapshotRef": map[string]interface{}{
-					"kind":      volSnapKind,
+					"kind":      VolSnapKind,
 					"name":      snapshotName,
 					"namespace": snapshotName,
 				},
@@ -230,24 +194,22 @@ func (sna *SnapshotAlpha) CreateFromSource(ctx context.Context, source *Source, 
 
 	snap := &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": fmt.Sprintf("%s/%s", snapshotGroup, snapshotVersionAlpha),
-			"kind":       volSnapKind,
+			"apiVersion": fmt.Sprintf("%s/%s", Group, VersionAlpha),
+			"kind":       VolSnapKind,
 			"metadata": map[string]interface{}{
 				"name": snapshotName,
 			},
 			"spec": map[string]interface{}{
-				"snapshotContentName": content.GetName(),
+				"snapshotContentName": contentName,
 				"snapshotClassName":   source.VolumeSnapshotClassName,
 			},
 		},
 	}
 
-	//content, err = snapCli.VolumesnapshotV1alpha1().VolumeSnapshotContents().Create(content)
 	_, err = sna.dynCli.Resource(VolSnapContentGVR).Namespace("").Create(content, metav1.CreateOptions{})
 	if err != nil {
 		return errors.Errorf("Failed to create content, VolumesnapshotContent: %s, Error: %v", content.GetName(), err)
 	}
-	//snap, err = snapCli.VolumesnapshotV1alpha1().VolumeSnapshots(namespace).Create(snap)
 	_, err = sna.dynCli.Resource(VolSnapGVR).Namespace(namespace).Create(snap, metav1.CreateOptions{})
 	if err != nil {
 		return errors.Errorf("Failed to create content, Volumesnapshot: %s, Error: %v", snap.GetName(), err)
@@ -256,7 +218,8 @@ func (sna *SnapshotAlpha) CreateFromSource(ctx context.Context, source *Source, 
 		return nil
 	}
 
-	return sna.WaitOnReadyToUse(ctx, snap.GetName(), snap.GetNamespace())
+	err = sna.WaitOnReadyToUse(ctx, snapshotName, namespace)
+	return err
 }
 
 // WaitOnReadyToUse will block until the Volumesnapshot in namespace 'namespace' with name 'snapshotName'
@@ -267,12 +230,8 @@ func (sna *SnapshotAlpha) WaitOnReadyToUse(ctx context.Context, snapshotName, na
 		if err != nil {
 			return false, err
 		}
-		ss, err := json.Marshal(us.Object)
-		if err != nil {
-			return false, err
-		}
-		vs := VolumeSnapshot{}
-		err = json.Unmarshal(ss, &vs)
+		vs := v1alpha1.VolumeSnapshot{}
+		err = TransformUnstructured(us, &vs)
 		if err != nil {
 			return false, err
 		}
@@ -284,14 +243,13 @@ func (sna *SnapshotAlpha) WaitOnReadyToUse(ctx context.Context, snapshotName, na
 	})
 }
 
-func (sna *SnapshotAlpha) getContent(ctx context.Context, contentName string) (*VolumeSnapshotContent, error) {
+func (sna *SnapshotAlpha) getContent(ctx context.Context, contentName string) (*v1alpha1.VolumeSnapshotContent, error) {
 	us, err := sna.dynCli.Resource(VolSnapContentGVR).Namespace("").Get(contentName, metav1.GetOptions{})
-	ss, err := json.Marshal(us.Object)
 	if err != nil {
 		return nil, err
 	}
-	vsc := VolumeSnapshotContent{}
-	err = json.Unmarshal(ss, &vsc)
+	vsc := v1alpha1.VolumeSnapshotContent{}
+	err = TransformUnstructured(us, &vsc)
 	if err != nil {
 		return nil, err
 	}
@@ -303,12 +261,8 @@ func (sna *SnapshotAlpha) getDeletionPolicyFromClass(snapClassName string) (stri
 	if err != nil {
 		return "", errors.Wrapf(err, "Failed to find VolumeSnapshotClass: %s", snapClassName)
 	}
-	vsc := VolumeSnapshotClass{}
-	st, err := json.Marshal(us.Object)
-	if err != nil {
-		return "", err
-	}
-	err = json.Unmarshal(st, &vsc)
+	vsc := v1alpha1.VolumeSnapshotClass{}
+	err = TransformUnstructured(us, &vsc)
 	if err != nil {
 		return "", err
 	}
@@ -318,8 +272,8 @@ func (sna *SnapshotAlpha) getDeletionPolicyFromClass(snapClassName string) (stri
 func (sna *SnapshotAlpha) createVolumeSnapshot(name, namespace string, pvcObjectRef corev1.ObjectReference, snapClassName string) error {
 	snap := &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": fmt.Sprintf("%s/%s", snapshotGroup, snapshotVersionAlpha),
-			"kind":       volSnapKind,
+			"apiVersion": fmt.Sprintf("%s/%s", Group, VersionAlpha),
+			"kind":       VolSnapKind,
 			"metadata": map[string]interface{}{
 				"name":      name,
 				"namespace": namespace,
@@ -339,12 +293,13 @@ func (sna *SnapshotAlpha) createVolumeSnapshot(name, namespace string, pvcObject
 	return err
 }
 
-func transformUnstructured(u *unstructured.Unstructured, object interface{}) error {
+// TransformUnstructured maps Unstructured object to object pointed by value
+func TransformUnstructured(u *unstructured.Unstructured, value interface{}) error {
 	b, err := json.Marshal(u.Object)
 	if err != nil {
 		return errors.Errorf("Failed to Marshal unstructured object: %v", err)
 	}
-	err = json.Unmarshal(b, object)
+	err = json.Unmarshal(b, value)
 	if err != nil {
 		return errors.Errorf("Failed to Unmarshal unstructured object: %v", err)
 	}

--- a/pkg/kube/snapshot/snapshot_test.go
+++ b/pkg/kube/snapshot/snapshot_test.go
@@ -170,7 +170,7 @@ func (s *SnapshotTestSuite) TestVolumeSnapshotCloneFake(c *C) {
 
 	vsc := &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": fmt.Sprintf("%s/%s", snapshot.Group, snapshot.VersionAlpha),
+			"apiVersion": fmt.Sprintf("%s/%s", v1alpha1.GroupName, v1alpha1.Version),
 			"kind":       snapshot.VolSnapClassKind,
 			"metadata": map[string]interface{}{
 				"name": fakeClass,
@@ -182,7 +182,7 @@ func (s *SnapshotTestSuite) TestVolumeSnapshotCloneFake(c *C) {
 
 	content := &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": fmt.Sprintf("%s/%s", snapshot.Group, snapshot.VersionAlpha),
+			"apiVersion": fmt.Sprintf("%s/%s", v1alpha1.GroupName, v1alpha1.Version),
 			"kind":       snapshot.VolSnapContentKind,
 			"metadata": map[string]interface{}{
 				"name": fakeContentName,
@@ -203,7 +203,7 @@ func (s *SnapshotTestSuite) TestVolumeSnapshotCloneFake(c *C) {
 
 	snap := &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": fmt.Sprintf("%s/%s", snapshot.Group, snapshot.VersionAlpha),
+			"apiVersion": fmt.Sprintf("%s/%s", v1alpha1.GroupName, v1alpha1.Version),
 			"kind":       snapshot.VolSnapKind,
 			"metadata": map[string]interface{}{
 				"name":      fakeSnapshotName,
@@ -424,7 +424,7 @@ func (s *SnapshotTestSuite) TestGetVolumeSnapshotClassFake(c *C) {
 	} {
 		vsc := &unstructured.Unstructured{
 			Object: map[string]interface{}{
-				"apiVersion": fmt.Sprintf("%s/%s", snapshot.Group, snapshot.VersionAlpha),
+				"apiVersion": fmt.Sprintf("%s/%s", v1alpha1.GroupName, v1alpha1.Version),
 				"kind":       snapshot.VolSnapClassKind,
 				"metadata": map[string]interface{}{
 					"name": tc.name,

--- a/pkg/kube/snapshot/snapshot_test.go
+++ b/pkg/kube/snapshot/snapshot_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package snapshot
+package snapshot_test
 
 import (
 	"context"
@@ -35,6 +35,10 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/kanisterio/kanister/pkg/kube"
+	"github.com/kanisterio/kanister/pkg/kube/snapshot"
+	"github.com/kanisterio/kanister/pkg/kube/snapshot/apis/v1alpha1"
+	"github.com/kanisterio/kanister/pkg/kube/volume"
+	"github.com/kanisterio/kanister/pkg/poll"
 )
 
 func Test(t *testing.T) { TestingT(t) }
@@ -42,7 +46,7 @@ func Test(t *testing.T) { TestingT(t) }
 type SnapshotTestSuite struct {
 	sourceNamespace string
 	targetNamespace string
-	snap            Snapshotter
+	snapshotter     snapshot.Snapshotter
 	cli             kubernetes.Interface
 	dynCli          dynamic.Interface
 	snapshotClass   *string
@@ -76,22 +80,22 @@ func (s *SnapshotTestSuite) SetUpSuite(c *C) {
 	c.Assert(err, IsNil)
 	s.dynCli = dynCli
 
-	s.snap = NewSnapshotAlpha(dynCli, cli)
+	s.snapshotter = snapshot.NewSnapshotter(cli, dynCli)
 
-	us, err := dynCli.Resource(VolSnapClassGVR).Namespace("").List(metav1.ListOptions{})
+	us, err := dynCli.Resource(snapshot.VolSnapClassGVR).Namespace("").List(metav1.ListOptions{})
 	if err != nil && !k8errors.IsNotFound(err) {
 		c.Logf("Failed to query VolumeSnapshotClass, skipping test. Error: %v", err)
 		c.Fail()
 	}
 	var snapshotterName string
-	if len(us.Items) != 0 {
-		usClass, err := dynCli.Resource(VolSnapClassGVR).Namespace("").Get(us.Items[0].GetName(), metav1.GetOptions{})
+	if (us != nil) && len(us.Items) != 0 {
+		usClass, err := dynCli.Resource(snapshot.VolSnapClassGVR).Namespace("").Get(us.Items[0].GetName(), metav1.GetOptions{})
 		if err != nil {
 			c.Logf("Failed to get VolumeSnapshotClass, skipping test. Error: %v", err)
 			c.Fail()
 		}
-		vsc := VolumeSnapshotClass{}
-		err = transformUnstructured(usClass, &vsc)
+		vsc := v1alpha1.VolumeSnapshotClass{}
+		err = snapshot.TransformUnstructured(usClass, &vsc)
 		if err != nil {
 			c.Logf("Failed to query VolumeSnapshotClass, skipping test. Error: %v", err)
 			c.Fail()
@@ -127,7 +131,7 @@ func (s *SnapshotTestSuite) TestVolumeSnapshotFake(c *C) {
 	volName := "pvc-1-fake"
 	scheme := runtime.NewScheme()
 	fakeCli := fake.NewSimpleClientset()
-	fakeSs := NewSnapshotAlpha(snapshotfake.NewSimpleDynamicClient(scheme), fakeCli)
+	fakeSs := snapshot.NewSnapshotter(fakeCli, snapshotfake.NewSimpleDynamicClient(scheme))
 
 	size, err := resource.ParseQuantity("1Gi")
 	c.Assert(err, IsNil)
@@ -166,8 +170,8 @@ func (s *SnapshotTestSuite) TestVolumeSnapshotCloneFake(c *C) {
 
 	vsc := &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": fmt.Sprintf("%s/%s", snapshotGroup, snapshotVersionAlpha),
-			"kind":       volSnapClassKind,
+			"apiVersion": fmt.Sprintf("%s/%s", snapshot.Group, snapshot.VersionAlpha),
+			"kind":       snapshot.VolSnapClassKind,
 			"metadata": map[string]interface{}{
 				"name": fakeClass,
 			},
@@ -178,17 +182,15 @@ func (s *SnapshotTestSuite) TestVolumeSnapshotCloneFake(c *C) {
 
 	content := &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": fmt.Sprintf("%s/%s", snapshotGroup, snapshotVersionAlpha),
-			"kind":       volSnapContentKind,
+			"apiVersion": fmt.Sprintf("%s/%s", snapshot.Group, snapshot.VersionAlpha),
+			"kind":       snapshot.VolSnapContentKind,
 			"metadata": map[string]interface{}{
 				"name": fakeContentName,
 			},
 			"spec": map[string]interface{}{
-				"volumeSnapshotSource": map[string]interface{}{
-					"csiVolumeSnapshotSource": map[string]interface{}{
-						"driver":         fakeDriver,
-						"snapshotHandle": fakeSnapshotHandle,
-					},
+				"csiVolumeSnapshotSource": map[string]interface{}{
+					"driver":         fakeDriver,
+					"snapshotHandle": fakeSnapshotHandle,
 				},
 				"snapshotClassName": fakeClass,
 				"volumeSnapshotRef": map[string]interface{}{
@@ -201,8 +203,8 @@ func (s *SnapshotTestSuite) TestVolumeSnapshotCloneFake(c *C) {
 
 	snap := &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": fmt.Sprintf("%s/%s", snapshotGroup, snapshotVersionAlpha),
-			"kind":       volSnapKind,
+			"apiVersion": fmt.Sprintf("%s/%s", snapshot.Group, snapshot.VersionAlpha),
+			"kind":       snapshot.VolSnapKind,
 			"metadata": map[string]interface{}{
 				"name":      fakeSnapshotName,
 				"namespace": defaultNamespace,
@@ -223,14 +225,14 @@ func (s *SnapshotTestSuite) TestVolumeSnapshotCloneFake(c *C) {
 	fakeTargetNamespace := "new-ns"
 	fakeClone := "clone-1"
 
-	_, err := dynCli.Resource(VolSnapClassGVR).Namespace("").Create(vsc, metav1.CreateOptions{})
+	_, err := dynCli.Resource(snapshot.VolSnapClassGVR).Namespace("").Create(vsc, metav1.CreateOptions{})
 	c.Assert(err, IsNil)
-	_, err = dynCli.Resource(VolSnapGVR).Namespace(defaultNamespace).Create(snap, metav1.CreateOptions{})
+	_, err = dynCli.Resource(snapshot.VolSnapGVR).Namespace(defaultNamespace).Create(snap, metav1.CreateOptions{})
 	c.Assert(err, IsNil)
-	_, err = dynCli.Resource(VolSnapContentGVR).Namespace("").Create(content, metav1.CreateOptions{})
+	_, err = dynCli.Resource(snapshot.VolSnapContentGVR).Namespace("").Create(content, metav1.CreateOptions{})
 	c.Assert(err, IsNil)
 
-	fakeSs := NewSnapshotAlpha(dynCli, nil)
+	fakeSs := snapshot.NewSnapshotter(nil, dynCli)
 	_, err = fakeSs.Get(context.Background(), fakeSnapshotName, defaultNamespace)
 	c.Assert(err, IsNil)
 
@@ -240,101 +242,101 @@ func (s *SnapshotTestSuite) TestVolumeSnapshotCloneFake(c *C) {
 	clone, err := fakeSs.Get(context.Background(), fakeClone, fakeTargetNamespace)
 	c.Assert(err, IsNil)
 
-	us, err := dynCli.Resource(VolSnapContentGVR).Namespace("").Get(clone.Spec.SnapshotContentName, metav1.GetOptions{})
+	us, err := dynCli.Resource(snapshot.VolSnapContentGVR).Namespace("").Get(clone.Spec.SnapshotContentName, metav1.GetOptions{})
 	c.Assert(err, IsNil)
-	cloneContent := VolumeSnapshotContent{}
-	err = transformUnstructured(us, &cloneContent)
+	cloneContent := v1alpha1.VolumeSnapshotContent{}
+	err = snapshot.TransformUnstructured(us, &cloneContent)
 	c.Assert(err, IsNil)
 	c.Assert(strings.HasPrefix(cloneContent.Name, fakeClone), Equals, true)
 	c.Assert(cloneContent.Spec.DeletionPolicy, Equals, vsc.Object["deletionPolicy"])
 }
 
-//func (s *SnapshotTestSuite) TestVolumeSnapshot(c *C) {
-//	if s.snapshotClass == nil {
-//		c.Skip("No Volumesnapshotclass in the cluster, create a volumesnapshotclass in the cluster")
-//	}
-//	if s.storageClassCSI == nil {
-//		c.Skip("No Storageclass with CSI provisioner, install CSI and create a storageclass for it")
-//	}
-//	c.Logf("VolumeSnapshot test - source namespace: %s - target namespace: %s", s.sourceNamespace, s.targetNamespace)
-//	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
-//	defer cancel()
-//
-//	size, err := resource.ParseQuantity("1Gi")
-//	c.Assert(err, IsNil)
-//
-//	pvc := &corev1.PersistentVolumeClaim{
-//		ObjectMeta: metav1.ObjectMeta{
-//			GenerateName: volNamePrefix,
-//			Namespace:    s.sourceNamespace,
-//		},
-//		Spec: corev1.PersistentVolumeClaimSpec{
-//			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
-//			Resources: corev1.ResourceRequirements{
-//				Requests: corev1.ResourceList{
-//					corev1.ResourceName(corev1.ResourceStorage): size,
-//				},
-//			},
-//			StorageClassName: s.storageClassCSI,
-//		},
-//	}
-//	pvc, err = s.cli.CoreV1().PersistentVolumeClaims(s.sourceNamespace).Create(pvc)
-//	c.Assert(err, IsNil)
-//	_ = poll.Wait(ctx, func(ctx context.Context) (bool, error) {
-//		pvc, err = s.cli.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(pvc.Name, metav1.GetOptions{})
-//		if err != nil {
-//			return false, err
-//		}
-//		return pvc.Status.Phase == corev1.ClaimBound, nil
-//	})
-//
-//	snapshotName := snapshotNamePrefix + strconv.Itoa(int(time.Now().UnixNano()))
-//	wait := true
-//	err = Create(ctx, s.cli, s.dynCli, snapshotName, s.sourceNamespace, pvc.Name, s.snapshotClass, wait)
-//	c.Assert(err, IsNil)
-//
-//	snap, err := Get(ctx, s.dynCli, snapshotName, s.sourceNamespace)
-//	c.Assert(err, IsNil)
-//	c.Assert(snap.Name, Equals, snapshotName)
-//	c.Assert(snap.Status.ReadyToUse, Equals, true)
-//
-//	err = Create(ctx, s.cli, s.dynCli, snapshotName, s.sourceNamespace, pvc.Name, s.snapshotClass, wait)
-//	c.Assert(err, NotNil)
-//
-//	snapshotCloneName := snapshotName + "-clone"
-//	volumeCloneName := pvc.Name + "-clone"
-//	err = Clone(ctx, s.dynCli, snapshotName, s.sourceNamespace, snapshotCloneName, s.targetNamespace, wait)
-//	c.Assert(err, IsNil)
-//
-//	_, err = volume.CreatePVCFromSnapshot(ctx, s.cli, s.dynCli, s.targetNamespace, volumeCloneName, "", snapshotCloneName, nil)
-//	c.Assert(err, IsNil)
-//	_ = poll.Wait(ctx, func(ctx context.Context) (bool, error) {
-//		pvc, err = s.cli.CoreV1().PersistentVolumeClaims(s.targetNamespace).Get(volumeCloneName, metav1.GetOptions{})
-//		if err != nil {
-//			return false, err
-//		}
-//		return pvc.Status.Phase == corev1.ClaimBound, nil
-//	})
-//
-//	// Try with a greater restore size.
-//	sizeNew := 2
-//	volumeCloneName += "-2"
-//	_, err = volume.CreatePVCFromSnapshot(ctx, s.cli, s.dynCli, s.targetNamespace, volumeCloneName, "", snapshotCloneName, &sizeNew)
-//	c.Assert(err, IsNil)
-//	_ = poll.Wait(ctx, func(ctx context.Context) (bool, error) {
-//		pvc, err = s.cli.CoreV1().PersistentVolumeClaims(s.targetNamespace).Get(volumeCloneName, metav1.GetOptions{})
-//		if err != nil {
-//			return false, err
-//		}
-//		return pvc.Status.Phase == corev1.ClaimBound, nil
-//	})
-//
-//	err = Delete(ctx, s.dynCli, snap.Name, snap.Namespace)
-//	c.Assert(err, IsNil)
-//
-//	err = Delete(ctx, s.dynCli, snap.Name, snap.Namespace)
-//	c.Assert(err, NotNil)
-//}
+func (s *SnapshotTestSuite) TestVolumeSnapshot(c *C) {
+	if s.snapshotClass == nil {
+		c.Skip("No Volumesnapshotclass in the cluster, create a volumesnapshotclass in the cluster")
+	}
+	if s.storageClassCSI == nil {
+		c.Skip("No Storageclass with CSI provisioner, install CSI and create a storageclass for it")
+	}
+	c.Logf("VolumeSnapshot test - source namespace: %s - target namespace: %s", s.sourceNamespace, s.targetNamespace)
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	defer cancel()
+
+	size, err := resource.ParseQuantity("1Gi")
+	c.Assert(err, IsNil)
+
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: volNamePrefix,
+			Namespace:    s.sourceNamespace,
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceName(corev1.ResourceStorage): size,
+				},
+			},
+			StorageClassName: s.storageClassCSI,
+		},
+	}
+	pvc, err = s.cli.CoreV1().PersistentVolumeClaims(s.sourceNamespace).Create(pvc)
+	c.Assert(err, IsNil)
+	_ = poll.Wait(ctx, func(ctx context.Context) (bool, error) {
+		pvc, err = s.cli.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(pvc.Name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		return pvc.Status.Phase == corev1.ClaimBound, nil
+	})
+
+	snapshotName := snapshotNamePrefix + strconv.Itoa(int(time.Now().UnixNano()))
+	wait := true
+	err = s.snapshotter.Create(ctx, snapshotName, s.sourceNamespace, pvc.Name, s.snapshotClass, wait)
+	c.Assert(err, IsNil)
+
+	snap, err := s.snapshotter.Get(ctx, snapshotName, s.sourceNamespace)
+	c.Assert(err, IsNil)
+	c.Assert(snap.Name, Equals, snapshotName)
+	c.Assert(snap.Status.ReadyToUse, Equals, true)
+
+	err = s.snapshotter.Create(ctx, snapshotName, s.sourceNamespace, pvc.Name, s.snapshotClass, wait)
+	c.Assert(err, NotNil)
+
+	snapshotCloneName := snapshotName + "-clone"
+	volumeCloneName := pvc.Name + "-clone"
+	err = s.snapshotter.Clone(ctx, snapshotName, s.sourceNamespace, snapshotCloneName, s.targetNamespace, wait)
+	c.Assert(err, IsNil)
+
+	_, err = volume.CreatePVCFromSnapshot(ctx, s.cli, s.dynCli, s.targetNamespace, volumeCloneName, "", snapshotCloneName, nil)
+	c.Assert(err, IsNil)
+	_ = poll.Wait(ctx, func(ctx context.Context) (bool, error) {
+		pvc, err = s.cli.CoreV1().PersistentVolumeClaims(s.targetNamespace).Get(volumeCloneName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		return pvc.Status.Phase == corev1.ClaimBound, nil
+	})
+
+	// Try with a greater restore size.
+	sizeNew := 2
+	volumeCloneName += "-2"
+	_, err = volume.CreatePVCFromSnapshot(ctx, s.cli, s.dynCli, s.targetNamespace, volumeCloneName, "", snapshotCloneName, &sizeNew)
+	c.Assert(err, IsNil)
+	_ = poll.Wait(ctx, func(ctx context.Context) (bool, error) {
+		pvc, err = s.cli.CoreV1().PersistentVolumeClaims(s.targetNamespace).Get(volumeCloneName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		return pvc.Status.Phase == corev1.ClaimBound, nil
+	})
+
+	err = s.snapshotter.Delete(ctx, snap.Name, snap.Namespace)
+	c.Assert(err, IsNil)
+
+	err = s.snapshotter.Delete(ctx, snap.Name, snap.Namespace)
+	c.Assert(err, IsNil)
+}
 
 func (s *SnapshotTestSuite) cleanupNamespace(c *C, ns string) {
 	pvcs, erra := s.cli.CoreV1().PersistentVolumeClaims(ns).List(metav1.ListOptions{})
@@ -349,13 +351,12 @@ func (s *SnapshotTestSuite) cleanupNamespace(c *C, ns string) {
 		}
 	}
 
-	vss, errb := s.dynCli.Resource(VolSnapGVR).Namespace(ns).List(metav1.ListOptions{})
+	vss, errb := s.dynCli.Resource(snapshot.VolSnapGVR).Namespace(ns).List(metav1.ListOptions{})
 	if errb != nil {
 		c.Logf("Failed to list snapshots, Namespace: %s, Error: %v", ns, errb)
 	} else {
 		for _, vs := range vss.Items {
-			if err := s.dynCli.Resource(VolSnapGVR).Namespace(ns).Delete(vs.GetName(), &metav1.DeleteOptions{}); err != nil {
-
+			if err := s.dynCli.Resource(snapshot.VolSnapGVR).Namespace(ns).Delete(vs.GetName(), &metav1.DeleteOptions{}); err != nil {
 				errb = err
 				c.Logf("Failed to delete snapshot, Volumesnapshot: %s, Namespace %s, Error: %v", vs.GetName(), vs.GetNamespace(), err)
 			}

--- a/pkg/kube/snapshot/snapshot_test.go
+++ b/pkg/kube/snapshot/snapshot_test.go
@@ -438,6 +438,7 @@ func (s *SnapshotTestSuite) TestGetVolumeSnapshotClassFake(c *C) {
 		}
 
 		_, err := dynCli.Resource(snapshot.VolSnapClassGVR).Namespace("").Create(vsc, metav1.CreateOptions{})
+		c.Assert(err, IsNil)
 		name, err := fakeSs.GetVolumeSnapshotClass(tc.testKey, tc.testValue)
 		c.Assert(err, tc.check)
 		if err == nil {

--- a/pkg/kube/volume/volume.go
+++ b/pkg/kube/volume/volume.go
@@ -22,16 +22,17 @@ import (
 	"strings"
 	"time"
 
-	snapshotclient "github.com/kubernetes-csi/external-snapshotter/pkg/client/clientset/versioned"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/kanisterio/kanister/pkg/blockstorage"
 	"github.com/kanisterio/kanister/pkg/kube"
+	"github.com/kanisterio/kanister/pkg/kube/snapshot"
 	"github.com/kanisterio/kanister/pkg/poll"
 )
 
@@ -99,8 +100,9 @@ func CreatePVC(ctx context.Context, kubeCli kubernetes.Interface, ns string, nam
 // 'snapshotName' is the name of the VolumeSnapshot that will be used for restoring.
 // 'namespace' is the namespace of the VolumeSnapshot. The PVC will be restored to the same namepsace.
 // 'restoreSize' will override existing restore size from snapshot content if provided.
-func CreatePVCFromSnapshot(ctx context.Context, kubeCli kubernetes.Interface, snapCli snapshotclient.Interface, namespace, volumeName, storageClassName, snapshotName string, restoreSize *int) (string, error) {
-	snap, err := snapCli.VolumesnapshotV1alpha1().VolumeSnapshots(namespace).Get(snapshotName, metav1.GetOptions{})
+func CreatePVCFromSnapshot(ctx context.Context, kubeCli kubernetes.Interface, dynCli dynamic.Interface, namespace, volumeName, storageClassName, snapshotName string, restoreSize *int) (string, error) {
+	sns := snapshot.NewSnapshotter(kubeCli, dynCli)
+	snap, err := sns.Get(ctx, snapshotName, namespace)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## Change Overview

Use dynamic client to create volume snapshots
Remove external-snapshotter dep from snapshot pkg
New interface Snapshotter to perform snapshot operations
Remove external-snapshotter dep from kube/volume package

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
