### PR TITLE
Update RDS BP to delete snapshot after taking dump

### DIFF
--- a/examples/aws-rds/postgresql/README.md
+++ b/examples/aws-rds/postgresql/README.md
@@ -113,20 +113,34 @@ s3-profile-sph7s   2h
 
 
 # Use correct blueprint name (one of `rds-postgres-dump-bp` or `rds-postgres-snapshot-bp`) you have created earlier
-#
-$ kanctl create actionset --action backup --namespacetargets pgtestrds --config-maps dbconfig=pgtestrds/dbconfig --profile pgtestrds/s3-profile-6hmhn -b <blueprint-name> -n kasten-io
-actionset backup-llfb8 created
+
+cat <<EOF | kubectl apply -f -
+> apiVersion: cr.kanister.io/v1alpha1
+> kind: ActionSet
+> metadata:
+>   name: rds-backup
+>   namespace: kasten-io
+> spec:
+>   actions:
+>   - name: backup
+>     blueprint: <blueprint-name>
+>     object:
+>       apiVersion: v1
+>       name: dbconfig
+>       namespace: pgtestrds
+>       resource: configmaps
+>     profile:
+>       name: s3-profile-sph7s
+>       namespace: pgtestrds
+> EOF
+actionset.cr.kanister.io/rds-backup created
 
 # Where,
 # dbconfig is a configmap holding RDS infromation
 # Please see pgtest/deploy/config.yaml for configmap format
 
-$ kubectl --namespace kasten-io get actionsets.cr.kanister.io
-NAME                 AGE
-backup-llfb8         2h
-
 # View the status of the actionset
-$ kubectl --namespace kasten-io describe actionset backup-llfb8
+$ kubectl --namespace kasten-io describe actionset rds-backup
 ```
 
 ### Restore the Application
@@ -135,11 +149,11 @@ To restore the missing data from RDS snapshot, you should use the backup that yo
 
 
 ```bash
-$ kanctl create actionset --namespace kasten-io --action restore --config-maps dbconfig=pgtestrds/dbconfig --from backup-llfb8
-actionset restore-backup-llfb8-64gqm created
+$ kanctl create actionset --namespace kasten-io --action restore --from rds-backup
+actionset restore-rds-backup-mrhmc created
 
 ## Check status
-$ kubectl --namespace kasten-io describe actionset restore-backup-llfb8-64gqm
+$ kubectl --namespace kasten-io describe actionset restore-rds-backup-mrhmc
 ```
 
 
@@ -148,11 +162,11 @@ $ kubectl --namespace kasten-io describe actionset restore-backup-llfb8-64gqm
 The snapshot created by Actionset can be deleted by the following command
 
 ```bash
-$ kanctl create actionset --namespace kasten-io --action delete -c dbconfig=pgtestrds/dbconfig --from backup-llfb8
-actionset "delete-backup-llfb8-k9ncm" created
+$ kanctl create actionset --namespace kasten-io --action delete --from rds-backup
+actionset "delete-rds-backup-677tb" created
 
 ## Check status
-$ kubectl --namespace kasten-io describe actionset delete-backup-llfb8-k9ncm
+$ kubectl --namespace kasten-io describe actionset delete-rds-backup-677tb
 
 ```
 
@@ -167,7 +181,7 @@ $ kubectl --namespace kasten-io logs -l app=kanister-operator
 you can also check events of the actionset
 
 ```bash
-$ kubectl describe actionset restore-backup-md6gb-d7g7w -n kasten-io
+$ kubectl describe actionset restore-rds-backup-d7g7w -n kasten-io
 ```
 
 ## Cleanup

--- a/examples/aws-rds/postgresql/rds-postgres-dump-blueprint.yaml
+++ b/examples/aws-rds/postgresql/rds-postgres-dump-blueprint.yaml
@@ -33,7 +33,10 @@ actions:
         databases: '{{ index .Object.data "postgres.databases" }}'
         snapshotID: "{{ .Phases.createSnapshot.Output.snapshotID }}"
         backupArtifactPrefix: test-postgresql-instance/postgres
-
+    - func: DeleteRDSSnapshot
+      name: deleteSnapshot
+      args:
+        snapshotID: "{{ .Phases.createSnapshot.Output.snapshotID }}"
   restore:
     inputArtifactNames:
     - backupInfo
@@ -56,10 +59,19 @@ actions:
         dbEngine: "PostgreSQL"
 
   delete:
-    inputArtifactNames:
-    - backupInfo
     phases:
-    - func: DeleteRDSSnapshot
-      name: deleteSnapshot
+    - func: KubeTask
+      name: deleteBackup
       args:
-        snapshotID: "{{ .ArtifactsIn.backupInfo.KeyValue.snapshotID }}"
+        namespace: "{{ .Object.metadata.namespace }}"
+        image: kanisterio/kanister-tools:0.29.0
+        command:
+          - bash
+          - -o
+          - pipefail
+          - -o
+          - errexit
+          - -c
+          - |
+            s3path='test-postgresql-instance/postgres/{{ .ArtifactsIn.backupInfo.KeyValue.backupID }}'
+            kando location delete --profile '{{ toJson .Profile }}' --path ${s3path}


### PR DESCRIPTION
## Change Overview

- Update RDS BP to delete snapshot after extracting dump from the RDS instance
- Fix actionset creation commands in the README

## Pull request type

Please check the type of change your PR introduces:

- [x] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :world_map: Documentation

## Issues

- #XXX

## Test Plan

Tested backup, restore and delete actions on manually

- [x] :muscle: Manual
