### PR TITLE
[K10-4631] Fix for deployment config pods param

### DIFF
--- a/pkg/param/param.go
+++ b/pkg/param/param.go
@@ -358,7 +358,14 @@ func fetchDeploymentConfigParams(ctx context.Context, cli kubernetes.Interface, 
 		PersistentVolumeClaims: make(map[string]map[string]string),
 	}
 
-	pods, _, err := kube.FetchPods(cli, namespace, dc.UID)
+	// deployment configs are managed by replicationcontrollers not replicaset
+	// get the replication controller
+	rc, err := kube.FetchReplicationController(cli, namespace, dc.UID, dc.Annotations[kube.RevisionAnnotation])
+	if err != nil {
+		return nil, err
+	}
+
+	pods, _, err := kube.FetchPods(cli, namespace, rc.UID)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/param/param.go
+++ b/pkg/param/param.go
@@ -359,7 +359,7 @@ func fetchDeploymentConfigParams(ctx context.Context, cli kubernetes.Interface, 
 	}
 
 	// deployment configs are managed by replicationcontrollers not replicaset
-	// get the replication controller
+	// get the replication controller of the deploymentconfig
 	rc, err := kube.FetchReplicationController(cli, namespace, dc.UID, dc.Annotations[kube.RevisionAnnotation])
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Change Overview

To get the `DeploymentConfig` params we were fetching the pods
    with ownerref to dep conf, but the pods in that case
    will be managed by replication controllers like in
    case of deployment replicasets.
    This change fixes that.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

Create a blueprint that just `echo`s something in the `0`th pod of the deployment config and that should be executed successfully.
```
phases:
    - func: KubeExec
      name: echohello
      args:
        namespace: "{{ .DeploymentConfig.Namespace }}"
        pod: "{{ index .DeploymentConfig.Pods 0 }}"
        container: router
        command:
          - bash
          - -o
          - errexit
          - -o
          - pipefail
          - -c
          - |
            echo "Helloo there"
```

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
