### PR TITLE
Call Ping once again before resetting the MySQL database 

### DIFF
--- a/pkg/app/mysql.go
+++ b/pkg/app/mysql.go
@@ -25,6 +25,7 @@ import (
 	"github.com/kanisterio/kanister/pkg/helm"
 	"github.com/kanisterio/kanister/pkg/kube"
 	"github.com/kanisterio/kanister/pkg/log"
+	"github.com/kanisterio/kanister/pkg/poll"
 	"github.com/pkg/errors"
 	"k8s.io/client-go/kubernetes"
 )
@@ -174,6 +175,18 @@ func (mdb *MysqlDB) Count(ctx context.Context) (int, error) {
 }
 
 func (mdb *MysqlDB) Reset(ctx context.Context) error {
+
+	timeoutCtx, waitCancel := context.WithTimeout(ctx, mysqlWaitTimeout)
+	defer waitCancel()
+	err := poll.Wait(timeoutCtx, func(ctx context.Context) (bool, error) {
+		err := mdb.Ping(ctx)
+		return err == nil, nil
+	})
+
+	if err != nil {
+		return errors.Wrapf(err, "Error waiting for application %s to be ready to reset it", mdb.name)
+	}
+
 	log.Print("Resetting the mysql instance.", field.M{"app": "mysql"})
 
 	// delete all the data from the table

--- a/pkg/app/mysql.go
+++ b/pkg/app/mysql.go
@@ -175,7 +175,6 @@ func (mdb *MysqlDB) Count(ctx context.Context) (int, error) {
 }
 
 func (mdb *MysqlDB) Reset(ctx context.Context) error {
-
 	timeoutCtx, waitCancel := context.WithTimeout(ctx, mysqlWaitTimeout)
 	defer waitCancel()
 	err := poll.Wait(timeoutCtx, func(ctx context.Context) (bool, error) {


### PR DESCRIPTION
## Change Overview
The e2e test in k10 fails while resetting the MySQL database stating that 
```
 Can't connect to local MySQL server through socket '/var/run/mysqld/mysqld.sock' (2)
```
I am not able to replicate that locally.
As part of this PR I am before resetting the database I am checking if the database is pingable.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
