### PR TITLE
Update PostgreSQL image from python2 to python3

### DIFF
--- a/docker/postgres-kanister-tools/Dockerfile
+++ b/docker/postgres-kanister-tools/Dockerfile
@@ -5,10 +5,9 @@ ENV DEBIAN_FRONTEND noninteractive
 
 USER root
 
-RUN apk -v --update add --no-cache curl python py-pip groff less jq && \
-    pip install --upgrade pip && \
-    pip install --upgrade awscli && \
-    apk -v --purge del py-pip && \
+RUN apk -v --update add --no-cache curl python3 groff less jq && \
+    pip3 install --upgrade pip && \
+    pip3 install --upgrade awscli && \
     rm -f /var/cache/apk/*
 
 COPY --from=restic/restic:0.9.5 /usr/bin/restic /usr/local/bin/restic


### PR DESCRIPTION
## Change Overview

Fixes the following:
```
Step 5/8 : RUN apk -v --update add --no-cache curl python py-pip groff less jq &&     pip install --upgrade pip &&     pip install --upgrade awscli &&     apk -v --purge del py-pip &&     rm -f /var/cache/apk/*
 ---> Running in a45e539ccd5d
fetch http://dl-cdn.alpinelinux.org/alpine/v3.12/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.12/community/x86_64/APKINDEX.tar.gz
ERROR: unsatisfiable constraints:
  python (missing):
    required by: world[python]
The command '/bin/sh -c apk -v --update add --no-cache curl python py-pip groff less jq &&     pip install --upgrade pip &&     pip install --upgrade awscli &&     apk -v --purge del py-pip &&     rm -f /var/cache/apk/*' returned a non-zero code: 1
: exit status 1
Makefile:196: recipe for target 'run' failed
make[1]: *** [run] Error 1
make[1]: Leaving directory '/var/lib/shippable/fcabc0c4-da22-48fa-abb6-97d45ee730cb/build/IN/kanister-repo/gitRepo'
Makefile:242: recipe for target 'gorelease' failed
make: *** [gorelease] Error 2
```

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

```
docker buil
d . -t kanisterio/postgres-kanister-tools:0.29.0-tmp
Sending build context to Docker daemon  38.24MB
Step 1/8 : FROM postgres:12.0-alpine
 ---> 5b681acb1cfc
Step 2/8 : LABEL maintainer="vkamra@kasten.io"
 ---> Using cache
 ---> 3c7159291324
Step 3/8 : ENV DEBIAN_FRONTEND noninteractive
 ---> Using cache
 ---> 71e327564550
Step 4/8 : USER root
 ---> Using cache
 ---> 65e229c053fb
Step 5/8 : RUN apk -v --update add --no-cache curl python3 groff less jq &&     pip3 install --upgrade pip &&     pip3 install --upgrade awscli &&     rm -f /var/cache/apk/*
 ---> Running in 629ac114cbf5
fetch http://dl-cdn.alpinelinux.org/alpine/v3.10/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.10/community/x86_64/APKINDEX.tar.gz
(1/15) Installing ca-certificates (20191127-r2)
(2/15) Installing nghttp2-libs (1.39.2-r1)
(3/15) Installing libcurl (7.66.0-r0)
(4/15) Installing curl (7.66.0-r0)
(5/15) Installing groff (1.22.4-r0)
(6/15) Installing oniguruma (6.9.4-r0)
(7/15) Installing jq (1.6-r0)
(8/15) Installing less (551-r0)
(9/15) Installing libbz2 (1.0.6-r7)
(10/15) Installing expat (2.2.8-r0)
(11/15) Installing libffi (3.2.1-r6)
(12/15) Installing gdbm (1.13-r1)
(13/15) Installing xz-libs (5.2.4-r0)
(14/15) Installing sqlite-libs (3.28.0-r3)
(15/15) Installing python3 (3.7.7-r0)
Executing busybox-1.30.1-r2.trigger
Executing ca-certificates-20191127-r2.trigger
OK: 46 packages, 413 dirs, 8186 files, 121 MiB
Collecting pip
  Downloading https://files.pythonhosted.org/packages/43/84/23ed6a1796480a6f1a2d38f2802901d078266bda38388954d01d3f2e821d/pip-20.1.1-py2.py3-none-any.whl (1.5MB)
Installing collected packages: pip
  Found existing installation: pip 19.2.3
    Uninstalling pip-19.2.3:
      Successfully uninstalled pip-19.2.3
Successfully installed pip-20.1.1
Collecting awscli
  Downloading awscli-1.18.80-py2.py3-none-any.whl (3.2 MB)
Collecting docutils<0.16,>=0.10
  Downloading docutils-0.15.2-py3-none-any.whl (547 kB)
Collecting PyYAML<5.4,>=3.10; python_version != "3.4"
  Downloading PyYAML-5.3.1.tar.gz (269 kB)
Collecting colorama<0.4.4,>=0.2.5; python_version != "3.4"
  Downloading colorama-0.4.3-py2.py3-none-any.whl (15 kB)
Collecting botocore==1.17.3
  Downloading botocore-1.17.3-py2.py3-none-any.whl (6.3 MB)
Collecting rsa<=3.5.0,>=3.1.2
  Downloading rsa-3.4.2-py2.py3-none-any.whl (46 kB)
Collecting s3transfer<0.4.0,>=0.3.0
  Downloading s3transfer-0.3.3-py2.py3-none-any.whl (69 kB)
Collecting python-dateutil<3.0.0,>=2.1
  Downloading python_dateutil-2.8.1-py2.py3-none-any.whl (227 kB)
Collecting urllib3<1.26,>=1.20; python_version != "3.4"
  Downloading urllib3-1.25.9-py2.py3-none-any.whl (126 kB)
Collecting jmespath<1.0.0,>=0.7.1
  Downloading jmespath-0.10.0-py2.py3-none-any.whl (24 kB)
Collecting pyasn1>=0.1.3
  Downloading pyasn1-0.4.8-py2.py3-none-any.whl (77 kB)
Collecting six>=1.5
  Downloading six-1.15.0-py2.py3-none-any.whl (10 kB)
Using legacy setup.py install for PyYAML, since package 'wheel' is not installed.
Installing collected packages: docutils, PyYAML, colorama, six, python-dateutil, urllib3, jmespath, botocore, pyasn1, rsa, s3transfer, awscli
    Running setup.py install for PyYAML: started
    Running setup.py install for PyYAML: finished with status 'done'
Successfully installed PyYAML-5.3.1 awscli-1.18.80 botocore-1.17.3 colorama-0.4.3 docutils-0.15.2 jmespath-0.10.0 pyasn1-0.4.8 python-dateutil-2.8.1 rsa-3.4.2 s3transfer-0.3.3 six-1.15.0 urllib3-1.25.9
Removing intermediate container 629ac114cbf5
 ---> 0366ed4b3f06
Step 6/8 : COPY --from=restic/restic:0.9.5 /usr/bin/restic /usr/local/bin/restic
 ---> 9d709386f9f5
Step 7/8 : ADD kando /usr/local/bin/
 ---> df7b0dd3dc75
Step 8/8 : CMD ["tail", "-f", "/dev/null"]
 ---> Running in 7c2006ec9b73
Removing intermediate container 7c2006ec9b73
 ---> 2e656a0233b6
Successfully built 2e656a0233b6
Successfully tagged kanisterio/postgres-kanister-tools:0.29.0-tmp
```

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
