### PR TITLE
Use namespace as subject instead of etcd pod for k8s etcd backup and restore

### DIFF
--- a/examples/etcd/etcd-in-cluster/k8s/README.md
+++ b/examples/etcd/etcd-in-cluster/k8s/README.md
@@ -48,7 +48,7 @@ secret is going to have the name of the format `etcd-<etcd-pod-namespace>` with 
 
 - **key** : TLS key file, would be `/etc/kubernetes/pki/etcd/server.key` in case of Kubeadm cluster
 
-- **labels** : Labels using which kaniter will identify one etcd member in case of multi member etcd cluster
+- **labels** : Labels using which Kanister will identify the etcd members in a namespace, in case of multi member etcd cluster
 
 
 ```
@@ -105,7 +105,7 @@ created above
 
 **Note**
 
-Pleae make sure to change the **profile name**, **pod namespace** and **blueprint name** in the `backup-actionset.yaml` manifest file. Where pod-namespace is the namespace
+Please make sure to change the **profile name**, **pod namespace** and **blueprint name** in the `backup-actionset.yaml` manifest file. Where pod-namespace is the namespace
 where etcd pods are running.
 
 ```

--- a/examples/etcd/etcd-in-cluster/k8s/README.md
+++ b/examples/etcd/etcd-in-cluster/k8s/README.md
@@ -48,9 +48,17 @@ secret is going to have the name of the format `etcd-<etcd-pod-namespace>` with 
 
 - **key** : TLS key file, would be `/etc/kubernetes/pki/etcd/server.key` in case of Kubeadm cluster
 
+- **labels** : Labels using which kaniter will identify one etcd member in case of multi member etcd cluster
+
 
 ```
-» kubectl create secret generic etcd-kube-system --from-literal=cacert=/etc/kubernetes/pki/etcd/ca.crt --from-literal=cert=/etc/kubernetes/pki/etcd/server.crt --from-literal=endpoints=https://[127.0.0.1]:2379 --from-literal=key=/etc/kubernetes/pki/etcd/server.key -n kube-system
+» kubectl create secret generic etcd-kube-system \
+    --from-literal=cacert=/etc/kubernetes/pki/etcd/ca.crt \
+    --from-literal=cert=/etc/kubernetes/pki/etcd/server.crt \
+    --from-literal=endpoints=https://127.0.0.1:2379 \
+    --from-literal=key=/etc/kubernetes/pki/etcd/server.key \
+    --from-literal=labels=component=etcd,tier=control-plane \
+    --namespace kube-system
 secret/etcd-kube-system created
 ```
 
@@ -97,7 +105,8 @@ created above
 
 **Note**
 
-Pleae make sure to change the **profile name**, the **ETCD pod name**, **pod namespace** and **blueprint name** in the `backup-actionset.yaml` manifest file.
+Pleae make sure to change the **profile name**, **pod namespace** and **blueprint name** in the `backup-actionset.yaml` manifest file. Where pod-namespace is the namespace
+where etcd pods are running.
 
 ```
 # find the profile name

--- a/examples/etcd/etcd-in-cluster/k8s/README.md
+++ b/examples/etcd/etcd-in-cluster/k8s/README.md
@@ -105,7 +105,7 @@ created above
 
 **Note**
 
-Please make sure to change the **profile name**, **pod namespace** and **blueprint name** in the `backup-actionset.yaml` manifest file. Where pod-namespace is the namespace
+Please make sure to change the **profile name**, **pod namespace** and **blueprint name** in the `backup-actionset.yaml` manifest file, where pod-namespace is the namespace
 where etcd pods are running.
 
 ```

--- a/examples/etcd/etcd-in-cluster/k8s/backup-actionset.yaml
+++ b/examples/etcd/etcd-in-cluster/k8s/backup-actionset.yaml
@@ -13,9 +13,9 @@ spec:
       apiVersion: v1
       group: ""
       kind: ""
-      name: <etcd-podname>
-      namespace: kube-system
-      resource: pods
+      name: <namespace-name>
+      namespace: ""
+      resource: namespaces
     options: {}
     preferredVersion: ""
     profile:

