### PR TITLE
Adding ability to specify persistent volume subPath

### DIFF
--- a/pkg/app/postgresql.go
+++ b/pkg/app/postgresql.go
@@ -41,7 +41,7 @@ type PostgresDB struct {
 }
 
 // Last tested chart version "9.0.0"
-func NewPostgresDB(name string) App {
+func NewPostgresDB(name string, subPath string) App {
 	return &PostgresDB{
 		name: name,
 		chart: helm.ChartInfo{
@@ -58,6 +58,7 @@ func NewPostgresDB(name string) App {
 				"postgresqlExtendedConf.archiveTimeout": "60",
 				"postgresqlExtendedConf.walLevel":       "archive",
 				"volumePermissions.enabled":             "true",
+				"persistence.subPath":                   subPath,
 			},
 		},
 	}

--- a/pkg/testing/integration_register.go
+++ b/pkg/testing/integration_register.go
@@ -32,7 +32,7 @@ var _ = Suite(&PITRPostgreSQL{
 	IntegrationSuite{
 		name:      "pitr-postgres",
 		namespace: "pitr-postgres-test",
-		app:       app.NewPostgresDB("pitr-postgres"),
+		app:       app.NewPostgresDB("pitr-postgres", ""),
 		bp:        app.NewPITRBlueprint("pitr-postgres", ""),
 		profile:   newSecretProfile(),
 	},
@@ -47,7 +47,7 @@ var _ = Suite(&PostgreSQL{
 	IntegrationSuite{
 		name:      "postgres",
 		namespace: "postgres-test",
-		app:       app.NewPostgresDB("postgres"),
+		app:       app.NewPostgresDB("postgres", ""),
 		bp:        app.NewBlueprint("postgres", ""),
 		profile:   newSecretProfile(),
 	},


### PR DESCRIPTION
## Change Overview

Adds the ability to specify persistent volume subPath for Postgres app.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
