### PR TITLE
Switch to ghcr to publish Kanister images

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,12 +39,12 @@ dockers:
 - binaries:
   - controller
   image_templates:
-  - 'kanisterio/controller:{{ .Tag }}'
+  - 'ghcr.io/kanisterio/controller:{{ .Tag }}'
   dockerfile: 'docker/controller/Dockerfile'
 - binaries:
   - kando
   image_templates:
-  - 'kanisterio/kanister-tools:{{ .Tag }}'
+  - 'ghcr.io/kanisterio/kanister-tools:{{ .Tag }}'
   dockerfile: 'docker/tools/Dockerfile'
   build_flag_templates:
   - "--build-arg=kan_tools_version={{ .Tag }}"
@@ -53,41 +53,41 @@ dockers:
 - binaries:
   - kando
   image_templates:
-  - 'kanisterio/postgres-kanister-tools:{{ .Tag }}'
+  - 'ghcr.io/kanisterio/postgres-kanister-tools:{{ .Tag }}'
   dockerfile: 'docker/postgres-kanister-tools/Dockerfile'
 - binaries:
   - kando
   image_templates:
-  - 'kanisterio/postgres-tools-9.6:{{ .Tag }}'
+  - 'ghcr.io/kanisterio/postgres-tools-9.6:{{ .Tag }}'
   dockerfile: 'docker/postgres-tools-9.6/Dockerfile'
 - image_templates:
-  - 'kanisterio/postgresql:{{ .Tag }}'
+  - 'ghcr.io/kanisterio/postgresql:{{ .Tag }}'
   dockerfile: 'docker/postgresql/Dockerfile'
 - binaries:
   - kando
   image_templates:
-  - 'kanisterio/es-sidecar:{{ .Tag }}'
+  - 'ghcr.io/kanisterio/es-sidecar:{{ .Tag }}'
   dockerfile: 'docker/kanister-elasticsearch/image/Dockerfile'
   build_flag_templates:
-  - "--build-arg=TOOLS_IMAGE=kanisterio/kanister-tools:{{ .Tag }}"
+  - "--build-arg=TOOLS_IMAGE=ghcr.io/kanisterio/kanister-tools:{{ .Tag }}"
   extra_files:
   - 'docker/kanister-elasticsearch/image/esdump-setup.sh'
 - binaries:
   - kando
   image_templates:
-  - 'kanisterio/mysql-sidecar:{{ .Tag }}'
+  - 'ghcr.io/kanisterio/mysql-sidecar:{{ .Tag }}'
   dockerfile: 'docker/kanister-mysql/image/Dockerfile'
   build_flag_templates:
-  - "--build-arg=TOOLS_IMAGE=kanisterio/kanister-tools:{{ .Tag }}"
+  - "--build-arg=TOOLS_IMAGE=ghcr.io/kanisterio/kanister-tools:{{ .Tag }}"
 - image_templates:
-  - 'kanisterio/kanister-kubectl:1.18'
+  - 'ghcr.io/kanisterio/kanister-kubectl:1.18'
   dockerfile: 'docker/kanister-kubectl/Dockerfile'
   build_flag_templates:
-  - "--build-arg=TOOLS_IMAGE=kanisterio/kanister-tools:{{ .Tag }}"
+  - "--build-arg=TOOLS_IMAGE=ghcr.io/kanisterio/kanister-tools:{{ .Tag }}"
 - binaries:
   - kando
   image_templates:
-  - 'kanisterio/mongo-sidecar:{{ .Tag }}'
+  - 'ghcr.io/kanisterio/mongo-sidecar:{{ .Tag }}'
   dockerfile: 'docker/kanister-mongodb-replicaset/image/Dockerfile'
   extra_files:
   - 'docker/kanister-mongodb-replicaset/image/install.sh'
@@ -97,22 +97,22 @@ dockers:
 - binaries:
   - kando
   image_templates:
-  - 'kanisterio/mongodb:{{ .Tag }}'
+  - 'ghcr.io/kanisterio/mongodb:{{ .Tag }}'
   dockerfile: 'docker/mongodb/Dockerfile'
 - binaries:
   - kando
   image_templates:
-  - 'kanisterio/cassandra:{{ .Tag }}'
+  - 'ghcr.io/kanisterio/cassandra:{{ .Tag }}'
   dockerfile: 'docker/cassandra/Dockerfile'
 - binaries:
   - kando
   image_templates:
-  - 'kanisterio/couchbase-tools:{{ .Tag }}'
+  - 'ghcr.io/kanisterio/couchbase-tools:{{ .Tag }}'
   dockerfile: 'docker/couchbase-tools/Dockerfile'
 - binaries:
   - kando
   image_templates:
