### PR TITLE
Correct minor issue where version is also added in group as part of #761

### DIFF
--- a/pkg/kube/discover.go
+++ b/pkg/kube/discover.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	osAppsGroupName  = `apps.openshift.io`
-	osRouteGroupName = `route.openshift.io/v1`
+	osRouteGroupName = `route.openshift.io`
 )
 
 // IsOSAppsGroupAvailable returns true if the openshift apps group is registered in service discovery.


### PR DESCRIPTION
## Change Overview

As part of #761 we added the group `route.openshift.io`, but by mistake I added version also which is not correct. This fixes that.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
