### PR TITLE
Error azure client creation if metadata GET fails

### DIFF
--- a/pkg/blockstorage/azure/azure_instance_metadata.go
+++ b/pkg/blockstorage/azure/azure_instance_metadata.go
@@ -18,6 +18,8 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
+
+	"github.com/pkg/errors"
 )
 
 const metadataURL = "http://169.254.169.254/metadata/"
@@ -106,7 +108,9 @@ func (i *InstanceMetadata) queryMetadataBytes(path, format string) ([]byte, erro
 	if err != nil {
 		return nil, err
 	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.Errorf("Failed to get instance metadata with statusCode: %d, Path: %s", resp.StatusCode, path)
+	}
 	defer resp.Body.Close()
-
 	return ioutil.ReadAll(resp.Body)
 }


### PR DESCRIPTION
## Change Overview

Error azure client creation if metadata GET fails

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E

Tested on both types of azure clusters where - metadata was accessible and metadata was not reachable