-  - 'kanisterio/foundationdb:6.2.20'
+  - 'ghcr.io/kanisterio/foundationdb:6.2.20'
   dockerfile: 'docker/foundationdb/Dockerfile'
 
 snapshot:

--- a/examples/aws-rds/postgresql/pgtest/Makefile
+++ b/examples/aws-rds/postgresql/pgtest/Makefile
@@ -54,7 +54,7 @@ endif
 
 IMAGE := $(REGISTRY)/$(BIN)-$(ARCH)
 
-BUILD_IMAGE ?= kanisterio/build:0.13.2-go1.11
+BUILD_IMAGE ?= ghcr.io/kanisterio/build:0.13.2-go1.11
 
 # If you want to build all binaries, see the 'all-build' rule.
 # If you want to build all containers, see the 'all-container' rule.

--- a/examples/aws-rds/postgresql/pgtest/deploy/deployment.yaml
+++ b/examples/aws-rds/postgresql/pgtest/deploy/deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: pgtestapp
-        image: kanisterio/pgtest-amd64:0.1.0
+        image: ghcr.io/kanisterio/pgtest-amd64:0.1.0
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/examples/aws-rds/postgresql/rds-postgres-blueprint.yaml
+++ b/examples/aws-rds/postgresql/rds-postgres-blueprint.yaml
@@ -13,7 +13,7 @@ actions:
     - func: KubeTask
       name: backupSnapshots
       args:
-        image: "kanisterio/postgres-kanister-tools:0.44.0"
+        image: "ghcr.io/kanisterio/postgres-kanister-tools:0.44.0"
         namespace: "{{ .Object.metadata.namespace }}"
         command:
           - bash
@@ -49,7 +49,7 @@ actions:
     - func: KubeTask
       name: restoreSnapshots
       args:
-        image: "kanisterio/postgres-kanister-tools:0.44.0"
+        image: "ghcr.io/kanisterio/postgres-kanister-tools:0.44.0"
         namespace: "{{ .Object.metadata.namespace }}"
         command:
           - bash
@@ -87,7 +87,7 @@ actions:
     - func: KubeTask
       name: restoreSnapshots
       args:
-        image: "kanisterio/postgres-kanister-tools:0.44.0"
+        image: "ghcr.io/kanisterio/postgres-kanister-tools:0.44.0"
         namespace: "{{ .Namespace.Name }}"
         command:
           - bash

--- a/examples/aws-rds/postgresql/rds-postgres-dump-blueprint.yaml
+++ b/examples/aws-rds/postgresql/rds-postgres-dump-blueprint.yaml
@@ -65,7 +65,7 @@ actions:
       name: deleteBackup
       args:
         namespace: "{{ .Namespace.Name }}"
-        image: kanisterio/kanister-tools:0.44.0
+        image: ghcr.io/kanisterio/kanister-tools:0.44.0
         command:
           - bash
           - -o

--- a/examples/etcd/etcd-in-cluster/k8s/etcd-incluster-blueprint.yaml
+++ b/examples/etcd/etcd-in-cluster/k8s/etcd-incluster-blueprint.yaml
@@ -12,7 +12,7 @@ actions:
     - func: KubeTask
       name: takeSnapshot
       args:
-        image: kanisterio/kanister-kubectl:1.18
+        image: ghcr.io/kanisterio/kanister-kubectl:1.18
         command:
           - sh
           - -o
@@ -37,7 +37,7 @@ actions:
     - func: KubeTask
       name: uploadSnapshot
       args:
-        image: kanisterio/kanister-kubectl:1.18
+        image: ghcr.io/kanisterio/kanister-kubectl:1.18
         command:
           - sh
           - -o
@@ -55,7 +55,7 @@ actions:
     - func: KubeTask
       name: removeSnapshot
       args:
-        image: kanisterio/kanister-kubectl:1.18
+        image: ghcr.io/kanisterio/kanister-kubectl:1.18
         command:
           - sh
           - -o
@@ -75,7 +75,7 @@ actions:
       name: deleteFromObjectStore
       args:
         namespace: "{{ .Namespace.Name }}"
-        image: "kanisterio/kanister-tools:0.32.0"
+        image: "ghcr.io/kanisterio/kanister-tools:0.32.0"
         command:
         - bash
         - -o

--- a/examples/etcd/etcd-in-cluster/ocp/etcd-incluster-ocp-blueprint.yaml
+++ b/examples/etcd/etcd-in-cluster/ocp/etcd-incluster-ocp-blueprint.yaml
@@ -12,7 +12,7 @@ actions:
     - func: KubeTask
       name: takeSnapshot
       args:
-        image: kanisterio/kanister-kubectl:1.18
+        image: ghcr.io/kanisterio/kanister-kubectl:1.18
         command:
           - sh
           - -o
