### PR TITLE
Add well-known path resolvers

### DIFF
--- a/build/test.sh
+++ b/build/test.sh
@@ -54,7 +54,7 @@ echo
 echo "Running tests:"
 go test -v -installsuffix "static" -i ${TARGETS}
 go test -v ${TARGETS} -list .
-go test -v -installsuffix "static" ${TARGETS} -check.v
+go test -v -installsuffix "static" -tags filesystem_tests ${TARGETS} -check.v
 echo
 
 echo "PASS"

--- a/pkg/app/wellknown.go
+++ b/pkg/app/wellknown.go
@@ -1,0 +1,109 @@
+// Copyright 2020 The Kanister Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+const (
+	// Stable Cassandra app
+	CassandraApp = "cassandra"
+	// Stable Couchbase app
+	CouchbaseApp = "couchbase"
+	// Stable Elasticsearch app
+	ElasticsearchApp = "elasticsearch"
+	// Stable FoundationDB app
+	FoundationDBApp = "foundationdb"
+	// Stable MongoDB app
+	MongoDBApp = "mongo"
+	// Stable MySQL app
+	MySQLApp = "mysql"
+	// Stable MongoDB app on OpenShift
+	OpenShiftMongoDBApp = "mongo-dep-config"
+	// Stable MySQL app on OpenShift
+	OpenShiftMySQLApp = "mysql-dep-config"
+	// Stable PostgreSQL app on OpenShift
+	OpenShiftPostgreSQLApp = "postgres-dep-config"
+	// Stable PITR PostgreSQL app
+	PITRPostgreSQLApp = "pitr-postgres"
+	// Stable PostgreSQL app
+	PostgreSQLApp = "postgres"
+	// RDS PostgreSQL instance
+	RDSPostgreSQLApp = "rds-postgres"
+	// RDS PostgreSQL instance dump
+	RDSPostgreSQLDumpApp = "rds-postgres-dump"
+	// RDS PostgreSQL instance snapshot
+	RDSPostgreSQLSnapApp = "rds-postgres-snap"
+)
+
+var (
+	ErrUnknownBlueprint = errors.New("unkown blueprint")
+)
+
+// wellknownBlueprintPaths is essentially a list of symlinks, matching those in
+// the blueprints/ subdirectory.
+//
+// This must be maintained manually as Go modules elides symlinks from the
+// downloaded module, making the actual symlinks useless in that context. Tests
+// are used to enforce that this list stays in sync with the symlinks.
+var wellknownBlueprintPaths = map[string]string{
+	CassandraApp:           "../../../examples/stable/cassandra/cassandra-blueprint.yaml",
+	CouchbaseApp:           "../../../examples/stable/couchbase/couchbase-blueprint.yaml",
+	ElasticsearchApp:       "../../../examples/stable/elasticsearch/elasticsearch-blueprint.yaml",
+	FoundationDBApp:        "../../../examples/stable/foundationdb/foundationdb-blueprint.yaml",
+	MongoDBApp:             "../../../examples/stable/mongodb/mongo-blueprint.yaml",
+	MySQLApp:               "../../../examples/stable/mysql/mysql-blueprint.yaml",
+	OpenShiftMongoDBApp:    "../../../examples/stable/mongodb-deploymentconfig/mongo-dep-config-blueprint.yaml",
+	OpenShiftMySQLApp:      "../../../examples/stable/mysql-deploymentconfig/mysql-dep-config-blueprint.yaml",
+	OpenShiftPostgreSQLApp: "../../../examples/stable/postgresql-deploymentconfig/postgres-dep-config-blueprint.yaml",
+	PITRPostgreSQLApp:      "../../../examples/stable/postgresql-wale/postgresql-blueprint.yaml",
+	PostgreSQLApp:          "../../../examples/stable/postgresql/postgres-blueprint.yaml",
+	RDSPostgreSQLApp:       "rds-postgres-blueprint.yaml",
+	RDSPostgreSQLDumpApp:   "../../../examples/aws-rds/postgresql/rds-postgres-dump-blueprint.yaml",
+	RDSPostgreSQLSnapApp:   "../../../examples/aws-rds/postgresql/rds-postgres-snap-blueprint.yaml",
+}
+
+func blueprintsPath() string {
+	_, goSource, _, _ := runtime.Caller(0)
+	return filepath.Join(filepath.Dir(goSource), "..", "blueprint", "blueprints")
+}
+
+// Wellknown returns the named well-known blueprint.
+//
+// Note: this function is only useful when source is available. If source is
+// not available, this function will always return an error.
+func WellknownApp(name string) (*AppBlueprint, error) {
+	symlinkPath, present := wellknownBlueprintPaths[name]
+	if !present {
+		return nil, ErrUnknownBlueprint
+	}
+
+	path := filepath.Join(blueprintsPath(), filepath.FromSlash(symlinkPath))
+	_, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return nil, os.ErrNotExist
+	} else if err != nil {
+		return nil, err
+	}
+
+	return &AppBlueprint{
+		App:  name,
+		Path: path,
+	}, nil
+}