--- a/examples/etcd/etcd-in-cluster/k8s/etcd-incluster-blueprint.yaml
+++ b/examples/etcd/etcd-in-cluster/k8s/etcd-incluster-blueprint.yaml
@@ -43,7 +43,7 @@ actions:
           - -c
           - |
             BACKUP_LOCATION=etcd_backups/{{ .Object.metadata.name }}/{{ toDate "2006-01-02T15:04:05.999999999Z07:00" .Time | date "2006-01-02T15:04:05Z07:00" }}/etcd-backup.db.gz
-            kubectl cp {{ .Object.metadata.name }}/"{{ .Phases.takeSnapshot.Output.etcdPod }}":/tmp/etcd-backup.db /tmp/etcd-backup.db
+            kubectl cp {{ .Object.metadata.name }}/{{ .Phases.takeSnapshot.Output.etcdPod }}:/tmp/etcd-backup.db /tmp/etcd-backup.db
             gzip /tmp/etcd-backup.db
             kando location push --profile '{{ toJson .Profile }}'  /tmp/etcd-backup.db.gz --path $BACKUP_LOCATION
             kando output backupLocation $BACKUP_LOCATION
@@ -56,7 +56,7 @@ actions:
           - sh
           - -c
           - |
-            kubectl exec -it -n {{ .Object.metadata.name }} "{{ .Phases.takeSnapshot.Output.etcdPod }}" -c etcd -- sh -c "rm -rf  /tmp/etcd-backup.db"
+            kubectl exec -it -n {{ .Object.metadata.name }} {{ .Phases.takeSnapshot.Output.etcdPod }} -c etcd -- sh -c "rm -rf  /tmp/etcd-backup.db"
 
   delete:
     type: Namespace

--- a/examples/etcd/etcd-in-cluster/k8s/etcd-incluster-blueprint.yaml
+++ b/examples/etcd/etcd-in-cluster/k8s/etcd-incluster-blueprint.yaml
@@ -10,17 +10,15 @@ actions:
         keyValue:
           backupLocation: "{{ .Phases.uploadSnapshot.Output.backupLocation }}"
     phases:
-    - func: KubeExec
+    - func: KubeTask
       name: takeSnapshot
       objects:
         etcdConfig:
           kind: Secret
-          name: "etcd-{{ .Object.metadata.namespace }}"
-          namespace: "{{ .Object.metadata.namespace }}"
+          name: "etcd-{{ .Object.metadata.name }}"
+          namespace: "{{ .Object.metadata.name }}"
       args:
-        namespace: "{{ .Object.metadata.namespace }}"
-        pod: "{{ .Object.metadata.name }}"
-        container: etcd
+        image: kanisterio/kanister-kubectl:1.18
         command:
           - sh
           - -c
@@ -29,36 +27,36 @@ actions:
             export cert="{{ index .Phases.takeSnapshot.Secrets.etcdConfig.Data "cert" | toString }}"
             export endpoints="{{ index .Phases.takeSnapshot.Secrets.etcdConfig.Data "endpoints" | toString }}"
             export key="{{ index .Phases.takeSnapshot.Secrets.etcdConfig.Data "key" | toString }}"
+            export labels="{{ index .Phases.takeSnapshot.Secrets.etcdConfig.Data "labels" | toString }}"
 
-            ETCDCTL_API=3 etcdctl --endpoints=$endpoints --cacert=$cacert  --cert=$cert  --key=$key snapshot save /tmp/etcd-backup.db
-            ETCDCTL_API=3 etcdctl --endpoints=$endpoints --cacert=$cacert  --cert=$cert  --key=$key snapshot status /tmp/etcd-backup.db
+            ETCD_POD=$(kubectl get pods -n {{ .Object.metadata.name }} -l $labels -ojsonpath='{.items[0].metadata.name}')
+
+            kubectl exec -it -n {{ .Object.metadata.name }} $ETCD_POD -c etcd -- sh -c "ETCDCTL_API=3 etcdctl --endpoints=$endpoints --cacert=$cacert  --cert=$cert  --key=$key snapshot save /tmp/etcd-backup.db"
+            kando output etcdPod $ETCD_POD
 
     - func: KubeTask
       name: uploadSnapshot
       args:
