### PR TITLE
Add go to license extractor image

### DIFF
--- a/docker/license_extractor/Dockerfile
+++ b/docker/license_extractor/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir /repo
 
 WORKDIR /repo
 
+ENV PATH /usr/local/go/bin:${PATH}
 COPY --from=go /usr/local/go/ /usr/local/go/
-RUN export PATH="/usr/local/go/bin:$PATH"
 
 ENTRYPOINT ["licext"]

--- a/docker/license_extractor/Dockerfile
+++ b/docker/license_extractor/Dockerfile
@@ -1,7 +1,12 @@
+FROM golang:1.14-alpine AS go
+
 FROM node:14-alpine
 RUN npm i -g license-extractor
 RUN mkdir /repo
 
 WORKDIR /repo
+
+COPY --from=go /usr/local/go/ /usr/local/go/
+RUN export PATH="/usr/local/go/bin:$PATH"
 
 ENTRYPOINT ["licext"]


### PR DESCRIPTION
## Change Overview

<!-- Insert PR description-->

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Test Plan
```
Sending build context to Docker daemon  4.096kB
Step 1/8 : FROM golang:1.14-alpine AS go
 ---> 3289bf11c284
Step 2/8 : FROM node:14-alpine
14-alpine: Pulling from library/node
cbdbe7a5bc2a: Pull complete
fb0e3739aee1: Pull complete
738de7869598: Pull complete
ffd68be3d86c: Pull complete
Digest: sha256:c247e6ad0a4a40ca7b83ef6de8af3be3e43c05e458370054c3a17e8fcae50aa8
Status: Downloaded newer image for node:14-alpine
 ---> 3bf5a7d41d77
Step 3/8 : RUN npm i -g license-extractor
 ---> Running in 851cfb6d7760
/usr/local/bin/licext -> /usr/local/lib/node_modules/license-extractor/bin/licext
+ license-extractor@1.0.4
added 16 packages from 5 contributors in 3.088s
Removing intermediate container 851cfb6d7760
 ---> 669419a65481
Step 4/8 : RUN mkdir /repo
 ---> Running in cd2619b21bf0
Removing intermediate container cd2619b21bf0
 ---> 004d320a4d45
Step 5/8 : WORKDIR /repo
 ---> Running in 90693d8bbc3d
Removing intermediate container 90693d8bbc3d
 ---> 494fc4b474e6
Step 6/8 : COPY --from=go /usr/local/go/ /usr/local/go/
 ---> 0b5a27264cae
Step 7/8 : RUN export PATH="/usr/local/go/bin:$PATH"
 ---> Running in 5cb09b137779
Removing intermediate container 5cb09b137779
 ---> 44d398cee114
Step 8/8 : ENTRYPOINT ["licext"]
 ---> Running in 7f743e2c2104
Removing intermediate container 7f743e2c2104
 ---> 45cd2116105c
Successfully built 45cd2116105c
Successfully tagged kanisterio/license-extractor:5fe6521
The push refers to repository [docker.io/kanisterio/license-extractor]
f6ef817840b8: Pushed
1e4ad5f818a5: Pushed
4585e1fd0eef: Pushed
109988400934: Mounted from library/node
0cdeb35eff67: Mounted from library/node
312072b77e32: Mounted from library/node
3e207b409db3: Mounted from library/node
5fe6521: digest: sha256:ad2d71d85d375aa88e0d93733e7a18f76bf9a2a65f9d07c646fa1b86e1bf4d56 size: 1787
```
