### PR TITLE
Add test for fetchDeploymentConfigparams

### DIFF
--- a/pkg/param/param.go
+++ b/pkg/param/param.go
@@ -16,6 +16,7 @@ package param
 
 import (
 	"context"
+	"strconv"
 	"strings"
 	"time"
 
@@ -360,7 +361,7 @@ func fetchDeploymentConfigParams(ctx context.Context, cli kubernetes.Interface, 
 
 	// deployment configs are managed by replicationcontrollers not replicaset
 	// get the replication controller of the deploymentconfig
-	rc, err := kube.FetchReplicationController(cli, namespace, dc.UID, dc.Annotations[kube.RevisionAnnotation])
+	rc, err := kube.FetchReplicationController(cli, namespace, dc.UID, strconv.FormatInt(dc.Status.LatestVersion, 10))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/param/param_test.go
+++ b/pkg/param/param_test.go
@@ -39,6 +39,8 @@ import (
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	crfake "github.com/kanisterio/kanister/pkg/client/clientset/versioned/fake"
 	"github.com/kanisterio/kanister/pkg/kube"
+	osapps "github.com/openshift/api/apps/v1"
+	osversioned "github.com/openshift/client-go/apps/clientset/versioned"
 	osfake "github.com/openshift/client-go/apps/clientset/versioned/fake"
 )
 
@@ -50,6 +52,7 @@ type ParamsSuite struct {
 	dynCli    dynamic.Interface
 	namespace string
 	pvc       string
+	osCli     osversioned.Interface
 }
 
 var _ = Suite(&ParamsSuite{})
@@ -203,6 +206,38 @@ func (s *ParamsSuite) TestFetchDeploymentParams(c *C) {
 			s.pvc: "/mnt/data/" + name,
 		},
 	})
+}
+
+func (s *ParamsSuite) TestFetchDeploymentConfigParams(c *C) {
+
+	ok, err := kube.IsOSAppsGroupAvailable(context.Background(), s.cli.Discovery())
+	c.Assert(err, IsNil)
+	if !ok {
+		c.Skip("Skipping test since this only runs on OpenShift")
+	}
+
+	cfg, err := kube.LoadConfig()
+	c.Assert(err, IsNil)
+
+	s.osCli, err = osversioned.NewForConfig(cfg)
+	c.Assert(err, IsNil)
+
+	depConf := newDeploymentConfig()
+	c.Assert(err, IsNil)
+
+	ctx := context.Background()
+	dc, err := s.osCli.AppsV1().DeploymentConfigs(s.namespace).Create(depConf)
+	c.Assert(err, IsNil)
+
+	err = kube.WaitOnDeploymentConfigReady(ctx, s.osCli, s.cli, dc.Namespace, dc.Name)
+	c.Assert(err, IsNil)
+
+	dconf, err := fetchDeploymentConfigParams(ctx, s.cli, s.osCli, s.namespace, dc.Name)
+	c.Assert(err, IsNil)
+	c.Assert(dconf.Namespace, Equals, s.namespace)
+	c.Assert(dconf.Pods, HasLen, 1)
+	c.Assert(dconf.Containers, DeepEquals, [][]string{{"container"}})
+
 }
 
 func (s *ParamsSuite) TestFetchPVCParams(c *C) {
@@ -652,5 +687,35 @@ func (s *ParamsSuite) TestRenderingPhaseParams(c *C) {
 		err = t.Execute(buf, tp)
 		c.Assert(err, IsNil)
 		c.Assert(buf.String(), Equals, tc.expected)
+	}
+}
+
+func newDeploymentConfig() *osapps.DeploymentConfig {
+	return &osapps.DeploymentConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "tmp",
+		},
+		Spec: osapps.DeploymentConfigSpec{
+			Replicas: 1,
+			Selector: map[string]string{
+				"app": "test",
+			},
+			Template: &v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": "test",
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						v1.Container{
+							Image:   "alpine",
+							Name:    "container",
+							Command: []string{"tail", "-f", "/dev/null"},
+						},
+					},
+				},
+			},
+		},
 	}
 }

--- a/pkg/param/param_test.go
+++ b/pkg/param/param_test.go
@@ -209,7 +209,6 @@ func (s *ParamsSuite) TestFetchDeploymentParams(c *C) {
 }
 
 func (s *ParamsSuite) TestFetchDeploymentConfigParams(c *C) {
-
 	ok, err := kube.IsOSAppsGroupAvailable(context.Background(), s.cli.Discovery())
 	c.Assert(err, IsNil)
 	if !ok {
@@ -237,7 +236,6 @@ func (s *ParamsSuite) TestFetchDeploymentConfigParams(c *C) {
 	c.Assert(dconf.Namespace, Equals, s.namespace)
 	c.Assert(dconf.Pods, HasLen, 1)
 	c.Assert(dconf.Containers, DeepEquals, [][]string{{"container"}})
-
 }
 
 func (s *ParamsSuite) TestFetchPVCParams(c *C) {


### PR DESCRIPTION
## Change Overview

This PR adds test for the change that we merged as part of the PR 
https://github.com/kanisterio/kanister/pull/705

Update:
There was an issue for multiple replication controller for a dpeloymetconfig, that fix has also been included in this.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [x] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->
```
go test -check.f "ParamsSuite"
OK: 13 passed
PASS
ok  	github.com/kanisterio/kanister/pkg/param	41.532s
```

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
