### PR TITLE
Changes to support azure types

### DIFF
--- a/pkg/blockstorage/azure/azuredisk.go
+++ b/pkg/blockstorage/azure/azuredisk.go
@@ -489,8 +489,7 @@ func (s *adStorage) VolumeCreateFromSnapshot(ctx context.Context, snapshot block
 	if id != "" {
 		createDisk.Zones = azto.StringSlicePtr([]string{id})
 	}
-	saTypes := azcompute.PossibleDiskStorageAccountTypesValues()
-	for _, saType := range saTypes {
+	for _, saType := range azcompute.PossibleDiskStorageAccountTypesValues() {
 		if string(saType) == snapshot.Volume.VolumeType {
 			createDisk.Sku = &azcompute.DiskSku{
 				Name: saType,


### PR DESCRIPTION
## Change Overview

Adding changes to support azure sku types. We were parsing the volume object incorrectly, and returning the tier instead of the type.

Additionally added support to set the sku type when creating volume from snapshot

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [x] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
