### PR TITLE
Fix OCP blueprint to run KubeTask functions in controller ns

### DIFF
--- a/examples/etcd/etcd-in-cluster/k8s/etcd-incluster-blueprint.yaml
+++ b/examples/etcd/etcd-in-cluster/k8s/etcd-incluster-blueprint.yaml
@@ -2,7 +2,6 @@ apiVersion: cr.kanister.io/v1alpha1
 kind: Blueprint
 metadata:
   name: etcd-blueprint
-  namespace: kanister
 actions:
   backup:
     outputArtifacts:

--- a/examples/etcd/etcd-in-cluster/ocp/etcd-incluster-ocp-blueprint.yaml
+++ b/examples/etcd/etcd-in-cluster/ocp/etcd-incluster-ocp-blueprint.yaml
@@ -17,7 +17,6 @@ actions:
           name: "etcd-{{ .Object.metadata.name }}"
           namespace: "{{ .Object.metadata.name }}"
       args:
-        namespace: "{{ .Object.metadata.name }}"
         image: kanisterio/kanister-kubectl:1.18
         command:
           - sh
@@ -35,7 +34,6 @@ actions:
     - func: KubeTask
       name: uploadSnapshot
       args:
-        namespace: "{{ .Object.metadata.name }}"
         image: kanisterio/kanister-kubectl:1.18
         command:
           - sh
@@ -50,7 +48,6 @@ actions:
     - func: KubeTask
       name: removeSnapshot
       args:
-        namespace: "{{ .Object.metadata.name }}"
         image: kanisterio/kanister-kubectl:1.18
         command:
           - sh


### PR DESCRIPTION
## Change Overview

Per current implementation KubeTask pod was running in the etcd pod namespace, this changes that to have the pods run controller NS.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