@@ -35,7 +35,7 @@ actions:
     - func: KubeTask
       name: uploadSnapshot
       args:
-        image: kanisterio/kanister-kubectl:1.18
+        image: ghcr.io/kanisterio/kanister-kubectl:1.18
         command:
           - sh
           - -o
@@ -53,7 +53,7 @@ actions:
     - func: KubeTask
       name: removeSnapshot
       args:
-        image: kanisterio/kanister-kubectl:1.18
+        image: ghcr.io/kanisterio/kanister-kubectl:1.18
         command:
           - sh
           - -o
@@ -73,7 +73,7 @@ actions:
       name: deleteFromObjectStore
       args:
         namespace: "{{ .Namespace.Name }}"
-        image: "kanisterio/kanister-tools:0.32.0"
+        image: "ghcr.io/kanisterio/kanister-tools:0.32.0"
         command:
         - bash
         - -o

--- a/examples/mongo-sidecar/mongo-cluster.yaml
+++ b/examples/mongo-sidecar/mongo-cluster.yaml
@@ -69,7 +69,7 @@ spec:
         - bash
         - -c
         env:
-        image: kanisterio/mongodb-sidecar:v0.2.0
+        image: ghcr.io/kanisterio/mongodb-sidecar:v0.2.0
         name: mongo-tools-sidecar
       - command:
         - mongod

--- a/examples/postgres-basic-pgdump/blueprint.yaml
+++ b/examples/postgres-basic-pgdump/blueprint.yaml
@@ -19,7 +19,7 @@ actions:
       name: takeBackup
       args:
         namespace: "{{ .StatefulSet.Namespace }}"
-        image: kanisterio/postgres-task:9.6
+        image: ghcr.io/kanisterio/postgres-task:9.6
         command:
           - bash
           - -o
@@ -45,7 +45,7 @@ actions:
       name: restoreBackup
       args:
         namespace: "{{ .StatefulSet.Namespace }}"
-        image: kanisterio/postgres-task:262fc0cbc8f0
+        image: ghcr.io/kanisterio/postgres-task:262fc0cbc8f0
         command:
           - bash
           - -o

--- a/examples/stable/cassandra/README.md
+++ b/examples/stable/cassandra/README.md
@@ -29,7 +29,7 @@ $ helm repo add bitnami https://charts.bitnami.com/bitnami
 $ helm repo update
 # remove app-namespace with the namespace you want to deploy the Cassandra app in
 $ kubectl create ns <app-namespace>
-$ helm install cassandra bitnami/cassandra --namespace <app-namespace> --set image.repository=kanisterio/cassandra --set image.tag=0.44.0 --set cluster.replicaCount=2 --set image.pullPolicy=Always
+$ helm install cassandra bitnami/cassandra --namespace <app-namespace> --set image.repository=ghcr.io/kanisterio/cassandra --set image.tag=0.44.0 --set cluster.replicaCount=2 --set image.pullPolicy=Always
 
 
 ```

--- a/examples/stable/cassandra/cassandra-blueprint.yaml
+++ b/examples/stable/cassandra/cassandra-blueprint.yaml
@@ -104,7 +104,7 @@ actions:
       name: restoreFromObjectStore
       args:
         namespace: "{{ .StatefulSet.Namespace }}"
-        image: kanisterio/kanister-tools:0.44.0
+        image: ghcr.io/kanisterio/kanister-tools:0.44.0
         backupArtifactPrefix: "{{ .ArtifactsIn.params.KeyValue.backupPrefixLocation }}"
         pods: "{{ range .StatefulSet.Pods }} {{.}}{{end}}"
         restorePath: "{{ .ArtifactsIn.params.KeyValue.restorePathPrefix }}"

--- a/examples/stable/couchbase/couchbase-blueprint.yaml
+++ b/examples/stable/couchbase/couchbase-blueprint.yaml
@@ -19,7 +19,7 @@ actions:
           namespace: "{{ .Object.metadata.namespace }}"
       args:
         namespace: "{{ .Object.metadata.namespace }}"
-        image: kanisterio/couchbase-tools:0.22.0
+        image: ghcr.io/kanisterio/couchbase-tools:0.22.0
         command:
           - bash
           - -o
@@ -53,7 +53,7 @@ actions:
           namespace: "{{ .Object.metadata.namespace }}"
       args:
         namespace: "{{ .Object.metadata.namespace }}"
-        image: kanisterio/couchbase-tools:0.22.0
+        image: ghcr.io/kanisterio/couchbase-tools:0.22.0
         command:
           - bash
           - -o
@@ -80,7 +80,7 @@ actions:
       name: deleteBackup
       args:
         namespace: "{{ .Namespace.Name }}"
-        image: kanisterio/kanister-tools:0.22.0
+        image: ghcr.io/kanisterio/kanister-tools:0.22.0
         command:
           - bash
           - -o

--- a/examples/stable/elasticsearch/elasticsearch-blueprint.yaml
+++ b/examples/stable/elasticsearch/elasticsearch-blueprint.yaml
@@ -14,7 +14,7 @@ actions:
       name: backupToObjectStore
       args:
         namespace: "{{ .StatefulSet.Namespace }}"
-        image: "kanisterio/es-sidecar:0.44.0"
+        image: "ghcr.io/kanisterio/es-sidecar:0.44.0"
         command:
         - bash
         - -o
@@ -38,7 +38,7 @@ actions:
       name: restoreFromObjectStore
       args:
         namespace: "{{ .StatefulSet.Namespace }}"
-        image: "kanisterio/es-sidecar:0.44.0"
+        image: "ghcr.io/kanisterio/es-sidecar:0.44.0"
         command:
         - bash
         - -o
@@ -58,7 +58,7 @@ actions:
       name: deleteFromObjectStore
       args:
         namespace: "{{ .Namespace.Name }}"
-        image: "kanisterio/es-sidecar:0.44.0"
+        image: "ghcr.io/kanisterio/es-sidecar:0.44.0"
         command:
         - bash
         - -o

--- a/examples/stable/foundationdb/README.md
+++ b/examples/stable/foundationdb/README.md
@@ -45,7 +45,7 @@ Steps that are mentioned below can be followed to install the foundationDB opera
 and run `mkdir foundationdb` to create the directory `foundationdb`.
 * `CD` into newly created directory and clone this github repo inside the created directory that is `foundationdb`
 using below command `git clone https://github.com/FoundationDB/fdb-kubernetes-operator.git`.
