### PR TITLE
Downgrade docker-cli to v1.18

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ IMAGE_NAME := $(BIN)
 
 IMAGE := $(REGISTRY)/$(IMAGE_NAME)
 
-BUILD_IMAGE ?= kanisterio/build:v0.0.10
+BUILD_IMAGE ?= kanisterio/build:v0.0.11
 DOCS_BUILD_IMAGE ?= kanisterio/docker-sphinx
 
 DOCS_RELEASE_BUCKET ?= s3://docs.kanister.io

--- a/build/test.sh
+++ b/build/test.sh
@@ -19,7 +19,6 @@
 set -o errexit
 set -o nounset
 
-export PATH=$GOPATH/bin:$GOROOT/bin:$PATH
 
 export CGO_ENABLED=0
 export GO111MODULE=on

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -1,9 +1,12 @@
-FROM golang:1.14.4-alpine3.12
+FROM alpine:3.10.5
+
 MAINTAINER Tom Manville <tom@kasten.io>
 
 RUN apk add --update --no-cache ca-certificates bash git docker jq \
     && update-ca-certificates \
     && rm -rf /var/cache/apk/*
+
+COPY --from=golang:1.14.4-alpine3.12 /usr/local/go/ /usr/local/go/
 
 COPY --from=bitnami/kubectl:1.17 /opt/bitnami/kubectl/bin/kubectl /usr/local/bin/
 
@@ -22,3 +25,4 @@ ENV CGO_ENABLED=0 \
     GOCACHE=/go/.cache/go-build \
     GO_EXTLINK_ENABLED=0 \
     PATH="/usr/local/go/bin:${PATH}" 
+  


### PR DESCRIPTION
## Change Overview

Use alpine3.10 instead of 3.12 to select an earlier version of the docker cli. This will unblock an issue where older versions of the docker daemon could not release Kanister.

Build log: https://gist.github.com/ad4c7e3e1b0838f010ce4965bca84783

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Test Plan

```
docker run --rm -it kan
isterio/build:v0.0.11 sh
/ # docker version
Client:
 Version:           18.09.8-ce
 API version:       1.39
 Go version:        go1.12.6
 Git commit:        0dd43dd87fd530113bf44c9bba9ad8b20ce4637f
 Built:             Sat Jul 20 15:20:06 2019
 OS/Arch:           linux/amd64
 Experimental:      false
```

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
