### PR TITLE
Fixing cassandra blueprint

### DIFF
--- a/examples/stable/cassandra/cassandra-blueprint.yaml
+++ b/examples/stable/cassandra/cassandra-blueprint.yaml
@@ -52,6 +52,7 @@ actions:
           - -c
           - |
             nodetool cleanup
+            nodetool clearsnapshot
             nodetool snapshot -t ${HOSTNAME}
             snapshot_prefix="{{ .Phases.getBackupPrefixLocation.Output.localSnapshotPrefixLocation }}"
             mkdir -p ${snapshot_prefix}/${HOSTNAME}


### PR DESCRIPTION
## Change Overview

Fixing problem where snapshots were not getting cleaned up. Added nodetool command to cleanup snapshots.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #K10-5821

## Test Plan

Test 1 -

Deployed cassandra and added sleep time in blueprint. While taking backup I deleted actionset.
I triggered backup process again and it worked as expected.
Test 2 -

Manually triggered snapshot in cassandra pod via kubectl using command "nodetool clearsnapshot".
Later triggered backup via cassandra blueprint. I got error "Snapshot cassandra-1 already exists".
Later I added triggered backup with new cassandra-blueprint and process completed without any error.