-        namespace: "kanister"
         image: kanisterio/kanister-kubectl:1.18
         command:
           - sh
           - -c
           - |
-            BACKUP_LOCATION=etcd_backups/{{ .Object.metadata.namespace }}/{{ .Object.metadata.name }}/{{ toDate "2006-01-02T15:04:05.999999999Z07:00" .Time | date "2006-01-02T15:04:05Z07:00" }}/etcd-backup.db.gz
-            kubectl cp {{ .Object.metadata.namespace }}/{{ .Object.metadata.name }}:/tmp/etcd-backup.db /tmp/etcd-backup.db
+            BACKUP_LOCATION=etcd_backups/{{ .Object.metadata.name }}/{{ toDate "2006-01-02T15:04:05.999999999Z07:00" .Time | date "2006-01-02T15:04:05Z07:00" }}/etcd-backup.db.gz
+            kubectl cp {{ .Object.metadata.name }}/"{{ .Phases.takeSnapshot.Output.etcdPod }}":/tmp/etcd-backup.db /tmp/etcd-backup.db
             gzip /tmp/etcd-backup.db
             kando location push --profile '{{ toJson .Profile }}'  /tmp/etcd-backup.db.gz --path $BACKUP_LOCATION
             kando output backupLocation $BACKUP_LOCATION
 
-    - func: KubeExec
+    - func: KubeTask
       name: removeSnapshot
       args:
-        namespace: "{{ .Object.metadata.namespace }}"
-        pod: "{{ .Object.metadata.name }}"
-        container: etcd
+        image: kanisterio/kanister-kubectl:1.18
         command:
           - sh
           - -c
           - |
-            rm -rf  /tmp/etcd-backup.db
+            kubectl exec -it -n {{ .Object.metadata.name }} "{{ .Phases.takeSnapshot.Output.etcdPod }}" -c etcd -- sh -c "rm -rf  /tmp/etcd-backup.db"
 
   delete:
     type: Namespace

--- a/examples/etcd/etcd-in-cluster/ocp/README.md
+++ b/examples/etcd/etcd-in-cluster/ocp/README.md
@@ -138,9 +138,7 @@ No resources found.
 ## Restore ETCD cluster
 
 To restore the ETCD cluster we can follow the [documentation](https://docs.openshift.com/container-platform/4.5/backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.html) that is provided by the OpenShift team.
-But we will have to make some modification in the restore script (`cluster-restore.sh`) because default
-restore script expects the static pods manifest as well, and in our case we didn't backup the static pod manifests. We have made respective changes
-in the script that is provided by OpenShift, that can be found in this repo.
+The restore script (`cluster-restore.sh`) mentioned above requires modification as it expects the static pods manifests which are not backed up in our case. The modified restore script can be found in this repo.
 
 You can follow the steps that are mentioned below along with the documentation that is mentioned above, most of the steps that are mentioned here are either directly taken from the documentation or are modified version of it. Among all the running leader nodes choose one node to be the restore node, make sure you have SSH connectivity to all of the leader nodes including the one that you have chosen to be restore node.
 

--- a/examples/etcd/etcd-in-cluster/ocp/README.md
+++ b/examples/etcd/etcd-in-cluster/ocp/README.md
@@ -139,7 +139,8 @@ No resources found.
 
 To restore the ETCD cluster we can follow the [documentation](https://docs.openshift.com/container-platform/4.5/backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.html) that is provided by the OpenShift team.
 But we will have to make some modification in the restore script (`cluster-restore.sh`) because default
-restore script expects the static pods manifest as well, and in our case we didn't backup the static pod manifests.
+restore script expects the static pods manifest as well, and in our case we didn't backup the static pod manifests. We have made respective changes
+in the script that is provided by OpenShift, that can be found in this repo.
 
 You can follow the steps that are mentioned below along with the documentation that is mentioned above, most of the steps that are mentioned here are either directly taken from the documentation or are modified version of it. Among all the running leader nodes choose one node to be the restore node, make sure you have SSH connectivity to all of the leader nodes including the one that you have chosen to be restore node.
 


### PR DESCRIPTION
## Change Overview

Per current blueprint we were using etcd pod as subject, which would result in issues because of static pods. This PR changes that to have namespace as subject.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [x] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
