### PR TITLE
Use ProviderConfig to check for bucket region.

### DIFF
--- a/pkg/objectstore/bucket.go
+++ b/pkg/objectstore/bucket.go
@@ -213,10 +213,10 @@ func (p *s3Provider) DeleteBucket(ctx context.Context, bucketName string) error 
 	return location.RemoveContainer(bucketName)
 }
 
-// GetRegionForBucketreturns the region for a particular bucket. It does not
-// the region set in the provider config is used as a hint, but may differ than
-// the actual region of the bucket. If the bucket does not have a region, then
-// the return value will be "",
+// GetRegionForBucket returns the region for a particular bucket. It does not
+// use the region set in the provider config is used as a hint, but may differ
+// from the actual region of the bucket. If the bucket does not have a region,
+// then the return value will be "".
 func (p *s3Provider) GetRegionForBucket(ctx context.Context, bucketName string) (string, error) {
 	cfg, r, err := awsConfig(ctx, p.config, *p.secret.Aws)
 	if err != nil {

--- a/pkg/objectstore/bucket.go
+++ b/pkg/objectstore/bucket.go
@@ -26,14 +26,15 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/graymeta/stow"
 	"github.com/pkg/errors"
+
+	"github.com/kanisterio/kanister/pkg/field"
+	"github.com/kanisterio/kanister/pkg/log"
 )
 
 var _ Provider = (*provider)(nil)
 
 // provider implements the Provider functionality
 type provider struct {
-	// e.g., s3-us-west-2.amazonaws.com
-	hostEndPoint string
 	// Object store information
 	config ProviderConfig
 	// Secret
@@ -51,79 +52,70 @@ type bucket struct {
 	region       string         // E.g., us-west-2
 }
 
-// CreateBucket creates the bucket. Bucket naming rules are provider dependent.
-func (p *provider) CreateBucket(ctx context.Context, bucketName string) (Bucket, error) {
-	location, err := getStowLocation(ctx, p.config, p.secret)
-	if err != nil {
-		return nil, err
-	}
-	c, err := location.CreateContainer(bucketName)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to create bucket %s", bucketName)
-	}
+func newBucket(cfg ProviderConfig, c stow.Container, l stow.Location) *bucket {
 	dir := &directory{
 		path: "/",
 	}
 	bucket := &bucket{
 		directory:    dir,
 		container:    c,
-		location:     location,
-		hostEndPoint: path.Join(p.hostEndPoint, c.ID()),
-		region:       p.config.Region,
+		location:     l,
+		hostEndPoint: bucketEndpoint(cfg, c.ID()),
+		region:       cfg.Region,
 	}
 	dir.bucket = bucket
-	return bucket, nil
+	return bucket
+}
+
+// CreateBucket creates the bucket. Bucket naming rules are provider dependent.
+func (p *provider) CreateBucket(ctx context.Context, bucketName string) (Bucket, error) {
+	cfg, err := p.bucketConfig(ctx, bucketName)
+	if err != nil {
+		return nil, err
+	}
+	l, err := getStowLocation(ctx, cfg, p.secret)
+	if err != nil {
+		return nil, err
+	}
+	c, err := l.CreateContainer(bucketName)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create bucket %s", bucketName)
+	}
+	return newBucket(cfg, c, l), nil
 }
 
 // GetBucket gets the handle for the specified bucket. Buckets are searched using prefix search;
 // if multiple buckets matched the name, then returns an error
 func (p *provider) GetBucket(ctx context.Context, bucketName string) (Bucket, error) {
-	location, err := getStowLocation(ctx, p.config, p.secret)
+	cfg, err := p.bucketConfig(ctx, bucketName)
 	if err != nil {
 		return nil, err
 	}
-	c, err := location.Container(bucketName)
+	l, err := getStowLocation(ctx, cfg, p.secret)
+	if err != nil {
+		return nil, err
+	}
+	c, err := l.Container(bucketName)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get bucket %s", bucketName)
 	}
-	dir := &directory{
-		path: "/",
-	}
-	bucket := &bucket{
-		directory:    dir,
-		container:    c,
-		location:     location,
-		hostEndPoint: path.Join(p.hostEndPoint, c.ID()),
-	}
-	dir.bucket = bucket
-	return bucket, nil
+	return newBucket(cfg, c, l), nil
 }
 
 // ListBuckets gets the handles of all the buckets.
 func (p *provider) ListBuckets(ctx context.Context) (map[string]Bucket, error) {
 	// Walk all the buckets
 	buckets := make(map[string]Bucket)
-	location, err := getStowLocation(ctx, p.config, p.secret)
+	l, err := getStowLocation(ctx, p.config, p.secret)
 	if err != nil {
 		return nil, err
 	}
-	err = stow.WalkContainers(location, stow.NoPrefix, 10000,
+	err = stow.WalkContainers(l, stow.NoPrefix, 10000,
 		func(c stow.Container, err error) error {
 			if err != nil {
 				return err
 			}
-
-			dir := &directory{
-				path: "/",
-			}
-			bucket := &bucket{
-				directory:    dir,
-				container:    c,
-				location:     location,
-				hostEndPoint: path.Join(p.hostEndPoint, c.ID()),
-			}
-			dir.bucket = bucket
-			buckets[c.ID()] = bucket
+			buckets[c.ID()] = newBucket(p.config, c, l)
 			return nil
 		})
 	if err != nil {
@@ -148,69 +140,35 @@ func (p *provider) getOrCreateBucket(ctx context.Context, bucketName string) (Bu
 	if err == nil {
 		return d, nil
 	}
-	// Attempt creating it
+	// Attempt to create it.
 	return p.CreateBucket(ctx, bucketName)
+}
+
+func (p *provider) bucketConfig(ctx context.Context, bucketName string) (ProviderConfig, error) {
+	if p.config.Type == ProviderTypeS3 {
+		return s3BucketConfig(ctx, p.config, p.secret, bucketName)
+	}
+	return p.config, nil
+}
+
+func s3BucketConfig(ctx context.Context, c ProviderConfig, s *Secret, bucketName string) (ProviderConfig, error) {
+	if s == nil || s.Aws == nil {
+		return c, errors.New("AWS Secret required to get region")
+	}
+	r, err := s3BucketRegion(ctx, c, *s, bucketName)
+	if err != nil {
+		log.Debug().
+			WithContext(ctx).
+			WithError(err).
+			Print("Couldn't get config for bucket", field.M{"config": c})
+		return c, nil
+	}
+	c.Region = r
+	return c, nil
 }
 
 type s3Provider struct {
 	*provider
-}
-
-// Stow uses path-style requests when specifying an endpoint.
-// https://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html#path-style-access
-// https://github.com/graymeta/stow/blob/master/s3/config.go#L159
-
-const awsS3HostFmt = "https://s3.%s.amazonaws.com"
-
-func awsS3Endpoint(region string) string {
-	return fmt.Sprintf(awsS3HostFmt, region)
-}
-
-func (p *s3Provider) GetBucket(ctx context.Context, bucketName string) (Bucket, error) {
-	cfg := p.config
-	var err error
-	cfg.Region, err = p.GetRegionForBucket(ctx, bucketName)
-	if err != nil {
-		return nil, errors.Wrapf(err, "could not get region for bucket %s", bucketName)
-	}
-	location, err := getStowLocation(ctx, cfg, p.secret)
-	if err != nil {
-		return nil, err
-	}
-	c, err := location.Container(bucketName)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get bucket %s", bucketName)
-	}
-	dir := &directory{
-		path: "/",
-	}
-	hostEndPoint := p.hostEndPoint
-	if hostEndPoint == "" {
-		hostEndPoint = awsS3Endpoint(cfg.Region)
-	}
-	bucket := &bucket{
-		directory:    dir,
-		container:    c,
-		location:     location,
-		hostEndPoint: path.Join(hostEndPoint, c.ID()),
-		region:       cfg.Region,
-	}
-	dir.bucket = bucket
-	return bucket, nil
-}
-
-func (p *s3Provider) DeleteBucket(ctx context.Context, bucketName string) error {
-	cfg := p.config
-	if cfg.Region == "" {
-		// We swalllow this error because region may not be required. If it is,
-		// we'll fail in the next few lines.
-		cfg.Region, _ = p.GetRegionForBucket(ctx, bucketName)
-	}
-	location, err := getStowLocation(ctx, p.config, p.secret)
-	if err != nil {
-		return errors.Wrapf(err, "Failed to get location for bucket deletion. bucket: %s", bucketName)
-	}
-	return location.RemoveContainer(bucketName)
 }
 
 // GetRegionForBucket returns the region for a particular bucket. It does not
@@ -218,11 +176,18 @@ func (p *s3Provider) DeleteBucket(ctx context.Context, bucketName string) error 
 // from the actual region of the bucket. If the bucket does not have a region,
 // then the return value will be "".
 func (p *s3Provider) GetRegionForBucket(ctx context.Context, bucketName string) (string, error) {
-	cfg, r, err := awsConfig(ctx, p.config, *p.secret.Aws)
+	if p.secret == nil || p.secret.Aws == nil {
+		return "", errors.New("AWS Secret required to get region")
+	}
+	return s3BucketRegion(ctx, p.config, *p.secret, bucketName)
+}
+
+func s3BucketRegion(ctx context.Context, cfg ProviderConfig, sec Secret, bucketName string) (string, error) {
+	c, r, err := awsConfig(ctx, cfg, *sec.Aws)
 	if err != nil {
 		return "", err
 	}
-	s, err := session.NewSession(cfg)
+	s, err := session.NewSession(c)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to create session, region = %s", r)
 	}
@@ -250,4 +215,36 @@ func (p *s3Provider) getOrCreateBucket(ctx context.Context, bucketName string) (
 		return p.CreateBucket(ctx, bucketName)
 	}
 	return d, err
+}
+
+func bucketEndpoint(c ProviderConfig, id string) string {
+	e := c.Endpoint
+	if c.Type == ProviderTypeS3 {
+		e = s3Endpoint(c)
+	}
+	return path.Join(e, id)
+}
+
+const defaultS3region = "us-east-1"
+
+func s3Endpoint(c ProviderConfig) string {
+	if c.Endpoint != "" {
+		return c.Endpoint
+	}
+	r := defaultS3region
+	if c.Region != "" {
+		r = c.Region
+	}
+	return awsS3Endpoint(r)
+
+}
+
+// Stow uses path-style requests when specifying an endpoint.
+// https://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html#path-style-access
+// https://github.com/graymeta/stow/blob/master/s3/config.go#L159
+
+const awsS3EndpointFmt = "https://s3.%s.amazonaws.com"
+
+func awsS3Endpoint(region string) string {
+	return fmt.Sprintf(awsS3EndpointFmt, region)
 }

--- a/pkg/objectstore/bucket.go
+++ b/pkg/objectstore/bucket.go
@@ -221,7 +221,6 @@ func s3Endpoint(c ProviderConfig) string {
 		r = c.Region
 	}
 	return awsS3Endpoint(r)
-
 }
 
 // Stow uses path-style requests when specifying an endpoint.

