### PR TITLE
Update Cassandra chart version to latest

### DIFF
--- a/pkg/app/cassandra.go
+++ b/pkg/app/cassandra.go
@@ -47,6 +47,7 @@ type CassandraInstance struct {
 }
 
 // NewCassandraInstance returns new cassandra application
+// Last tested working version "0.13.3"
 func NewCassandraInstance(name string) App {
 	return &CassandraInstance{
 		name: name,
@@ -55,7 +56,6 @@ func NewCassandraInstance(name string) App {
 			RepoURL:  helm.IncubatorRepoURL,
 			Chart:    "cassandra",
 			RepoName: helm.IncubatorRepoName,
-			Version:  "0.13.3",
 			Values: map[string]string{
 				"image.repo":          "kanisterio/cassandra",
 				"image.tag":           "0.34.0",

--- a/pkg/app/cassandra.go
+++ b/pkg/app/cassandra.go
@@ -53,9 +53,9 @@ func NewCassandraInstance(name string) App {
 		name: name,
 		chart: helm.ChartInfo{
 			Release:  appendRandString(name),
-			RepoURL:  helm.IncubatorRepoURL,
+			RepoURL:  helm.BitnamiRepoURL,
+			RepoName: helm.BitnamiRepoName,
 			Chart:    "cassandra",
-			RepoName: helm.IncubatorRepoName,
 			Values: map[string]string{
 				"image.repo":          "kanisterio/cassandra",
 				"image.tag":           "0.34.0",

--- a/pkg/helm/client.go
+++ b/pkg/helm/client.go
@@ -31,6 +31,10 @@ type HelmVersion string
 const (
 	DefaultCommandTimeout = 5 * time.Minute
 
+	// Add Bitnami charts url
+	BitnamiRepoName = "bitnami"
+	BitnamiRepoURL  = "https://charts.bitnami.com/bitnami"
+
 	// Add elastic charts url
 	ElasticRepoName = "elastic"
 	ElasticRepoURL  = "https://helm.elastic.co"


### PR DESCRIPTION
## Change Overview

Updated the Cassandra app helm chart version to the latest from 0.13.3

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

* $ kind create cluster
* $ make install-minio

```
make[1]: Entering directory '/root/go/src/github.com/kanisterio/kanister'
running CMD in the containerized build environment
Deploying minio...
"stable" has been added to your repositories
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "stable" chart repository
Update Complete. ⎈ Happy Helming!⎈ 
namespace/minio created
NAME: minio
LAST DEPLOYED: Tue Sep  8 15:42:35 2020
NAMESPACE: minio
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
Minio can be accessed via port 9000 on the following DNS name from within your cluster:
minio.minio.svc.cluster.local

To access Minio from localhost, run the below commands:

  1. export POD_NAME=$(kubectl get pods --namespace minio -l "release=minio" -o jsonpath="{.items[0].metadata.name}")

  2. kubectl port-forward $POD_NAME 9000 --namespace minio

Read more about port forwarding here: http://kubernetes.io/docs/user-guide/kubectl/kubectl_port-forward/

You can now access Minio server on http://localhost:9000. Follow the below steps to connect to Minio server with mc client:

  1. Download the Minio mc client - https://docs.minio.io/docs/minio-client-quickstart-guide

  2. mc config host add minio-local http://localhost:9000 AKIAIOSFODNN7EXAMPLE wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY S3v4

  3. mc ls minio-local

Alternately, you can use your browser or the Minio SDK to access the server - https://docs.minio.io/categories/17

Use following creds to access MinIO
AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
AWS_REGION=us-west-2
LOCATION_ENDPOINT=http://minio.minio.svc.cluster.local:9000

minio deployment successful!
make[1]: Leaving directory '/root/go/src/github.com/kanisterio/kanister'

```

* $ make integration-test short

https://gist.github.com/arush-sal/c71fdf0f2cf31471c1936c5166c35d43

<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [x] :green_heart: E2E
