### PR TITLE
Add check if os route group is available

### DIFF
--- a/pkg/kube/discover.go
+++ b/pkg/kube/discover.go
@@ -7,7 +7,10 @@ import (
 	"k8s.io/client-go/discovery"
 )
 
-const osAppsGroupName = `apps.openshift.io`
+const (
+	osAppsGroupName  = `apps.openshift.io`
+	osRouteGroupName = `route.openshift.io/v1`
+)
 
 // IsOSAppsGroupAvailable returns true if the openshift apps group is registered in service discovery.
 func IsOSAppsGroupAvailable(ctx context.Context, cli discovery.DiscoveryInterface) (bool, error) {
@@ -17,6 +20,20 @@ func IsOSAppsGroupAvailable(ctx context.Context, cli discovery.DiscoveryInterfac
 	}
 	for _, g := range sgs.Groups {
 		if g.Name == osAppsGroupName {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// IsOSRouteGroupAvailable returns true is the opneshift route group is registered in service discovery
+func IsOSRouteGroupAvailable(ctx context.Context, cli discovery.DiscoveryInterface) (bool, error) {
+	sgs, err := cli.ServerGroups()
+	if err != nil {
+		return false, err
+	}
+	for _, g := range sgs.Groups {
+		if g.Name == osRouteGroupName {
 			return true, nil
 		}
 	}

--- a/pkg/kube/discover.go
+++ b/pkg/kube/discover.go
@@ -26,7 +26,7 @@ func IsOSAppsGroupAvailable(ctx context.Context, cli discovery.DiscoveryInterfac
 	return false, nil
 }
 
-// IsOSRouteGroupAvailable returns true is the opneshift route group is registered in service discovery
+// IsOSRouteGroupAvailable returns true is the openshift route group is registered in service discovery
 func IsOSRouteGroupAvailable(ctx context.Context, cli discovery.DiscoveryInterface) (bool, error) {
 	sgs, err := cli.ServerGroups()
 	if err != nil {


### PR DESCRIPTION
## Change Overview

This PR adds a check in our discover.go to verify if OpenShift route group is available.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