--- a/pkg/app/wellknown_test.go
+++ b/pkg/app/wellknown_test.go
@@ -1,0 +1,112 @@
+// +build filesystem_tests
+
+// Copyright 2020 The Kanister Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type BlueprintsSuite struct{}
+
+var _ = Suite(&BlueprintsSuite{})
+
+// Ensure that each ../blueprint/blueprints/*-blueprint.yaml exists in the
+// wellknownBlueprintPaths map.
+func (s *BlueprintsSuite) TestMissingWellknownBlueprints(c *C) {
+	// List all ../blueprint/blueprints/*-blueprint.yaml files
+	files, err := filepath.Glob(filepath.Join(blueprintsPath(), "*-blueprint.yaml"))
+	c.Assert(err, IsNil)
+
+	missingBlueprintPaths := make(map[string]string)
+	for _, file := range files {
+		blueprint := strings.TrimSuffix(filepath.Base(file), "-blueprint.yaml")
+
+		// Ensure the well-known blueprint name is present
+		if _, present := wellknownBlueprintPaths[blueprint]; !present {
+			// Collect information on the missing blueprint
+			lstat, err := os.Lstat(file)
+			c.Assert(err, IsNil)
+			if lstat.Mode()&os.ModeSymlink == os.ModeSymlink {
+				link, err := os.Readlink(file)
+				c.Assert(err, IsNil)
+				missingBlueprintPaths[blueprint] = link
+			} else {
+				missingBlueprintPaths[blueprint] = filepath.Base(file)
+			}
+		}
+	}
+
+	// List missing blueprint paths
+	if len(missingBlueprintPaths) > 0 {
+		c.Log("The following symlinks are missing from wellknownBlueprintPaths:")
+		for blueprint, path := range missingBlueprintPaths {
+			c.Logf("\t%q: %q,", blueprint, path)
+		}
+		c.Fail()
+	}
+}
+
+// Ensure that each blueprint path in the wellknownBlueprintPaths matches the
+// file/symlink on the filesystem.
+func (s *BlueprintsSuite) TestBlueprintPathsMatchSymlinks(c *C) {
+	for blueprint, path := range wellknownBlueprintPaths {
+		// Stat the corresponding file/symlink
+		file := filepath.Join(blueprintsPath(), blueprint+"-blueprint.yaml")
+		lstat, err := os.Lstat(file)
+		c.Assert(err, IsNil)
+
+		if lstat.Mode()&os.ModeSymlink == os.ModeSymlink {
+			// Ensure the symlink matches the well-known path
+			link, err := os.Readlink(file)
+			c.Assert(err, IsNil)
+			c.Assert(path, Equals, link)
+		} else {
+			// Ensure the filename matches the well-known path
+			c.Assert(path, Equals, filepath.Base(file))
+		}
+	}
+}
+
+// Ensure WellknownApp returns the correct, resolved paths for each well-known
+// blueprint path.
+func (s *BlueprintsSuite) TestWellknownApp(c *C) {
+	for blueprint, _ := range wellknownBlueprintPaths {
+		appBlueprint, err := WellknownApp(blueprint)
+		c.Assert(err, IsNil)
+
+		// .App should match the blueprint
+		c.Assert(appBlueprint.App, Equals, blueprint)
+
+		// .Path should match the resolved path (resolved by the Stat call)
+		directStat, err := os.Stat(filepath.Join(blueprintsPath(), blueprint+"-blueprint.yaml"))
+		c.Assert(err, IsNil)
+		wellknownStat, err := os.Stat(appBlueprint.Path)
+		c.Assert(err, IsNil)
+		if !os.SameFile(directStat, wellknownStat) {
+			c.Errorf("WellknownApp returned %q, which doesn't match the symlink for %q", appBlueprint.Path, blueprint)
+		}
+	}
+}

