### PR TITLE
Remove env var from MySQL openshift app

### DIFF
--- a/pkg/app/mysql-deploymentconfig.go
+++ b/pkg/app/mysql-deploymentconfig.go
@@ -54,9 +54,6 @@ func NewMysqlDepConfig(name string, storageType storage) App {
 		params: map[string]string{
 			"MYSQL_ROOT_PASSWORD": "secretpassword",
 		},
-		envVar: map[string]string{
-			"MYSQL_ROOT_PASSWORD": "secretpassword",
-		},
 		storageType: storageType,
 		osClient:    openshift.NewOpenShiftClient(),
 	}


### PR DESCRIPTION
## Change Overview

To install MySQL deployment config app we dont need to set env var for password.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
