### PR TITLE
Update restic and kopia binaries in es-sidecar image

### DIFF
--- a/build/integration-test.sh
+++ b/build/integration-test.sh
@@ -25,7 +25,7 @@ TEST_TIMEOUT="30m"
 # Set default options
 TEST_OPTIONS="-tags=integration -timeout ${TEST_TIMEOUT} -check.suitep ${DOP}"
 # Regex to match apps to run in short mode
-SHORT_APPS="^PostgreSQL$|^PITRPostgreSQL|MySQL|^MongoDB$"
+SHORT_APPS="^PostgreSQL$|^PITRPostgreSQL|MySQL|Elasticsearch|^MongoDB$"
 # OCAPPS has all the apps that are to be tested against openshift cluster
 OC_APPS="MysqlDBDepConfig|MongoDBDepConfig|PostgreSQLDepConfig"
 

--- a/examples/helm/kanister/kanister-elasticsearch/image/Dockerfile
+++ b/examples/helm/kanister/kanister-elasticsearch/image/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.11.3
 
-COPY --from=restic/restic:0.9.5 /usr/bin/restic /usr/local/bin/restic
-COPY --from=kanisterio/kopia:alpine-2fb6bc8 /kopia/kopia /usr/local/bin/kopia
+COPY --from=kanisterio/kanister-tools:0.29.0 /usr/local/bin/restic /usr/local/bin/restic
+COPY --from=kanisterio/kanister-tools:0.29.0 /usr/local/bin/kopia /usr/local/bin/kopia
 ADD kando /usr/local/bin/
 
 ADD examples/helm/kanister/kanister-elasticsearch/image/esdump-setup.sh /esdump-setup.sh

--- a/examples/stable/elasticsearch/elasticsearch-blueprint.yaml
+++ b/examples/stable/elasticsearch/elasticsearch-blueprint.yaml
@@ -23,14 +23,12 @@ actions:
         - pipefail
         - -c
         - |
-          echo "{{ .Object.spec.serviceName }}"
           host_name="{{ .Object.spec.serviceName }}.{{ .StatefulSet.Namespace }}.svc.cluster.local"
-          echo $host_name
           BACKUP_LOCATION=es_backups/{{ .StatefulSet.Namespace }}/{{ .StatefulSet.Name }}/{{ toDate "2006-01-02T15:04:05.999999999Z07:00" .Time | date "2006-01-02T15:04:05Z07:00" }}/backup.gz
-          echo $BACKUP_LOCATION
-          elasticdump --bulk=true --input=http://${host_name}:9200 --output=$ | gzip | kando location push --profile '{{ toJson .Profile }}' --path $BACKUP_LOCATION -
+          elasticdump --bulk=true --input=http://${host_name}:9200 --output=/backup
+          gzip /backup
+          kando location push --profile '{{ toJson .Profile }}'  /backup.gz --path $BACKUP_LOCATION
           kando output backupLocation $BACKUP_LOCATION
-          echo "exiting from backup"
   restore:
     type: StatefulSet
     inputArtifactNames:

--- a/pkg/app/elasticsearch.go
+++ b/pkg/app/elasticsearch.go
@@ -66,7 +66,7 @@ func NewElasticsearchInstance(name string) App {
 			RepoName: helm.ElasticRepoName,
 			Version:  "7.4.1",
 			Values: map[string]string{
-				"antiAffinity": "sort",
+				"antiAffinity": "soft",
 				"replicas":     "1",
 			},
 		},


### PR DESCRIPTION
## Change Overview

Install dependencies from kanister-tools image

This is what elasticdump produces 
```
{"_index":"testindex","_type":"_doc","_id":"_un5m3EBKSMLeJgq9iGz","_score":1,"_source":{"appname":"kanister"}}
{"_index":"testindex","_type":"_doc","_id":"_en5m3EBKSMLeJgq9CFq","_score":1,"_source":{"appname":"kanister"}}
{"_index":"testindex","_type":"_doc","_id":"_On5m3EBKSMLeJgq8CGQ","_score":1,"_source":{"appname":"kanister"}}
```
But while restoring the file that we get has
```
Tue, 21 Apr 2020 09:03:35 GMT | lastScrollId: DXF1ZXJ5QW5kRmV0Y2gBAAAAAAAAAAIWOTl3ek94ZE1TUWFNRUZfNktOeVVjdw==
{"_index":"testindex","_type":"_doc","_id":"_On5m3EBKSMLeJgq8CGQ","_score":1,"_source":{"appname":"kanister"}}
{"_index":"testindex","_type":"_doc","_id":"_en5m3EBKSMLeJgq9CFq","_score":1,"_source":{"appname":"kanister"}}
{"_index":"testindex","_type":"_doc","_id":"_un5m3EBKSMLeJgq9iGz","_score":1,"_source":{"appname":"kanister"}}
```
we can see that the first line is not valid json, I am looking how that first line is being added.
And it seems when we stream the output of `elasticdump` to `stdout` in that case the line is being added, but we just stream that to a file and then upload that to s3 things work.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [x] :robot: Test

## Issues

- #XXX

## Test Plan
```
make integration-test 
```
the log can be found [here](https://gist.github.com/viveksinghggits/7245ef3171053036b65b1239eb886104)

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [x] :green_heart: E2E
