### PR TITLE
Add region to Get/DeleteBucket

### DIFF
--- a/pkg/location/location.go
+++ b/pkg/location/location.go
@@ -138,7 +138,8 @@ func getBucket(ctx context.Context, pType objectstore.ProviderType, profile para
 	if err != nil {
 		return nil, err
 	}
-	return provider.GetBucket(ctx, profile.Location.Bucket)
+
+	return provider.GetBucket(ctx, profile.Location.Bucket, profile.Location.Region)
 }
 
 func getOSSecret(ctx context.Context, pType objectstore.ProviderType, cred param.Credential) (*objectstore.Secret, error) {

--- a/pkg/objectstore/bucket_test.go
+++ b/pkg/objectstore/bucket_test.go
@@ -50,5 +50,4 @@ func (s *BucketSuite) TestRegionEndpointMismatch(c *C) {
 	err = p.DeleteBucket(ctx, bn, r)
 	c.Assert(err, ErrorMatches, ahmRe)
 	c.Assert(err, NotNil)
-
 }

--- a/pkg/objectstore/bucket_test.go
+++ b/pkg/objectstore/bucket_test.go
@@ -1,0 +1,54 @@
+package objectstore
+
+import (
+	"context"
+
+	. "gopkg.in/check.v1"
+)
+
+type BucketSuite struct{}
+
+var _ = Suite(&BucketSuite{})
+
+func (s *BucketSuite) SetUpSuite(c *C) {
+	getEnvOrSkip(c, "AWS_ACCESS_KEY_ID")
+	getEnvOrSkip(c, "AWS_SECRET_ACCESS_KEY")
+}
+
+func (s *BucketSuite) TestRegionEndpointMismatch(c *C) {
+	ctx := context.Background()
+	const pt = ProviderTypeS3
+	const bn = `kanister-fake-bucket`
+	const r = `us-east-1`
+	const endpoint = `https://s3.us-gov-west-1.amazonaws.com`
+
+	secret := getSecret(ctx, c, pt)
+	p, err := NewProvider(
+		ctx,
+		ProviderConfig{
+			Type:     pt,
+			Endpoint: endpoint,
+		},
+		secret,
+	)
+	c.Assert(err, IsNil)
+
+	const ahmRe = `[\w\W]*AuthorizationHeaderMalformed[\w\W]*`
+
+	_, err = p.GetBucket(ctx, bn, r)
+	c.Assert(err, ErrorMatches, ahmRe)
+	c.Assert(err, NotNil)
+
+	_, err = p.CreateBucket(ctx, bn, r)
+	c.Assert(err, ErrorMatches, ahmRe)
+	c.Assert(err, NotNil)
+
+	err = p.DeleteBucket(ctx, bn, r)
+	c.Assert(err, ErrorMatches, ahmRe)
+	c.Assert(err, NotNil)
+
+	err = p.DeleteBucket(ctx, bn, r)
+	c.Assert(err, ErrorMatches, ahmRe)
+	c.Assert(err, NotNil)
+
+}

--- a/pkg/objectstore/objectstore.go
+++ b/pkg/objectstore/objectstore.go
@@ -36,10 +36,10 @@ type Provider interface {
 	CreateBucket(ctx context.Context, bucketName, region string) (Bucket, error)
 
 	// GetBucket access a specific bucket
-	GetBucket(context.Context, string) (Bucket, error)
+	GetBucket(context.Context, string, string) (Bucket, error)
 
 	// DeleteBucket deletes the bucket
-	DeleteBucket(context.Context, string) error
+	DeleteBucket(context.Context, string, string) error
 
 	// ListBuckets returns all buckets and their Directory handle
 	ListBuckets(context.Context) (map[string]Bucket, error)

--- a/pkg/objectstore/objectstore_test.go
+++ b/pkg/objectstore/objectstore_test.go
@@ -117,7 +117,7 @@ func (s *ObjectStoreProviderSuite) TestBuckets(c *C) {
 	buckets, _ := s.provider.ListBuckets(ctx)
 	c.Check(len(buckets), Not(Equals), len(origBuckets))
 
-	bucket, err := s.provider.GetBucket(ctx, bucketName)
+	bucket, err := s.provider.GetBucket(ctx, bucketName, s.region)
 	c.Assert(err, IsNil)
 	c.Logf("Created bucket: %s", bucket)
 	c.Check(len(buckets), Not(Equals), len(origBuckets))
@@ -130,7 +130,7 @@ func (s *ObjectStoreProviderSuite) TestBuckets(c *C) {
 func (s *ObjectStoreProviderSuite) TestCreateExistingBucket(c *C) {
 	ctx := context.Background()
 	// The bucket should already exist, the suite setup creates it
-	d, err := s.provider.GetBucket(ctx, testBucketName)
+	d, err := s.provider.GetBucket(ctx, testBucketName, s.region)
 	c.Check(err, IsNil)
 	c.Check(d, NotNil)
 	d, err = s.provider.CreateBucket(ctx, testBucketName, s.region)
@@ -144,7 +144,7 @@ func (s *ObjectStoreProviderSuite) TestGetNonExistingBucket(c *C) {
 	}
 	ctx := context.Background()
 	bucketName := s.createBucketName(c)
-	bucket, err := s.provider.GetBucket(ctx, bucketName)
+	bucket, err := s.provider.GetBucket(ctx, bucketName, s.region)
 	c.Check(err, NotNil)
 	c.Assert(IsBucketNotFoundError(err), Equals, true)
 	c.Check(bucket, IsNil)

--- a/pkg/objectstore/objectstore_test.go
+++ b/pkg/objectstore/objectstore_test.go
@@ -123,7 +123,7 @@ func (s *ObjectStoreProviderSuite) TestBuckets(c *C) {
 	c.Check(len(buckets), Not(Equals), len(origBuckets))
 
 	// Check if deletion succeeds
-	err = s.provider.DeleteBucket(ctx, bucketName)
+	err = s.provider.DeleteBucket(ctx, bucketName, s.region)
 	c.Check(err, IsNil)
 }
 

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -209,7 +209,7 @@ func ProfileBucket(ctx context.Context, p *crv1alpha1.Profile, cli kubernetes.In
 	if err != nil {
 		return err
 	}
-	_, err = provider.GetBucket(ctx, bucketName)
+	_, err = provider.GetBucket(ctx, bucketName, p.Location.Region)
 	if err != nil {
 		return err
 	}
@@ -243,7 +243,7 @@ func ReadAccess(ctx context.Context, p *crv1alpha1.Profile, cli kubernetes.Inter
 	if err != nil {
 		return err
 	}
-	bucket, err := provider.GetBucket(ctx, p.Location.Bucket)
+	bucket, err := provider.GetBucket(ctx, p.Location.Bucket, p.Location.Region)
 	if err != nil {
 		return err
 	}
@@ -282,7 +282,7 @@ func WriteAccess(ctx context.Context, p *crv1alpha1.Profile, cli kubernetes.Inte
 	if err != nil {
 		return err
 	}
-	bucket, err := provider.GetBucket(ctx, p.Location.Bucket)
+	bucket, err := provider.GetBucket(ctx, p.Location.Bucket, p.Location.Region)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Change Overview

We cannot discover the region for buckets in AWS S3 that use non-standard regions like `us-gov-west-1`. This PR adds region to Get/Delete

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [x] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Test Plan

Ran a manual test with a bucket in `us-gov-west-1`:

https://gist.github.com/844c65e12f4ee9484522292f51c53807

- [x] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
