### PR TITLE
Add pip3 to pg 9.6 tools image

### DIFF
--- a/docker/postgres-tools-9.6/Dockerfile
+++ b/docker/postgres-tools-9.6/Dockerfile
@@ -6,7 +6,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 USER root
 
-RUN apk -v --update add --no-cache curl python3 groff less jq && \
+RUN apk -v --update add --no-cache curl python3 py3-pip groff less jq && \
     pip3 install --upgrade pip && \
     pip3 install --upgrade awscli && \
     rm -f /var/cache/apk/*


### PR DESCRIPTION
## Change Overview

It turns out that installing python3 is not enough to install pip3 in the older alone version we use for postgresql9.6. This explicitly installs it.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Test Plan

https://gist.github.com/tdmanv/badde4e3a0f1bba6a3d032b2f2e3a09b

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
