### PR TITLE
Fix es-sidecar Dockerfile to have correct kanister image version

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -68,6 +68,8 @@ dockers:
   image_templates:
   - 'kanisterio/es-sidecar:{{ .Tag }}'
   dockerfile: 'docker/kanister-elasticsearch/image/Dockerfile'
+  build_flag_templates:
+  - "--build-arg=TOOLS_IMAGE=kanisterio/kanister-tools:{{ .Tag }}"
   extra_files:
   - 'docker/kanister-elasticsearch/image/esdump-setup.sh'
 - binaries:

--- a/docker/kanister-elasticsearch/image/Dockerfile
+++ b/docker/kanister-elasticsearch/image/Dockerfile
@@ -1,7 +1,9 @@
-FROM alpine:3.11.3
+ARG TOOLS_IMAGE
+FROM ${TOOLS_IMAGE} AS TOOLS_IMAGE
 
-COPY --from=kanisterio/kanister-tools:0.35.0 /usr/local/bin/restic /usr/local/bin/restic
-COPY --from=kanisterio/kanister-tools:0.35.0 /usr/local/bin/kopia /usr/local/bin/kopia
+FROM alpine:3.11.3
+COPY --from=TOOLS_IMAGE /usr/local/bin/restic /usr/local/bin/restic
+COPY --from=TOOLS_IMAGE /usr/local/bin/kopia /usr/local/bin/kopia
 ADD kando /usr/local/bin/
 
 ADD docker/kanister-elasticsearch/image/esdump-setup.sh /esdump-setup.sh

--- a/docker/kanister-elasticsearch/image/Dockerfile
+++ b/docker/kanister-elasticsearch/image/Dockerfile
@@ -10,3 +10,4 @@ ADD docker/kanister-elasticsearch/image/esdump-setup.sh /esdump-setup.sh
 RUN chmod +x /esdump-setup.sh && sync && /esdump-setup.sh
 
 CMD [ "/usr/bin/tail", "-f", "/dev/null" ]
+


### PR DESCRIPTION
## Change Overview

The `es-sidecar` Dockerfile has the kanister-tools image in that so when we build this we did that with previous version of the kanister-tools image. 
This changes that so have correct version of the kanister-tools image.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
