### PR TITLE
Specify ObjectStore region via ProviderConfig

### DIFF
--- a/pkg/location/location.go
+++ b/pkg/location/location.go
@@ -128,6 +128,7 @@ func getBucket(ctx context.Context, pType objectstore.ProviderType, profile para
 	pc := objectstore.ProviderConfig{
 		Type:          pType,
 		Endpoint:      profile.Location.Endpoint,
+		Region:        profile.Location.Region,
 		SkipSSLVerify: profile.SkipSSLVerify,
 	}
 	secret, err := getOSSecret(ctx, pType, profile.Credential)

--- a/pkg/location/location_test.go
+++ b/pkg/location/location_test.go
@@ -83,14 +83,17 @@ func (s *LocationSuite) SetUpSuite(c *C) {
 	ctx := context.Background()
 
 	s.rand = rand.New(rand.NewSource(time.Now().UnixNano()))
-	pc := objectstore.ProviderConfig{Type: s.osType}
+	pc := objectstore.ProviderConfig{
+		Type:   s.osType,
+		Region: s.region,
+	}
 	secret, err := getOSSecret(ctx, s.osType, s.profile.Credential)
 	c.Check(err, IsNil)
 	s.provider, err = objectstore.NewProvider(ctx, pc, secret)
 	c.Check(err, IsNil)
 	c.Assert(s.provider, NotNil)
 
-	s.root, err = objectstore.GetOrCreateBucket(ctx, s.provider, testBucketName, s.region)
+	s.root, err = objectstore.GetOrCreateBucket(ctx, s.provider, testBucketName)
 	c.Check(err, IsNil)
 	c.Assert(s.root, NotNil)
 	s.suiteDirPrefix = time.Now().UTC().Format(time.RFC3339Nano)

--- a/pkg/objectstore/bucket_test.go
+++ b/pkg/objectstore/bucket_test.go
@@ -1,0 +1,54 @@
+package objectstore
+
+import (
+	"context"
+
+	. "gopkg.in/check.v1"
+)
+
+type BucketSuite struct{}
+
+var _ = Suite(&BucketSuite{})
+
+func (s *BucketSuite) SetUpSuite(c *C) {
+	getEnvOrSkip(c, "AWS_ACCESS_KEY_ID")
+	getEnvOrSkip(c, "AWS_SECRET_ACCESS_KEY")
+}
+
+func (s *BucketSuite) TestRegionEndpointMismatch(c *C) {
+	ctx := context.Background()
+	const pt = ProviderTypeS3
+	const bn = `kanister-fake-bucket`
+	const r = `us-east-1`
+	const endpoint = `https://s3.us-gov-west-1.amazonaws.com`
+
+	secret := getSecret(ctx, c, pt)
+	p, err := NewProvider(
+		ctx,
+		ProviderConfig{
+			Type:     pt,
+			Endpoint: endpoint,
+			Region:   r,
+		},
+		secret,
+	)
+	c.Assert(err, IsNil)
+
+	const ahmRe = `[\w\W]*AuthorizationHeaderMalformed[\w\W]*`
+
+	_, err = p.GetBucket(ctx, bn)
+	c.Assert(err, ErrorMatches, ahmRe)
+	c.Assert(err, NotNil)
+
+	_, err = p.CreateBucket(ctx, bn)
+	c.Assert(err, ErrorMatches, ahmRe)
+	c.Assert(err, NotNil)
+
+	err = p.DeleteBucket(ctx, bn)
+	c.Assert(err, ErrorMatches, ahmRe)
+	c.Assert(err, NotNil)
+
+	err = p.DeleteBucket(ctx, bn)
+	c.Assert(err, ErrorMatches, ahmRe)
+	c.Assert(err, NotNil)
+}

--- a/pkg/objectstore/helper.go
+++ b/pkg/objectstore/helper.go
@@ -17,8 +17,8 @@ package objectstore
 import "context"
 
 // GetOrCreateBucket is a helper function to access the package level getOrCreateBucket
-func GetOrCreateBucket(ctx context.Context, p Provider, bucketName string, region string) (Directory, error) {
-	return p.getOrCreateBucket(ctx, bucketName, region)
+func GetOrCreateBucket(ctx context.Context, p Provider, bucketName string) (Directory, error) {
+	return p.getOrCreateBucket(ctx, bucketName)
 }
 
 // IsS3Provider is a helper function to find out if a provider is an s3Provider

--- a/pkg/objectstore/models.go
+++ b/pkg/objectstore/models.go
@@ -22,6 +22,8 @@ type ProviderConfig struct {
 	// stores from certain cloud providers such as AWS. In that case it can
 	// be empty
 	Endpoint string
+	// Region specifies the region of the object store.
+	Region string
 	// If true, disable SSL verification. If false (the default), SSL
 	// verification is enabled.
 	SkipSSLVerify bool

--- a/pkg/objectstore/objectstore.go
+++ b/pkg/objectstore/objectstore.go
@@ -33,7 +33,7 @@ import (
 type Provider interface {
 	// CreateBucket creates a new bucket. Bucket name must
 	// honors provider naming restrictions
-	CreateBucket(ctx context.Context, bucketName, region string) (Bucket, error)
+	CreateBucket(context.Context, string) (Bucket, error)
 
 	// GetBucket access a specific bucket
 	GetBucket(context.Context, string) (Bucket, error)
@@ -45,7 +45,7 @@ type Provider interface {
 	ListBuckets(context.Context) (map[string]Bucket, error)
 
 	// getOrCreateBucket creates bucket if it does not already exist
-	getOrCreateBucket(ctx context.Context, bucketName, region string) (Bucket, error)
+	getOrCreateBucket(ctx context.Context, bucketName string) (Bucket, error)
 }
 
 // Bucket abstracts the object store of different cloud providers
@@ -111,7 +111,7 @@ func Supported(t ProviderType) bool {
 	return t == ProviderTypeS3 || t == ProviderTypeGCS || t == ProviderTypeAzure
 }
 
-func s3Config(ctx context.Context, config ProviderConfig, secret *Secret, region string) (stowKind string, stowConfig stow.Config, err error) {
+func s3Config(ctx context.Context, config ProviderConfig, secret *Secret) (stowKind string, stowConfig stow.Config, err error) {
 	if secret == nil {
 		return "", nil, errors.New("Invalid Secret value: nil")
 	}
@@ -127,8 +127,8 @@ func s3Config(ctx context.Context, config ProviderConfig, secret *Secret, region
 		stows3.ConfigSecretKey:   awsSecretAccessKey,
 		stows3.ConfigToken:       awsSessionToken,
 	}
-	if region != "" {
-		cm[stows3.ConfigRegion] = region
+	if config.Region != "" {
+		cm[stows3.ConfigRegion] = config.Region
 	}
 	if config.Endpoint != "" {
 		cm[stows3.ConfigEndpoint] = config.Endpoint
@@ -189,10 +189,10 @@ func azureConfig(ctx context.Context, secret *Secret) (stowKind string, stowConf
 	}, nil
 }
 
-func getConfig(ctx context.Context, config ProviderConfig, secret *Secret, region string) (stowKind string, stowConfig stow.Config, err error) {
+func getConfig(ctx context.Context, config ProviderConfig, secret *Secret) (stowKind string, stowConfig stow.Config, err error) {
 	switch config.Type {
 	case ProviderTypeS3:
-		return s3Config(ctx, config, secret, region)
+		return s3Config(ctx, config, secret)
 	case ProviderTypeGCS:
 		return gcsConfig(ctx, secret)
 	case ProviderTypeAzure:
@@ -202,8 +202,8 @@ func getConfig(ctx context.Context, config ProviderConfig, secret *Secret, regio
 	}
 }
 
-func getStowLocation(ctx context.Context, config ProviderConfig, secret *Secret, region string) (stow.Location, error) {
-	kind, stowConfig, err := getConfig(ctx, config, secret, region)
+func getStowLocation(ctx context.Context, config ProviderConfig, secret *Secret) (stow.Location, error) {
+	kind, stowConfig, err := getConfig(ctx, config, secret)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -200,7 +200,10 @@ func ProfileBucket(ctx context.Context, p *crv1alpha1.Profile, cli kubernetes.In
 	default:
 		return errorf("unknown or unsupported location type '%s'", p.Location.Type)
 	}
-	pc := objectstore.ProviderConfig{Type: pType}
+	pc := objectstore.ProviderConfig{
+		Type:   pType,
+		Region: p.Location.Region,
+	}
 	secret, err := osSecretFromProfile(ctx, pType, p, cli)
 	if err != nil {
 		return err
@@ -237,6 +240,7 @@ func ReadAccess(ctx context.Context, p *crv1alpha1.Profile, cli kubernetes.Inter
 	pc := objectstore.ProviderConfig{
 		Type:          pType,
 		Endpoint:      p.Location.Endpoint,
+		Region:        p.Location.Region,
 		SkipSSLVerify: p.SkipSSLVerify,
 	}
 	provider, err := objectstore.NewProvider(ctx, pc, secret)


### PR DESCRIPTION
## Change Overview

We cannot discover the region for buckets in AWS S3 that use non-standard regions like us-gov-west-1. This PR adds region to the provider config

This is an alternative to https://github.com/kanisterio/kanister/pull/655

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [x] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test


## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
