### PR TITLE
Remove unnecessary `sleep` from Cassandra blueprint 

### DIFF
--- a/examples/stable/cassandra/cassandra-blueprint.yaml
+++ b/examples/stable/cassandra/cassandra-blueprint.yaml
@@ -62,7 +62,6 @@ actions:
               cd ${snapshot_prefix}/${HOSTNAME}/
               cqlsh -e "DESCRIBE SCHEMA" > schema.cql
             fi
-            sleep 300
             nodetool clearsnapshot
     - func: BackupDataAll
       name: backupToObjectStore

--- a/examples/stable/cassandra/cassandra-blueprint.yaml
+++ b/examples/stable/cassandra/cassandra-blueprint.yaml
@@ -171,7 +171,7 @@ actions:
                 cd ..
               done
             fi
-            rm -rf {{ .ArtifactsIn.params.KeyValue.snapshotPrefix }}
+            rm -rf {{ .ArtifactsIn.params.KeyValue.snapshotPrefix }} 
   delete:
     type: StatefulSet
     inputArtifactNames:


### PR DESCRIPTION

## Change Overview

We somehow had unnecessary `sleep` in the Cassandra blueprint, this change removes that.

Signed-off-by: Vivek Singh <vsingh.ggits.2010@gmail.com>

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan
To run the tests use below command (you can optionally change the `integration_test.sh` to just run cassandra test app)
```
make integration_test
```
the output can be found [here](https://gist.github.com/viveksinghggits/281c899d7e315d7c4b438ccce07f012f).

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
