### PR TITLE
Removing checks for snapshot ReadyToUse

### DIFF
--- a/pkg/kube/snapshot/snapshot.go
+++ b/pkg/kube/snapshot/snapshot.go
@@ -101,6 +101,9 @@ type Snapshotter interface {
 	// WaitOnReadyToUse will block until the Volumesnapshot in namespace 'namespace' with name 'snapshotName'
 	// has status 'ReadyToUse' or 'ctx.Done()' is signalled.
 	WaitOnReadyToUse(ctx context.Context, snapshotName, namespace string) error
+	// WaitForContent will block until the Volumesnapshot in namespace 'namespace' with name 'snapshotName'
+	// has the snapshotContentName field populated.
+	WaitForContent(ctx context.Context, snapshotName, namespace string) error
 }
 
 // Source represents the CSI source of the Volumesnapshot.

--- a/pkg/kube/snapshot/snapshot_alpha.go
+++ b/pkg/kube/snapshot/snapshot_alpha.go
@@ -172,9 +172,6 @@ func (sna *SnapshotAlpha) GetSource(ctx context.Context, snapshotName, namespace
 	if err != nil {
 		return nil, errors.Errorf("Failed to get snapshot, VolumeSnapshot: %s, Error: %v", snapshotName, err)
 	}
-	if !snap.Status.ReadyToUse {
-		return nil, errors.Errorf("Snapshot is not ready, VolumeSnapshot: %s, Namespace: %s", snapshotName, namespace)
-	}
 	if snap.Spec.SnapshotContentName == "" {
 		return nil, errors.Errorf("Snapshot does not have content, VolumeSnapshot: %s, Namespace: %s", snapshotName, namespace)
 	}

--- a/pkg/kube/snapshot/snapshot_beta.go
+++ b/pkg/kube/snapshot/snapshot_beta.go
@@ -201,9 +201,6 @@ func (sna *SnapshotBeta) GetSource(ctx context.Context, snapshotName, namespace 
 	if err != nil {
 		return nil, errors.Errorf("Failed to get snapshot, VolumeSnapshot: %s, Error: %v", snapshotName, err)
 	}
-	if !snap.Status.ReadyToUse {
-		return nil, errors.Errorf("Snapshot is not ready, VolumeSnapshot: %s, Namespace: %s", snapshotName, namespace)
-	}
 	if snap.Spec.SnapshotContentName == "" {
 		return nil, errors.Errorf("Snapshot does not have content, VolumeSnapshot: %s, Namespace: %s", snapshotName, namespace)
 	}


### PR DESCRIPTION
## Change Overview

The availability of the VolumeSnapshotContent object is not dependent on the ReadyToUse field. This field must be set by the driver after it is done doing whatever processing is necessary for the snapshot to be usable. 
https://github.com/container-storage-interface/spec/blob/master/spec.md#the-ready_to_use-parameter

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
