### PR TITLE
We dont need to include generated html file in the bump version

### DIFF
--- a/build/bump_version.sh
+++ b/build/bump_version.sh
@@ -33,7 +33,7 @@ main() {
             pkgs=( "$@" )
     fi
     # -F matches for exact words, not regular expression (-E), that is what required here
-    grep -F "${prev}" -Ir  "${pkgs[@]}" --exclude-dir={mod,bin} | cut -d ':' -f 1 | uniq | xargs sed -ri "s/${prev}/${next//./\\.}/g"
+    grep -F "${prev}" -Ir  "${pkgs[@]}" --exclude-dir={mod,bin,html} | cut -d ':' -f 1 | uniq | xargs sed -ri "s/${prev}/${next//./\\.}/g"
 }
 
 main $@


### PR DESCRIPTION
## Change Overview

When we bump tools version, we don need to update the generated files that are inside html dir, especially in the case of K10, because we are using same script to bump version in K10.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
