### PR TITLE
Update MySQL chart version to latest

### DIFF
--- a/pkg/app/mysql.go
+++ b/pkg/app/mysql.go
@@ -41,6 +41,7 @@ type MysqlDB struct {
 	chart     helm.ChartInfo
 }
 
+// Last tested working version "1.6.7"
 func NewMysqlDB(name string) App {
 	return &MysqlDB{
 		name: name,
@@ -49,7 +50,6 @@ func NewMysqlDB(name string) App {
 			RepoURL:  helm.StableRepoURL,
 			Chart:    "mysql",
 			RepoName: helm.StableRepoName,
-			Version:  "1.6.7",
 			Values: map[string]string{
 				"mysqlRootPassword":   "mysecretpassword",
 				"persistence.enabled": "false",

--- a/pkg/app/mysql.go
+++ b/pkg/app/mysql.go
@@ -49,7 +49,7 @@ func NewMysqlDB(name string) App {
 			RepoURL:  helm.StableRepoURL,
 			Chart:    "mysql",
 			RepoName: helm.StableRepoName,
-			Version:  "1.4.0",
+			Version:  "1.6.7",
 			Values: map[string]string{
 				"mysqlRootPassword":   "mysecretpassword",
 				"persistence.enabled": "false",


### PR DESCRIPTION
## Change Overview

Updated the MySQL app helm chart version to the latest from 1.4.0

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

* $ kind create cluster
* $ make install-minio

```
make[1]: Entering directory '/root/go/src/github.com/kanisterio/kanister'
running CMD in the containerized build environment
Deploying minio...
"stable" has been added to your repositories
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "stable" chart repository
Update Complete. ⎈ Happy Helming!⎈ 
namespace/minio created
NAME: minio
LAST DEPLOYED: Tue Sep  8 15:42:35 2020
NAMESPACE: minio
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
Minio can be accessed via port 9000 on the following DNS name from within your cluster:
minio.minio.svc.cluster.local

To access Minio from localhost, run the below commands:

  1. export POD_NAME=$(kubectl get pods --namespace minio -l "release=minio" -o jsonpath="{.items[0].metadata.name}")

  2. kubectl port-forward $POD_NAME 9000 --namespace minio

Read more about port forwarding here: http://kubernetes.io/docs/user-guide/kubectl/kubectl_port-forward/

You can now access Minio server on http://localhost:9000. Follow the below steps to connect to Minio server with mc client:

  1. Download the Minio mc client - https://docs.minio.io/docs/minio-client-quickstart-guide

  2. mc config host add minio-local http://localhost:9000 AKIAIOSFODNN7EXAMPLE wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY S3v4

  3. mc ls minio-local

Alternately, you can use your browser or the Minio SDK to access the server - https://docs.minio.io/categories/17

Use following creds to access MinIO
AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
AWS_REGION=us-west-2
LOCATION_ENDPOINT=http://minio.minio.svc.cluster.local:9000

minio deployment successful!
make[1]: Leaving directory '/root/go/src/github.com/kanisterio/kanister'

```

* $ make integration-test short

https://gist.github.com/arush-sal/c71fdf0f2cf31471c1936c5166c35d43

<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [x] :green_heart: E2E
