### PR TITLE
Fix image repository helm option in cassandra chart

### DIFF
--- a/pkg/app/cassandra.go
+++ b/pkg/app/cassandra.go
@@ -57,7 +57,7 @@ func NewCassandraInstance(name string) App {
 			RepoName: helm.BitnamiRepoName,
 			Chart:    "cassandra",
 			Values: map[string]string{
-				"image.repo":          "kanisterio/cassandra",
+				"image.repository":    "kanisterio/cassandra",
 				"image.tag":           "0.34.0",
 				"config.cluster_size": "1",
 			},


### PR DESCRIPTION
With kanisterio/kanister#755, we switched to the bitnami chart.

This uses a different option to specify the image repository.
