### PR TITLE
Set cassandra app image pullPolicy to Always to avoid base image mismatch

### DIFF
--- a/examples/stable/cassandra/README.md
+++ b/examples/stable/cassandra/README.md
@@ -17,15 +17,15 @@ The helm commands that are mentioned in this document are run with the helm vers
 
 ## Chart Details
 
-We will be using [Cassandra helm chart](https://github.com/helm/charts/tree/master/incubator/cassandra) from official helm repo wchich bootstraps a [Cassandra](http://cassandra.apache.org/) cluster on Kubernetes.
+We will be using [Cassandra helm chart](https://github.com/bitnami/charts/tree/master/bitnami/cassandra) from official helm repo which bootstraps a [Cassandra](http://cassandra.apache.org/) cluster on Kubernetes.
 
-You can decide the number of nodes that will be there in your configured Cassandra cluster using the flag `--set config.cluster_size=n` where `n` is the number of nodes you want in your Cassandra cluster. For this demo example we will be spinning up our Cassandra cluster with 2 nodes.
+You can decide the number of nodes that will be there in your configured Cassandra cluster using the flag `--set cluster.replicaCount=n` where `n` is the number of nodes you want in your Cassandra cluster. For this demo example we will be spinning up our Cassandra cluster with 2 nodes.
 
 ## Installing the Chart
 
 To install the Cassandra in your Kubernetes cluster you can run below command
 ```bash
-$ helm repo add incubator https://kubernetes-charts-incubator.storage.googleapis.com
+$ helm repo add bitnami https://charts.bitnami.com/bitnami
 $ helm repo update
 # remove app-namespace with the namespace you want to deploy the Cassandra app in
 $ kubectl create ns <app-namespace>

--- a/examples/stable/cassandra/README.md
+++ b/examples/stable/cassandra/README.md
@@ -29,7 +29,7 @@ $ helm repo add bitnami https://charts.bitnami.com/bitnami
 $ helm repo update
 # remove app-namespace with the namespace you want to deploy the Cassandra app in
 $ kubectl create ns <app-namespace>
-$ helm install cassandra bitnami/cassandra --namespace <app-namespace> --set image.repository=kanisterio/cassandra --set image.tag=0.40.0 --set cluster.replicaCount=2 
+$ helm install cassandra bitnami/cassandra --namespace <app-namespace> --set image.repository=kanisterio/cassandra --set image.tag=0.40.0 --set cluster.replicaCount=2 --set image.pullPolicy=Always
 
 
 ```

--- a/pkg/app/cassandra.go
+++ b/pkg/app/cassandra.go
@@ -58,6 +58,7 @@ func NewCassandraInstance(name string) App {
 			Values: map[string]string{
 				"image.repository":     "kanisterio/cassandra",
 				"image.tag":            "0.40.0",
+				"image.pullPolicy":     "Always",
 				"cluster.replicaCount": "1",
 			},
 		},


### PR DESCRIPTION
## Change Overview

The default image `pullPolicy` for cassandra bitnami helm chart is `IfNotPresent`. In cases where an older version of kanisterio/cassandra image is present, the image mismatch could causes failure in pod launch. This PR sets `pullPolicy` to `Always` to avoid failures due to such cases.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [x] :green_heart: E2E

Manual testing done by running:
`$ helm install my-release bitnami/cassandra --namespace cassandra-test --set image.repository=kanisterio/cassandra --set image.tag=0.40.0 --set cluster.replicaCount=2 --set image.pullPolicy=Always`

Ran e2e test using:
`$ make integration-test cassandra`