### PR TITLE
Refactor pkg/objectstore to remove duplicated code

### DIFF
--- a/pkg/objectstore/bucket.go
+++ b/pkg/objectstore/bucket.go
@@ -153,14 +153,14 @@ func (p *provider) bucketConfig(ctx context.Context, bucketName string) (Provide
 
 func s3BucketConfig(ctx context.Context, c ProviderConfig, s *Secret, bucketName string) (ProviderConfig, error) {
 	if s == nil || s.Aws == nil {
-		return c, errors.New("AWS Secret regquired to get region")
+		return c, errors.New("AWS Secret required to get region")
 	}
 	r, err := s3BucketRegion(ctx, c, *s, bucketName)
 	if err != nil {
 		log.Debug().
 			WithContext(ctx).
 			WithError(err).
-			Print("Could get config for bucket", field.M{"config": c})
+			Print("Couldn't get config for bucket", field.M{"config": c})
 		return c, nil
 	}
 	c.Region = r
@@ -177,7 +177,7 @@ type s3Provider struct {
 // then the return value will be "".
 func (p *s3Provider) GetRegionForBucket(ctx context.Context, bucketName string) (string, error) {
 	if p.secret == nil || p.secret.Aws == nil {
-		return "", errors.New("AWS Secret regquired to get region")
+		return "", errors.New("AWS Secret required to get region")
 	}
 	return s3BucketRegion(ctx, p.config, *p.secret, bucketName)
 }

--- a/pkg/objectstore/bucket.go
+++ b/pkg/objectstore/bucket.go
@@ -26,14 +26,15 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/graymeta/stow"
 	"github.com/pkg/errors"
+
+	"github.com/kanisterio/kanister/pkg/field"
+	"github.com/kanisterio/kanister/pkg/log"
 )
 
 var _ Provider = (*provider)(nil)
 
 // provider implements the Provider functionality
 type provider struct {
-	// e.g., s3-us-west-2.amazonaws.com
-	hostEndPoint string
 	// Object store information
 	config ProviderConfig
 	// Secret
@@ -51,79 +52,70 @@ type bucket struct {
 	region       string         // E.g., us-west-2
 }
 
-// CreateBucket creates the bucket. Bucket naming rules are provider dependent.
-func (p *provider) CreateBucket(ctx context.Context, bucketName string) (Bucket, error) {
-	location, err := getStowLocation(ctx, p.config, p.secret)
-	if err != nil {
-		return nil, err
-	}
-	c, err := location.CreateContainer(bucketName)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to create bucket %s", bucketName)
-	}
+func newBucket(cfg ProviderConfig, c stow.Container, l stow.Location) *bucket {
 	dir := &directory{
 		path: "/",
 	}
 	bucket := &bucket{
 		directory:    dir,
 		container:    c,
-		location:     location,
-		hostEndPoint: path.Join(p.hostEndPoint, c.ID()),
-		region:       p.config.Region,
+		location:     l,
+		hostEndPoint: bucketEndpoint(cfg, c.ID()),
+		region:       cfg.Region,
 	}
 	dir.bucket = bucket
-	return bucket, nil
+	return bucket
+}
+
+// CreateBucket creates the bucket. Bucket naming rules are provider dependent.
+func (p *provider) CreateBucket(ctx context.Context, bucketName string) (Bucket, error) {
+	cfg, err := p.bucketConfig(ctx, bucketName)
+	if err != nil {
+		return nil, err
+	}
+	l, err := getStowLocation(ctx, cfg, p.secret)
+	if err != nil {
+		return nil, err
+	}
+	c, err := l.CreateContainer(bucketName)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create bucket %s", bucketName)
+	}
+	return newBucket(cfg, c, l), nil
 }
 
 // GetBucket gets the handle for the specified bucket. Buckets are searched using prefix search;
 // if multiple buckets matched the name, then returns an error
 func (p *provider) GetBucket(ctx context.Context, bucketName string) (Bucket, error) {
-	location, err := getStowLocation(ctx, p.config, p.secret)
+	cfg, err := p.bucketConfig(ctx, bucketName)
 	if err != nil {
 		return nil, err
 	}
-	c, err := location.Container(bucketName)
+	l, err := getStowLocation(ctx, cfg, p.secret)
+	if err != nil {
+		return nil, err
+	}
+	c, err := l.Container(bucketName)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get bucket %s", bucketName)
 	}
-	dir := &directory{
-		path: "/",
-	}
-	bucket := &bucket{
-		directory:    dir,
-		container:    c,
-		location:     location,
-		hostEndPoint: path.Join(p.hostEndPoint, c.ID()),
-	}
-	dir.bucket = bucket
-	return bucket, nil
+	return newBucket(cfg, c, l), nil
 }
 
 // ListBuckets gets the handles of all the buckets.
 func (p *provider) ListBuckets(ctx context.Context) (map[string]Bucket, error) {
 	// Walk all the buckets
 	buckets := make(map[string]Bucket)
-	location, err := getStowLocation(ctx, p.config, p.secret)
+	l, err := getStowLocation(ctx, p.config, p.secret)
 	if err != nil {
 		return nil, err
 	}
-	err = stow.WalkContainers(location, stow.NoPrefix, 10000,
+	err = stow.WalkContainers(l, stow.NoPrefix, 10000,
 		func(c stow.Container, err error) error {
 			if err != nil {
 				return err
 			}
-
-			dir := &directory{
-				path: "/",
-			}
-			bucket := &bucket{
-				directory:    dir,
-				container:    c,
-				location:     location,
-				hostEndPoint: path.Join(p.hostEndPoint, c.ID()),
-			}
-			dir.bucket = bucket
-			buckets[c.ID()] = bucket
+			buckets[c.ID()] = newBucket(p.config, c, l)
 			return nil
 		})
 	if err != nil {
@@ -148,69 +140,35 @@ func (p *provider) getOrCreateBucket(ctx context.Context, bucketName string) (Bu
 	if err == nil {
 		return d, nil
 	}
-	// Attempt creating it
+	// Attempt to create it.
 	return p.CreateBucket(ctx, bucketName)
+}
+
+func (p *provider) bucketConfig(ctx context.Context, bucketName string) (ProviderConfig, error) {
+	if p.config.Type == ProviderTypeS3 {
+		return s3BucketConfig(ctx, p.config, p.secret, bucketName)
+	}
+	return p.config, nil
+}
+
+func s3BucketConfig(ctx context.Context, c ProviderConfig, s *Secret, bucketName string) (ProviderConfig, error) {
+	if s == nil || s.Aws == nil {
+		return c, errors.New("AWS Secret regquired to get region")
+	}
+	r, err := s3BucketRegion(ctx, c, *s, bucketName)
+	if err != nil {
+		log.Debug().
+			WithContext(ctx).
+			WithError(err).
+			Print("Could get config for bucket", field.M{"config": c})
+		return c, nil
+	}
+	c.Region = r
+	return c, nil
 }
 
 type s3Provider struct {
 	*provider
-}
-
-// Stow uses path-style requests when specifying an endpoint.
-// https://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html#path-style-access
-// https://github.com/graymeta/stow/blob/master/s3/config.go#L159
-
-const awsS3HostFmt = "https://s3.%s.amazonaws.com"
-
-func awsS3Endpoint(region string) string {
-	return fmt.Sprintf(awsS3HostFmt, region)
-}
-
-func (p *s3Provider) GetBucket(ctx context.Context, bucketName string) (Bucket, error) {
-	cfg := p.config
-	var err error
-	cfg.Region, err = p.GetRegionForBucket(ctx, bucketName)
-	if err != nil {
-		return nil, errors.Wrapf(err, "could not get region for bucket %s", bucketName)
-	}
-	location, err := getStowLocation(ctx, cfg, p.secret)
-	if err != nil {
-		return nil, err
-	}
-	c, err := location.Container(bucketName)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get bucket %s", bucketName)
-	}
-	dir := &directory{
-		path: "/",
-	}
-	hostEndPoint := p.hostEndPoint
-	if hostEndPoint == "" {
-		hostEndPoint = awsS3Endpoint(cfg.Region)
-	}
-	bucket := &bucket{
-		directory:    dir,
-		container:    c,
-		location:     location,
-		hostEndPoint: path.Join(hostEndPoint, c.ID()),
-		region:       cfg.Region,
-	}
-	dir.bucket = bucket
-	return bucket, nil
-}
-
-func (p *s3Provider) DeleteBucket(ctx context.Context, bucketName string) error {
-	cfg := p.config
-	if cfg.Region == "" {
-		// We swalllow this error because region may not be required. If it is,
-		// we'll fail in the next few lines.
-		cfg.Region, _ = p.GetRegionForBucket(ctx, bucketName)
-	}
-	location, err := getStowLocation(ctx, p.config, p.secret)
-	if err != nil {
-		return errors.Wrapf(err, "Failed to get location for bucket deletion. bucket: %s", bucketName)
-	}
-	return location.RemoveContainer(bucketName)
 }
 
 // GetRegionForBucket returns the region for a particular bucket. It does not
@@ -218,11 +176,18 @@ func (p *s3Provider) DeleteBucket(ctx context.Context, bucketName string) error 
 // from the actual region of the bucket. If the bucket does not have a region,
 // then the return value will be "".
 func (p *s3Provider) GetRegionForBucket(ctx context.Context, bucketName string) (string, error) {
-	cfg, r, err := awsConfig(ctx, p.config, *p.secret.Aws)
+	if p.secret == nil || p.secret.Aws == nil {
+		return "", errors.New("AWS Secret regquired to get region")
+	}
+	return s3BucketRegion(ctx, p.config, *p.secret, bucketName)
+}
+
+func s3BucketRegion(ctx context.Context, cfg ProviderConfig, sec Secret, bucketName string) (string, error) {
+	c, r, err := awsConfig(ctx, cfg, *sec.Aws)
 	if err != nil {
 		return "", err
 	}
-	s, err := session.NewSession(cfg)
+	s, err := session.NewSession(c)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to create session, region = %s", r)
 	}
@@ -250,4 +215,36 @@ func (p *s3Provider) getOrCreateBucket(ctx context.Context, bucketName string) (
 		return p.CreateBucket(ctx, bucketName)
 	}
 	return d, err
+}
+
+func bucketEndpoint(c ProviderConfig, id string) string {
+	e := c.Endpoint
+	if c.Type == ProviderTypeS3 {
+		e = s3Endpoint(c)
+	}
+	return path.Join(e, id)
+}
+
+const defaultS3region = "us-east-1"
+
+func s3Endpoint(c ProviderConfig) string {
+	if c.Endpoint != "" {
+		return c.Endpoint
+	}
+	r := defaultS3region
+	if c.Region != "" {
+		r = c.Region
+	}
+	return awsS3Endpoint(r)
+
+}
+
+// Stow uses path-style requests when specifying an endpoint.
+// https://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html#path-style-access
+// https://github.com/graymeta/stow/blob/master/s3/config.go#L159
+
+const awsS3EndpointFmt = "https://s3.%s.amazonaws.com"
+
+func awsS3Endpoint(region string) string {
+	return fmt.Sprintf(awsS3EndpointFmt, region)
 }

--- a/pkg/objectstore/objectstore_test.go
+++ b/pkg/objectstore/objectstore_test.go
@@ -44,6 +44,7 @@ type ObjectStoreProviderSuite struct {
 	suiteDirPrefix string // directory name prefix for all tests in this suite
 	testDir        string // directory name for a given test
 	region         string // bucket region
+	endpoint       string // bucket region
 }
 
 const (
@@ -99,8 +100,9 @@ func (s *ObjectStoreProviderSuite) initProvider(c *C, region string) {
 	ctx := context.Background()
 	var err error
 	pc := ProviderConfig{
-		Type:   s.osType,
-		Region: region,
+		Type:     s.osType,
+		Region:   region,
+		Endpoint: s.endpoint,
 	}
 	secret := getSecret(ctx, c, s.osType)
 	s.provider, err = NewProvider(ctx, pc, secret)


### PR DESCRIPTION
## Change Overview

* Uses Provider.config.Endpoint to store provider endpoint, rather than duplicating it in Provider
* Consolidates implementations of methods by factoring out bucket configuration. *s3Provider and *provider now use the same implementation, but *s3Provider now uses different configuration
* Consolidates instantiation of a bucket into the new helper function

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [x] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test



## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
