### PR TITLE
Enhance objectstore streaming test

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -503,7 +503,9 @@ github.com/kastenhq/check v0.0.0-20180626002341-0264cfcea734 h1:qulsCaCv+O2y9/sQ
 github.com/kastenhq/check v0.0.0-20180626002341-0264cfcea734/go.mod h1:rdqSnvOJuKCPFW/h2rVLuXOAkRnHHdp9PZcKx4HCoDM=
 github.com/kastenhq/stow v0.1.2-kasten h1:3msAbg6woEPWzYaBPmsOY4a0V55QosWD86XMOE+gDbM=
 github.com/kastenhq/stow v0.1.2-kasten/go.mod h1:ABI2whmZOX25JbmbVuHRLFuPiGnv5lxXhduCtof7UHk=
+github.com/kastenhq/stow v0.2.6-kasten.0 h1:KVb6LvSqTDmlA2XinRd78zMgGcGNU4u7jrVm0bJX1yY=
 github.com/kastenhq/stow v0.2.6-kasten.0/go.mod h1:+0vRL9oMECKjPMP7OeVWl8EIqRCpFwDlth3mrAeV2Kw=
+github.com/kastenhq/stow v0.2.6-kasten.1 h1:QPJmo4T/cROplSfs4LDbpgPmPvR5S4aRCECATdl4pXU=
 github.com/kastenhq/stow v0.2.6-kasten.1/go.mod h1:+0vRL9oMECKjPMP7OeVWl8EIqRCpFwDlth3mrAeV2Kw=
 github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=

--- a/pkg/objectstore/objectstore_test.go
+++ b/pkg/objectstore/objectstore_test.go
@@ -452,7 +452,7 @@ func (s *ObjectStoreProviderSuite) TestObjectsStreaming(c *C) {
 			dir:     "/Some/deep/directory/structure/",
 			r:       &zeroReader{size: 50 * 1024 * 1024},
 			data:    "",
-			inSize:  0,
+			inSize:  500 * 1024 * 1024,
 			outSize: 50 * 1024 * 1024,
 			tags:    tags,
 		},


### PR DESCRIPTION
## Change Overview

Used the test in this PR to validate stow's new Azure behavior.

For sizes less than the multi-part upload limit (256MiB), the size specified must be 0 or an accurate size.
For sizes greater than the multi-part upload limit, the size can be anything larger than the limit size.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
