### PR TITLE
Updating tutorial.rst to allow users using other S3 like object storage other than AWS S3.

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -321,9 +321,7 @@ data. We can use the templating engine ``toString`` and ``quote`` functions, cou
 ::
 
 **Note**
-
 If you are not using AWS S3 as the Object Storage, you need to add ``--endpoint {{ .Profile.Location.Endpoint }}`` to the end of the aws command so it can connect to the propper S3 object storage.
-
 
 For more on this templating, see :ref:`templates`
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -318,12 +318,12 @@ variables. Because we now have access to the bucket in the ConfigMap, we can
 also push the log to S3. In this Secret, we store the credentials as binary
 data. We can use the templating engine ``toString`` and ``quote`` functions, courtesy of sprig.
 
-___
+```
 **Note**
 
 If you are not using AWS S3 as the Object Storage, you need to add ``--endpoint {{ .Profile.Location.Endpoint }}``
 to the end of the aws command so it can connect to the propper S3 object storage.
-___
+```
 
 For more on this templating, see :ref:`templates`
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -317,6 +317,8 @@ section. We can then consume it through templates and assign it to bash
 variables. Because we now have access to the bucket in the ConfigMap, we can
 also push the log to S3. In this Secret, we store the credentials as binary
 data. We can use the templating engine ``toString`` and ``quote`` functions, courtesy of sprig.
+Since not everyone uses AWS S3, we need to add ``--endpoint {{ .Profile.Location.Endpoint }}``
+to the end of the aws command so it can connect to the propper S3 object storage.
 
 For more on this templating, see :ref:`templates`
 
@@ -348,7 +350,8 @@ For more on this templating, see :ref:`templates`
             - |
               AWS_ACCESS_KEY_ID={{ .Secrets.aws.Data.aws_access_key_id | toString }}         \
               AWS_SECRET_ACCESS_KEY={{ .Secrets.aws.Data.aws_secret_access_key | toString }} \
-              aws s3 cp /var/log/time.log {{ .ConfigMaps.location.Data.path | quote }}
+              aws s3 cp /var/log/time.log {{ .ConfigMaps.location.Data.path | quote }} \
+              --endpoint {{ .Profile.Location.Endpoint }}
   EOF
 
 Create a new ActionSet that has the name-to-Secret reference in its action's
@@ -435,7 +438,8 @@ ConfigMap.
               - |
                 AWS_ACCESS_KEY_ID={{ .Secrets.aws.Data.aws_access_key_id | toString }}         \
                 AWS_SECRET_ACCESS_KEY={{ .Secrets.aws.Data.aws_secret_access_key | toString }} \
-                aws s3 cp /var/log/time.log {{ .ConfigMaps.location.Data.path }}/time-log/
+                aws s3 cp /var/log/time.log {{ .ConfigMaps.location.Data.path }}/time-log/ \
+                --endpoint {{ .Profile.Location.Endpoint }}
   EOF
 
 If you re-execute this Kanister Action, you'll be able to see the Artifact in the
@@ -516,7 +520,8 @@ ConfigMap because the ``inputArtifact`` contains the fully specified path.
               - |
                 AWS_ACCESS_KEY_ID={{ .Secrets.aws.Data.aws_access_key_id | toString }}         \
                 AWS_SECRET_ACCESS_KEY={{ .Secrets.aws.Data.aws_secret_access_key | toString }} \
-                aws s3 cp /var/log/time.log {{ .ConfigMaps.location.Data.path }}/time-log/
+                aws s3 cp /var/log/time.log {{ .ConfigMaps.location.Data.path }}/time-log/ \
+                --endpoint {{ .Profile.Location.Endpoint }}
     restore:
       type: Deployment
       secretNames:
@@ -536,7 +541,8 @@ ConfigMap because the ``inputArtifact`` contains the fully specified path.
             - |
               AWS_ACCESS_KEY_ID={{ .Secrets.aws.Data.aws_access_key_id | toString }}         \
               AWS_SECRET_ACCESS_KEY={{ .Secrets.aws.Data.aws_secret_access_key | toString }} \
