### PR TITLE
Add script to delete tag if it is already present

### DIFF
--- a/build/managetags.sh
+++ b/build/managetags.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Copyright 2019 The Kanister Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+usage () {
+    echo ./build/managetags.sh remote_name tag_name
+    exit 1
+}
+
+# deletes a git tag locally as well as from remote if it is already persent
+main() {
+    local remote=${1:?"$(usage)"}
+    local tag=${2:?"$(usage)"}
+
+    if [ $(git tag -l ${tag}) ] ; then
+        git tag -d ${tag}
+        git push --delete ${remote} ${tag}
+    fi
+}
+
+main $@


### PR DESCRIPTION
## Change Overview

While releasing kanister we sometime face below issue 

```
/var/lib/shippable/8b02d0bd-012b-46c7-83de-9ad0c3eacd9a/build/IN/kanister-repo/gitRepo /var/lib/shippable/8b02d0bd-012b-46c7-83de-9ad0c3eacd9a/build
fatal: tag '0.34.0' already exists
```

this PR adds a script that should be call to delete the tag if it already exists.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

```
./managetags.sh tagthis 0.0.1
```

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