--- a/pkg/helm/client_test.go
+++ b/pkg/helm/client_test.go
@@ -16,7 +16,6 @@ package helm
 
 import (
 	"context"
-	"testing"
 
 	. "gopkg.in/check.v1"
 )
@@ -47,9 +46,6 @@ var _ = Suite(&ExecSuite{
 	args:    []string{"11m"},
 	err:     true,
 })
-
-// Hook up gocheck into the "go test" runner.
-func Test(t *testing.T) { TestingT(t) }
 
 func (s *ExecSuite) TestRunCmdWithTimeout(c *C) {
 	ctx := context.Background()

--- a/pkg/helm/example_repo.go
+++ b/pkg/helm/example_repo.go
@@ -1,0 +1,38 @@
+// Copyright 2020 The Kanister Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helm
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// KanisterExamplesRepoPath attempts to locate the path for the Kanister helm
+// examples repo.
+//
+// An error is returned if the repo doesn't exist in the local filesystem. This
+// happens when the source is unavailable on the local system.
+func KanisterExamplesRepoPath() (string, error) {
+	_, goSource, _, _ := runtime.Caller(0)
+
+	repoPath := filepath.Join(filepath.Dir(goSource), "..", "..", "examples", "helm", "kanister")
+	_, err := os.Stat(repoPath)
+	if os.IsNotExist(err) {
+		return "", os.ErrNotExist
+	}
+
+	return repoPath, nil
+}

--- a/pkg/helm/example_repo_test.go
+++ b/pkg/helm/example_repo_test.go
@@ -1,0 +1,37 @@
+// +build filesystem_tests
+
+// Copyright 2020 The Kanister Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helm_test
+
+import (
+	"os"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/kanisterio/kanister/pkg/helm"
+)
+
+type ExampleRepoSuite struct{}
+
+var _ = Suite(&ExampleRepoSuite{})
+
+func (*ExampleRepoSuite) TestKanisterExamplesRepoPath(c *C) {
+	repoPath, err := helm.KanisterExamplesRepoPath()
+	c.Assert(err, IsNil)
+
+	_, err = os.Stat(repoPath)
+	c.Assert(err, IsNil)
+}

--- a/pkg/helm/helm_test.go
+++ b/pkg/helm/helm_test.go
@@ -1,0 +1,24 @@
+// Copyright 2020 The Kanister Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helm
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) { TestingT(t) }


### PR DESCRIPTION
## Change Overview

The blueprints and charts repo are often referenced by external dependents of Kanister.

Unfortunately, the path to the version of Kanister being compiled against often changes, especially when using Go modules which includes the version in the path. To better facilitate dependents using these assets from Kanister, two path resolvers have been added:

* pkg/app.WellKnownApp
* pkg/helm.KanisterExamplesRepoPath

These resolvers lookup the paths relative to the location of the Go source files. This allows the greater flexibility in where Kanister is located.

## Pull request type

- [X] :sunflower: Feature

## Issues

- N/A

## Test Plan

- [ ] :muscle: Manual
- [X] :zap: Unit test
- [ ] :green_heart: E2E
