### PR TITLE
Cleaning up initializeClients function in kanctl

### DIFF
--- a/pkg/kanctl/actionset.go
+++ b/pkg/kanctl/actionset.go
@@ -98,11 +98,11 @@ func newActionSetCmd() *cobra.Command {
 }
 
 func initializeAndPerform(cmd *cobra.Command, args []string) error {
-	cli, crCli, osCli, err := initializeClients()
+	clients, err := initializeClients()
 	if err != nil {
 		return err
 	}
-	params, err := extractPerformParams(cmd, args, cli, osCli)
+	params, err := extractPerformParams(cmd, args, clients.KubeClient, clients.OsClient)
 	if err != nil {
 		return err
 	}
@@ -110,12 +110,12 @@ func initializeAndPerform(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 	valFlag, _ := cmd.Flags().GetBool(skipValidationFlag)
 	if !valFlag {
-		err = verifyParams(ctx, params, cli, crCli, osCli)
+		err = verifyParams(ctx, params, clients)
 		if err != nil {
 			return err
 		}
 	}
-	return perform(ctx, crCli, params)
+	return perform(ctx, clients.CrdClient, params)
 }
 
 func perform(ctx context.Context, crCli versioned.Interface, params *PerformParams) error {
@@ -587,7 +587,7 @@ func parseName(k string, r string) (namespace, name string, err error) {
 	return m[1], m[2], nil
 }
 
-func verifyParams(ctx context.Context, p *PerformParams, cli kubernetes.Interface, crCli versioned.Interface, osCli osversioned.Interface) error {
+func verifyParams(ctx context.Context, p *PerformParams, cli *Clients) error {
 	const notFoundTmpl = "Please make sure '%s' with name '%s' exists in namespace '%s'"
 	msgs := make(chan error)
 	wg := sync.WaitGroup{}
@@ -597,7 +597,7 @@ func verifyParams(ctx context.Context, p *PerformParams, cli kubernetes.Interfac
 	go func() {
 		defer wg.Done()
 		if p.Blueprint != "" {
-			_, err := crCli.CrV1alpha1().Blueprints(p.Namespace).Get(ctx, p.Blueprint, metav1.GetOptions{})
+			_, err := cli.CrdClient.CrV1alpha1().Blueprints(p.Namespace).Get(ctx, p.Blueprint, metav1.GetOptions{})
 			if err != nil {
 				msgs <- errors.Wrapf(err, notFoundTmpl, "blueprint", p.Blueprint, p.Namespace)
 			}
@@ -608,7 +608,7 @@ func verifyParams(ctx context.Context, p *PerformParams, cli kubernetes.Interfac
 	go func() {
 		defer wg.Done()
 		if p.Profile != nil {
-			_, err := crCli.CrV1alpha1().Profiles(p.Profile.Namespace).Get(ctx, p.Profile.Name, metav1.GetOptions{})
+			_, err := cli.CrdClient.CrV1alpha1().Profiles(p.Profile.Namespace).Get(ctx, p.Profile.Name, metav1.GetOptions{})
 			if err != nil {
 				msgs <- errors.Wrapf(err, notFoundTmpl, "profile", p.Profile.Name, p.Profile.Namespace)
 			}
@@ -622,16 +622,16 @@ func verifyParams(ctx context.Context, p *PerformParams, cli kubernetes.Interfac
 		for _, obj := range p.Objects {
 			switch obj.Kind {
 			case param.DeploymentKind:
-				_, err = cli.AppsV1().Deployments(obj.Namespace).Get(ctx, obj.Name, metav1.GetOptions{})
+				_, err = cli.KubeClient.AppsV1().Deployments(obj.Namespace).Get(ctx, obj.Name, metav1.GetOptions{})
 			case param.StatefulSetKind:
-				_, err = cli.AppsV1().StatefulSets(obj.Namespace).Get(ctx, obj.Name, metav1.GetOptions{})
+				_, err = cli.KubeClient.AppsV1().StatefulSets(obj.Namespace).Get(ctx, obj.Name, metav1.GetOptions{})
 			case param.DeploymentConfigKind:
 				// use open shift client to get the deployment config resource
-				_, err = osCli.AppsV1().DeploymentConfigs(obj.Namespace).Get(ctx, obj.Name, metav1.GetOptions{})
+				_, err = cli.OsClient.AppsV1().DeploymentConfigs(obj.Namespace).Get(ctx, obj.Name, metav1.GetOptions{})
 			case param.PVCKind:
-				_, err = cli.CoreV1().PersistentVolumeClaims(obj.Namespace).Get(ctx, obj.Name, metav1.GetOptions{})
+				_, err = cli.KubeClient.CoreV1().PersistentVolumeClaims(obj.Namespace).Get(ctx, obj.Name, metav1.GetOptions{})
 			case param.NamespaceKind:
-				_, err = cli.CoreV1().Namespaces().Get(ctx, obj.Name, metav1.GetOptions{})
+				_, err = cli.KubeClient.CoreV1().Namespaces().Get(ctx, obj.Name, metav1.GetOptions{})
 			default:
 				gvr := schema.GroupVersionResource{
 					Group:    obj.Group,
@@ -650,7 +650,7 @@ func verifyParams(ctx context.Context, p *PerformParams, cli kubernetes.Interfac
 	go func() {
 		defer wg.Done()
 		for _, cm := range p.ConfigMaps {
-			_, err := cli.CoreV1().ConfigMaps(cm.Namespace).Get(ctx, cm.Name, metav1.GetOptions{})
+			_, err := cli.KubeClient.CoreV1().ConfigMaps(cm.Namespace).Get(ctx, cm.Name, metav1.GetOptions{})
 			if err != nil {
 				msgs <- errors.Wrapf(err, notFoundTmpl, "config map", cm.Name, cm.Namespace)
 			}
@@ -661,7 +661,7 @@ func verifyParams(ctx context.Context, p *PerformParams, cli kubernetes.Interfac
 	go func() {
 		defer wg.Done()
 		for _, secret := range p.Secrets {
-			_, err := cli.CoreV1().Secrets(secret.Namespace).Get(ctx, secret.Name, metav1.GetOptions{})
+			_, err := cli.KubeClient.CoreV1().Secrets(secret.Namespace).Get(ctx, secret.Name, metav1.GetOptions{})
 			if err != nil {
 				msgs <- errors.Wrapf(err, notFoundTmpl, "secret", secret.Name, secret.Namespace)
 			}

--- a/pkg/kanctl/kanctl_test.go
+++ b/pkg/kanctl/kanctl_test.go
@@ -1,0 +1,45 @@
+// Copyright 2020 The Kanister Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kanctl
+
+import (
+	"github.com/kanisterio/kanister/pkg/client/clientset/versioned"
+	osversioned "github.com/openshift/client-go/apps/clientset/versioned"
+	. "gopkg.in/check.v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+func (k *KanctlTestSuite) TestInitializeClients(c *C) {
+	clients, err := initializeClients()
+
+	// No errors are thrown
+	c.Assert(err, IsNil)
+
+	// return value has the correct type
+	c.Assert(clients, FitsTypeOf, &Clients{})
+
+	// check all struct fields
+	var kubeInterface kubernetes.Interface
+
+	c.Assert(clients.KubeClient, Implements, &kubeInterface)
+
+	var verInterface versioned.Interface
+
+	c.Assert(clients.CrdClient, Implements, &verInterface)
+
+	var osVerInterface osversioned.Interface
+
+	c.Assert(clients.OsClient, Implements, &osVerInterface)
+}

--- a/pkg/kanctl/types.go
+++ b/pkg/kanctl/types.go
@@ -1,0 +1,27 @@
+// Copyright 2019 The Kanister Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kanctl
+
+import (
+	"github.com/kanisterio/kanister/pkg/client/clientset/versioned"
+	osversioned "github.com/openshift/client-go/apps/clientset/versioned"
+	"k8s.io/client-go/kubernetes"
+)
+
+type Clients struct {
+	KubeClient kubernetes.Interface
+	CrdClient  versioned.Interface
+	OsClient   osversioned.Interface
+}


### PR DESCRIPTION
## Change Overview

As requested, I cleaned up the `initializeClients` function inside the `kanctl` package.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [x] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [x] :robot: Test

## Issues

- #531 

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->
`go test -timeout 30s github.com/kanisterio/kanister/pkg/kanctl`

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
