### PR TITLE
EFS: Assign RecoveryPoint.BackupSize to blockstorage.Snapshot in SnapshotCreate

### DIFF
--- a/pkg/blockstorage/awsefs/awsefs.go
+++ b/pkg/blockstorage/awsefs/awsefs.go
@@ -372,12 +372,20 @@ func (e *efs) SnapshotCreate(ctx context.Context, volume blockstorage.Volume, ta
 	if err = e.setBackupTags(ctx, *resp.RecoveryPointArn, infraTags); err != nil {
 		return nil, errors.Wrap(err, "Failed to set backup tags")
 	}
+
+	req = &backup.DescribeRecoveryPointInput{}
+	req.SetBackupVaultName(k10BackupVaultName)
+	req.SetRecoveryPointArn(*resp.RecoveryPointArn)
+	describeRP, err := e.DescribeRecoveryPointWithContext(ctx, req)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to get recovery point information")
+	}
 	return &blockstorage.Snapshot{
 		CreationTime: blockstorage.TimeStamp(*resp.CreationDate),
 		Encrypted:    volume.Encrypted,
 		ID:           *resp.RecoveryPointArn,
 		Region:       e.region,
-		Size:         volume.Size,
+		Size:         bytesInGiB(*describeRP.BackupSizeInBytes),
 		Tags:         blockstorage.MapToKeyValue(allTags),
 		Volume:       &volume,
 		Type:         blockstorage.TypeEFS,

--- a/pkg/blockstorage/awsefs/awsefs.go
+++ b/pkg/blockstorage/awsefs/awsefs.go
@@ -373,10 +373,10 @@ func (e *efs) SnapshotCreate(ctx context.Context, volume blockstorage.Volume, ta
 		return nil, errors.Wrap(err, "Failed to set backup tags")
 	}
 
-	req = &backup.DescribeRecoveryPointInput{}
-	req.SetBackupVaultName(k10BackupVaultName)
-	req.SetRecoveryPointArn(*resp.RecoveryPointArn)
-	describeRP, err := e.DescribeRecoveryPointWithContext(ctx, req)
+	req2 := &backup.DescribeRecoveryPointInput{}
+	req2.SetBackupVaultName(k10BackupVaultName)
+	req2.SetRecoveryPointArn(*resp.RecoveryPointArn)
+	describeRP, err := e.DescribeRecoveryPointWithContext(ctx, req2)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to get recovery point information")
 	}


### PR DESCRIPTION
## Change Overview

EFS: Assign RecoveryPoint.BackupSize to blockstorage.Snapshot in SnapshotCreate
While invoking  `SnapshotCreate()` we set the `blockstorage.Snapshot.Size  = blockstorage.Volume.Size`

where as, while invoking `SnapshotGet()` we set the `blockstorage.Snapshot.Size  = RecoveryPoint.BackupSizeInBytes`

Hence we get different size. It is a capacity vs length issue.

This PR will fix this issue

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
