### PR TITLE
Kanister docs correct argument DeleteData

### DIFF
--- a/docs/functions.rst
+++ b/docs/functions.rst
@@ -597,8 +597,8 @@ This function deletes the snapshot data backed up by the BackupData function.
 
    `namespace`, Yes, `string`, namespace in which to execute
    `backupArtifactPrefix`, Yes, `string`, path to the backup on the object store
-   `backupIdentifier`, No, `string`, (required if backupTag not provided) unique snapshot id generated during backup
-   `backupTag`, No, `string`, (required if backupIdentifier not provided) unique tag added during the backup
+   `backupID`, No, `string`, (required if backupTag not provided) unique snapshot id generated during backup
+   `backupTag`, No, `string`, (required if backupID not provided) unique tag added during the backup
    `encryptionKey`, No, `string`, encryption key to be used during backups
    `podOverride`, No, `map[string]interface{}`, specs to override default pod specs with
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -2,6 +2,7 @@ actionset
 args
 aws
 backupIdentifier
+backupID
 backupInfo
 backupTag
 boolean


### PR DESCRIPTION
## Change Overview

There is an inconsistency in the Kanister docs. The function `DeleteData` does not have an argument named `backupIdentifier`, it should be `backupID`.

See the relevant source code: https://github.com/kanisterio/kanister/blob/ea72b13de3631fce145629b4acac72871f3c4bfe/pkg/function/delete_data.go#L42

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [x] :world_map: Documentation
- [ ] :robot: Test

## Issues

- no issue present

## Test Plan

N/A