### PR TITLE
License Extractor Docker Image

### DIFF
--- a/docker/license_extractor/Dockerfile
+++ b/docker/license_extractor/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:14-alpine
+RUN npm i -g license-extractor
+RUN mkdir /repo
+
+WORKDIR /repo
+
+ENTRYPOINT ["licext"]

--- a/docker/license_extractor/README.md
+++ b/docker/license_extractor/README.md
@@ -1,0 +1,3 @@
+# Docker image for license extractor "licext"
+
+Build and push with `build.sh`

--- a/docker/license_extractor/build.sh
+++ b/docker/license_extractor/build.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+
+readonly IMAGE_TAG="kanisterio/license-extractor:$(git rev-parse --short=7 HEAD:docker/license_extractor)"
+
+docker build -t "${IMAGE_TAG}" .
+docker push "${IMAGE_TAG}"


### PR DESCRIPTION
Image built and pushed to Kanister's Docker Hub repo

https://hub.docker.com/r/kanisterio/license-extractor

## Pull request type

- [x] :hamster: Trivial/Minor

## Test Plan

- [x] :muscle: Manual
