### PR TITLE
Log the error instead of just handling

### DIFF
--- a/pkg/location/location.go
+++ b/pkg/location/location.go
@@ -98,7 +98,7 @@ func writeData(ctx context.Context, pType objectstore.ProviderType, profile para
 		return err
 	}
 	if err := bucket.Put(ctx, path, in, 0, nil); err != nil {
-		return errors.Errorf("failed to write contents to bucket '%s', error: %s", profile.Location.Bucket, err.Error())
+		return errors.Wrapf(err, "failed to write contents to bucket '%s'", profile.Location.Bucket)
 	}
 	return nil
 }

--- a/pkg/location/location.go
+++ b/pkg/location/location.go
@@ -98,7 +98,7 @@ func writeData(ctx context.Context, pType objectstore.ProviderType, profile para
 		return err
 	}
 	if err := bucket.Put(ctx, path, in, 0, nil); err != nil {
-		return errors.Errorf("failed to write contents to bucket '%s'", profile.Location.Bucket)
+		return errors.Errorf("failed to write contents to bucket '%s', error: %s", profile.Location.Bucket, err.Error())
 	}
 	return nil
 }

--- a/pkg/validate/error.go
+++ b/pkg/validate/error.go
@@ -22,8 +22,8 @@ import (
 
 var validateErr = fmt.Errorf("Validation Failed")
 
-func errorf(format string, args ...interface{}) error {
-	return errors.Wrapf(validateErr, format, args...)
+func errorf(err error, format string, args ...interface{}) error {
+	return errors.Wrapf(err, format, args...)
 }
 
 // IsError returns true iff the underlying cause was a validation error.

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -279,7 +279,7 @@ func WriteAccess(ctx context.Context, p *crv1alpha1.Profile, cli kubernetes.Inte
 	}
 	data := []byte("sample content")
 	if err := bucket.PutBytes(ctx, objName, data, nil); err != nil {
-		return errorf("failed to write contents to bucket '%s'", p.Location.Bucket)
+		return errorf("failed to write contents to bucket '%s', error: %s", p.Location.Bucket, err.Error())
 	}
 	if err := bucket.Delete(ctx, objName); err != nil {
 		return errorf("failed to delete contents in bucket '%s'", p.Location.Bucket)


### PR DESCRIPTION
## Change Overview

If something went wrong while uploading data into the object storage we were just handling that with a message but were not actually logging the error message. This PR tried to improve that.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
