### PR TITLE
Fix region handling in ObjectStore tests

### DIFF
--- a/pkg/objectstore/bucket_test.go
+++ b/pkg/objectstore/bucket_test.go
@@ -15,7 +15,9 @@ func (s *BucketSuite) SetUpSuite(c *C) {
 	getEnvOrSkip(c, "AWS_SECRET_ACCESS_KEY")
 }
 
-func (s *BucketSuite) TestRegionEndpointMismatch(c *C) {
+const ahmRe = `[\w\W]*AuthorizationHeaderMalformed[\w\W]*`
+
+func (s *BucketSuite) TestInvalidS3RegionEndpointMismatch(c *C) {
 	ctx := context.Background()
 	const pt = ProviderTypeS3
 	const bn = `kanister-fake-bucket`
@@ -34,11 +36,9 @@ func (s *BucketSuite) TestRegionEndpointMismatch(c *C) {
 	)
 	c.Assert(err, IsNil)
 
-	const ahmRe = `[\w\W]*AuthorizationHeaderMalformed[\w\W]*`
-
+	// Get Bucket will use the regions correct endpoint.
 	_, err = p.GetBucket(ctx, bn)
-	c.Assert(err, ErrorMatches, ahmRe)
-	c.Assert(err, NotNil)
+	c.Assert(IsBucketNotFoundError(err), Equals, true)
 
 	_, err = p.CreateBucket(ctx, bn)
 	c.Assert(err, ErrorMatches, ahmRe)
@@ -47,8 +47,80 @@ func (s *BucketSuite) TestRegionEndpointMismatch(c *C) {
 	err = p.DeleteBucket(ctx, bn)
 	c.Assert(err, ErrorMatches, ahmRe)
 	c.Assert(err, NotNil)
+}
 
-	err = p.DeleteBucket(ctx, bn)
+func (s *BucketSuite) TestValidS3ClientBucketRegionMismatch(c *C) {
+	ctx := context.Background()
+	const pt = ProviderTypeS3
+	const bn = `kanister-test-bucket-us-west-1`
+	const r1 = `us-west-1`
+	const r2 = `us-west-2`
+
+	pc1 := ProviderConfig{
+		Type:     pt,
+		Endpoint: awsS3Endpoint(r1),
+		Region:   r1,
+	}
+
+	pc2 := ProviderConfig{
+		Type:   pt,
+		Region: r2,
+	}
+
+	pc3 := ProviderConfig{
+		Type:     pt,
+		Endpoint: awsS3Endpoint(r2),
+		Region:   r2,
+	}
+
+	secret := getSecret(ctx, c, pt)
+
+	// p1's region matches the bucket's region.
+	p1, err := NewProvider(ctx, pc1, secret)
+	c.Assert(err, IsNil)
+
+	// p2's region does not match the bucket's region, but does not specify an
+	// endpoint.
+	p2, err := NewProvider(ctx, pc2, secret)
+	c.Assert(err, IsNil)
+
+	// p3's region does not match the bucket's region and specifies an endpoint.
+	p3, err := NewProvider(ctx, pc3, secret)
+	c.Assert(err, IsNil)
+
+	// Delete and recreate the bucket to ensure it's region is r1.
+	_ = p1.DeleteBucket(ctx, bn)
+	_, err = p1.CreateBucket(ctx, bn)
+	c.Assert(err, IsNil)
+	defer func() {
+		err = p1.DeleteBucket(ctx, bn)
+		c.Assert(err, IsNil)
+	}()
+
+	// Check the bucket's region is r1
+	checkProviderWithBucket(c, ctx, p1, bn, r1)
+
+	// We can read a bucket even though it our provider's does not match, as
+	// long as we don't specify an endpoint.
+	checkProviderWithBucket(c, ctx, p2, bn, r1)
+
+	// Specifying an endpoint causes this to fail.
+	_, err = p3.GetBucket(ctx, bn)
 	c.Assert(err, ErrorMatches, ahmRe)
-	c.Assert(err, NotNil)
+}
+
+func checkProviderWithBucket(c *C, ctx context.Context, p Provider, bucketName, region string) {
+	bs, err := p.ListBuckets(ctx)
+	c.Assert(err, IsNil)
+	_, ok := bs[bucketName]
+	c.Assert(ok, Equals, true)
+	b, err := p.GetBucket(ctx, bucketName)
+	c.Assert(err, IsNil)
+	c.Assert(b, NotNil)
+	bu, ok := b.(*bucket)
+	c.Assert(ok, Equals, true)
+	c.Assert(bu, NotNil)
+	c.Assert(bu.region, Equals, region)
+	_, err = b.ListObjects(ctx)
+	c.Assert(err, IsNil)
 }

--- a/pkg/objectstore/const.go
+++ b/pkg/objectstore/const.go
@@ -14,10 +14,7 @@
 
 package objectstore
 
-const (
-	awsS3HostFmt  = "https://s3-%s.amazonaws.com"
-	googleGCSHost = "https://storage.googleapis.com"
-)
+const googleGCSHost = "https://storage.googleapis.com"
 
 // ProviderType enum for different providers
 type ProviderType string

--- a/pkg/objectstore/objectstore.go
+++ b/pkg/objectstore/objectstore.go
@@ -16,7 +16,6 @@ package objectstore
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"os"
 
@@ -221,8 +220,4 @@ func getHostURI(config ProviderConfig) string {
 	default:
 		return config.Endpoint
 	}
-}
-
-func awsS3Endpoint(region string) string {
-	return fmt.Sprintf(awsS3HostFmt, region)
 }


### PR DESCRIPTION
## Change Overview

Fixes a test issue introduced by https://github.com/kanisterio/kanister/pull/657

* Adds more test coverage
* Updates `awsS3Endpoint()`
  * now uses non-legacy format i.e. dot syntax per https://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html#VirtualHostingBackwardsCompatibility
  * moved function and format constant next to single caller
* always checks the bucket's region in get bucket

See AWS docs for more info:
* https://docs.aws.amazon.com/sdk-for-go/api/service/s3/#S3.CreateBucket
* https://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html#path-style-access

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [x] :robot: Test


## Test Plan

```
[01:21:38]tom@tom-XPS-13-9360: (master)~/src/kanister/ go test -v ./pkg/objectstore -check.v
=== RUN   Test
PASS: bucket_test.go:20: BucketSuite.TestInvalidS3RegionEndpointMismatch        0.856s
PASS: bucket_test.go:52: BucketSuite.TestValidS3ClientBucketRegionMismatch      2.030s
PASS: objectstore_test.go:433: ObjectStoreProviderSuite.TestBucketGetRegions    0.706s
PASS: objectstore_test.go:459: ObjectStoreProviderSuite.TestBucketWrongRegion   0.787s
SKIP: objectstore_test.go:112: ObjectStoreProviderSuite.TestBuckets (intermittently fails due to rate limits on bucket creation)
PASS: objectstore_test.go:141: ObjectStoreProviderSuite.TestCreateExistingBucket        0.353s
PASS: objectstore_test.go:164: ObjectStoreProviderSuite.TestCreateExistingBucketS3Regions       1.418s
PASS: objectstore_test.go:282: ObjectStoreProviderSuite.TestDeleteAllWithPrefix 0.447s
PASS: objectstore_test.go:178: ObjectStoreProviderSuite.TestDirectories 1.911s
PASS: objectstore_test.go:152: ObjectStoreProviderSuite.TestGetNonExistingBucket        0.135s
PASS: objectstore_test.go:317: ObjectStoreProviderSuite.TestObjects     0.977s
PASS: objectstore_test.go:361: ObjectStoreProviderSuite.TestObjectsStreaming    0.824s
SKIP: objectstore_test.go:433: ObjectStoreProviderSuite.TestBucketGetRegions
SKIP: objectstore_test.go:459: ObjectStoreProviderSuite.TestBucketWrongRegion
SKIP: objectstore_test.go:112: ObjectStoreProviderSuite.TestBuckets
SKIP: objectstore_test.go:141: ObjectStoreProviderSuite.TestCreateExistingBucket
SKIP: objectstore_test.go:164: ObjectStoreProviderSuite.TestCreateExistingBucketS3Regions
SKIP: objectstore_test.go:282: ObjectStoreProviderSuite.TestDeleteAllWithPrefix
SKIP: objectstore_test.go:178: ObjectStoreProviderSuite.TestDirectories
SKIP: objectstore_test.go:152: ObjectStoreProviderSuite.TestGetNonExistingBucket
SKIP: objectstore_test.go:317: ObjectStoreProviderSuite.TestObjects
SKIP: objectstore_test.go:361: ObjectStoreProviderSuite.TestObjectsStreaming
SKIP: objectstore_test.go:433: ObjectStoreProviderSuite.TestBucketGetRegions
SKIP: objectstore_test.go:459: ObjectStoreProviderSuite.TestBucketWrongRegion
SKIP: objectstore_test.go:112: ObjectStoreProviderSuite.TestBuckets
SKIP: objectstore_test.go:141: ObjectStoreProviderSuite.TestCreateExistingBucket
SKIP: objectstore_test.go:164: ObjectStoreProviderSuite.TestCreateExistingBucketS3Regions
SKIP: objectstore_test.go:282: ObjectStoreProviderSuite.TestDeleteAllWithPrefix
SKIP: objectstore_test.go:178: ObjectStoreProviderSuite.TestDirectories
SKIP: objectstore_test.go:152: ObjectStoreProviderSuite.TestGetNonExistingBucket
SKIP: objectstore_test.go:317: ObjectStoreProviderSuite.TestObjects
SKIP: objectstore_test.go:361: ObjectStoreProviderSuite.TestObjectsStreaming
OK: 11 passed, 21 skipped
--- PASS: Test (11.92s)
PASS
ok      github.com/kanisterio/kanister/pkg/objectstore  11.930s
```

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
