### PR TITLE
changes to support passing storage class to VSC fetch

### DIFF
--- a/pkg/kube/snapshot/snapshot.go
+++ b/pkg/kube/snapshot/snapshot.go
@@ -32,7 +32,7 @@ type Snapshotter interface {
 	// 'annotationKey' is the annotation key which has to be present on VolumeSnapshotClass.
 	// 'annotationValue' is the value for annotationKey in VolumeSnapshotClass spec.
 	// This returns error if no VolumeSnapshotClass found.
-	GetVolumeSnapshotClass(annotationKey, annotationValue string) (string, error)
+	GetVolumeSnapshotClass(annotationKey, annotationValue, storageClassName string) (string, error)
 	// Create creates a VolumeSnapshot and returns it or any error happened meanwhile.
 	//
 	// 'name' is the name of the VolumeSnapshot.

--- a/pkg/kube/snapshot/snapshot_alpha.go
+++ b/pkg/kube/snapshot/snapshot_alpha.go
@@ -52,8 +52,8 @@ func NewSnapshotAlpha(kubeCli kubernetes.Interface, dynCli dynamic.Interface) Sn
 }
 
 // GetVolumeSnapshotClass returns VolumeSnapshotClass name which is annotated with given key.
-func (sna *SnapshotAlpha) GetVolumeSnapshotClass(annotationKey, annotationValue string) (string, error) {
-	return getSnapshotClassbyAnnotation(sna.dynCli, v1alpha1.VolSnapClassGVR, annotationKey, annotationValue)
+func (sna *SnapshotAlpha) GetVolumeSnapshotClass(annotationKey, annotationValue, storageClassName string) (string, error) {
+	return getSnapshotClassbyAnnotation(sna.dynCli, sna.kubeCli, v1alpha1.VolSnapClassGVR, annotationKey, annotationValue, storageClassName)
 }
 
 // Create creates a VolumeSnapshot and returns it or any error that happened meanwhile.
@@ -294,7 +294,7 @@ func TransformUnstructured(u *unstructured.Unstructured, value interface{}) erro
 	return errors.Wrapf(err, "Failed to Unmarshal unstructured object")
 }
 
-func getSnapshotClassbyAnnotation(dynCli dynamic.Interface, gvr schema.GroupVersionResource, annotationKey, annotationValue string) (string, error) {
+func getSnapshotClassbyAnnotation(dynCli dynamic.Interface, kubeCli kubernetes.Interface, gvr schema.GroupVersionResource, annotationKey, annotationValue, storageClass string) (string, error) {
 	us, err := dynCli.Resource(gvr).List(metav1.ListOptions{})
 	if err != nil {
 		return "", errors.Errorf("Failed to get VolumeSnapshotClasses in the cluster: %v", err)
@@ -302,11 +302,37 @@ func getSnapshotClassbyAnnotation(dynCli dynamic.Interface, gvr schema.GroupVers
 	if us == nil || len(us.Items) == 0 {
 		return "", errors.Errorf("Failed to find any VolumeSnapshotClass in the cluster: %v", err)
 	}
+	// fetch storageClass
+	sc, err := kubeCli.StorageV1().StorageClasses().Get(storageClass, metav1.GetOptions{})
+	if err != nil {
+		return "", errors.Errorf("Failed to find StorageClass (%s) in the cluster: %v", storageClass, err)
+	}
 	for _, vsc := range us.Items {
 		ans := vsc.GetAnnotations()
-		if val, ok := ans[annotationKey]; ok && val == annotationValue {
+		driver, err := getDriverFromUnstruturedVSC(vsc)
+		if err != nil {
+			return "", errors.Errorf("Failed to get driver for VolumeSnapshotClass (%s): %v", vsc.GetName(), err)
+		}
+		if val, ok := ans[annotationKey]; ok && val == annotationValue && driver == sc.Provisioner {
 			return vsc.GetName(), nil
 		}
 	}
-	return "", errors.Errorf("Failed to find VolumesnapshotClass with %s=%s annotation in the cluster", annotationKey, annotationValue)
+	return "", errors.Errorf("Failed to find VolumeSnapshotClass with %s=%s annotation in the cluster", annotationKey, annotationValue)
+}
+
+func getDriverFromUnstruturedVSC(uVSC unstructured.Unstructured) (string, error) {
+	if uVSC.GetKind() != VolSnapClassKind {
+		return "", errors.Errorf("Cannot get diver for %s kind", uVSC.GetKind())
+	}
+	driver, ok := uVSC.Object["snapshotter"]
+	if !ok {
+		driver, ok = uVSC.Object["driver"]
+	}
+	if !ok {
+		return "", errors.Errorf("VolumeSnapshotClass (%s) missing driver/snapshotter field", uVSC.GetName())
+	}
+	if driverString, ok := driver.(string); ok {
+		return driverString, nil
+	}
+	return "", errors.Errorf("Failed to convert driver to string")
 }

--- a/pkg/kube/snapshot/snapshot_beta.go
+++ b/pkg/kube/snapshot/snapshot_beta.go
@@ -44,8 +44,8 @@ func NewSnapshotBeta(kubeCli kubernetes.Interface, dynCli dynamic.Interface) Sna
 }
 
 // GetVolumeSnapshotClass returns VolumeSnapshotClass name which is annotated with given key.
-func (sna *SnapshotBeta) GetVolumeSnapshotClass(annotationKey, annotationValue string) (string, error) {
-	return getSnapshotClassbyAnnotation(sna.dynCli, v1beta1.VolSnapClassGVR, annotationKey, annotationValue)
+func (sna *SnapshotBeta) GetVolumeSnapshotClass(annotationKey, annotationValue, storageClassName string) (string, error) {
+	return getSnapshotClassbyAnnotation(sna.dynCli, sna.kubeCli, v1beta1.VolSnapClassGVR, annotationKey, annotationValue, storageClassName)
 }
 
 // Create creates a VolumeSnapshot and returns it or any error happened meanwhile.


### PR DESCRIPTION
## Change Overview

This change modifies the GetVolumeSnapshotClass interface enabling it to take a storageClassName. It will use this field along with the an annotation to derive a VolumeSnapshotClass that matches

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
