### PR TITLE
Fix TOCTOU bug in CloneVolumeSnapshotClass 

### DIFF
--- a/pkg/kube/snapshot/snapshot.go
+++ b/pkg/kube/snapshot/snapshot.go
@@ -58,12 +58,14 @@ type Snapshotter interface {
 	// 'name' is the name of the VolumeSnapshot that will be returned.
 	// 'namespace' is the namespace of the VolumeSnapshot that will be returned.
 	Get(ctx context.Context, name, namespace string) (*v1alpha1.VolumeSnapshot, error)
-	// Delete will delete the VolumeSnapshot and returns any error as a result.
+	// Delete will delete the VolumeSnapshot.
+	// Returns the `VolumeSnapshot` deleted and any error as a result.
 	//
 	// 'name' is the name of the VolumeSnapshot that will be deleted.
 	// 'namespace' is the namespace of the VolumeSnapshot that will be deleted.
 	Delete(ctx context.Context, name, namespace string) (*v1alpha1.VolumeSnapshot, error)
-	// Delete will delete the VolumeSnapshot and returns any error as a result.
+	// DeleteContent will delete the VolumeSnapshot and returns any error as a
+	// result.
 	//
 	// 'name' is the name of the VolumeSnapshotContent that will be deleted.
 	DeleteContent(ctx context.Context, name string) error

--- a/pkg/kube/snapshot/snapshot_test.go
+++ b/pkg/kube/snapshot/snapshot_test.go
@@ -213,6 +213,10 @@ func (s *SnapshotTestSuite) TestVolumeSnapshotClassCloneFake(c *C) {
 		scWithOldAnnotation, err := tc.snapshotter.GetVolumeSnapshotClass(annotationKeyToRemove, "true", fakeSC)
 		c.Assert(err, IsNil)
 		c.Assert(scWithOldAnnotation, Equals, tc.sourceSnapClassSpec.GetName())
+
+		// Clone again succeeds
+		err = tc.snapshotter.CloneVolumeSnapshotClass(tc.sourceSnapClassSpec.GetName(), "targetClass", snapshot.DeletionPolicyRetain, []string{annotationKeyToRemove})
+		c.Assert(err, IsNil)
 	}
 }
 


### PR DESCRIPTION
## Change Overview

Fixes a bug where racing `CloneVolumeSnapshotClass` would fail.

Also address review comments from previous PR.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
