### PR TITLE
Add volumePermissions configuration to postgres app

### DIFF
--- a/pkg/app/postgresql.go
+++ b/pkg/app/postgresql.go
@@ -57,6 +57,7 @@ func NewPostgresDB(name string) App {
 				"postgresqlExtendedConf.archiveMode":    "true",
 				"postgresqlExtendedConf.archiveTimeout": "60",
 				"postgresqlExtendedConf.walLevel":       "archive",
+				"volumePermissions.enabled":             "true",
 			},
 		},
 	}


### PR DESCRIPTION
## Change Overview

This PR updates the postgres app for enabling `volumePermissions`. Starting 8.4.0 helm chart version, default permissions were disabled for initContainers. Setting `volumePermissions.enabled=true` provides the required permissions.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
