### PR TITLE
Use single controller for concurrent suites in integration_test

### DIFF
--- a/pkg/testing/integration_test.go
+++ b/pkg/testing/integration_test.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	check "gopkg.in/check.v1"
+	. "gopkg.in/check.v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -44,7 +44,7 @@ import (
 // Hook up gocheck into the "go test" runner for integration builds
 func Test(t *test.T) {
 	integrationSetup(t)
-	check.TestingT(t)
+	TestingT(t)
 	integrationCleanup(t)
 }
 
@@ -134,7 +134,7 @@ func newSecretProfile() *secretProfile {
 	}
 }
 
-func (s *IntegrationSuite) SetUpSuite(c *check.C) {
+func (s *IntegrationSuite) SetUpSuite(c *C) {
 	ctx := context.Background()
 	ctx, s.cancel = context.WithCancel(ctx)
 
@@ -155,7 +155,7 @@ func (s *IntegrationSuite) SetUpSuite(c *check.C) {
 // 5. Delete DB data
 // 6. Restore data from backup
 // 7. Uninstall DB app
-func (s *IntegrationSuite) TestRun(c *check.C) {
+func (s *IntegrationSuite) TestRun(c *C) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -306,7 +306,7 @@ func newActionSet(bpName, profile, profileNs string, object crv1alpha1.ObjectRef
 	}
 }
 
-func (s *IntegrationSuite) createProfile(c *check.C) string {
+func (s *IntegrationSuite) createProfile(c *C) string {
 	secret, err := s.cli.CoreV1().Secrets(controllerNamespace).Create(s.profile.secret)
 	c.Assert(err, IsNil)
 
@@ -321,7 +321,7 @@ func (s *IntegrationSuite) createProfile(c *check.C) string {
 	return profile.GetName()
 }
 
-func validateBlueprint(c *check.C, bp crv1alpha1.Blueprint, configMaps, secrets map[string]crv1alpha1.ObjectReference) {
+func validateBlueprint(c *C, bp crv1alpha1.Blueprint, configMaps, secrets map[string]crv1alpha1.ObjectReference) {
 	for _, action := range bp.Actions {
 		// Validate BP action ConfigMapNames with the app.ConfigMaps references
 		for _, bpc := range action.ConfigMapNames {
@@ -347,7 +347,7 @@ func validateBlueprint(c *check.C, bp crv1alpha1.Blueprint, configMaps, secrets 
 }
 
 // createActionset creates and wait for actionset to complete
-func (s *IntegrationSuite) createActionset(ctx context.Context, c *check.C, as *crv1alpha1.ActionSet, action string, options map[string]string) string {
+func (s *IntegrationSuite) createActionset(ctx context.Context, c *C, as *crv1alpha1.ActionSet, action string, options map[string]string) string {
 	var err error
 	switch action {
 	case "backup":
@@ -415,7 +415,7 @@ func createNamespace(cli kubernetes.Interface, name string) error {
 	return nil
 }
 
-func (s *IntegrationSuite) TearDownSuite(c *check.C) {
+func (s *IntegrationSuite) TearDownSuite(c *C) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/pkg/testing/integration_test.go
+++ b/pkg/testing/integration_test.go
@@ -18,11 +18,11 @@ package testing
 import (
 	"context"
 	"os"
-	"testing"
+	test "testing"
 	"time"
 
 	"github.com/pkg/errors"
-	. "gopkg.in/check.v1"
+	check "gopkg.in/check.v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -51,7 +51,7 @@ type kanisterKontroller struct {
 
 var kontroller kanisterKontroller
 
-func integrationSetup(t *testing.T) {
+func integrationSetup(t *test.T) {
 	ns := "integration-test-controller-" + rand.String(5)
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -83,7 +83,7 @@ func integrationSetup(t *testing.T) {
 	kontroller.kubeCli = cli
 }
 
-func integrationCleanup(t *testing.T) {
+func integrationCleanup(t *test.T) {
 	if kontroller.cancel != nil {
 		kontroller.cancel()
 	}
@@ -127,7 +127,7 @@ func newSecretProfile() *secretProfile {
 	}
 }
 
-func (s *IntegrationSuite) SetUpSuite(c *C) {
+func (s *IntegrationSuite) SetUpSuite(c *check.C) {
 	ctx := context.Background()
 	ctx, s.cancel = context.WithCancel(ctx)
 
@@ -148,7 +148,7 @@ func (s *IntegrationSuite) SetUpSuite(c *C) {
 // 5. Delete DB data
 // 6. Restore data from backup
 // 7. Uninstall DB app
-func (s *IntegrationSuite) TestRun(c *C) {
+func (s *IntegrationSuite) TestRun(c *check.C) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -299,7 +299,7 @@ func newActionSet(bpName, profile, profileNs string, object crv1alpha1.ObjectRef
 	}
 }
 
-func (s *IntegrationSuite) createProfile(c *C) string {
+func (s *IntegrationSuite) createProfile(c *check.C) string {
 	secret, err := s.cli.CoreV1().Secrets(controllerNamespace).Create(s.profile.secret)
 	c.Assert(err, IsNil)
 
@@ -314,7 +314,7 @@ func (s *IntegrationSuite) createProfile(c *C) string {
 	return profile.GetName()
 }
 
-func validateBlueprint(c *C, bp crv1alpha1.Blueprint, configMaps, secrets map[string]crv1alpha1.ObjectReference) {
+func validateBlueprint(c *check.C, bp crv1alpha1.Blueprint, configMaps, secrets map[string]crv1alpha1.ObjectReference) {
 	for _, action := range bp.Actions {
 		// Validate BP action ConfigMapNames with the app.ConfigMaps references
 		for _, bpc := range action.ConfigMapNames {
@@ -340,7 +340,7 @@ func validateBlueprint(c *C, bp crv1alpha1.Blueprint, configMaps, secrets map[st
 }
 
 // createActionset creates and wait for actionset to complete
-func (s *IntegrationSuite) createActionset(ctx context.Context, c *C, as *crv1alpha1.ActionSet, action string, options map[string]string) string {
+func (s *IntegrationSuite) createActionset(ctx context.Context, c *check.C, as *crv1alpha1.ActionSet, action string, options map[string]string) string {
 	var err error
 	switch action {
 	case "backup":
@@ -408,7 +408,7 @@ func createNamespace(cli kubernetes.Interface, name string) error {
 	return nil
 }
 
-func (s *IntegrationSuite) TearDownSuite(c *C) {
+func (s *IntegrationSuite) TearDownSuite(c *check.C) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/pkg/testing/integration_test.go
+++ b/pkg/testing/integration_test.go
@@ -41,6 +41,13 @@ import (
 	"github.com/kanisterio/kanister/pkg/testutil"
 )
 
+// Hook up gocheck into the "go test" runner for integration builds
+func Test(t *test.T) {
+	integrationSetup(t)
+	check.TestingT(t)
+	integrationCleanup(t)
+}
+
 // Global variables shared across Suite instances
 type kanisterKontroller struct {
 	namespace string

--- a/pkg/testing/integration_test.go
+++ b/pkg/testing/integration_test.go
@@ -254,7 +254,7 @@ func (s *IntegrationSuite) TestRun(c *C) {
 	}
 
 	// Restore backup
-	pas, err := s.crCli.ActionSets(s.namespace).Get(backup, metav1.GetOptions{})
+	pas, err := s.crCli.ActionSets(controllerNamespace).Get(backup, metav1.GetOptions{})
 	c.Assert(err, IsNil)
 	s.createActionset(ctx, c, pas, "restore", restoreOptions)
 

--- a/pkg/testing/integration_test.go
+++ b/pkg/testing/integration_test.go
@@ -95,7 +95,7 @@ func integrationCleanup(t *test.T) {
 		kontroller.cancel()
 	}
 	if kontroller.namespace != "" {
-		kanister.kubeCli.CoreV1().Namespaces().Delete(kanister.namespace, nil)
+		kontroller.kubeCli.CoreV1().Namespaces().Delete(kontroller.namespace, nil)
 	}
 }
 

--- a/pkg/testing/integration_test.go
+++ b/pkg/testing/integration_test.go
@@ -107,7 +107,7 @@ func (s *IntegrationSuite) SetUpSuite(c *C) {
 }
 
 func resetNamespace(ctx context.Context, c *C, cli kubernetes.Interface) {
-	// Try to delete namespace and wait til it doesn't exist.
+	// Try to delete namespace and wait until it doesn't exist.
 	err := cli.CoreV1().Namespaces().Delete(controllerNamespace, nil)
 	if !apierrors.IsNotFound(err) {
 		c.Assert(err, IsNil)

--- a/pkg/testing/integration_test.go
+++ b/pkg/testing/integration_test.go
@@ -25,6 +25,7 @@ import (
 	. "gopkg.in/check.v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/kubernetes"
 
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"

--- a/pkg/testing/testing_test.go
+++ b/pkg/testing/testing_test.go
@@ -15,14 +15,14 @@
 package testing
 
 import (
-	"testing"
+	test "testing"
 
-	. "gopkg.in/check.v1"
+	check "gopkg.in/check.v1"
 )
 
 // Hook up gocheck into the "go test" runner.
-func Test(t *testing.T) {
+func Test(t *test.T) {
 	integrationSetup(t)
-	TestingT(t)
+	check.TestingT(t)
 	integrationCleanup(t)
 }

--- a/pkg/testing/testing_test.go
+++ b/pkg/testing/testing_test.go
@@ -1,3 +1,4 @@
+// +build !integration
 // Copyright 2019 The Kanister Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,9 +21,7 @@ import (
 	check "gopkg.in/check.v1"
 )
 
-// Hook up gocheck into the "go test" runner.
+// Hook up gocheck into the "go test" runner (non-integration builds)
 func Test(t *test.T) {
-	integrationSetup(t)
 	check.TestingT(t)
-	integrationCleanup(t)
 }

--- a/pkg/testing/testing_test.go
+++ b/pkg/testing/testing_test.go
@@ -21,4 +21,8 @@ import (
 )
 
 // Hook up gocheck into the "go test" runner.
-func Test(t *testing.T) { TestingT(t) }
+func Test(t *testing.T) {
+	integrationSetup(t)
+	TestingT(t)
+	integrationCleanup(t)
+}

--- a/pkg/testing/testing_test.go
+++ b/pkg/testing/testing_test.go
@@ -18,10 +18,10 @@ package testing
 import (
 	test "testing"
 
-	check "gopkg.in/check.v1"
+	. "gopkg.in/check.v1"
 )
 
 // Hook up gocheck into the "go test" runner (non-integration builds)
 func Test(t *test.T) {
-	check.TestingT(t)
+	TestingT(t)
 }


### PR DESCRIPTION
## Change Overview

Fix concurrency issues with concurrent suites and multiple Kanister controller watches.

Alternative approach to fix race in Suite setup.

## Pull request type

Please check the type of change your PR introduces:
- [x] :bug: Bugfix