-              aws s3 cp {{ .ArtifactsIn.timeLog.KeyValue.path | quote }} /var/log/time.log
+              aws s3 cp {{ .ArtifactsIn.timeLog.KeyValue.path | quote }} /var/log/time.log \
+              --endpoint {{ .Profile.Location.Endpoint }}              
   EOF
 
 We can check the controller logs to see that the time log was restored

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -317,9 +317,13 @@ section. We can then consume it through templates and assign it to bash
 variables. Because we now have access to the bucket in the ConfigMap, we can
 also push the log to S3. In this Secret, we store the credentials as binary
 data. We can use the templating engine ``toString`` and ``quote`` functions, courtesy of sprig.
+
+---
+**Note**
+
 If you are not using AWS S3 as the Object Storage, you need to add ``--endpoint {{ .Profile.Location.Endpoint }}``
 to the end of the aws command so it can connect to the propper S3 object storage.
-
+--
 For more on this templating, see :ref:`templates`
 
 .. code-block:: yaml
@@ -542,7 +546,7 @@ ConfigMap because the ``inputArtifact`` contains the fully specified path.
               AWS_ACCESS_KEY_ID={{ .Secrets.aws.Data.aws_access_key_id | toString }}         \
               AWS_SECRET_ACCESS_KEY={{ .Secrets.aws.Data.aws_secret_access_key | toString }} \
               aws s3 cp {{ .ArtifactsIn.timeLog.KeyValue.path | quote }} /var/log/time.log \
-              --endpoint {{ .Profile.Location.Endpoint }}              
+              --endpoint {{ .Profile.Location.Endpoint }}
   EOF
 
 We can check the controller logs to see that the time log was restored

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -318,12 +318,12 @@ variables. Because we now have access to the bucket in the ConfigMap, we can
 also push the log to S3. In this Secret, we store the credentials as binary
 data. We can use the templating engine ``toString`` and ``quote`` functions, courtesy of sprig.
 
----
+***
 **Note**
 
 If you are not using AWS S3 as the Object Storage, you need to add ``--endpoint {{ .Profile.Location.Endpoint }}``
 to the end of the aws command so it can connect to the propper S3 object storage.
----
+***
 
 For more on this templating, see :ref:`templates`
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -319,10 +319,7 @@ also push the log to S3. In this Secret, we store the credentials as binary
 data. We can use the templating engine ``toString`` and ``quote`` functions, courtesy of sprig.
 
 
-> **Note**
-> 
-> If you are not using AWS S3 as the Object Storage, you need to add ``--endpoint {{ .Profile.Location.Endpoint }}``
-> to the end of the aws command so it can connect to the propper S3 object storage.
+> **Note** If you are not using AWS S3 as the Object Storage, you need to add ``--endpoint {{ .Profile.Location.Endpoint }}`` to the end of the aws command so it can connect to the propper S3 object storage.
 
 
 For more on this templating, see :ref:`templates`

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -318,8 +318,8 @@ variables. Because we now have access to the bucket in the ConfigMap, we can
 also push the log to S3. In this Secret, we store the credentials as binary
 data. We can use the templating engine ``toString`` and ``quote`` functions, courtesy of sprig.
 
-
-> **Note** If you are not using AWS S3 as the Object Storage, you need to add ``--endpoint {{ .Profile.Location.Endpoint }}`` to the end of the aws command so it can connect to the propper S3 object storage.
+| **Note**
+| If you are not using AWS S3 as the Object Storage, you need to add ``--endpoint {{ .Profile.Location.Endpoint }}`` to the end of the aws command so it can connect to the propper S3 object storage.
 
 
 For more on this templating, see :ref:`templates`

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -318,12 +318,12 @@ variables. Because we now have access to the bucket in the ConfigMap, we can
 also push the log to S3. In this Secret, we store the credentials as binary
 data. We can use the templating engine ``toString`` and ``quote`` functions, courtesy of sprig.
 
-***
+___
 **Note**
 
 If you are not using AWS S3 as the Object Storage, you need to add ``--endpoint {{ .Profile.Location.Endpoint }}``
 to the end of the aws command so it can connect to the propper S3 object storage.
-***
+___
 
 For more on this templating, see :ref:`templates`
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -318,8 +318,11 @@ variables. Because we now have access to the bucket in the ConfigMap, we can
 also push the log to S3. In this Secret, we store the credentials as binary
 data. We can use the templating engine ``toString`` and ``quote`` functions, courtesy of sprig.
 