--- a/pkg/objectstore/bucket.go
+++ b/pkg/objectstore/bucket.go
@@ -21,9 +21,8 @@ import (
 	"fmt"
 	"path"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/graymeta/stow"
 	"github.com/pkg/errors"
 
@@ -191,21 +190,7 @@ func s3BucketRegion(ctx context.Context, cfg ProviderConfig, sec Secret, bucketN
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to create session, region = %s", r)
 	}
-	cli := s3.New(s)
-	if cli == nil {
-		return "", errors.New("failed to create s3 client")
-	}
-	gbli := &s3.GetBucketLocationInput{
-		Bucket: aws.String(bucketName),
-	}
-	gblo, err := cli.GetBucketLocation(gbli)
-	if err != nil {
-		return "", errors.Wrap(err, "failed to get bucket location")
-	}
-	if gblo.LocationConstraint != nil {
-		return *gblo.LocationConstraint, nil
-	}
-	return "", nil
+	return s3manager.GetBucketRegion(ctx, s, bucketName, cfg.Region)
 }
 
 func (p *s3Provider) getOrCreateBucket(ctx context.Context, bucketName string) (Bucket, error) {

--- a/pkg/objectstore/bucket_test.go
+++ b/pkg/objectstore/bucket_test.go
@@ -111,6 +111,7 @@ func (s *BucketSuite) TestValidS3ClientBucketRegionMismatch(c *C) {
 	// Specifying an the wrong endpoint causes bucket ops to fail.
 	err = checkProviderWithBucket(c, ctx, p3, bn, r1)
 	c.Assert(err, NotNil)
+	c.Assert(err, ErrorMatches, ahmRe)
 }
 
 func checkProviderWithBucket(c *C, ctx context.Context, p Provider, bucketName, region string) error {
@@ -118,7 +119,11 @@ func checkProviderWithBucket(c *C, ctx context.Context, p Provider, bucketName, 
 	c.Assert(err, IsNil)
 	_, ok := bs[bucketName]
 	c.Assert(ok, Equals, true)
+	// We should fail here if the endpoint is set and does not match bucket region.
 	b, err := p.GetBucket(ctx, bucketName)
+	if err != nil {
+		return err
+	}
 	c.Assert(err, IsNil)
 	c.Assert(b, NotNil)
 
@@ -130,7 +135,8 @@ func checkProviderWithBucket(c *C, ctx context.Context, p Provider, bucketName, 
 	c.Assert(r, Equals, region)
 
 	_, err = b.ListObjects(ctx)
-	return err
+	c.Assert(err, IsNil)
+	return nil
 }
 
 func (s *BucketSuite) TestGetRegionForBucket(c *C) {
@@ -228,7 +234,7 @@ func (s *BucketSuite) TestGetRegionForBucket(c *C) {
 			valid:        false,
 		},
 		{
-			bucketName:   "tom-test-govcloud",
+			bucketName:   "kanister-test-govcloud",
 			endpoint:     "",
 			clientRegion: "us-gov-east-1",
 			bucketRegion: "us-gov-west-1",

--- a/pkg/objectstore/bucket_test.go
+++ b/pkg/objectstore/bucket_test.go
@@ -133,7 +133,7 @@ func (s *BucketSuite) TestGetRegionForBucket(c *C) {
 
 	// Ensure existingBucket exists and non-existing bucket does not
 	const existingBucket = testBucketName
-	const nonExistantBucket = "kanister-test-should-not-exist"
+	const nonExistentBucket = "kanister-test-should-not-exist"
 	pc := ProviderConfig{
 		Type:   pt,
 		Region: testRegionS3,
@@ -142,7 +142,7 @@ func (s *BucketSuite) TestGetRegionForBucket(c *C) {
 	c.Assert(err, IsNil)
 	_, err = p.getOrCreateBucket(ctx, existingBucket)
 	c.Assert(err, IsNil)
-	_, err = p.GetBucket(ctx, nonExistantBucket)
+	_, err = p.GetBucket(ctx, nonExistentBucket)
 	c.Assert(IsBucketNotFoundError(err), Equals, true)
 
 	for _, tc := range []struct {
@@ -181,14 +181,14 @@ func (s *BucketSuite) TestGetRegionForBucket(c *C) {
 			valid:        false,
 		},
 		{
-			bucketName:   nonExistantBucket,
+			bucketName:   nonExistentBucket,
 			endpoint:     "",
 			clientRegion: testRegionS3,
 			bucketRegion: "",
 			valid:        false,
 		},
 		{
-			bucketName:   nonExistantBucket,
+			bucketName:   nonExistentBucket,
 			endpoint:     "",
 			clientRegion: "",
 			bucketRegion: "",

--- a/pkg/objectstore/objectstore_test.go
+++ b/pkg/objectstore/objectstore_test.go
@@ -44,6 +44,7 @@ type ObjectStoreProviderSuite struct {
 	suiteDirPrefix string // directory name prefix for all tests in this suite
 	testDir        string // directory name for a given test
 	region         string // bucket region
+	endpoint       string // bucket region
 }
 
 const (
@@ -99,8 +100,9 @@ func (s *ObjectStoreProviderSuite) initProvider(c *C, region string) {
 	ctx := context.Background()
 	var err error
 	pc := ProviderConfig{
-		Type:   s.osType,
-		Region: region,
+		Type:     s.osType,
+		Region:   region,
+		Endpoint: s.endpoint,
 	}
 	secret := getSecret(ctx, c, s.osType)
 	s.provider, err = NewProvider(ctx, pc, secret)

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -182,17 +182,7 @@ func ProfileBucket(ctx context.Context, p *crv1alpha1.Profile, cli kubernetes.In
 
 	switch p.Location.Type {
 	case crv1alpha1.LocationTypeS3Compliant:
-		givenRegion := p.Location.Region
-		if givenRegion != "" {
-			actualRegion, err := objectstore.GetS3BucketRegion(ctx, bucketName, givenRegion)
-			if err != nil {
-				return err
-			}
-			if actualRegion != givenRegion {
-				return errorf("Incorrect region for bucket. Expected '%s', Got '%s'", actualRegion, givenRegion)
-			}
-		}
-		return nil
+		pType = objectstore.ProviderTypeS3
 	case crv1alpha1.LocationTypeGCS:
 		pType = objectstore.ProviderTypeGCS
 	case crv1alpha1.LocationTypeAzure:
@@ -213,10 +203,7 @@ func ProfileBucket(ctx context.Context, p *crv1alpha1.Profile, cli kubernetes.In
 		return err
 	}
 	_, err = provider.GetBucket(ctx, bucketName)
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 func ReadAccess(ctx context.Context, p *crv1alpha1.Profile, cli kubernetes.Interface) error {


### PR DESCRIPTION
## Change Overview

GetRegion call was not honoring settings in the profile

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Test Plan

Also tested manually in govcloud and minio w/ regions and minio w/o regions

```
go test -v ./pkg/objectstore -ch
eck.v    -check.f TestGetRegionForBucket
=== RUN   Test
PASS: bucket_test.go:129: BucketSuite.TestGetRegionForBucket    2.171s
OK: 1 passed
--- PASS: Test (2.17s)
PASS
ok      github.com/kanisterio/kanister/pkg/objectstore  2.179s

```
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
