### PR TITLE
Fix race in setting controller namespace

### DIFF
--- a/pkg/testing/integration_test.go
+++ b/pkg/testing/integration_test.go
@@ -254,7 +254,7 @@ func (s *IntegrationSuite) TestRun(c *C) {
 	}
 
 	// Restore backup
-	pas, err := s.crCli.ActionSets(s.namespace).Get(backup, metav1.GetOptions{})
+	pas, err := s.crCli.ActionSets(controllerNamespace).Get(backup, metav1.GetOptions{})
 	c.Assert(err, IsNil)
 	s.createActionset(ctx, c, pas, "restore", restoreOptions)
 

--- a/pkg/testing/integration_test.go
+++ b/pkg/testing/integration_test.go
@@ -107,7 +107,7 @@ func (s *IntegrationSuite) SetUpSuite(c *C) {
 }
 
 func resetNamespace(ctx context.Context, c *C, cli kubernetes.Interface) {
-	// Try to delete namespace and wait til it doesn't exist.
+	// Try to delete namespace and wait until it doesn't exist.
 	err := cli.CoreV1().Namespaces().Delete(controllerNamespace, nil)
 	if !apierrors.IsNotFound(err) {
 		c.Assert(err, IsNil)


### PR DESCRIPTION
## Change Overview

* Uses a well known namespace to run the controller
* Delete/recreates the namespace at test startup

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [x] :robot: Test


## Test Plan

Fixes integration test

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
