### PR TITLE
Use secret as subject in blueprint in case of ocp etcd backup restore

### DIFF
--- a/examples/etcd/etcd-in-cluster/ocp/README.md
+++ b/examples/etcd/etcd-in-cluster/ocp/README.md
@@ -35,19 +35,25 @@ can be shared between Kanister-enabled application instances.
 
 ## Create Blueprint
 
-Before actually creating the Blueprint, we will have to create a secret in the same namespace where your ETCD pod is running. This
-secret is going to have the name of the format `etcd-<etcd-pod-namespace>` with these fields
+Before actually creating the Blueprint, we will have to create a secret in a new or an existing namespace. This
+secret is going to have the details about the ETCD members that are running on your cluster
 
 - **endpoints** : ETCD server client listen URL, https://[127.0.0.1]:2379
 - **labels** : These labels will be used to identify the ETCD pods that are running, for ex `app=etcd,etcd=true`
+- **etcdns** : Namespace where the etcd pods are running
 
 Below command can be used to create the secret, assuming the ETCD pods are running in the `openshift-etcd` namespace
 
 ```
+# Create a new namespace
+» oc create ns etcd-backup
+namespace/etcd-backup created
+
 » oc create secret generic etcd-openshift-etcd \
     --from-literal=endpoints=https://10.0.133.5:2379 \
     --from-literal=labels=app=etcd,etcd=true \
-    --namespace openshift-etcd
+    --from-literal=etcdns=openshift-etcd \
+    --namespace etcd-backup
 secret/etcd-openshift-etcd created
 ```
 
@@ -85,7 +91,7 @@ created above
 
 **Note**
 
-Please make sure to change the **profile-name**,  **namespace-name** and **blueprint name** in the `backup-actionset.yaml` manifest file. Where `namespace-name` is the namespace where the ETCD pods are running.
+Please make sure to change the **profile-name**, **blueprint name**, **secret-name** and **secret-namespace** in the `backup-actionset.yaml` manifest file. Where `secret-name` is the name of secret that has all the details and we crreated earlier.
 
 ```
 # find the profile name

--- a/examples/etcd/etcd-in-cluster/ocp/README.md
+++ b/examples/etcd/etcd-in-cluster/ocp/README.md
@@ -91,7 +91,7 @@ created above
 
 **Note**
 
-Please make sure to change the **profile-name**, **blueprint name**, **secret-name** and **secret-namespace** in the `backup-actionset.yaml` manifest file. Where `secret-name` is the name of secret that has all the details and we crreated earlier.
+Please make sure to change the **profile-name**, **blueprint name**, **secret-name** and **secret-namespace** in the `backup-actionset.yaml` manifest file. Where `secret-name` is the name of secret that has all the details and we created earlier.
 
 ```
 # find the profile name

--- a/examples/etcd/etcd-in-cluster/ocp/backup-actionset.yaml
+++ b/examples/etcd/etcd-in-cluster/ocp/backup-actionset.yaml
@@ -13,9 +13,9 @@ spec:
       apiVersion: v1
       group: ""
       kind: ""
-      name: <namespace-name>
-      namespace: ""
-      resource: namespaces
+      name: <secret-name>
+      namespace: <secret-namespace>
+      resource: secrets
     options: {}
     preferredVersion: ""
     profile:

--- a/examples/etcd/etcd-in-cluster/ocp/etcd-incluster-ocp-blueprint.yaml
+++ b/examples/etcd/etcd-in-cluster/ocp/etcd-incluster-ocp-blueprint.yaml
@@ -11,25 +11,22 @@ actions:
     phases:
     - func: KubeTask
       name: takeSnapshot
-      objects:
-        etcdConfig:
-          kind: Secret
-          name: "etcd-{{ .Object.metadata.name }}"
-          namespace: "{{ .Object.metadata.name }}"
       args:
         image: kanisterio/kanister-kubectl:1.18
         command:
           - sh
           - -c
           - |
-            export endpoints="{{ index .Phases.takeSnapshot.Secrets.etcdConfig.Data "endpoints" | toString }}"
-            export labels="{{ index .Phases.takeSnapshot.Secrets.etcdConfig.Data "labels" | toString }}"
+            export endpoints="{{ index .Object.data "endpoints" | toString | b64dec }}"
+            export labels="{{ index .Object.data "labels" | toString | b64dec }}"
+            export etcdns="{{ index .Object.data "etcdns" | toString | b64dec }}"
             # Get a member of etcd cluster
-            ETCD_POD=$(kubectl get pods -n {{ .Object.metadata.name }} -l $labels -ojsonpath='{.items[0].metadata.name}')
+            ETCD_POD=$(kubectl get pods -n $etcdns -l $labels -ojsonpath='{.items[0].metadata.name}')
             # exec the snapshot save command
-            kubectl exec -it -n {{ .Object.metadata.name }} $ETCD_POD -c etcd -- sh -c "ETCDCTL_ENDPOINTS=$endpoints etcdctl snapshot save /tmp/etcd-backup.db"
+            kubectl exec -it -n $etcdns $ETCD_POD -c etcd -- sh -c "ETCDCTL_ENDPOINTS=$endpoints etcdctl snapshot save /tmp/etcd-backup.db"
             # this pod name will be used to copy and remove the snapshot
             kando output etcdPod $ETCD_POD
+            kando output etcdNS $etcdns
 
     - func: KubeTask
       name: uploadSnapshot
@@ -39,8 +36,8 @@ actions:
           - sh
           - -c
           - |
-            BACKUP_LOCATION=etcd_backups/{{ .Object.metadata.name }}/{{ toDate "2006-01-02T15:04:05.999999999Z07:00" .Time | date "2006-01-02T15:04:05Z07:00" }}/etcd-backup.db.gz
-            kubectl cp -c etcd {{ .Object.metadata.name }}/"{{ .Phases.takeSnapshot.Output.etcdPod }}":/tmp/etcd-backup.db /tmp/etcd-backup.db
+            BACKUP_LOCATION=etcd_backups/{{ .Phases.takeSnapshot.Output.etcdPod }}/{{ toDate "2006-01-02T15:04:05.999999999Z07:00" .Time | date "2006-01-02T15:04:05Z07:00" }}/etcd-backup.db.gz
+            kubectl cp -c etcd {{ .Phases.takeSnapshot.Output.etcdNS }}/{{ .Phases.takeSnapshot.Output.etcdPod }}:/tmp/etcd-backup.db /tmp/etcd-backup.db
             gzip /tmp/etcd-backup.db
             kando location push --profile '{{ toJson .Profile }}'  /tmp/etcd-backup.db.gz --path $BACKUP_LOCATION
             kando output backupLocation $BACKUP_LOCATION
@@ -53,7 +50,7 @@ actions:
           - sh
           - -c
           - |
-            kubectl exec -it -n {{ .Object.metadata.name }} "{{ .Phases.takeSnapshot.Output.etcdPod }}" -c etcd -- sh -c "rm -rf  /tmp/etcd-backup.db"
+            kubectl exec -it -n {{ .Phases.takeSnapshot.Output.etcdNS }} "{{ .Phases.takeSnapshot.Output.etcdPod }}" -c etcd -- sh -c "rm -rf  /tmp/etcd-backup.db"
 
   delete:
     type: Namespace


### PR DESCRIPTION
## Change Overview

Until we were using namespace, where etcd members are running as subject in the blueprint for backup and restore. This PR changes that and now we use a secret as subject that is going to have the details about etcd members.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [x] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
