### PR TITLE
Fix couchbase test app as per latest couchbase chart version 2.1.0

### DIFF
--- a/examples/stable/couchbase/couchbase-blueprint.yaml
+++ b/examples/stable/couchbase/couchbase-blueprint.yaml
@@ -80,7 +80,7 @@ actions:
       name: deleteBackup
       args:
         namespace: "{{ .Namespace.Name }}"
-        image: ghcr.io/kanisterio/kanister-tools:0.22.0
+        image: ghcr.io/kanisterio/kanister-tools:0.45.0
         command:
           - bash
           - -o

--- a/pkg/app/couchbase.go
+++ b/pkg/app/couchbase.go
@@ -48,7 +48,7 @@ type CouchbaseDB struct {
 	chart     helm.ChartInfo
 }
 
-// Last tested woking version "2.0.2"
+// Last tested woking version "2.1.0"
 func NewCouchbaseDB(name string) App {
 	return &CouchbaseDB{
 		name: name,
@@ -112,7 +112,7 @@ func (cb *CouchbaseDB) IsReady(ctx context.Context) (bool, error) {
 	}
 
 	// Read cluster creds from Secret
-	secret, err := cb.cli.CoreV1().Secrets(cb.namespace).Get(ctx, fmt.Sprintf("%s-couchbase-cluster", cb.chart.Release), metav1.GetOptions{})
+	secret, err := cb.cli.CoreV1().Secrets(cb.namespace).Get(ctx, fmt.Sprintf("auth-%s-couchbase-cluster", cb.chart.Release), metav1.GetOptions{})
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
## Change Overview

The latest `couchbase` chart has secret name created as `auth-RELEASE_NAME-couchbase-cluster` as can be seen [here](https://github.com/couchbase-partners/helm-charts/blob/f3f0d764d0b29ef1c87ec4064bb288851e344b51/couchbase-operator/templates/_helpers.tpl#L147). This PR updates the test app for the same.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [x] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [x] :green_heart: E2E

- Tested by running `make integration-test` for Couchbase app and verified the test was passing after changes.