-| **Note**
-| If you are not using AWS S3 as the Object Storage, you need to add ``--endpoint {{ .Profile.Location.Endpoint }}`` to the end of the aws command so it can connect to the propper S3 object storage.
+::
+
+**Note**
+
+If you are not using AWS S3 as the Object Storage, you need to add ``--endpoint {{ .Profile.Location.Endpoint }}`` to the end of the aws command so it can connect to the propper S3 object storage.
 
 
 For more on this templating, see :ref:`templates`

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -323,6 +323,8 @@ data. We can use the templating engine ``toString`` and ``quote`` functions, cou
 **Note**
 If you are not using AWS S3 as the Object Storage, you need to add ``--endpoint {{ .Profile.Location.Endpoint }}`` to the end of the aws command so it can connect to the propper S3 object storage.
 
+::
+
 For more on this templating, see :ref:`templates`
 
 .. code-block:: yaml

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -319,7 +319,7 @@ also push the log to S3. In this Secret, we store the credentials as binary
 data. We can use the templating engine ``toString`` and ``quote`` functions, courtesy of sprig.
 
 
-..**Note**
+**Note**
 
 If you are not using AWS S3 as the Object Storage, you need to add ``--endpoint {{ .Profile.Location.Endpoint }}`` to the end of the aws command so it can connect to the propper S3 object storage.
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -317,7 +317,7 @@ section. We can then consume it through templates and assign it to bash
 variables. Because we now have access to the bucket in the ConfigMap, we can
 also push the log to S3. In this Secret, we store the credentials as binary
 data. We can use the templating engine ``toString`` and ``quote`` functions, courtesy of sprig.
-Since not everyone uses AWS S3, we need to add ``--endpoint {{ .Profile.Location.Endpoint }}``
+If you are not using AWS S3 as the Object Storage, you need to add ``--endpoint {{ .Profile.Location.Endpoint }}``
 to the end of the aws command so it can connect to the propper S3 object storage.
 
 For more on this templating, see :ref:`templates`

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -323,7 +323,8 @@ data. We can use the templating engine ``toString`` and ``quote`` functions, cou
 
 If you are not using AWS S3 as the Object Storage, you need to add ``--endpoint {{ .Profile.Location.Endpoint }}``
 to the end of the aws command so it can connect to the propper S3 object storage.
---
+---
+
 For more on this templating, see :ref:`templates`
 
 .. code-block:: yaml

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -318,12 +318,12 @@ variables. Because we now have access to the bucket in the ConfigMap, we can
 also push the log to S3. In this Secret, we store the credentials as binary
 data. We can use the templating engine ``toString`` and ``quote`` functions, courtesy of sprig.
 
-```
-**Note**
 
-If you are not using AWS S3 as the Object Storage, you need to add ``--endpoint {{ .Profile.Location.Endpoint }}``
-to the end of the aws command so it can connect to the propper S3 object storage.
-```
+> **Note**
+> 
+> If you are not using AWS S3 as the Object Storage, you need to add ``--endpoint {{ .Profile.Location.Endpoint }}``
+> to the end of the aws command so it can connect to the propper S3 object storage.
+
 
 For more on this templating, see :ref:`templates`
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -318,12 +318,10 @@ variables. Because we now have access to the bucket in the ConfigMap, we can
 also push the log to S3. In this Secret, we store the credentials as binary
 data. We can use the templating engine ``toString`` and ``quote`` functions, courtesy of sprig.
 
-::
 
-**Note**
+..**Note**
+
 If you are not using AWS S3 as the Object Storage, you need to add ``--endpoint {{ .Profile.Location.Endpoint }}`` to the end of the aws command so it can connect to the propper S3 object storage.
-
-::
 
 For more on this templating, see :ref:`templates`
 


### PR DESCRIPTION
Since we can't assume that people trying this tutorial are using AWS S3 and this is not necessarily true. By adding the --endpoint we force the command to pull the endpoint from the profile.

## Change Overview

Updating the tutorial to allow people trying with other S3 object storage other than AWS S3.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [X] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
