### PR TITLE
Add a blueprints resolver

### DIFF
--- a/build/test.sh
+++ b/build/test.sh
@@ -54,7 +54,7 @@ echo
 echo "Running tests:"
 go test -v -installsuffix "static" -i ${TARGETS}
 go test -v ${TARGETS} -list .
-go test -v -installsuffix "static" ${TARGETS} -check.v
+go test -v -installsuffix "static" -tags blueprints_test ${TARGETS} -check.v
 echo
 
 echo "PASS"

--- a/pkg/blueprint/blueprints/blueprints.go
+++ b/pkg/blueprint/blueprints/blueprints.go
@@ -1,0 +1,51 @@
+package blueprints
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// these paths need to be kept in-sync with the symlinks in this directory
+// (the build tag 'blueprints_test' enables tests that enforce this)
+var blueprintPaths = map[string]string{
+	"cassandra-blueprint.yaml":           "../../../examples/stable/cassandra/cassandra-blueprint.yaml",
+	"couchbase-blueprint.yaml":           "../../../examples/stable/couchbase/couchbase-blueprint.yaml",
+	"elasticsearch-blueprint.yaml":       "../../../examples/stable/elasticsearch/elasticsearch-blueprint.yaml",
+	"foundationdb-blueprint.yaml":        "../../../examples/stable/foundationdb/foundationdb-blueprint.yaml",
+	"mongo-blueprint.yaml":               "../../../examples/stable/mongodb/mongo-blueprint.yaml",
+	"mongo-dep-config-blueprint.yaml":    "../../../examples/stable/mongodb-deploymentconfig/mongo-dep-config-blueprint.yaml",
+	"mysql-blueprint.yaml":               "../../../examples/stable/mysql/mysql-blueprint.yaml",
+	"mysql-dep-config-blueprint.yaml":    "../../../examples/stable/mysql-deploymentconfig/mysql-dep-config-blueprint.yaml",
+	"pitr-postgres-blueprint.yaml":       "../../../examples/stable/postgresql-wale/postgresql-blueprint.yaml",
+	"postgres-blueprint.yaml":            "../../../examples/stable/postgresql/postgres-blueprint.yaml",
+	"postgres-dep-config-blueprint.yaml": "../../../examples/stable/postgresql-deploymentconfig/postgres-dep-config-blueprint.yaml",
+	"rds-postgres-dump-blueprint.yaml":   "../../../examples/aws-rds/postgresql/rds-postgres-dump-blueprint.yaml",
+	"rds-postgres-snap-blueprint.yaml":   "../../../examples/aws-rds/postgresql/rds-postgres-snap-blueprint.yaml",
+}
+
+// PathFor returns the well known path for a blueprint.
+//
+// Note: this function is only useful when the source is available while being
+//       called (i.e. if the executable is moved away from the source, this
+//       function will always return an error)
+func PathFor(blueprint string) (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+
+	var blueprintPath string
+	path, present := blueprintPaths[blueprint]
+	if present {
+		blueprintPath = filepath.Join(dir, path)
+	} else {
+		// can't hurt to attempt to resolve it locally
+		blueprintPath = filepath.Join(dir, blueprint)
+	}
+
+	_, err := os.Stat(blueprintPath)
+	if err != nil {
+		return "", err
+	}
+
+	return blueprintPath, nil
+}

--- a/pkg/blueprint/blueprints/blueprints_test.go
+++ b/pkg/blueprint/blueprints/blueprints_test.go
@@ -1,0 +1,80 @@
+// +build blueprints_test
+
+package blueprints
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type BlueprintsSuite struct{}
+
+var _ = Suite(&BlueprintsSuite{})
+
+func (s *BlueprintsSuite) TestEnsureNoMissingBlueprints(c *C) {
+	// Ensure there are no extraneous .yaml symlinks present (not in blueprintPaths)
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+
+	files, err := filepath.Glob(filepath.Join(dir, "*.yaml"))
+	c.Assert(err, IsNil)
+
+	missingBlueprintPaths := make(map[string]string)
+	for _, file := range files {
+		lstat, err := os.Lstat(file)
+		c.Assert(err, IsNil)
+		// ignore non-symlink files
+		if lstat.Mode()&os.ModeSymlink == os.ModeSymlink {
+			blueprint := filepath.Base(file)
+			link, err := os.Readlink(file)
+			c.Assert(err, IsNil)
+
+			if _, present := blueprintPaths[blueprint]; !present {
+				missingBlueprintPaths[blueprint] = link
+			}
+		}
+	}
+
+	if len(missingBlueprintPaths) > 0 {
+		c.Log("The following symlinks are missing from blueprintPaths:")
+		for blueprint, path := range missingBlueprintPaths {
+			c.Logf("\t%q: %q,", blueprint, path)
+		}
+		c.Fail()
+	}
+}
+
+func (s *BlueprintsSuite) TestBlueprintPathsMatchSymlinks(c *C) {
+	// Ensure all of the paths in blueprintPaths match the symlinks
+	for blueprint, path := range blueprintPaths {
+		link, err := os.Readlink(blueprint)
+		c.Assert(err, IsNil)
+		c.Assert(path, Equals, link)
+	}
+}
+
+func (s *BlueprintsSuite) TestPathFor(c *C) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+
+	for blueprint, _ := range blueprintPaths {
+		directStat, err := os.Stat(filepath.Join(dir, blueprint))
+		c.Assert(err, IsNil)
+
+		path, err := PathFor(blueprint)
+		c.Assert(err, IsNil)
+		pathForStat, err := os.Stat(path)
+
+		if !os.SameFile(directStat, pathForStat) {
+			c.Errorf("PathFor returned %q, which doesn't match the symlink for %q", path, blueprint)
+		}
+	}
+}


### PR DESCRIPTION
## Change Overview

This package is only intended to be used to aid in testing with Kanister's blueprints. The is due to the blueprints only being resolvable when source code is present (the files aren't embedded in the Go package).

## Pull request type

- [X] :sunflower: Feature

## Issues

- N/A

## Test Plan

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