-* Run `sed -i '/IMG ?= fdb-kubernetes-operator:latest/c\IMG ?= kanisterio/fdb-kubernetes-operator:latest' Makefile` to correct the name of the operator image.
+* Run `sed -i '/IMG ?= fdb-kubernetes-operator:latest/c\IMG ?= ghcr.io/kanisterio/fdb-kubernetes-operator:latest' Makefile` to correct the name of the operator image.
 * Create Secrets to set up a secret with self-signed test certs using the command `./config/test-certs/generate_secrets.bash`
 * Run `make rebuild-operator` to install the operator. Please make sure this completes successfully.
 

--- a/examples/stable/foundationdb/foundationdb-blueprint.yaml
+++ b/examples/stable/foundationdb/foundationdb-blueprint.yaml
@@ -67,7 +67,7 @@ actions:
       name: deleteBackup
       args:
         namespace: "{{ .Namespace.Name }}"
-        image: kanisterio/kanister-tools:0.22.0
+        image: ghcr.io/kanisterio/kanister-tools:0.22.0
         command:
           - bash
           - -o

--- a/examples/stable/foundationdb/local_cluster.yaml
+++ b/examples/stable/foundationdb/local_cluster.yaml
@@ -20,7 +20,7 @@ spec:
       secret:
         secretName: fdb-kubernetes-operator-secrets
   mainContainer:
-    imageName: kanisterio/foundationdb
+    imageName: ghcr.io/kanisterio/foundationdb
     enableTls: true
     env:
       - name: FDB_TLS_CERTIFICATE_FILE

--- a/examples/stable/mongodb-deploymentconfig/mongo-dep-config-blueprint.yaml
+++ b/examples/stable/mongodb-deploymentconfig/mongo-dep-config-blueprint.yaml
@@ -19,7 +19,7 @@ actions:
           namespace: "{{ .DeploymentConfig.Namespace }}"
       args:
         namespace: "{{ .DeploymentConfig.Namespace }}"
-        image: kanisterio/mongodb:0.44.0
+        image: ghcr.io/kanisterio/mongodb:0.44.0
         command:
           - bash
           - -o
@@ -47,7 +47,7 @@ actions:
           namespace: "{{ .DeploymentConfig.Namespace }}"
       args:
         namespace: "{{ .DeploymentConfig.Namespace }}"
-        image: kanisterio/mongodb:0.44.0
+        image: ghcr.io/kanisterio/mongodb:0.44.0
         command:
           - bash
           - -o
@@ -69,7 +69,7 @@ actions:
       name: deleteFromBlobStore
       args:
         namespace: "{{ .Namespace.Name }}"
-        image: kanisterio/mongodb:0.44.0
+        image: ghcr.io/kanisterio/mongodb:0.44.0
         command:
           - bash
           - -o

--- a/examples/stable/mongodb-restic/README.md
+++ b/examples/stable/mongodb-restic/README.md
@@ -28,7 +28,7 @@ $ kubectl create namespace mongo-test
 # Using helm v3
 $ helm install my-release bitnami/mongodb --namespace mongo-test \
 	--set architecture="replicaset" \
