### PR TITLE
[Minor] Add skeleton for new kando command

### DIFF
--- a/pkg/kando/kando.go
+++ b/pkg/kando/kando.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The Kanister Authors.
+// Copyright 2020 The Kanister Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -52,6 +52,7 @@ func newRootCommand() *cobra.Command {
 	rootCmd.AddCommand(newLocationCommand())
 	rootCmd.AddCommand(newOutputCommand())
 	rootCmd.AddCommand(newChronicleCommand())
+	rootCmd.AddCommand(newStreamCommand())
 	return rootCmd
 }
 

--- a/pkg/kando/stream.go
+++ b/pkg/kando/stream.go
@@ -1,0 +1,38 @@
+// Copyright 2020 The Kanister Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kando
+
+import (
+	"github.com/spf13/cobra"
+)
+
+const (
+	passwordFlagName = "password"
+)
+
+func newStreamCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "stream <command>",
+		Short: "Manage data streams in object storage",
+	}
+	cmd.AddCommand(newStreamPushCommand())
+	cmd.PersistentFlags().StringP(passwordFlagName, "p", "", "Specify the password for object storage repository (required)")
+	_ = cmd.MarkPersistentFlagRequired(passwordFlagName)
+	return cmd
+}
+
+func passwordFlag(cmd *cobra.Command) string {
+	return cmd.Flag(passwordFlagName).Value.String()
+}

--- a/pkg/kando/stream_push.go
+++ b/pkg/kando/stream_push.go
@@ -20,6 +20,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	sourcePathFlagName = "path"
+	fileNameFlagName   = "file"
+)
+
 func newStreamPushCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "push <source>",
@@ -29,25 +34,43 @@ func newStreamPushCommand() *cobra.Command {
 			return runStreamPush(c, args)
 		},
 	}
+	cmd.Flags().StringP(fileNameFlagName, "f", "", "Specify a name for the data stream (required)")
+	cmd.Flags().StringP(sourcePathFlagName, "d", "", "Specify a directory path for the data stream (required)")
+	_ = cmd.MarkFlagRequired(fileNameFlagName)
+	_ = cmd.MarkFlagRequired(sourcePathFlagName)
 	return cmd
 }
 
 func runStreamPush(cmd *cobra.Command, args []string) error {
 	// TODO: Implement stream push
 	_ = passwordFlag(cmd)
+	_ = fileNameFlag(cmd)
+	_ = pathFlag(cmd)
 	_ = args[0]
 	return nil
 }
 
+func fileNameFlag(cmd *cobra.Command) string {
+	return cmd.Flag(fileNameFlagName).Value.String()
+}
+
+func pathFlag(cmd *cobra.Command) string {
+	return cmd.Flag(sourcePathFlagName).Value.String()
+}
+
 // GenerateStreamPushCommand generates a bash command for
 // kando stream push with given password and source
-func GenerateStreamPushCommand(password, sourceEndpoint string) []string {
+func GenerateStreamPushCommand(fileName, password, path, sourceEndpoint string) []string {
 	kandoCmd := []string{
 		"kando",
 		"stream",
 		"push",
 		"-p",
 		password,
+		"-f",
+		fileName,
+		"-d",
+		path,
 		sourceEndpoint,
 	}
 	return []string{

--- a/pkg/kando/stream_push.go
+++ b/pkg/kando/stream_push.go
@@ -1,0 +1,36 @@
+// Copyright 2020 The Kanister Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kando
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func newStreamPushCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "push <source>",
+		Short: "Push the output of a stream source to object storage",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			return runStreamPush(c, args)
+		},
+	}
+	return cmd
+}
+
+func runStreamPush(cmd *cobra.Command, args []string) error {
+	// TODO: Implement stream push
+	return nil
+}

--- a/pkg/kando/stream_push.go
+++ b/pkg/kando/stream_push.go
@@ -45,7 +45,7 @@ func runStreamPush(cmd *cobra.Command, args []string) error {
 	// TODO: Implement stream push
 	_ = passwordFlag(cmd)
 	_ = fileNameFlag(cmd)
-	_ = pathFlag(cmd)
+	_ = sourcePathFlag(cmd)
 	_ = args[0]
 	return nil
 }
@@ -54,12 +54,12 @@ func fileNameFlag(cmd *cobra.Command) string {
 	return cmd.Flag(fileNameFlagName).Value.String()
 }
 
-func pathFlag(cmd *cobra.Command) string {
+func sourcePathFlag(cmd *cobra.Command) string {
 	return cmd.Flag(sourcePathFlagName).Value.String()
 }
 
 // GenerateStreamPushCommand generates a bash command for
-// kando stream push with given password and source
+// kando stream push with given flags and arguments
 func GenerateStreamPushCommand(fileName, password, path, sourceEndpoint string) []string {
 	kandoCmd := []string{
 		"kando",

--- a/pkg/kando/stream_push.go
+++ b/pkg/kando/stream_push.go
@@ -15,6 +15,8 @@
 package kando
 
 import (
+	"strings"
+
 	"github.com/spf13/cobra"
 )
 
@@ -32,5 +34,29 @@ func newStreamPushCommand() *cobra.Command {
 
 func runStreamPush(cmd *cobra.Command, args []string) error {
 	// TODO: Implement stream push
+	_ = passwordFlag(cmd)
+	_ = args[0]
 	return nil
+}
+
+// GenerateStreamPushCommand generates a bash command for
+// kando stream push with given password and source
+func GenerateStreamPushCommand(password, sourceEndpoint string) []string {
+	kandoCmd := []string{
+		"kando",
+		"stream",
+		"push",
+		"-p",
+		password,
+		sourceEndpoint,
+	}
+	return []string{
+		"bash",
+		"-o",
+		"errexit",
+		"-o",
+		"pipefail",
+		"-c",
+		strings.Join(kandoCmd, " "),
+	}
 }


### PR DESCRIPTION
## Change Overview

- Adding a new command to stream data.
- Implementation will come in a separate PR.

## Pull request type

Please check the type of change your PR introduces:
- [x] :sunflower: Feature

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual