### PR TITLE
Allow custom config file in Kando stream command

### DIFF
--- a/pkg/kando/stream.go
+++ b/pkg/kando/stream.go
@@ -19,7 +19,10 @@ import (
 )
 
 const (
-	streamPasswordFlagName = "password"
+	streamPasswordFlag           = "--password"
+	streamPasswordFlagName       = "password"
+	streamRepoConfigFileFlag     = "--config-file"
+	streamRepoConfigFileFlagName = "config-file"
 )
 
 func newStreamCommand() *cobra.Command {
@@ -29,10 +32,15 @@ func newStreamCommand() *cobra.Command {
 	}
 	cmd.AddCommand(newStreamPushCommand())
 	cmd.PersistentFlags().StringP(streamPasswordFlagName, "p", "", "Specify the password for object storage repository (required)")
+	cmd.PersistentFlags().StringP(streamRepoConfigFileFlagName, "c", "", "Custom config file for object storage repository configuration")
 	_ = cmd.MarkPersistentFlagRequired(streamPasswordFlagName)
 	return cmd
 }
 
-func streamPasswordFlag(cmd *cobra.Command) string {
+func streamPasswordFlagValue(cmd *cobra.Command) string {
 	return cmd.Flag(streamPasswordFlagName).Value.String()
+}
+
+func streamRepoConfigFileFlagValue(cmd *cobra.Command) string {
+	return cmd.Flag(streamRepoConfigFileFlagName).Value.String()
 }

--- a/pkg/kando/stream_push.go
+++ b/pkg/kando/stream_push.go
@@ -24,7 +24,9 @@ import (
 )
 
 const (
+	streamPushDirPathFlag      = "--dirPath"
 	streamPushDirPathFlagName  = "dirPath"
+	streamPushFilePathFlag     = "--filePath"
 	streamPushFilePathFlagName = "filePath"
 )
 
@@ -45,36 +47,44 @@ func newStreamPushCommand() *cobra.Command {
 }
 
 func runStreamPush(cmd *cobra.Command, args []string) error {
-	dirPath := streamPushDirPathFlag(cmd)
-	filePath := streamPushFilePathFlag(cmd)
-	pwd := streamPasswordFlag(cmd)
+	configFile := streamRepoConfigFileFlagValue(cmd)
+	dirPath := streamPushDirPathFlagValue(cmd)
+	filePath := streamPushFilePathFlagValue(cmd)
+	pwd := streamPasswordFlagValue(cmd)
 	sourceEndpoint := args[0]
-	return stream.Push(context.Background(), dirPath, filePath, pwd, sourceEndpoint)
+	return stream.Push(context.Background(), configFile, dirPath, filePath, pwd, sourceEndpoint)
 }
 
-func streamPushDirPathFlag(cmd *cobra.Command) string {
+func streamPushDirPathFlagValue(cmd *cobra.Command) string {
 	return cmd.Flag(streamPushDirPathFlagName).Value.String()
 }
 
-func streamPushFilePathFlag(cmd *cobra.Command) string {
+func streamPushFilePathFlagValue(cmd *cobra.Command) string {
 	return cmd.Flag(streamPushFilePathFlagName).Value.String()
 }
 
 // GenerateStreamPushCommand generates a bash command for
 // kando stream push with given flags and arguments
-func GenerateStreamPushCommand(dirPath, filePath, password, sourceEndpoint string) []string {
+func GenerateStreamPushCommand(configFile, dirPath, filePath, password, sourceEndpoint string) []string {
 	kandoCmd := []string{
 		"kando",
 		"stream",
 		"push",
-		"--password",
+		streamPasswordFlag,
 		password,
-		"--dirPath",
-		dirPath,
-		"--filePath",
-		filePath,
-		sourceEndpoint,
 	}
+
+	if configFile != "" {
+		kandoCmd = append(kandoCmd, streamRepoConfigFileFlag, configFile)
+	}
+
+	kandoCmd = append(
+		kandoCmd,
+		streamPushDirPathFlag, dirPath,
+		streamPushFilePathFlag, filePath,
+		sourceEndpoint,
+	)
+
 	return []string{
 		"bash",
 		"-o",


### PR DESCRIPTION
## Change Overview

- Add `config-file` flag to accept custom file path for storing kopia repository config in `kando stream push` command.

## Pull request type

Please check the type of change your PR introduces:

- [x] :sunflower: Feature

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
