### PR TITLE
Minor improvement in the bump version script

### DIFF
--- a/build/bump_version.sh
+++ b/build/bump_version.sh
@@ -33,7 +33,7 @@ main() {
             pkgs=( "$@" )
     fi
     # -F matches for exact words, not regular expression (-E), that is what required here
-    grep -F "${prev}" -r  "${pkgs[@]}" | cut -d ':' -f 1 | uniq | xargs sed -ri "s/${prev}/${next//./\\.}/g"
+    grep -F "${prev}" -Ir  "${pkgs[@]}" --exclude-dir={mod,bin} | cut -d ':' -f 1 | uniq | xargs sed -ri "s/${prev}/${next//./\\.}/g"
 }
 
 main $@


### PR DESCRIPTION
## Change Overview

We ran the bump version script against specific dirs
which is not ideal, there are chances that some
files that we dont know of have these versions.
Now we just ignore mod,bin dirs and binary files
and running the script on the entire K10 repo.
We already introduced the issue by not running it
in the demos dir.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
