### PR TITLE
Pull Kanister tools image only if not present

### DIFF
--- a/pkg/kube/pod.go
+++ b/pkg/kube/pod.go
@@ -82,7 +82,7 @@ func CreatePod(ctx context.Context, cli kubernetes.Interface, opts *PodOptions) 
 				Name:            "container",
 				Image:           opts.Image,
 				Command:         opts.Command,
-				ImagePullPolicy: v1.PullPolicy(v1.PullAlways),
+				ImagePullPolicy: v1.PullPolicy(v1.PullIfNotPresent),
 				VolumeMounts:    volumeMounts,
 			},
 		},

--- a/pkg/kube/pod_test.go
+++ b/pkg/kube/pod_test.go
@@ -249,7 +249,7 @@ func (s *PodSuite) TestPatchDefaultPodSpecs(c *C) {
 				Name:            "container",
 				Image:           "kanisterio/kanister-tools:0.41.0",
 				Command:         []string{"sh", "-c", "echo in default specs"},
-				ImagePullPolicy: v1.PullPolicy(v1.PullAlways),
+				ImagePullPolicy: v1.PullPolicy(v1.PullIfNotPresent),
 				VolumeMounts: []v1.VolumeMount{
 					{
 						Name:      "data",
@@ -295,7 +295,7 @@ func (s *PodSuite) TestPatchDefaultPodSpecs(c *C) {
 						Name:            "container",
 						Image:           "kanisterio/kanister-tools:0.41.0",
 						Command:         []string{"sh", "-c", "echo in default specs"},
-						ImagePullPolicy: v1.PullPolicy(v1.PullAlways),
+						ImagePullPolicy: v1.PullPolicy(v1.PullIfNotPresent),
 						VolumeMounts: []v1.VolumeMount{
 							{
 								Name:      "data",
@@ -389,7 +389,7 @@ func (s *PodSuite) TestPatchDefaultPodSpecs(c *C) {
 						Name:            "container",
 						Image:           "kanisterio/kanister-tools:0.41.0",
 						Command:         []string{"sh", "-c", "echo in default specs"},
-						ImagePullPolicy: v1.PullPolicy(v1.PullAlways),
+						ImagePullPolicy: v1.PullPolicy(v1.PullIfNotPresent),
 						VolumeMounts: []v1.VolumeMount{
 							{
 								Name:      "data",
@@ -450,7 +450,7 @@ func (s *PodSuite) TestPatchDefaultPodSpecs(c *C) {
 						Name:            "container",
 						Image:           "kanisterio/kanister-tools:0.41.0",
 						Command:         []string{"sh", "-c", "echo in default specs"},
-						ImagePullPolicy: v1.PullPolicy(v1.PullAlways),
+						ImagePullPolicy: v1.PullPolicy(v1.PullIfNotPresent),
 						VolumeMounts: []v1.VolumeMount{
 							{
 								Name:      "data",
@@ -513,7 +513,7 @@ func (s *PodSuite) TestPatchDefaultPodSpecs(c *C) {
 						Name:            "container",
 						Image:           "kanisterio/kanister-tools:0.41.0",
 						Command:         []string{"echo", "override command"},
-						ImagePullPolicy: v1.PullPolicy(v1.PullAlways),
+						ImagePullPolicy: v1.PullPolicy(v1.PullIfNotPresent),
 						VolumeMounts: []v1.VolumeMount{
 							{
 								Name:      "data",
@@ -553,7 +553,7 @@ func (s *PodSuite) TestPatchDefaultPodSpecs(c *C) {
 						Name:            "container",
 						Image:           "kanisterio/kanister-tools:0.41.0",
 						Command:         []string{"echo", "override command"},
-						ImagePullPolicy: v1.PullPolicy(v1.PullAlways),
+						ImagePullPolicy: v1.PullPolicy(v1.PullIfNotPresent),
 						VolumeMounts: []v1.VolumeMount{
 							{
 								Name:      "data",


### PR DESCRIPTION
## Change Overview

This will reduce the number of times the same `kanister-tools` image is pulled.

## Pull request type

Please check the type of change your PR introduces:

- [x] :bug: Bugfix

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :zap: Unit test
