### PR TITLE
Add an API to clone an existing volume snapshot class

### DIFF
--- a/pkg/kube/snapshot/snapshot.go
+++ b/pkg/kube/snapshot/snapshot.go
@@ -28,13 +28,23 @@ import (
 
 type Snapshotter interface {
 	// GetVolumeSnapshotClass returns VolumeSnapshotClass name which is annotated with given key
-	// as well as its deletion policy
 	//
 	// 'annotationKey' is the annotation key which has to be present on VolumeSnapshotClass.
 	// 'annotationValue' is the value for annotationKey in VolumeSnapshotClass spec.
 	// 'storageClassName' is the name of the storageClass that shares the same driver as the VolumeSnapshotClass.
 	// This returns error if no VolumeSnapshotClass found.
-	GetVolumeSnapshotClass(annotationKey, annotationValue, storageClassName string) (string, string, error)
+	GetVolumeSnapshotClass(annotationKey, annotationValue, storageClassName string) (string, error)
+
+	// CloneVolumeSnapshotClass creates a copy of the source volume snapshot
+	// class with the specified deletion policy and name. If the target
+	// already exists, it returns no error.
+	//
+	// 'sourceClassName' is the name of the source VolumeSnapshotClass.
+	// 'targetClassName' is the name of the target VolumeSnapshotClass
+	// 'newDeletionPolicy' is the deletion policy to set on the target.
+	// 'excludeAnnotations' are the annotations that should not be set on the
+	// target
+	CloneVolumeSnapshotClass(sourceClassName, targetClassName, newDeletionPolicy string, excludeAnnotations []string) error
 	// Create creates a VolumeSnapshot and returns it or any error happened meanwhile.
 	//
 	// 'name' is the name of the VolumeSnapshot.
@@ -52,7 +62,7 @@ type Snapshotter interface {
 	//
 	// 'name' is the name of the VolumeSnapshot that will be deleted.
 	// 'namespace' is the namespace of the VolumeSnapshot that will be deleted.
-	Delete(ctx context.Context, name, namespace string) error
+	Delete(ctx context.Context, name, namespace string) (*v1alpha1.VolumeSnapshot, error)
 	// Delete will delete the VolumeSnapshot and returns any error as a result.
 	//
 	// 'name' is the name of the VolumeSnapshotContent that will be deleted.

--- a/pkg/kube/snapshot/snapshot_alpha.go
+++ b/pkg/kube/snapshot/snapshot_alpha.go
@@ -37,13 +37,14 @@ const (
 	PVCKind = "PersistentVolumeClaim"
 
 	// Snapshot resource Kinds
-	VolSnapClassKind           = "VolumeSnapshotClass"
-	VolSnapKind                = "VolumeSnapshot"
-	VolSnapContentKind         = "VolumeSnapshotContent"
-	VolSnapClassAlphaDriverKey = "snapshotter"
-	VolSnapClassBetaDriverKey  = "driver"
-	DeletionPolicyDelete       = "Delete"
-	DeletionPolicyRetain       = "Retain"
+	VolSnapClassKind                  = "VolumeSnapshotClass"
+	VolSnapKind                       = "VolumeSnapshot"
+	VolSnapContentKind                = "VolumeSnapshotContent"
+	VolSnapClassAlphaDriverKey        = "snapshotter"
+	VolSnapClassBetaDriverKey         = "driver"
+	DeletionPolicyDelete              = "Delete"
+	DeletionPolicyRetain              = "Retain"
+	CloneVolumeSnapshotClassLabelName = "cloned-from"
 )
 
 type SnapshotAlpha struct {
@@ -55,17 +56,38 @@ func NewSnapshotAlpha(kubeCli kubernetes.Interface, dynCli dynamic.Interface) Sn
 	return &SnapshotAlpha{kubeCli: kubeCli, dynCli: dynCli}
 }
 
+// CloneVolumeSnapshotClass creates a copy of the source volume snapshot class
+func (sna *SnapshotAlpha) CloneVolumeSnapshotClass(sourceClassName, targetClassName, newDeletionPolicy string, excludeAnnotations []string) error {
+	// If the target snapshot class already exists, treat this as a no-op
+	if _, err := sna.dynCli.Resource(v1alpha1.VolSnapClassGVR).Get(targetClassName, metav1.GetOptions{}); err == nil {
+		return nil
+	}
+	usSourceSnapClass, err := sna.dynCli.Resource(v1alpha1.VolSnapClassGVR).Get(sourceClassName, metav1.GetOptions{})
+	if err != nil {
+		return errors.Wrapf(err, "Failed to find source VolumeSnapshotClass: %s", sourceClassName)
+	}
+	sourceSnapClass := v1alpha1.VolumeSnapshotClass{}
+	if err := TransformUnstructured(usSourceSnapClass, &sourceSnapClass); err != nil {
+		return err
+	}
+	existingAnnotations := sourceSnapClass.GetAnnotations()
+	for _, key := range excludeAnnotations {
+		delete(existingAnnotations, key)
+	}
+	usNew := UnstructuredVolumeSnapshotClassAlpha(targetClassName, sourceSnapClass.Snapshotter, newDeletionPolicy)
+	// Set Annotations/Labels
+	usNew.SetAnnotations(existingAnnotations)
+	usNew.SetLabels(map[string]string{CloneVolumeSnapshotClassLabelName: sourceClassName})
+	_, err = sna.dynCli.Resource(v1alpha1.VolSnapClassGVR).Create(usNew, metav1.CreateOptions{})
+	if err != nil {
+		return errors.Wrapf(err, "Failed to create VolumeSnapshotClass: %s", targetClassName)
+	}
+	return nil
+}
+
 // GetVolumeSnapshotClass returns VolumeSnapshotClass name which is annotated with given key.
-func (sna *SnapshotAlpha) GetVolumeSnapshotClass(annotationKey, annotationValue, storageClassName string) (string, string, error) {
-	scName, err := getSnapshotClassbyAnnotation(sna.dynCli, sna.kubeCli, v1alpha1.VolSnapClassGVR, annotationKey, annotationValue, storageClassName)
-	if err != nil {
-		return "", "", err
-	}
-	deletionPolicy, err := sna.getDeletionPolicyFromClass(scName)
-	if err != nil {
-		return "", "", err
-	}
-	return scName, deletionPolicy, nil
+func (sna *SnapshotAlpha) GetVolumeSnapshotClass(annotationKey, annotationValue, storageClassName string) (string, error) {
+	return getSnapshotClassbyAnnotation(sna.dynCli, sna.kubeCli, v1alpha1.VolSnapClassGVR, annotationKey, annotationValue, storageClassName)
 }
 
 // Create creates a VolumeSnapshot and returns it or any error that happened meanwhile.
@@ -106,21 +128,19 @@ func (sna *SnapshotAlpha) Get(ctx context.Context, name, namespace string) (*v1a
 }
 
 // Delete will delete the VolumeSnapshot and returns any error as a result.
-func (sna *SnapshotAlpha) Delete(ctx context.Context, name, namespace string) error {
+func (sna *SnapshotAlpha) Delete(ctx context.Context, name, namespace string) (*v1alpha1.VolumeSnapshot, error) {
 	snap, err := sna.Get(ctx, name, namespace)
 	if apierrors.IsNotFound(err) {
-		return nil
+		return nil, nil
 	}
 	if err != nil {
-		return errors.Wrapf(err, "Failed to find VolumeSnapshot: %s/%s", namespace, name)
+		return nil, errors.Wrapf(err, "Failed to find VolumeSnapshot: %s/%s", namespace, name)
 	}
 	if err := sna.dynCli.Resource(v1alpha1.VolSnapGVR).Namespace(namespace).Delete(name, &metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
-		return errors.Wrapf(err, "Failed to delete VolumeSnapshot: %s/%s", namespace, name)
+		return nil, errors.Wrapf(err, "Failed to delete VolumeSnapshot: %s/%s", namespace, name)
 	}
 	// If the Snapshot does not exist, that's an acceptable error and we ignore it
-
-	// Delete the underlying VolumeSnapshotContent
-	return sna.DeleteContent(ctx, snap.Spec.SnapshotContentName)
+	return snap, nil
 }
 
 // DeleteContent will delete the specified VolumeSnapshotContent


### PR DESCRIPTION
## Change Overview

Introduces an API to clone an existing volume snapshot class.

This can be used to create a new volume snapshot class with a different
deletion policy.

Additional changes:
- `GetVolumeSnapshotClass` no longer returns the deletion policy
- `Delete` no longer deletes the underlying snapshot content implicitly.
    It returns the `VolumeSnapshot` spec so the caller can decide what to do
    and if deletion is required, can use the `DeleteContent` API
 
## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [x] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