-	--set image.repository=kanisterio/mongodb \
+	--set image.repository=ghcr.io/kanisterio/mongodb \
 	--set image.tag=0.44.0
 ```
 

--- a/examples/stable/mongodb-restic/mongodb-blueprint.yaml
+++ b/examples/stable/mongodb-restic/mongodb-blueprint.yaml
@@ -41,7 +41,7 @@ actions:
       name: restorePrimary
       args:
         namespace: "{{ .StatefulSet.Namespace }}"
-        image: kanisterio/kanister-tools:0.44.0
+        image: ghcr.io/kanisterio/kanister-tools:0.44.0
         backupArtifactPrefix: "{{ .Profile.Location.Bucket }}/mongodb-backups/{{ .StatefulSet.Name }}/rs_backup"
         backupInfo: "{{ .ArtifactsIn.backupInfo.KeyValue.backupIdentifier }}"
 

--- a/examples/stable/mongodb/7.8.10/mongo-blueprint.yaml
+++ b/examples/stable/mongodb/7.8.10/mongo-blueprint.yaml
@@ -19,7 +19,7 @@ actions:
           namespace: "{{ .StatefulSet.Namespace }}"
       args:
         namespace: "{{ .StatefulSet.Namespace }}"
-        image: kanisterio/mongodb:0.36.0
+        image: ghcr.io/kanisterio/mongodb:0.36.0
         command:
           - bash
           - -o
@@ -46,7 +46,7 @@ actions:
           namespace: "{{ .StatefulSet.Namespace }}"
       args:
         namespace: "{{ .StatefulSet.Namespace }}"
-        image: kanisterio/mongodb:0.36.0
+        image: ghcr.io/kanisterio/mongodb:0.36.0
         command:
           - bash
           - -o
@@ -68,7 +68,7 @@ actions:
       name: deleteFromBlobStore
       args:
         namespace: "{{ .Namespace.Name }}"
-        image: kanisterio/mongodb:0.36.0
+        image: ghcr.io/kanisterio/mongodb:0.36.0
         command:
           - bash
           - -o

--- a/examples/stable/mongodb/mongo-blueprint.yaml
+++ b/examples/stable/mongodb/mongo-blueprint.yaml
@@ -19,7 +19,7 @@ actions:
           namespace: "{{ .StatefulSet.Namespace }}"
       args:
         namespace: "{{ .StatefulSet.Namespace }}"
-        image: kanisterio/mongodb:0.44.0
+        image: ghcr.io/kanisterio/mongodb:0.44.0
         command:
           - bash
           - -o
@@ -46,7 +46,7 @@ actions:
           namespace: "{{ .StatefulSet.Namespace }}"
       args:
         namespace: "{{ .StatefulSet.Namespace }}"
-        image: kanisterio/mongodb:0.44.0
+        image: ghcr.io/kanisterio/mongodb:0.44.0
         command:
           - bash
           - -o
@@ -68,7 +68,7 @@ actions:
       name: deleteFromBlobStore
       args:
         namespace: "{{ .Namespace.Name }}"
-        image: kanisterio/mongodb:0.44.0
+        image: ghcr.io/kanisterio/mongodb:0.44.0
         command:
           - bash
           - -o

--- a/examples/stable/mysql-deploymentconfig/mysql-dep-config-blueprint.yaml
+++ b/examples/stable/mysql-deploymentconfig/mysql-dep-config-blueprint.yaml
@@ -18,7 +18,7 @@ actions:
           name: "{{ .DeploymentConfig.Name }}"
           namespace: "{{ .DeploymentConfig.Namespace }}"
       args:
-        image: kanisterio/mysql-sidecar:0.44.0
+        image: ghcr.io/kanisterio/mysql-sidecar:0.44.0
         namespace: "{{ .DeploymentConfig.Namespace }}"
         command:
         - bash
@@ -45,7 +45,7 @@ actions:
           name: "{{ .DeploymentConfig.Name }}"
           namespace: "{{ .DeploymentConfig.Namespace }}"
       args:
-        image: kanisterio/mysql-sidecar:0.44.0
+        image: ghcr.io/kanisterio/mysql-sidecar:0.44.0
         namespace: "{{ .DeploymentConfig.Namespace }}"
         command:
         - bash
@@ -66,7 +66,7 @@ actions:
     - func: KubeTask
       name: deleteFromBlobStore
       args:
-        image: kanisterio/mysql-sidecar:0.44.0
+        image: ghcr.io/kanisterio/mysql-sidecar:0.44.0
         namespace: "{{ .Namespace.Name }}"
         command:
         - bash

--- a/examples/stable/mysql/6.x/mysql-blueprint.yaml
+++ b/examples/stable/mysql/6.x/mysql-blueprint.yaml
@@ -18,7 +18,7 @@ actions:
           name: '{{ index .Object.metadata.labels "release" | toString }}'
           namespace: '{{ .StatefulSet.Namespace }}'
       args:
-        image: kanisterio/mysql-sidecar:0.43.0
+        image: ghcr.io/kanisterio/mysql-sidecar:0.43.0
         namespace: "{{ .StatefulSet.Namespace }}"
         command:
         - bash
@@ -45,7 +45,7 @@ actions:
           name: '{{ index .Object.metadata.labels "release" | toString }}'
           namespace: '{{ .StatefulSet.Namespace }}'
       args:
-        image: kanisterio/mysql-sidecar:0.43.0
+        image: ghcr.io/kanisterio/mysql-sidecar:0.43.0
         namespace: "{{ .StatefulSet.Namespace }}"
         command:
         - bash
@@ -66,7 +66,7 @@ actions:
     - func: KubeTask
       name: deleteFromBlobStore
       args:
-        image: kanisterio/mysql-sidecar:0.43.0
+        image: ghcr.io/kanisterio/mysql-sidecar:0.43.0
         namespace: "{{ .Namespace.Name }}"
         command:
         - bash

--- a/examples/stable/mysql/mysql-blueprint.yaml
+++ b/examples/stable/mysql/mysql-blueprint.yaml
@@ -18,7 +18,7 @@ actions:
           name: '{{ index .Object.metadata.labels "app.kubernetes.io/instance" }}'
           namespace: '{{ .StatefulSet.Namespace }}'
       args:
-        image: kanisterio/mysql-sidecar:0.44.0
+        image: ghcr.io/kanisterio/mysql-sidecar:0.44.0
         namespace: "{{ .StatefulSet.Namespace }}"
         command:
         - bash
@@ -45,7 +45,7 @@ actions:
           name: '{{ index .Object.metadata.labels "app.kubernetes.io/instance" }}'
           namespace: '{{ .StatefulSet.Namespace }}'
       args:
-        image: kanisterio/mysql-sidecar:0.44.0
+        image: ghcr.io/kanisterio/mysql-sidecar:0.44.0
         namespace: "{{ .StatefulSet.Namespace }}"
         command:
         - bash
@@ -66,7 +66,7 @@ actions:
     - func: KubeTask
       name: deleteFromBlobStore
       args:
-        image: kanisterio/mysql-sidecar:0.44.0
+        image: ghcr.io/kanisterio/mysql-sidecar:0.44.0
         namespace: "{{ .Namespace.Name }}"
         command:
         - bash

--- a/examples/stable/postgresql-deploymentconfig/postgres-dep-config-blueprint.yaml
+++ b/examples/stable/postgresql-deploymentconfig/postgres-dep-config-blueprint.yaml
@@ -18,7 +18,7 @@ actions:
           name: '{{ .DeploymentConfig.Name }}-{{ .DeploymentConfig.Namespace }}'
           namespace: '{{ .DeploymentConfig.Namespace }}'
       args:
-        image: kanisterio/postgres-kanister-tools:0.44.0
+        image: ghcr.io/kanisterio/postgres-kanister-tools:0.44.0
         namespace: '{{ .DeploymentConfig.Namespace }}'
         command:
         - bash
@@ -47,7 +47,7 @@ actions:
           name: '{{ .DeploymentConfig.Name }}-{{ .DeploymentConfig.Namespace }}'
           namespace: '{{ .DeploymentConfig.Namespace }}'
       args:
-        image: kanisterio/postgres-kanister-tools:0.44.0
+        image: ghcr.io/kanisterio/postgres-kanister-tools:0.44.0
         namespace: '{{ .DeploymentConfig.Namespace }}'
         command:
         - bash
@@ -70,7 +70,7 @@ actions:
     - func: KubeTask
       name: deleteDump
       args:
-        image: kanisterio/postgres-kanister-tools:0.44.0
+        image: ghcr.io/kanisterio/postgres-kanister-tools:0.44.0
         namespace: "{{ .Namespace.Name }}"
         command:
           - bash

--- a/examples/stable/postgresql-wale/README.md
+++ b/examples/stable/postgresql-wale/README.md
@@ -24,7 +24,7 @@ $ helm repo update
 
 $ helm install my-release bitnami/postgresql  \
 	--namespace postgres-test \
-	--set image.repository=kanisterio/postgresql \
+	--set image.repository=ghcr.io/kanisterio/postgresql \
 	--set image.tag=0.44.0 \
 	--set postgresqlPassword=postgres-12345 \
 	--set postgresqlExtendedConf.archiveCommand="'envdir /bitnami/postgresql/data/env wal-e wal-push %p'" \

--- a/examples/stable/postgresql-wale/postgresql-blueprint.yaml
+++ b/examples/stable/postgresql-wale/postgresql-blueprint.yaml
@@ -134,7 +134,7 @@ actions:
     - func: PrepareData
       name: performRestore
       args:
-        image: "kanisterio/postgresql:0.44.0"
+        image: "ghcr.io/kanisterio/postgresql:0.44.0"
         namespace: "{{ .StatefulSet.Namespace }}"
         volumes:
           "data-{{ .StatefulSet.Name }}-0": "/bitnami/postgresql"
@@ -282,7 +282,7 @@ actions:
       name: deleteArtifact
       args:
         namespace: "{{ .Namespace.Name }}"
-        image: "kanisterio/postgresql:0.44.0"
+        image: "ghcr.io/kanisterio/postgresql:0.44.0"
         command:
           - bash
           - -o

--- a/examples/stable/postgresql/postgres-blueprint.yaml
+++ b/examples/stable/postgresql/postgres-blueprint.yaml
@@ -18,7 +18,7 @@ actions:
           name: '{{ index .Object.metadata.labels "app.kubernetes.io/instance" }}-postgresql'
           namespace: '{{ .StatefulSet.Namespace }}'
       args:
-        image: kanisterio/postgres-kanister-tools:0.44.0
+        image: ghcr.io/kanisterio/postgres-kanister-tools:0.44.0
         namespace: '{{ .StatefulSet.Namespace }}'
         command:
         - bash
@@ -47,7 +47,7 @@ actions:
           name: '{{ index .Object.metadata.labels "app.kubernetes.io/instance" }}-postgresql'
           namespace: '{{ .StatefulSet.Namespace }}'
       args:
-        image: kanisterio/postgres-kanister-tools:0.44.0
+        image: ghcr.io/kanisterio/postgres-kanister-tools:0.44.0
         namespace: '{{ .StatefulSet.Namespace }}'
         command:
         - bash
@@ -70,7 +70,7 @@ actions:
     - func: KubeTask
       name: deleteDump
       args:
-        image: kanisterio/postgres-kanister-tools:0.44.0
+        image: ghcr.io/kanisterio/postgres-kanister-tools:0.44.0
         namespace: "{{ .Namespace.Name }}"
         command:
           - bash

--- a/examples/stable/postgresql/v8.6.4/postgres-blueprint.yaml
+++ b/examples/stable/postgresql/v8.6.4/postgres-blueprint.yaml
@@ -18,7 +18,7 @@ actions:
           name: '{{ .Object.metadata.labels.release }}-postgresql'
           namespace: '{{ .StatefulSet.Namespace }}'
       args:
-        image: kanisterio/postgres-kanister-tools:0.34.0
+        image: ghcr.io/kanisterio/postgres-kanister-tools:0.34.0
         namespace: '{{ .StatefulSet.Namespace }}'
         command:
         - bash
@@ -47,7 +47,7 @@ actions:
           name: '{{ .Object.metadata.labels.release }}-postgresql'
           namespace: '{{ .StatefulSet.Namespace }}'
       args:
-        image: kanisterio/postgres-kanister-tools:0.34.0
+        image: ghcr.io/kanisterio/postgres-kanister-tools:0.34.0
         namespace: '{{ .StatefulSet.Namespace }}'
         command:
         - bash
@@ -70,7 +70,7 @@ actions:
     - func: KubeTask
       name: deleteDump
       args:
-        image: kanisterio/postgres-kanister-tools:0.34.0
+        image: ghcr.io/kanisterio/postgres-kanister-tools:0.34.0
         namespace: "{{ .Namespace.Name }}"
         command:
           - bash

--- a/examples/time-log/blueprint.yaml
+++ b/examples/time-log/blueprint.yaml
@@ -40,7 +40,7 @@ actions:
       args:
         namespace: "{{ .Deployment.Namespace }}"
         pod: "{{ index .Deployment.Pods 0 }}"
-        image: kanisterio/kanister-tools:0.44.0
+        image: ghcr.io/kanisterio/kanister-tools:0.44.0
         backupArtifactPrefix: "{{ .ArtifactsIn.timeLog.KeyValue.path }}"
         backupIdentifier: "{{ .ArtifactsIn.backupIdentifier.KeyValue.id }}"
     - func: ScaleWorkload

--- a/examples/time-log/time-logger-deployment.yaml
+++ b/examples/time-log/time-logger-deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: test-container
-        image: kanisterio/kanister-tools:0.44.0
+        image: ghcr.io/kanisterio/kanister-tools:0.44.0
         command: ["sh", "-c"]
         args: ["while true; do for x in $(seq 1200); do date >> /var/log/time.log; sleep 1; done; truncate /var/log/time.log --size 0; done"]
         volumeMounts:


### PR DESCRIPTION
## Change Overview

Authenticating docker client:
```
docker login https://ghcr.io -u github_username -p GITHUB_PERSONAL_ACCESS_TOKEN
```
Scopes needed while creating PA token:

```
read:packages
write:packages
delete:packages
```
Kanister packages: https://github.com/orgs/kanisterio/packages

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [x] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test


## Test Plan

Logs while building using goreleaser:
```
$ goreleaser release --skip-publish --snapshot --rm-dist
   _ releasing using goreleaser 0.127.0...
   _ loading config file       file=.goreleaser.yml
   _ RUNNING BEFORE HOOKS     
      _ running go mod download  
   _ LOADING ENVIRONMENT VARIABLES
      _ pipe skipped              error=publishing is disabled
   _ GETTING AND VALIDATING GIT STATE
      _ releasing 0.43.0, commit 66afb247e9564a7a0d9100d88bb27668848a3b76
      _ pipe skipped              error=disabled during snapshot mode
   _ PARSING TAG              
   _ SETTING DEFAULTS         
      _ LOADING ENVIRONMENT VARIABLES
      _ SNAPSHOTING              
      _ GITHUB/GITLAB/GITEA RELEASES
      _ PROJECT NAME             
      _ BUILDING BINARIES        
      _ ARCHIVES                 
      _ LINUX PACKAGES WITH NFPM 
      _ SNAPCRAFT PACKAGES       
      _ CALCULATING CHECKSUMS    
      _ SIGNING ARTIFACTS        
      _ DOCKER IMAGES            
      _ ARTIFACTORY              
      _ BLOB                     
      _ HOMEBREW TAP FORMULA     
      _ SCOOP MANIFEST           
   _ SNAPSHOTING              
   _ CHECKING ./DIST          
      _ --rm-dist is set, cleaning it up
   _ WRITING EFFECTIVE CONFIG FILE
      _ writing                   config=dist/config.yaml
   _ GENERATING CHANGELOG     
      _ pipe skipped              error=not available for snapshots
   _ BUILDING BINARIES        
      _ building                  binary=/home/prasad/go-ws/src/github.com/kanisterio/kanister/dist/kanctl_linux_amd64/kanctl
      _ building                  binary=/home/prasad/go-ws/src/github.com/kanisterio/kanister/dist/kanctl_darwin_amd64/kanctl
      _ building                  binary=/home/prasad/go-ws/src/github.com/kanisterio/kanister/dist/kando_linux_amd64/kando
      _ building                  binary=/home/prasad/go-ws/src/github.com/kanisterio/kanister/dist/controller_linux_amd64/controller
   _ ARCHIVES                 
      _ creating                  archive=dist/kanister_0.43.0_darwin_amd64.tar.gz
      _ creating                  archive=dist/kanister_0.43.0_linux_amd64.tar.gz
   _ LINUX PACKAGES WITH NFPM 
   _ SNAPCRAFT PACKAGES       
   _ CALCULATING CHECKSUMS    
      _ checksumming              file=kanister_0.43.0_linux_amd64.tar.gz
      _ checksumming              file=kanister_0.43.0_darwin_amd64.tar.gz
   _ SIGNING ARTIFACTS        
      _ pipe skipped              error=artifact signing is disabled
   _ DOCKER IMAGES            
      _ building docker image     image=ghcr.io/kanisterio/kanister-kubectl:1.18
      _ building docker image     image=ghcr.io/kanisterio/foundationdb:6.2.20
      _ building docker image     image=ghcr.io/kanisterio/kanister-tools:0.43.0
      _ building docker image     image=ghcr.io/kanisterio/mysql-sidecar:0.43.0
      _ building docker image     image=ghcr.io/kanisterio/postgresql:0.43.0
      _ building docker image     image=ghcr.io/kanisterio/postgres-kanister-tools:0.43.0
      _ building docker image     image=ghcr.io/kanisterio/postgres-tools-9.6:0.43.0
      _ building docker image     image=ghcr.io/kanisterio/mongodb:0.43.0
      _ building docker image     image=ghcr.io/kanisterio/mongo-sidecar:0.43.0
      _ building docker image     image=ghcr.io/kanisterio/controller:0.43.0
      _ building docker image     image=ghcr.io/kanisterio/es-sidecar:0.43.0
      _ building docker image     image=ghcr.io/kanisterio/cassandra:0.43.0
      _ building docker image     image=ghcr.io/kanisterio/couchbase-tools:0.43.0
      _ pipe skipped              error=publishing is disabled
   _ PUBLISHING               
      _ pipe skipped              error=publishing is disabled
   _ release succeeded after 368.15s

```

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
