### PR TITLE
Add VolumeSnapshotContent APIs to snapshot pkg

### DIFF
--- a/pkg/kube/snapshot/snapshot.go
+++ b/pkg/kube/snapshot/snapshot.go
@@ -27,13 +27,14 @@ import (
 )
 
 type Snapshotter interface {
-	// GetVolumeSnapshotClass returns VolumeSnapshotClass name which is annotated with given key.
+	// GetVolumeSnapshotClass returns VolumeSnapshotClass name which is annotated with given key
+	// as well as its deletion policy
 	//
 	// 'annotationKey' is the annotation key which has to be present on VolumeSnapshotClass.
 	// 'annotationValue' is the value for annotationKey in VolumeSnapshotClass spec.
 	// 'storageClassName' is the name of the storageClass that shares the same driver as the VolumeSnapshotClass.
 	// This returns error if no VolumeSnapshotClass found.
-	GetVolumeSnapshotClass(annotationKey, annotationValue, storageClassName string) (string, error)
+	GetVolumeSnapshotClass(annotationKey, annotationValue, storageClassName string) (string, string, error)
 	// Create creates a VolumeSnapshot and returns it or any error happened meanwhile.
 	//
 	// 'name' is the name of the VolumeSnapshot.
@@ -52,6 +53,10 @@ type Snapshotter interface {
 	// 'name' is the name of the VolumeSnapshot that will be deleted.
 	// 'namespace' is the namespace of the VolumeSnapshot that will be deleted.
 	Delete(ctx context.Context, name, namespace string) error
+	// Delete will delete the VolumeSnapshot and returns any error as a result.
+	//
+	// 'name' is the name of the VolumeSnapshotContent that will be deleted.
+	DeleteContent(ctx context.Context, name string) error
 	// Clone will clone the VolumeSnapshot to namespace 'cloneNamespace'.
 	// Underlying VolumeSnapshotContent will be cloned with a different name.
 	//
@@ -73,6 +78,14 @@ type Snapshotter interface {
 	// 'namespace' is the namespace of the snapshot.
 	// 'waitForReady' blocks the caller until snapshot is ready to use or context is cancelled.
 	CreateFromSource(ctx context.Context, source *Source, snapshotName, namespace string, waitForReady bool) error
+	// CreateContentFromSource will create a 'VolumesnaphotContent' for the underlying snapshot source.
+	//
+	// 'source' contains information about CSI snapshot.
+	// 'contentName' is the name of the VSC that will be created
+	// 'snapshotName' is the name of the snapshot that will be reference the VSC
+	// 'namespace' is the namespace of the snapshot.
+	// 'deletionPolicy' is the deletion policy to set on the created VSC
+	CreateContentFromSource(ctx context.Context, source *Source, contentName, snapshotName, namespace, deletionPolicy string) error
 	// WaitOnReadyToUse will block until the Volumesnapshot in namespace 'namespace' with name 'snapshotName'
 	// has status 'ReadyToUse' or 'ctx.Done()' is signalled.
 	WaitOnReadyToUse(ctx context.Context, snapshotName, namespace string) error


### PR DESCRIPTION
## Change Overview

Adds API support to operate on `VolumeSnapshotContent`.
Specifically, it adds a `CreateContentFromSource` and `DeleteContent` API.

This supports use cases where a namespaced `VolumeSnapshot` object
is not required.

Additional changes:
- Return the snapshot class deletion policy from `GetVolumeSnapshotClass`
- Modify `Delete` to also delete the underlying `VolumeSnapshotContent`.
   This supports cases where the `VolumeSnapshot` is marked `Retain`
- Fix a unit test bug which caused the test to fail on DigitalOcean (no
    restore size set)

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [x] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
