### PR TITLE
Update mysql helm chart to bitnami

### DIFF
--- a/examples/stable/mysql/README.md
+++ b/examples/stable/mysql/README.md
@@ -18,7 +18,7 @@ This chart bootstraps a single node MySQL deployment on a [Kubernetes](http://ku
 To install the MySQL database using the `bitnami` chart with the release name `mysql-release`:
 
 ```bash
-# Add stable in your local chart repository
+# Add bitnami in your local chart repository
 $ helm repo add bitnami https://charts.bitnami.com/bitnami
 
 # Update your local chart repository
@@ -39,7 +39,7 @@ You can retrieve your root password by running the following command. Make sure 
 
     `kubectl get secret [YOUR_RELEASE_NAME] --namespace [YOUR_NAMESPACE] -o jsonpath="{.data.mysql-root-password}" | base64 --decode`
 
-> **Tip**: List all releases using `helm list --all-namespaces`, in case of Helm Version 3.
+> **Tip**: List all releases using `helm list --all-namespaces`, using Helm Version 3.
 
 ## Integrating with Kanister
 
@@ -121,10 +121,10 @@ s3-profile-drnw9   2m
 
 # Create Actionset
 # Please make sure the value of profile and blueprint matches with the names of profile and blueprint that we have created already
-$ kanctl create actionset --action backup --namespace kasten-io --blueprint mysql-blueprint --statefulset mysql-test/mysql-release-master --profile mysql-test/s3-profile-drnw9 --secrets mysql=mysql-test/mysql-release
+$ kanctl create actionset --action backup --namespace kanister --blueprint mysql-blueprint --statefulset mysql-test/mysql-release-master --profile mysql-test/s3-profile-drnw9 --secrets mysql=mysql-test/mysql-release
 actionset backup-rslmb created
 
-$ kubectl --namespace kasten-io get actionsets.cr.kanister.io
+$ kubectl --namespace kanister get actionsets.cr.kanister.io
 NAME                 AGE
 backup-rslmb         1m
 
@@ -228,11 +228,11 @@ mysql> SELECT * FROM pets;
 The artifacts created by the backup action can be cleaned up using the following command:
 
 ```bash
-$ kanctl --namespace kasten-io create actionset --action delete --from backup-rslmb --namespacetargets kasten-io
+$ kanctl --namespace kanister create actionset --action delete --from backup-rslmb --namespacetargets kanister
 actionset delete-backup-glptq-cq6bw created
 
 # View the status of the ActionSet
-$ kubectl --namespace kasten-io describe actionset delete-backup-glptq-cq6bw
+$ kubectl --namespace kanister describe actionset delete-backup-glptq-cq6bw
 ```
 
 
@@ -258,9 +258,6 @@ $ kubectl describe actionset restore-backup-62vxm-2hdsz -n kanister
 To uninstall/delete the `mysql-release` deployment:
 
 ```bash
-# Helm Version 2
-$ helm delete mysql-release --purge
-
 # Helm Version 3
 $ helm delete mysql-release -n mysql-test
 ```

--- a/examples/stable/mysql/mysql-blueprint.yaml
+++ b/examples/stable/mysql/mysql-blueprint.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mysql-blueprint
 actions:
   backup:
-    type: Deployment
+    type: StatefulSet
     outputArtifacts:
       mysqlCloudDump:
         keyValue:
@@ -15,11 +15,11 @@ actions:
       objects:
         mysqlSecret:
           kind: Secret
-          name: '{{ .Deployment.Name }}'
-          namespace: '{{ .Deployment.Namespace }}'
+          name: '{{ index .Object.metadata.labels "release" | toString }}'
+          namespace: '{{ .StatefulSet.Namespace }}'
       args:
         image: kanisterio/mysql-sidecar:0.40.0
-        namespace: "{{ .Deployment.Namespace }}"
+        namespace: "{{ .StatefulSet.Namespace }}"
         command:
         - bash
         - -o
@@ -28,12 +28,12 @@ actions:
         - pipefail
         - -c
         - |
-          s3_path="/mysql-backups/{{ .Deployment.Namespace }}/{{ .Deployment.Name }}/{{ toDate "2006-01-02T15:04:05.999999999Z07:00" .Time  | date "2006-01-02T15-04-05" }}/dump.sql.gz"
+          s3_path="/mysql-backups/{{ .StatefulSet.Namespace }}/{{ index .Object.metadata.labels "release" | toString }}/{{ toDate "2006-01-02T15:04:05.999999999Z07:00" .Time  | date "2006-01-02T15-04-05" }}/dump.sql.gz"
           root_password="{{ index .Phases.dumpToObjectStore.Secrets.mysqlSecret.Data "mysql-root-password" | toString }}"
-          mysqldump --column-statistics=0 -u root --password=${root_password} -h {{ .Deployment.Name }} --single-transaction --all-databases | gzip - | kando location push --profile '{{ toJson .Profile }}' --path ${s3_path} -
+          mysqldump --column-statistics=0 -u root --password=${root_password} -h {{ index .Object.metadata.labels "release" | toString }} --single-transaction --all-databases | gzip - | kando location push --profile '{{ toJson .Profile }}' --path ${s3_path} -
           kando output s3path ${s3_path}
   restore:
-    type: Deployment
+    type: StatefulSet
     inputArtifactNames:
     - mysqlCloudDump
     phases:
@@ -42,11 +42,11 @@ actions:
       objects:
         mysqlSecret:
           kind: Secret
-          name: '{{ .Deployment.Name }}'
-          namespace: '{{ .Deployment.Namespace }}'
+          name: '{{ index .Object.metadata.labels "release" | toString }}'
+          namespace: '{{ .StatefulSet.Namespace }}'
       args:
         image: kanisterio/mysql-sidecar:0.40.0
-        namespace: "{{ .Deployment.Namespace }}"
+        namespace: "{{ .StatefulSet.Namespace }}"
         command:
         - bash
         - -o
@@ -57,7 +57,7 @@ actions:
         - |
           s3_path="{{ .ArtifactsIn.mysqlCloudDump.KeyValue.s3path }}"
           root_password="{{ index .Phases.restoreFromBlobStore.Secrets.mysqlSecret.Data "mysql-root-password" | toString }}"
-          kando location pull --profile '{{ toJson .Profile }}' --path ${s3_path} - | gunzip | mysql -u root --password=${root_password} -h {{ .Deployment.Name }}
+          kando location pull --profile '{{ toJson .Profile }}' --path ${s3_path} - | gunzip | mysql -u root --password=${root_password} -h {{ index .Object.metadata.labels "release" | toString }}
   delete:
     type: Namespace
     inputArtifactNames:

--- a/examples/stable/mysql/mysql-blueprint.yaml
+++ b/examples/stable/mysql/mysql-blueprint.yaml
@@ -45,13 +45,8 @@ actions:
           name: '{{ index .Object.metadata.labels "release" | toString }}'
           namespace: '{{ .StatefulSet.Namespace }}'
       args:
-<<<<<<< HEAD
-        image: kanisterio/mysql-sidecar:0.40.0
-        namespace: "{{ .StatefulSet.Namespace }}"
-=======
         image: kanisterio/mysql-sidecar:0.41.0
-        namespace: "{{ .Deployment.Namespace }}"
->>>>>>> master
+        namespace: "{{ .StatefulSet.Namespace }}"
         command:
         - bash
         - -o

--- a/pkg/app/mysql.go
+++ b/pkg/app/mysql.go
@@ -42,7 +42,7 @@ type MysqlDB struct {
 	chart     helm.ChartInfo
 }
 
-// Last tested working version "1.6.7"
+// Last tested working version "6.14.11"
 func NewMysqlDB(name string) App {
 	return &MysqlDB{
 		name: name,

--- a/pkg/helm/client.go
+++ b/pkg/helm/client.go
@@ -39,10 +39,6 @@ const (
 	ElasticRepoName = "elastic"
 	ElasticRepoURL  = "https://helm.elastic.co"
 
-	// Add incubator charts url
-	IncubatorRepoName = "incubator"
-	IncubatorRepoURL  = "https://kubernetes-charts-incubator.storage.googleapis.com"
-
 	// Add couchbase chart
 	CouchbaseRepoName = "couchbase"
 	CouchbaseRepoURL  = "https://couchbase-partners.github.io/helm-charts"

--- a/pkg/helm/client.go
+++ b/pkg/helm/client.go
@@ -43,10 +43,6 @@ const (
 	IncubatorRepoName = "incubator"
 	IncubatorRepoURL  = "https://kubernetes-charts-incubator.storage.googleapis.com"
 
-	// Add stable charts url
-	StableRepoName = "stable"
-	StableRepoURL  = "https://kubernetes-charts.storage.googleapis.com"
-
 	// Add couchbase chart
 	CouchbaseRepoName = "couchbase"
 	CouchbaseRepoURL  = "https://couchbase-partners.github.io/helm-charts"


### PR DESCRIPTION
## Change Overview

This PR updates the MySQL helm chart to be used from bitnami repo. With this PR, all the app/blueprints are moved from stable and incubator charts to their respective repos.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [x] :robot: Test

## Issues

- #XXX

## Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [x] :green_heart: E2E

- Tested with manual steps as per README, using the bitnami chart.
- Tested with integration test:
` $ make integration-test MySQL`
Output: https://gist.github.com/ankitjain235/7511106aa35bc012d645edf9ffa3eeeb