### PR TITLE
Add support for v1 k8s volume snapshot APIs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/json-iterator/go v1.1.10
 	github.com/kelseyhightower/envconfig v1.4.0 // indirect
 	github.com/kopia/kopia v0.4.1-0.20200608151401-25934a544df4
+	github.com/kubernetes-csi/external-snapshotter/client/v4 v4.0.0
 	github.com/lib/pq v1.2.0
 	github.com/luci/go-render v0.0.0-20160219211803-9a04cc21af0f
 	github.com/mitchellh/mapstructure v1.1.2
@@ -61,7 +62,6 @@ require (
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637
 
-	//pinned k8s.io to v0.18.3 tag
 	k8s.io/api v0.19.5
 	k8s.io/apiextensions-apiserver v0.19.5
 	k8s.io/apimachinery v0.19.5

--- a/go.mod
+++ b/go.mod
@@ -22,8 +22,6 @@ require (
 	github.com/Masterminds/sprig v2.15.0+incompatible
 	github.com/aokoli/goutils v1.1.0 // indirect
 	github.com/aws/aws-sdk-go v1.31.3
-	github.com/coreos/go-etcd v2.0.0+incompatible // indirect
-	github.com/cpuguy83/go-md2man v1.0.10 // indirect
 	github.com/dnaeon/go-vcr v1.0.1 // indirect
 	github.com/docker/spdystream v0.0.0-20181023171402-6480d4af844c // indirect
 	github.com/elazarl/goproxy v0.0.0-20190711103511-473e67f1d7d2 // indirect
@@ -62,6 +60,7 @@ require (
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637
 
+	//pinned k8s.io to v0.19.5 tag
 	k8s.io/api v0.19.5
 	k8s.io/apiextensions-apiserver v0.19.5
 	k8s.io/apimachinery v0.19.5

--- a/go.sum
+++ b/go.sum
@@ -565,6 +565,9 @@ github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kubernetes-csi/external-snapshotter v1.2.2 h1:OPXoJydNqkWjhLwJ20dSqOhkmUYcpm+CCO0pYm+C8Q8=
+github.com/kubernetes-csi/external-snapshotter/client/v4 v4.0.0 h1:ipLtV9ubLEYx42YvwDa12eVPQvjuGZoPdbCozGzVNRc=
+github.com/kubernetes-csi/external-snapshotter/client/v4 v4.0.0/go.mod h1:YBCo4DoEeDndqvAn6eeu0vWM7QdXmHEeI9cFWplmBys=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lib/pq v1.1.1/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
@@ -1080,6 +1083,8 @@ golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 h1:SvFZT6jyqRaOeXpc5h/JSfZe
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0 h1:/5xXl8Y5W96D+TtHSlonuFqGHIWVuyCkGJLwGh9JJFs=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.0.0-20200416051211-89c76fbcd5d1 h1:NusfzzA6yGQ+ua51ck7E3omNUX/JuqbFSaRGqU8CcLI=
+golang.org/x/time v0.0.0-20200416051211-89c76fbcd5d1/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20181011042414-1f849cf54d09/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/go.sum
+++ b/go.sum
@@ -173,6 +173,7 @@ github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx2
 github.com/census-instrumentation/opencensus-proto v0.2.0 h1:LzQXZOgg4CQfE6bFvXGM30YZL1WW/M337pXml+GrcZ4=
 github.com/census-instrumentation/opencensus-proto v0.2.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
+github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -194,7 +195,6 @@ github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkE
 github.com/coreos/bbolt v1.3.3/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.12+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
-github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-oidc v2.1.0+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHoZ1nMCKZlZ9V6mm3/LKc=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
@@ -202,10 +202,8 @@ github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7/go.mod h1:F5haX7
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e h1:Wf6HqHfScWJN9/ZjdUKyjop4mf3Qdd+1TvvltAvM3m8=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
-github.com/coreos/pkg v0.0.0-20180108230652-97fdf19511ea/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f h1:lBNOc5arjvs8E5mO2tbpBpLoyyu8B6e44T7hJy6potg=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
-github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/danieljoos/wincred v1.0.2 h1:zf4bhty2iLuwgjgpraD2E9UbvO+fe54XXGJbOwe23fU=
@@ -223,7 +221,6 @@ github.com/dimchansky/utfbom v1.1.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQ
 github.com/djherbis/atime v1.0.0/go.mod h1:5W+KBIuTwVGcqjIfaTwt+KSYX1o6uep8dtevevQP/f8=
 github.com/dnaeon/go-vcr v1.0.1 h1:r8L/HqC0Hje5AXMu1ooW8oyQyOFv4GxqpL0nRP7SLLY=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
-github.com/docker/docker v0.7.3-0.20190327010347-be7ac8be2ae0/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
@@ -254,8 +251,7 @@ github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.m
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
-github.com/evanphx/json-patch v4.5.0+incompatible h1:ouOWdg56aJriqS0huScTkVXPC5IcNrDCXZ6OoTAWu7M=
-github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
+github.com/evanphx/json-patch v4.9.0+incompatible h1:kLcOMZeuLAJvL2BPWLMIj5oaZQobrkAqrL+WFZwQses=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
@@ -270,6 +266,7 @@ github.com/frankban/quicktest v1.4.1/go.mod h1:36zfPVQyHxymz4cH7wlDmVwDrJuljRB60
 github.com/frankban/quicktest v1.7.2/go.mod h1:jaStnuzAqU1AJdCO0l53JDCJrVDKcS03DbaAcR7Ks/o=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
@@ -438,8 +435,6 @@ github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/googleapis/gnostic v0.1.0/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
-github.com/googleapis/gnostic v0.3.0 h1:CcQijm0XKekKjP/YCz28LXVSpgguuB+nCxaSjCe09y0=
-github.com/googleapis/gnostic v0.3.0/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/googleapis/gnostic v0.4.1 h1:DLJCy1n/vrD4HPjOvYcT8aYQXpPIzoRZONaYwyycI+I=
 github.com/googleapis/gnostic v0.4.1/go.mod h1:LRhVm6pbyptWbWbuZ38d1eyptfvIytN3ir6b65WBswg=
 github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
@@ -565,7 +560,6 @@ github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/kubernetes-csi/external-snapshotter v1.2.2 h1:OPXoJydNqkWjhLwJ20dSqOhkmUYcpm+CCO0pYm+C8Q8=
 github.com/kubernetes-csi/external-snapshotter/client/v4 v4.0.0 h1:ipLtV9ubLEYx42YvwDa12eVPQvjuGZoPdbCozGzVNRc=
 github.com/kubernetes-csi/external-snapshotter/client/v4 v4.0.0/go.mod h1:YBCo4DoEeDndqvAn6eeu0vWM7QdXmHEeI9cFWplmBys=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
@@ -608,6 +602,7 @@ github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzp
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/miekg/dns v1.1.8/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/minio/cli v1.22.0/go.mod h1:bYxnK0uS629N3Bq+AOZZ+6lwF77Sodk4+UL9vNuXhOY=
@@ -726,6 +721,7 @@ github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDf
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.6.0 h1:YVPodQOcK15POxhgARIvnDRVpLcuK8mglnMrWfyrw6A=
 github.com/prometheus/client_golang v1.6.0/go.mod h1:ZLOG9ck3JLRdB5MgO8f+lLTe83AXG6ro35rLTxvnIl4=
+github.com/prometheus/client_golang v1.7.1 h1:NTGy1Ja9pByO+xAeH/qiWnLrKtr3hJPNjaVUwnjpdpA=
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f h1:BVwpUVJDADN2ufcGik7W992pyps0wZ888b/y9GXcLTU=
@@ -742,6 +738,7 @@ github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y8
 github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/common v0.9.1 h1:KOMtN28tlbam3/7ZKEYKHhKoJZYYj3gMH4uc62x7X7U=
 github.com/prometheus/common v0.9.1/go.mod h1:yhUN8i9wzaXS3w1O07YhxHEBxD+W35wd8bs7vj7HSQ4=
+github.com/prometheus/common v0.10.0 h1:RyRA7RzGXQZiW+tGMr7sxa85G1z0yOpM1qq5c8lNawc=
 github.com/prometheus/common v0.10.0/go.mod h1:Tlit/dnDKsSWFlCLTWaA1cyBgKHSMdTB80sz/V91rCo=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20181204211112-1dc9a6cbc91a/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
@@ -751,6 +748,7 @@ github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7z
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.11 h1:DhHlBtkHWPYi8O2y31JkK0TF+DGM+51OopZjH/Ia5qI=
 github.com/prometheus/procfs v0.0.11/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
+github.com/prometheus/procfs v0.1.3 h1:F0+tqvhOksq22sc6iCHF5WGlWjdwj92p0udFh1VFBS8=
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
@@ -762,7 +760,6 @@ github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6So
 github.com/rogpeppe/go-charset v0.0.0-20180617210344-2471d30d28b4/go.mod h1:qgYeAmZ5ZIpBWTGllZSQnw97Dj+woV0toclVaRGI8pc=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rs/cors v1.6.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
-github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
@@ -798,8 +795,6 @@ github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTd
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.3 h1:ZlrZ4XsMRm04Fr5pSFxBgfND2EBVa1nLpiy1stUsX/8=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
-github.com/spf13/cobra v0.0.5 h1:f0B+LkLX6DtmRH1isoNA9VTtNUK9K8xYd28JNNfOv/s=
-github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
 github.com/spf13/cobra v1.0.0 h1:6m/oheQuQ13N9ks4hubMG6BnvwOeaJrqSPLahSnczz8=
 github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
@@ -808,7 +803,6 @@ github.com/spf13/pflag v1.0.1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
-github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -838,7 +832,6 @@ github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqri
 github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c/go.mod h1:hzIxponao9Kjc7aWznkXaL4U4TWaDSs8zcsY4Ka08nM=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go v1.1.5-pre/go.mod h1:FwP/aQVg39TXzItUBMwnWp9T9gPQnXw4Poh4/oBQZ/0=
-github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/ugorji/go/codec v1.1.5-pre/go.mod h1:tULtS6Gy1AE1yCENaw4Vb//HLH5njI2tfCQDUqRd8fI=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
@@ -859,8 +852,6 @@ github.com/zalando/go-keyring v0.0.0-20200121091418-667557018717/go.mod h1:RaxNw
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.5/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=
-go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738 h1:VcrIfasaLFkyjk6KNlXQSzO+B0fZcnECiDrKJsfxka0=
-go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=
 go.etcd.io/etcd v0.5.0-alpha.5.0.20200819165624-17cef6e3e9d5/go.mod h1:skWido08r9w6Lq/w70DO5XYIKMu4QFu1+4VsqLQuJy8=
 go.mongodb.org/mongo-driver v1.0.3/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=
 go.mongodb.org/mongo-driver v1.1.1/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=
@@ -890,7 +881,6 @@ gocloud.dev v0.19.0/go.mod h1:SmKwiR8YwIMMJvQBKLsC3fHNyMwXLw3PMDO+VVteJMI=
 golang.org/x/arch v0.0.0-20190909030613-46d78d1859ac/go.mod h1:flIaEI6LNU6xOCD5PaJvn9wGP0agmIOqjrtsKGRguv4=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181106171534-e4dc69e5b2fd/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
-golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190211182817-74369b46fc67/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190228161510-8dd112bcdc25/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -990,6 +980,7 @@ golang.org/x/net v0.0.0-20200501053045-e0ff5e5a1de5/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/net v0.0.0-20200506145744-7e3656a0809f/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2 h1:eDrdRpKgkcCqKZQwyZRyeFZgfqt37SL7Kv3tok06cKE=
 golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
+golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b h1:uwuIcX0g4Yl1NC5XAz37xsr2lTtcqevgzYNVt49waME=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -1018,7 +1009,6 @@ golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20180926160741-c2ed4eda69e7/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190129075346-302c3dd5f1cc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190130150945-aca44879d564/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190209173611-3b5209105503/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -1063,6 +1053,7 @@ golang.org/x/sys v0.0.0-20200501052902-10377860bb8e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200511232937-7e40ca221e25 h1:OKbAoGs4fGM5cPLlVQLZGYkFC8OnOfgo6tt0Smf9XhM=
 golang.org/x/sys v0.0.0-20200511232937-7e40ca221e25/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200622214017-ed371f2e16b4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201112073958-5cba982894dd h1:5CtCZbICpIOFdgO940moixOPjc0178IU44m4EjOO5IY=
 golang.org/x/sys v0.0.0-20201112073958-5cba982894dd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -1137,6 +1128,7 @@ golang.org/x/tools v0.0.0-20200501065659-ab2804fb9c9d/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20200512131952-2bc93b1c0c88/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200521155704-91d71f6c2f04 h1:LbW6ziLoA0vw8ZR4bmjKAzgEpunUBaEX1ia1Q1jEGC4=
 golang.org/x/tools v0.0.0-20200521155704-91d71f6c2f04/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools v0.0.0-20200616133436-c1934b75d054 h1:HHeAlu5H9b71C+Fx0K+1dGgVFN1DM1/wz4aoGOA5qS8=
 golang.org/x/tools v0.0.0-20200616133436-c1934b75d054/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -1210,7 +1202,6 @@ google.golang.org/grpc v1.21.0/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ij
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
 google.golang.org/grpc v1.22.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
-google.golang.org/grpc v1.23.1/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
 google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
@@ -1281,25 +1272,25 @@ honnef.co/go/tools v0.0.1-2020.1.3 h1:sXmLre5bzIR6ypkjXCDI3jHPssRhc8KD/Ome589sc3
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 k8s.io/api v0.18.3 h1:2AJaUQdgUZLoDZHrun21PW2Nx9+ll6cUzvn3IKhSIn0=
 k8s.io/api v0.18.3/go.mod h1:UOaMwERbqJMfeeeHc8XJKawj4P9TgDRnViIqqBeH2QA=
+k8s.io/api v0.19.0/go.mod h1:I1K45XlvTrDjmj5LoM5LuP/KYrhWbjUKT/SoPG0qTjw=
 k8s.io/api v0.19.5 h1:p0MRzyhokJ9Kn5jcJAHNup0s+COMBPfn1mTasls6mMg=
 k8s.io/api v0.19.5/go.mod h1:yGZReuNa0vj56op6eT+NLrXJne0R0u9ktexZ8jdJzpc=
-k8s.io/apiextensions-apiserver v0.18.3 h1:h6oZO+iAgg0HjxmuNnguNdKNB9+wv3O1EBDdDWJViQ0=
-k8s.io/apiextensions-apiserver v0.18.3/go.mod h1:TMsNGs7DYpMXd+8MOCX8KzPOCx8fnZMoIGB24m03+JE=
 k8s.io/apiextensions-apiserver v0.19.5 h1:LMlydaZH8UXo8Qi86IFXSQHdjb13uij7D6D+OubX5MU=
 k8s.io/apiextensions-apiserver v0.19.5/go.mod h1:7jrSIYOYk22PnQv03LJrcSBS0WA0v1WsGJzd0Gv3BiQ=
 k8s.io/apimachinery v0.18.3 h1:pOGcbVAhxADgUYnjS08EFXs9QMl8qaH5U4fr5LGUrSk=
 k8s.io/apimachinery v0.18.3/go.mod h1:OaXp26zu/5J7p0f92ASynJa1pZo06YlV9fG7BoWbCko=
+k8s.io/apimachinery v0.19.0/go.mod h1:DnPGDnARWFvYa3pMHgSxtbZb7gpzzAZ1pTfaUNDVlmA=
 k8s.io/apimachinery v0.19.5 h1:Yvz6dOE0WbVE+FXBEFqc9lSvo87VPtq6mCSsrtC95HI=
 k8s.io/apimachinery v0.19.5/go.mod h1:6sRbGRAVY5DOCuZwB5XkqguBqpqLU6q/kOaOdk29z6Q=
-k8s.io/apiserver v0.18.3/go.mod h1:tHQRmthRPLUtwqsOnJJMoI8SW3lnoReZeE861lH8vUw=
 k8s.io/apiserver v0.19.5/go.mod h1:CDH8gHbC/y1nhkkN9NTZ2Nr29BNA0OWCJDP0QcKwsuE=
 k8s.io/client-go v0.18.3 h1:QaJzz92tsN67oorwzmoB0a9r9ZVHuD5ryjbCKP0U22k=
 k8s.io/client-go v0.18.3/go.mod h1:4a/dpQEvzAhT1BbuWW09qvIaGw6Gbu1gZYiQZIi1DMw=
+k8s.io/client-go v0.19.0/go.mod h1:H9E/VT95blcFQnlyShFgnFT9ZnJOAceiUHM3MlRC+mU=
 k8s.io/client-go v0.19.5 h1:Y7LsFwgbm9+5oVXER04KNCSPhY6TblYRgG1DQdVq+ig=
 k8s.io/client-go v0.19.5/go.mod h1:BSG3iuxI40Bs0nNDLS1JRa/7ReBQDHzf0x8nZZrK0fo=
 k8s.io/code-generator v0.18.3/go.mod h1:TgNEVx9hCyPGpdtCWA34olQYLkh3ok9ar7XfSsr8b6c=
+k8s.io/code-generator v0.19.0/go.mod h1:moqLn7w0t9cMs4+5CQyxnfA/HV8MF6aAVENF+WZZhgk=
 k8s.io/code-generator v0.19.5/go.mod h1:lwEq3YnLYb/7uVXLorOJfxg+cUu2oihFhHZ0n9NIla0=
-k8s.io/component-base v0.18.3/go.mod h1:bp5GzGR0aGkYEfTj+eTY0AN/vXTgkJdQXjNTTVUaa3k=
 k8s.io/component-base v0.19.5/go.mod h1:5N/uv5A7fyr0d+t/b1HynXKkUVPEhc8ljkMaBJv4Tp8=
 k8s.io/gengo v0.0.0-20190128074634-0689ccc1d7d6/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/gengo v0.0.0-20200114144118-36b2048a9120/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
@@ -1326,8 +1317,6 @@ rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8
 rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
-sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.7 h1:uuHDyjllyzRyCIvvn0OBjiRB0SgBZGqHNYAmjR7fO50=
-sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.7/go.mod h1:PHgbrJT7lCHcxMU+mDHEm+nx46H4zuuHZkDP6icnhu0=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.9/go.mod h1:dzAXnQbTRyDlZPJX2SUPEqvnB+j7AJjtlox7PEwigU0=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0-20200116222232-67a7b8c61874/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0 h1:dOmIZBMfhcHS09XZkMyUgkq5trg3/jRyJYFZUiaOp8E=

--- a/pkg/kube/snapshot/snapshot.go
+++ b/pkg/kube/snapshot/snapshot.go
@@ -115,6 +115,7 @@ type Source struct {
 // NewSnapshotter creates and return new Snapshotter object
 func NewSnapshotter(kubeCli kubernetes.Interface, dynCli dynamic.Interface) (Snapshotter, error) {
 	ctx := context.Background()
+	// Check if v1alpha1 snapshot API exists
 	exists, err := kube.IsGroupVersionAvailable(ctx, kubeCli.Discovery(), v1alpha1.GroupName, v1alpha1.Version)
 	if err != nil {
 		return nil, errors.Errorf("Failed to call discovery APIs: %v", err)
@@ -122,6 +123,7 @@ func NewSnapshotter(kubeCli kubernetes.Interface, dynCli dynamic.Interface) (Sna
 	if exists {
 		return NewSnapshotAlpha(kubeCli, dynCli), nil
 	}
+	// Check if v1beta1 snapshot API exists
 	exists, err = kube.IsGroupVersionAvailable(ctx, kubeCli.Discovery(), v1beta1.GroupName, v1beta1.Version)
 	if err != nil {
 		return nil, errors.Errorf("Failed to call discovery APIs: %v", err)
@@ -129,6 +131,7 @@ func NewSnapshotter(kubeCli kubernetes.Interface, dynCli dynamic.Interface) (Sna
 	if exists {
 		return NewSnapshotBeta(kubeCli, dynCli), nil
 	}
+	// Check if v1 (stable) snapshot API exists
 	exists, err = kube.IsGroupVersionAvailable(ctx, kubeCli.Discovery(), GroupName, Version)
 	if err != nil {
 		return nil, errors.Errorf("Failed to call discovery APIs: %v", err)

--- a/pkg/kube/snapshot/snapshot.go
+++ b/pkg/kube/snapshot/snapshot.go
@@ -129,5 +129,12 @@ func NewSnapshotter(kubeCli kubernetes.Interface, dynCli dynamic.Interface) (Sna
 	if exists {
 		return NewSnapshotBeta(kubeCli, dynCli), nil
 	}
+	exists, err = kube.IsGroupVersionAvailable(ctx, kubeCli.Discovery(), GroupName, Version)
+	if err != nil {
+		return nil, errors.Errorf("Failed to call discovery APIs: %v", err)
+	}
+	if exists {
+		return NewSnapshotStable(kubeCli, dynCli), nil
+	}
 	return nil, errors.New("Snapshot resources not supported")
 }

--- a/pkg/kube/snapshot/snapshot.go
+++ b/pkg/kube/snapshot/snapshot.go
@@ -17,6 +17,7 @@ package snapshot
 import (
 	"context"
 
+	"github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
 	"github.com/pkg/errors"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
@@ -57,13 +58,13 @@ type Snapshotter interface {
 	//
 	// 'name' is the name of the VolumeSnapshot that will be returned.
 	// 'namespace' is the namespace of the VolumeSnapshot that will be returned.
-	Get(ctx context.Context, name, namespace string) (*v1alpha1.VolumeSnapshot, error)
+	Get(ctx context.Context, name, namespace string) (*v1.VolumeSnapshot, error)
 	// Delete will delete the VolumeSnapshot.
 	// Returns the `VolumeSnapshot` deleted and any error as a result.
 	//
 	// 'name' is the name of the VolumeSnapshot that will be deleted.
 	// 'namespace' is the namespace of the VolumeSnapshot that will be deleted.
-	Delete(ctx context.Context, name, namespace string) (*v1alpha1.VolumeSnapshot, error)
+	Delete(ctx context.Context, name, namespace string) (*v1.VolumeSnapshot, error)
 	// DeleteContent will delete the VolumeSnapshot and returns any error as a
 	// result.
 	//

--- a/pkg/kube/snapshot/snapshot_alpha.go
+++ b/pkg/kube/snapshot/snapshot_alpha.go
@@ -216,7 +216,7 @@ func (sna *SnapshotAlpha) GetSource(ctx context.Context, snapshotName, namespace
 	if err != nil {
 		return nil, errors.Errorf("Failed to get snapshot, VolumeSnapshot: %s, Error: %v", snapshotName, err)
 	}
-	if snap.Status.ReadyToUse == nil || !*snap.Status.ReadyToUse != true {
+	if snap.Status.ReadyToUse == nil || !*snap.Status.ReadyToUse {
 		return nil, errors.Errorf("Snapshot is not ready, VolumeSnapshot: %s, Namespace: %s", snapshotName, namespace)
 	}
 	if snap.Status.BoundVolumeSnapshotContentName == nil {

--- a/pkg/kube/snapshot/snapshot_alpha.go
+++ b/pkg/kube/snapshot/snapshot_alpha.go
@@ -216,7 +216,7 @@ func (sna *SnapshotAlpha) GetSource(ctx context.Context, snapshotName, namespace
 	if err != nil {
 		return nil, errors.Errorf("Failed to get snapshot, VolumeSnapshot: %s, Error: %v", snapshotName, err)
 	}
-	if snap.Status.ReadyToUse == nil || *snap.Status.ReadyToUse != true {
+	if snap.Status.ReadyToUse == nil || !*snap.Status.ReadyToUse != true {
 		return nil, errors.Errorf("Snapshot is not ready, VolumeSnapshot: %s, Namespace: %s", snapshotName, namespace)
 	}
 	if snap.Status.BoundVolumeSnapshotContentName == nil {

--- a/pkg/kube/snapshot/snapshot_alpha.go
+++ b/pkg/kube/snapshot/snapshot_alpha.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	k8errors "k8s.io/apimachinery/pkg/api/errors"
@@ -113,18 +114,61 @@ func (sna *SnapshotAlpha) Create(ctx context.Context, name, namespace, pvcName s
 }
 
 // Get will return the VolumeSnapshot in the 'namespace' with given 'name'.
-func (sna *SnapshotAlpha) Get(ctx context.Context, name, namespace string) (*v1alpha1.VolumeSnapshot, error) {
+func (sna *SnapshotAlpha) Get(ctx context.Context, name, namespace string) (*v1.VolumeSnapshot, error) {
 	us, err := sna.dynCli.Resource(v1alpha1.VolSnapGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
 
 	vs := &v1alpha1.VolumeSnapshot{}
-	return vs, TransformUnstructured(us, vs)
+	if err := TransformUnstructured(us, vs); err != nil {
+		return nil, err
+	}
+
+	// Populate v1alpha1.VolumeSnapshot object from v1beta1.VolumeSnapshot
+	vsRet := v1.VolumeSnapshot{}
+	meta := vs.ObjectMeta.DeepCopy()
+	if meta == nil {
+		return nil, fmt.Errorf("Invalid VolumeSnapshotObject: ObjectMeta is nil")
+	}
+	vsRet.ObjectMeta = *meta
+
+	if vs.Spec.Source != nil && vs.Spec.Source.Kind == "PersistentVolumeClaim" {
+		vsRet.Spec.Source.PersistentVolumeClaimName = &vs.Spec.Source.Name
+	}
+	if vs.Spec.VolumeSnapshotClassName != "" {
+		vsRet.Spec.VolumeSnapshotClassName = &vs.Spec.VolumeSnapshotClassName
+	}
+	if vs.Spec.SnapshotContentName != "" {
+		vsRet.Spec.Source.VolumeSnapshotContentName = &vs.Spec.SnapshotContentName
+	}
+
+	if vs.Status == (v1alpha1.VolumeSnapshotStatus{}) {
+		return &vsRet, nil
+	}
+
+	// If Status is not nil, set VolumeSnapshotContentName from status
+	vsRet.Status = &v1.VolumeSnapshotStatus{
+		CreationTime: vs.Status.CreationTime,
+		RestoreSize:  vs.Status.RestoreSize,
+	}
+	if vs.Spec.SnapshotContentName != "" {
+		vsRet.Status.BoundVolumeSnapshotContentName = &vs.Spec.SnapshotContentName
+	}
+	if vs.Status.ReadyToUse {
+		vsRet.Status.ReadyToUse = &vs.Status.ReadyToUse
+	}
+	if vs.Status.Error != nil {
+		vsRet.Status.Error = &v1.VolumeSnapshotError{
+			Time:    &vs.Status.Error.Time,
+			Message: &vs.Status.Error.Message,
+		}
+	}
+	return &vsRet, nil
 }
 
 // Delete will delete the VolumeSnapshot and returns any error as a result.
-func (sna *SnapshotAlpha) Delete(ctx context.Context, name, namespace string) (*v1alpha1.VolumeSnapshot, error) {
+func (sna *SnapshotAlpha) Delete(ctx context.Context, name, namespace string) (*v1.VolumeSnapshot, error) {
 	snap, err := sna.Get(ctx, name, namespace)
 	if apierrors.IsNotFound(err) {
 		return nil, nil
@@ -172,16 +216,16 @@ func (sna *SnapshotAlpha) GetSource(ctx context.Context, snapshotName, namespace
 	if err != nil {
 		return nil, errors.Errorf("Failed to get snapshot, VolumeSnapshot: %s, Error: %v", snapshotName, err)
 	}
-	if !snap.Status.ReadyToUse {
+	if snap.Status.ReadyToUse == nil || *snap.Status.ReadyToUse != true {
 		return nil, errors.Errorf("Snapshot is not ready, VolumeSnapshot: %s, Namespace: %s", snapshotName, namespace)
 	}
-	if snap.Spec.SnapshotContentName == "" {
+	if snap.Status.BoundVolumeSnapshotContentName == nil {
 		return nil, errors.Errorf("Snapshot does not have content, VolumeSnapshot: %s, Namespace: %s", snapshotName, namespace)
 	}
 
-	cont, err := sna.getContent(ctx, snap.Spec.SnapshotContentName)
+	cont, err := sna.getContent(ctx, *snap.Status.BoundVolumeSnapshotContentName)
 	if err != nil {
-		return nil, errors.Errorf("Failed to get snapshot content, VolumeSnapshot: %s, VolumeSnapshotContent: %s, Error: %v", snapshotName, snap.Spec.SnapshotContentName, err)
+		return nil, errors.Errorf("Failed to get snapshot content, VolumeSnapshot: %s, VolumeSnapshotContent: %s, Error: %v", snapshotName, *snap.Status.BoundVolumeSnapshotContentName, err)
 	}
 	src := &Source{
 		Handle:                  cont.Spec.CSI.SnapshotHandle,

--- a/pkg/kube/snapshot/snapshot_alpha.go
+++ b/pkg/kube/snapshot/snapshot_alpha.go
@@ -125,7 +125,7 @@ func (sna *SnapshotAlpha) Get(ctx context.Context, name, namespace string) (*v1.
 		return nil, err
 	}
 
-	// Populate v1alpha1.VolumeSnapshot object from v1beta1.VolumeSnapshot
+	// Populate v1.VolumeSnapshot object from v1alpha1.VolumeSnapshot
 	vsRet := v1.VolumeSnapshot{}
 	meta := vs.ObjectMeta.DeepCopy()
 	if meta == nil {

--- a/pkg/kube/snapshot/snapshot_beta.go
+++ b/pkg/kube/snapshot/snapshot_beta.go
@@ -181,7 +181,7 @@ func getSnapshotSource(ctx context.Context, dynCli dynamic.Interface, snapGVR, s
 	if err != nil {
 		return nil, errors.Errorf("Failed to get snapshot, VolumeSnapshot: %s, Error: %v", snapshotName, err)
 	}
-	if snap.Status.ReadyToUse == nil || !*snap.Status.ReadyToUse != true {
+	if snap.Status.ReadyToUse == nil || !*snap.Status.ReadyToUse {
 		return nil, errors.Errorf("Snapshot is not ready, VolumeSnapshot: %s, Namespace: %s", snapshotName, namespace)
 	}
 	if snap.Status.BoundVolumeSnapshotContentName == nil {

--- a/pkg/kube/snapshot/snapshot_beta.go
+++ b/pkg/kube/snapshot/snapshot_beta.go
@@ -181,7 +181,7 @@ func getSnapshotSource(ctx context.Context, dynCli dynamic.Interface, snapGVR, s
 	if err != nil {
 		return nil, errors.Errorf("Failed to get snapshot, VolumeSnapshot: %s, Error: %v", snapshotName, err)
 	}
-	if snap.Status.ReadyToUse == nil || *snap.Status.ReadyToUse != true {
+	if snap.Status.ReadyToUse == nil || !*snap.Status.ReadyToUse != true {
 		return nil, errors.Errorf("Snapshot is not ready, VolumeSnapshot: %s, Namespace: %s", snapshotName, namespace)
 	}
 	if snap.Status.BoundVolumeSnapshotContentName == nil {

--- a/pkg/kube/snapshot/snapshot_beta.go
+++ b/pkg/kube/snapshot/snapshot_beta.go
@@ -20,17 +20,15 @@ import (
 
 	"github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
 	"github.com/pkg/errors"
-	//corev1 "k8s.io/api/core/v1"
-	//storage "k8s.io/api/storage/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	k8errors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 
-	//"github.com/kanisterio/kanister/pkg/kube/snapshot/apis/v1alpha1"
 	"github.com/kanisterio/kanister/pkg/kube/snapshot/apis/v1beta1"
 	"github.com/kanisterio/kanister/pkg/poll"
 )
@@ -46,11 +44,16 @@ func NewSnapshotBeta(kubeCli kubernetes.Interface, dynCli dynamic.Interface) Sna
 
 // CloneVolumeSnapshotClass creates a copy of the source volume snapshot class
 func (sna *SnapshotBeta) CloneVolumeSnapshotClass(sourceClassName, targetClassName, newDeletionPolicy string, excludeAnnotations []string) error {
-	usSourceSnapClass, err := sna.dynCli.Resource(v1beta1.VolSnapClassGVR).Get(context.TODO(), sourceClassName, metav1.GetOptions{})
+	return cloneSnapshotClass(sna.dynCli, v1beta1.VolSnapClassGVR, sourceClassName, targetClassName, newDeletionPolicy, excludeAnnotations)
+}
+
+func cloneSnapshotClass(dynCli dynamic.Interface, snapClassGVR schema.GroupVersionResource, sourceClassName, targetClassName, newDeletionPolicy string, excludeAnnotations []string) error {
+	usSourceSnapClass, err := dynCli.Resource(snapClassGVR).Get(context.TODO(), sourceClassName, metav1.GetOptions{})
 	if err != nil {
 		return errors.Wrapf(err, "Failed to find source VolumeSnapshotClass: %s", sourceClassName)
 	}
-	sourceSnapClass := v1beta1.VolumeSnapshotClass{}
+
+	sourceSnapClass := v1.VolumeSnapshotClass{}
 	if err := TransformUnstructured(usSourceSnapClass, &sourceSnapClass); err != nil {
 		return err
 	}
@@ -58,11 +61,11 @@ func (sna *SnapshotBeta) CloneVolumeSnapshotClass(sourceClassName, targetClassNa
 	for _, key := range excludeAnnotations {
 		delete(existingAnnotations, key)
 	}
-	usNew := UnstructuredVolumeSnapshotClassBeta(targetClassName, sourceSnapClass.Driver, newDeletionPolicy)
+	usNew := UnstructuredVolumeSnapshotClass(snapClassGVR, targetClassName, sourceSnapClass.Driver, newDeletionPolicy)
 	// Set Annotations/Labels
 	usNew.SetAnnotations(existingAnnotations)
 	usNew.SetLabels(map[string]string{CloneVolumeSnapshotClassLabelName: sourceClassName})
-	if _, err = sna.dynCli.Resource(v1beta1.VolSnapClassGVR).Create(context.TODO(), usNew, metav1.CreateOptions{}); !apierrors.IsAlreadyExists(err) {
+	if _, err = dynCli.Resource(snapClassGVR).Create(context.TODO(), usNew, metav1.CreateOptions{}); !apierrors.IsAlreadyExists(err) {
 		return errors.Wrapf(err, "Failed to create VolumeSnapshotClass: %s", targetClassName)
 	}
 	return nil
@@ -75,15 +78,19 @@ func (sna *SnapshotBeta) GetVolumeSnapshotClass(annotationKey, annotationValue, 
 
 // Create creates a VolumeSnapshot and returns it or any error happened meanwhile.
 func (sna *SnapshotBeta) Create(ctx context.Context, name, namespace, volumeName string, snapshotClass *string, waitForReady bool) error {
-	if _, err := sna.kubeCli.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, volumeName, metav1.GetOptions{}); err != nil {
+	return createSnapshot(ctx, sna.dynCli, sna.kubeCli, v1beta1.VolSnapGVR, name, namespace, volumeName, snapshotClass, waitForReady)
+}
+
+func createSnapshot(ctx context.Context, dynCli dynamic.Interface, kubeCli kubernetes.Interface, snapGVR schema.GroupVersionResource, name, namespace, volumeName string, snapshotClass *string, waitForReady bool) error {
+	if _, err := kubeCli.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, volumeName, metav1.GetOptions{}); err != nil {
 		if k8errors.IsNotFound(err) {
 			return errors.Errorf("Failed to find PVC %s, Namespace %s", volumeName, namespace)
 		}
 		return errors.Wrapf(err, "Failed to query PVC %s, Namespace %s", volumeName, namespace)
 	}
 
-	snap := UnstructuredVolumeSnapshotBeta(name, namespace, volumeName, "", *snapshotClass)
-	if _, err := sna.dynCli.Resource(v1beta1.VolSnapGVR).Namespace(namespace).Create(ctx, snap, metav1.CreateOptions{}); err != nil {
+	snap := UnstructuredVolumeSnapshot(snapGVR, name, namespace, volumeName, "", *snapshotClass)
+	if _, err := dynCli.Resource(snapGVR).Namespace(namespace).Create(ctx, snap, metav1.CreateOptions{}); err != nil {
 		return errors.Wrapf(err, "Failed to create snapshot resource %s, Namespace %s", name, namespace)
 	}
 
@@ -91,17 +98,21 @@ func (sna *SnapshotBeta) Create(ctx context.Context, name, namespace, volumeName
 		return nil
 	}
 
-	if err := sna.WaitOnReadyToUse(ctx, name, namespace); err != nil {
+	if err := waitOnReadyToUse(ctx, dynCli, snapGVR, name, namespace); err != nil {
 		return err
 	}
 
-	_, err := sna.Get(ctx, name, namespace)
+	_, err := getSnapshot(ctx, dynCli, snapGVR, name, namespace)
 	return err
 }
 
 // Get will return the VolumeSnapshot in the 'namespace' with given 'name'.
 func (sna *SnapshotBeta) Get(ctx context.Context, name, namespace string) (*v1.VolumeSnapshot, error) {
-	us, err := sna.dynCli.Resource(v1beta1.VolSnapGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	return getSnapshot(ctx, sna.dynCli, v1beta1.VolSnapGVR, name, namespace)
+}
+
+func getSnapshot(ctx context.Context, dynCli dynamic.Interface, snapGVR schema.GroupVersionResource, name, namespace string) (*v1.VolumeSnapshot, error) {
+	us, err := dynCli.Resource(snapGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -115,14 +126,18 @@ func (sna *SnapshotBeta) Get(ctx context.Context, name, namespace string) (*v1.V
 
 // Delete will delete the VolumeSnapshot and returns any error as a result.
 func (sna *SnapshotBeta) Delete(ctx context.Context, name, namespace string) (*v1.VolumeSnapshot, error) {
-	snap, err := sna.Get(ctx, name, namespace)
+	return deleteSnapshot(ctx, sna.dynCli, v1beta1.VolSnapGVR, name, namespace)
+}
+
+func deleteSnapshot(ctx context.Context, dynCli dynamic.Interface, snapGVR schema.GroupVersionResource, name, namespace string) (*v1.VolumeSnapshot, error) {
+	snap, err := getSnapshot(ctx, dynCli, snapGVR, name, namespace)
 	if apierrors.IsNotFound(err) {
 		return nil, nil
 	}
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed to find VolumeSnapshot: %s/%s", namespace, name)
 	}
-	if err := sna.dynCli.Resource(v1beta1.VolSnapGVR).Namespace(namespace).Delete(ctx, name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+	if err := dynCli.Resource(snapGVR).Namespace(namespace).Delete(ctx, name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 		return nil, errors.Wrapf(err, "Failed to delete VolumeSnapshot: %s/%s", namespace, name)
 	}
 	// If the Snapshot does not exist, that's an acceptable error and we ignore it
@@ -158,7 +173,11 @@ func (sna *SnapshotBeta) Clone(ctx context.Context, name, namespace, cloneName, 
 
 // GetSource will return the CSI source that backs the volume snapshot.
 func (sna *SnapshotBeta) GetSource(ctx context.Context, snapshotName, namespace string) (*Source, error) {
-	snap, err := sna.Get(ctx, snapshotName, namespace)
+	return getSnapshotSource(ctx, sna.dynCli, v1beta1.VolSnapGVR, v1beta1.VolSnapContentGVR, snapshotName, namespace)
+}
+
+func getSnapshotSource(ctx context.Context, dynCli dynamic.Interface, snapGVR, snapContentGVR schema.GroupVersionResource, snapshotName, namespace string) (*Source, error) {
+	snap, err := getSnapshot(ctx, dynCli, snapGVR, snapshotName, namespace)
 	if err != nil {
 		return nil, errors.Errorf("Failed to get snapshot, VolumeSnapshot: %s, Error: %v", snapshotName, err)
 	}
@@ -169,7 +188,7 @@ func (sna *SnapshotBeta) GetSource(ctx context.Context, snapshotName, namespace 
 		return nil, errors.Errorf("Snapshot does not have content, VolumeSnapshot: %s, Namespace: %s", snapshotName, namespace)
 	}
 
-	cont, err := sna.getContent(ctx, *snap.Status.BoundVolumeSnapshotContentName)
+	cont, err := getSnapshotContent(ctx, dynCli, snapContentGVR, *snap.Status.BoundVolumeSnapshotContentName)
 	if err != nil {
 		return nil, errors.Errorf("Failed to get snapshot content, VolumeSnapshot: %s, VolumeSnapshotContent: %s, Error: %v", snapshotName, *snap.Status.BoundVolumeSnapshotContentName, err)
 	}
@@ -185,12 +204,12 @@ func (sna *SnapshotBeta) GetSource(ctx context.Context, snapshotName, namespace 
 
 // CreateFromSource will create a 'Volumesnapshot' and 'VolumesnaphotContent' pair for the underlying snapshot source.
 func (sna *SnapshotBeta) CreateFromSource(ctx context.Context, source *Source, snapshotName, namespace string, waitForReady bool) error {
-	deletionPolicy, err := sna.getDeletionPolicyFromClass(source.VolumeSnapshotClassName)
+	deletionPolicy, err := getDeletionPolicyFromClass(sna.dynCli, v1beta1.VolSnapClassGVR, source.VolumeSnapshotClassName)
 	if err != nil {
 		return errors.Wrap(err, "Failed to get DeletionPolicy from VolumeSnapshotClass")
 	}
 	contentName := snapshotName + "-content-" + string(uuid.NewUUID())
-	snap := UnstructuredVolumeSnapshotBeta(snapshotName, namespace, "", contentName, source.VolumeSnapshotClassName)
+	snap := UnstructuredVolumeSnapshot(v1beta1.VolSnapGVR, snapshotName, namespace, "", contentName, source.VolumeSnapshotClassName)
 
 	if err := sna.CreateContentFromSource(ctx, source, contentName, snapshotName, namespace, deletionPolicy); err != nil {
 		return err
@@ -216,7 +235,11 @@ func (sna *SnapshotBeta) CreateFromSource(ctx context.Context, source *Source, s
 
 // UpdateVolumeSnapshotStatusBeta sets the readyToUse valuse of a VolumeSnapshot.
 func (sna *SnapshotBeta) UpdateVolumeSnapshotStatusBeta(ctx context.Context, namespace string, snapshotName string, readyToUse bool) error {
-	us, err := sna.dynCli.Resource(v1beta1.VolSnapGVR).Namespace(namespace).Get(ctx, snapshotName, metav1.GetOptions{})
+	return updateVolumeSnapshotStatus(ctx, sna.dynCli, v1beta1.VolSnapGVR, namespace, snapshotName, readyToUse)
+}
+
+func updateVolumeSnapshotStatus(ctx context.Context, dynCli dynamic.Interface, snapGVR schema.GroupVersionResource, namespace string, snapshotName string, readyToUse bool) error {
+	us, err := dynCli.Resource(snapGVR).Namespace(namespace).Get(ctx, snapshotName, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
@@ -226,7 +249,7 @@ func (sna *SnapshotBeta) UpdateVolumeSnapshotStatusBeta(ctx context.Context, nam
 	}
 	status["readyToUse"] = readyToUse
 	us.Object["status"] = status
-	if _, err := sna.dynCli.Resource(v1beta1.VolSnapGVR).Namespace(namespace).UpdateStatus(ctx, us, metav1.UpdateOptions{}); err != nil {
+	if _, err := dynCli.Resource(snapGVR).Namespace(namespace).UpdateStatus(ctx, us, metav1.UpdateOptions{}); err != nil {
 		return errors.Errorf("Failed to update status, Volumesnapshot: %s, Error: %v", snapshotName, err)
 	}
 	return nil
@@ -234,7 +257,7 @@ func (sna *SnapshotBeta) UpdateVolumeSnapshotStatusBeta(ctx context.Context, nam
 
 // CreateContentFromSource will create a 'VolumesnaphotContent' for the underlying snapshot source.
 func (sna *SnapshotBeta) CreateContentFromSource(ctx context.Context, source *Source, contentName, snapshotName, namespace, deletionPolicy string) error {
-	content := UnstructuredVolumeSnapshotContentBeta(contentName, snapshotName, namespace, deletionPolicy, source.Driver, source.Handle, source.VolumeSnapshotClassName)
+	content := UnstructuredVolumeSnapshotContent(v1beta1.VolSnapContentGVR, contentName, snapshotName, namespace, deletionPolicy, source.Driver, source.Handle, source.VolumeSnapshotClassName)
 	if _, err := sna.dynCli.Resource(v1beta1.VolSnapContentGVR).Create(ctx, content, metav1.CreateOptions{}); err != nil {
 		return errors.Errorf("Failed to create content, VolumesnapshotContent: %s, Error: %v", content.GetName(), err)
 	}
@@ -244,8 +267,12 @@ func (sna *SnapshotBeta) CreateContentFromSource(ctx context.Context, source *So
 // WaitOnReadyToUse will block until the Volumesnapshot in 'namespace' with name 'snapshotName'
 // has status 'ReadyToUse' or 'ctx.Done()' is signalled.
 func (sna *SnapshotBeta) WaitOnReadyToUse(ctx context.Context, snapshotName, namespace string) error {
+	return waitOnReadyToUse(ctx, sna.dynCli, v1beta1.VolSnapGVR, snapshotName, namespace)
+}
+
+func waitOnReadyToUse(ctx context.Context, dynCli dynamic.Interface, snapGVR schema.GroupVersionResource, snapshotName, namespace string) error {
 	return poll.Wait(ctx, func(context.Context) (bool, error) {
-		us, err := sna.dynCli.Resource(v1beta1.VolSnapGVR).Namespace(namespace).Get(ctx, snapshotName, metav1.GetOptions{})
+		us, err := dynCli.Resource(snapGVR).Namespace(namespace).Get(ctx, snapshotName, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -265,20 +292,20 @@ func (sna *SnapshotBeta) WaitOnReadyToUse(ctx context.Context, snapshotName, nam
 	})
 }
 
-func (sna *SnapshotBeta) getContent(ctx context.Context, contentName string) (*v1beta1.VolumeSnapshotContent, error) {
-	us, err := sna.dynCli.Resource(v1beta1.VolSnapContentGVR).Get(ctx, contentName, metav1.GetOptions{})
+func getSnapshotContent(ctx context.Context, dynCli dynamic.Interface, snapContentGVR schema.GroupVersionResource, contentName string) (*v1.VolumeSnapshotContent, error) {
+	us, err := dynCli.Resource(snapContentGVR).Get(ctx, contentName, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
-	vsc := v1beta1.VolumeSnapshotContent{}
+	vsc := v1.VolumeSnapshotContent{}
 	if err := TransformUnstructured(us, &vsc); err != nil {
 		return nil, err
 	}
 	return &vsc, nil
 }
 
-func (sna *SnapshotBeta) getDeletionPolicyFromClass(snapClassName string) (string, error) {
-	us, err := sna.dynCli.Resource(v1beta1.VolSnapClassGVR).Get(context.TODO(), snapClassName, metav1.GetOptions{})
+func getDeletionPolicyFromClass(dynCli dynamic.Interface, snapClassGVR schema.GroupVersionResource, snapClassName string) (string, error) {
+	us, err := dynCli.Resource(snapClassGVR).Get(context.TODO(), snapClassName, metav1.GetOptions{})
 	if err != nil {
 		return "", errors.Wrapf(err, "Failed to find VolumeSnapshotClass: %s", snapClassName)
 	}
@@ -289,10 +316,10 @@ func (sna *SnapshotBeta) getDeletionPolicyFromClass(snapClassName string) (strin
 	return vsc.DeletionPolicy, nil
 }
 
-func UnstructuredVolumeSnapshotBeta(name, namespace, pvcName, contentName, snapClassName string) *unstructured.Unstructured {
+func UnstructuredVolumeSnapshot(gvr schema.GroupVersionResource, name, namespace, pvcName, contentName, snapClassName string) *unstructured.Unstructured {
 	snap := &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": fmt.Sprintf("%s/%s", v1beta1.GroupName, v1beta1.Version),
+			"apiVersion": fmt.Sprintf("%s/%s", gvr.Group, gvr.Version),
 			"kind":       VolSnapKind,
 			"metadata": map[string]interface{}{
 				"name":      name,
@@ -319,10 +346,10 @@ func UnstructuredVolumeSnapshotBeta(name, namespace, pvcName, contentName, snapC
 	return snap
 }
 
-func UnstructuredVolumeSnapshotContentBeta(name, snapshotName, snapshotNs, deletionPolicy, driver, handle, snapClassName string) *unstructured.Unstructured {
+func UnstructuredVolumeSnapshotContent(gvr schema.GroupVersionResource, name, snapshotName, snapshotNs, deletionPolicy, driver, handle, snapClassName string) *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": fmt.Sprintf("%s/%s", v1beta1.GroupName, v1beta1.Version),
+			"apiVersion": fmt.Sprintf("%s/%s", gvr.Group, gvr.Version),
 			"kind":       VolSnapContentKind,
 			"metadata": map[string]interface{}{
 				"name": name,
@@ -344,10 +371,10 @@ func UnstructuredVolumeSnapshotContentBeta(name, snapshotName, snapshotNs, delet
 	}
 }
 
-func UnstructuredVolumeSnapshotClassBeta(name, driver, deletionPolicy string) *unstructured.Unstructured {
+func UnstructuredVolumeSnapshotClass(gvr schema.GroupVersionResource, name, driver, deletionPolicy string) *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": fmt.Sprintf("%s/%s", v1beta1.GroupName, v1beta1.Version),
+			"apiVersion": fmt.Sprintf("%s/%s", gvr.Group, gvr.Version),
 			"kind":       VolSnapClassKind,
 			"metadata": map[string]interface{}{
 				"name": name,

--- a/pkg/kube/snapshot/snapshot_stable.go
+++ b/pkg/kube/snapshot/snapshot_stable.go
@@ -1,0 +1,179 @@
+// Copyright 2020 The Kanister Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package snapshot
+
+import (
+	"context"
+
+	"github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
+	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	k8errors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	// VolumeSnapshotContentResourcePlural is "volumesnapshotcontents"
+	VolumeSnapshotContentResourcePlural = "volumesnapshotcontents"
+	// VolumeSnapshotResourcePlural is "volumesnapshots"
+	VolumeSnapshotResourcePlural = "volumesnapshots"
+	// VolumeSnapshotClassResourcePlural is "volumesnapshotclasses"
+	VolumeSnapshotClassResourcePlural = "volumesnapshotclasses"
+
+	GroupName = "snapshot.storage.k8s.io"
+	Version   = "v1"
+)
+
+var (
+	// VolSnapGVR specifies GVR schema for VolumeSnapshots
+	VolSnapGVR = schema.GroupVersionResource{Group: GroupName, Version: Version, Resource: VolumeSnapshotResourcePlural}
+	// VolSnapClassGVR specifies GVR schema for VolumeSnapshotClasses
+	VolSnapClassGVR = schema.GroupVersionResource{Group: GroupName, Version: Version, Resource: VolumeSnapshotClassResourcePlural}
+	// VolSnapContentGVR specifies GVR schema for VolumeSnapshotContents
+	VolSnapContentGVR = schema.GroupVersionResource{Group: GroupName, Version: Version, Resource: VolumeSnapshotContentResourcePlural}
+)
+
+type SnapshotStable struct {
+	kubeCli kubernetes.Interface
+	dynCli  dynamic.Interface
+}
+
+func NewSnapshotStable(kubeCli kubernetes.Interface, dynCli dynamic.Interface) Snapshotter {
+	return &SnapshotStable{kubeCli: kubeCli, dynCli: dynCli}
+}
+
+// CloneVolumeSnapshotClass creates a copy of the source volume snapshot class
+func (sna *SnapshotStable) CloneVolumeSnapshotClass(sourceClassName, targetClassName, newDeletionPolicy string, excludeAnnotations []string) error {
+	return cloneSnapshotClass(sna.dynCli, VolSnapClassGVR, sourceClassName, targetClassName, newDeletionPolicy, excludeAnnotations)
+}
+
+// GetVolumeSnapshotClass returns VolumeSnapshotClass name which is annotated with given key.
+func (sna *SnapshotStable) GetVolumeSnapshotClass(annotationKey, annotationValue, storageClassName string) (string, error) {
+	return getSnapshotClassbyAnnotation(sna.dynCli, sna.kubeCli, VolSnapClassGVR, annotationKey, annotationValue, storageClassName)
+}
+
+// Create creates a VolumeSnapshot and returns it or any error happened meanwhile.
+func (sna *SnapshotStable) Create(ctx context.Context, name, namespace, volumeName string, snapshotClass *string, waitForReady bool) error {
+	return createSnapshot(ctx, sna.dynCli, sna.kubeCli, VolSnapGVR, name, namespace, volumeName, snapshotClass, waitForReady)
+}
+
+// Get will return the VolumeSnapshot in the 'namespace' with given 'name'.
+func (sna *SnapshotStable) Get(ctx context.Context, name, namespace string) (*v1.VolumeSnapshot, error) {
+	return getSnapshot(ctx, sna.dynCli, VolSnapGVR, name, namespace)
+}
+
+// Delete will delete the VolumeSnapshot and returns any error as a result.
+func (sna *SnapshotStable) Delete(ctx context.Context, name, namespace string) (*v1.VolumeSnapshot, error) {
+	return deleteSnapshot(ctx, sna.dynCli, VolSnapGVR, name, namespace)
+}
+
+// DeleteContent will delete the specified VolumeSnapshotContent
+func (sna *SnapshotStable) DeleteContent(ctx context.Context, name string) error {
+	if err := sna.dynCli.Resource(VolSnapContentGVR).Delete(ctx, name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+		return errors.Wrapf(err, "Failed to delete VolumeSnapshotContent: %s", name)
+	}
+	// If the Snapshot Content does not exist, that's an acceptable error and we ignore it
+	return nil
+}
+
+// Clone will clone the VolumeSnapshot to namespace 'cloneNamespace'.
+// Underlying VolumeSnapshotContent will be cloned with a different name.
+func (sna *SnapshotStable) Clone(ctx context.Context, name, namespace, cloneName, cloneNamespace string, waitForReady bool) error {
+	_, err := sna.Get(ctx, cloneName, cloneNamespace)
+	if err == nil {
+		return errors.Errorf("Target snapshot already exists in target namespace, Volumesnapshot: %s, Namespace: %s", cloneName, cloneNamespace)
+	}
+	if !k8errors.IsNotFound(err) {
+		return errors.Errorf("Failed to query target Volumesnapshot: %s, Namespace: %s: %v", cloneName, cloneNamespace, err)
+	}
+
+	src, err := sna.GetSource(ctx, name, namespace)
+	if err != nil {
+		return errors.Errorf("Failed to get source")
+	}
+	return sna.CreateFromSource(ctx, src, cloneName, cloneNamespace, waitForReady)
+}
+
+// GetSource will return the CSI source that backs the volume snapshot.
+func (sna *SnapshotStable) GetSource(ctx context.Context, snapshotName, namespace string) (*Source, error) {
+	return getSnapshotSource(ctx, sna.dynCli, VolSnapGVR, VolSnapContentGVR, snapshotName, namespace)
+}
+
+// CreateFromSource will create a 'Volumesnapshot' and 'VolumesnaphotContent' pair for the underlying snapshot source.
+func (sna *SnapshotStable) CreateFromSource(ctx context.Context, source *Source, snapshotName, namespace string, waitForReady bool) error {
+	deletionPolicy, err := getDeletionPolicyFromClass(sna.dynCli, VolSnapClassGVR, source.VolumeSnapshotClassName)
+	if err != nil {
+		return errors.Wrap(err, "Failed to get DeletionPolicy from VolumeSnapshotClass")
+	}
+	contentName := snapshotName + "-content-" + string(uuid.NewUUID())
+	snap := UnstructuredVolumeSnapshot(VolSnapGVR, snapshotName, namespace, "", contentName, source.VolumeSnapshotClassName)
+
+	if err := sna.CreateContentFromSource(ctx, source, contentName, snapshotName, namespace, deletionPolicy); err != nil {
+		return err
+	}
+	if _, err := sna.dynCli.Resource(VolSnapGVR).Namespace(namespace).Create(ctx, snap, metav1.CreateOptions{}); err != nil {
+		return errors.Errorf("Failed to create content, Volumesnapshot: %s, Error: %v", snap.GetName(), err)
+	}
+	if !waitForReady {
+		return nil
+	}
+	if source.Driver == DellFlexOSDriver {
+		// Temporary work around till upstream issue is resolved-
+		// github- https://github.com/dell/csi-vxflexos/pull/11
+		// forum- https://www.dell.com/community/Containers/Issue-where-volumeSnapshots-have-ReadyToUse-field-set-to-false/m-p/7685881#M249
+		err := sna.UpdateVolumeSnapshotStatusStable(ctx, namespace, snap.GetName(), true)
+		if err != nil {
+			return err
+		}
+	}
+	err = sna.WaitOnReadyToUse(ctx, snapshotName, namespace)
+	return err
+}
+
+// UpdateVolumeSnapshotStatusStable sets the readyToUse valuse of a VolumeSnapshot.
+func (sna *SnapshotStable) UpdateVolumeSnapshotStatusStable(ctx context.Context, namespace string, snapshotName string, readyToUse bool) error {
+	return updateVolumeSnapshotStatus(ctx, sna.dynCli, VolSnapGVR, namespace, snapshotName, readyToUse)
+}
+
+// CreateContentFromSource will create a 'VolumesnaphotContent' for the underlying snapshot source.
+func (sna *SnapshotStable) CreateContentFromSource(ctx context.Context, source *Source, contentName, snapshotName, namespace, deletionPolicy string) error {
+	content := UnstructuredVolumeSnapshotContent(VolSnapContentGVR, contentName, snapshotName, namespace, deletionPolicy, source.Driver, source.Handle, source.VolumeSnapshotClassName)
+	if _, err := sna.dynCli.Resource(VolSnapContentGVR).Create(ctx, content, metav1.CreateOptions{}); err != nil {
+		return errors.Errorf("Failed to create content, VolumesnapshotContent: %s, Error: %v", content.GetName(), err)
+	}
+	return nil
+}
+
+// WaitOnReadyToUse will block until the Volumesnapshot in 'namespace' with name 'snapshotName'
+// has status 'ReadyToUse' or 'ctx.Done()' is signalled.
+func (sna *SnapshotStable) WaitOnReadyToUse(ctx context.Context, snapshotName, namespace string) error {
+	return waitOnReadyToUse(ctx, sna.dynCli, VolSnapGVR, snapshotName, namespace)
+}
+
+func (sna *SnapshotStable) getDeletionPolicyFromClass(snapClassName string) (string, error) {
+	us, err := sna.dynCli.Resource(VolSnapClassGVR).Get(context.TODO(), snapClassName, metav1.GetOptions{})
+	if err != nil {
+		return "", errors.Wrapf(err, "Failed to find VolumeSnapshotClass: %s", snapClassName)
+	}
+	vsc := v1.VolumeSnapshotClass{}
+	if err := TransformUnstructured(us, &vsc); err != nil {
+		return "", err
+	}
+	return string(vsc.DeletionPolicy), nil
+}

--- a/pkg/kube/snapshot/snapshot_stable.go
+++ b/pkg/kube/snapshot/snapshot_stable.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The Kanister Authors.
+// Copyright 2021 The Kanister Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/kube/snapshot/snapshot_stable.go
+++ b/pkg/kube/snapshot/snapshot_stable.go
@@ -165,15 +165,3 @@ func (sna *SnapshotStable) CreateContentFromSource(ctx context.Context, source *
 func (sna *SnapshotStable) WaitOnReadyToUse(ctx context.Context, snapshotName, namespace string) error {
 	return waitOnReadyToUse(ctx, sna.dynCli, VolSnapGVR, snapshotName, namespace)
 }
-
-func (sna *SnapshotStable) getDeletionPolicyFromClass(snapClassName string) (string, error) {
-	us, err := sna.dynCli.Resource(VolSnapClassGVR).Get(context.TODO(), snapClassName, metav1.GetOptions{})
-	if err != nil {
-		return "", errors.Wrapf(err, "Failed to find VolumeSnapshotClass: %s", snapClassName)
-	}
-	vsc := v1.VolumeSnapshotClass{}
-	if err := TransformUnstructured(us, &vsc); err != nil {
-		return "", err
-	}
-	return string(vsc.DeletionPolicy), nil
-}

--- a/pkg/kube/snapshot/snapshot_test.go
+++ b/pkg/kube/snapshot/snapshot_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	snapv1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
 	. "gopkg.in/check.v1"
 	corev1 "k8s.io/api/core/v1"
 	scv1 "k8s.io/api/storage/v1"
@@ -48,16 +49,19 @@ import (
 func Test(t *testing.T) { TestingT(t) }
 
 type SnapshotTestSuite struct {
-	sourceNamespace      string
-	targetNamespace      string
-	snapshotterAlpha     snapshot.Snapshotter
-	snapshotterBeta      snapshot.Snapshotter
-	cli                  kubernetes.Interface
-	dynCli               dynamic.Interface
-	snapshotClassAlpha   *string
-	snapshotClassBeta    *string
-	storageClassCSIAlpha string
-	storageClassCSIBeta  string
+	sourceNamespace       string
+	targetNamespace       string
+	snapshotterAlpha      snapshot.Snapshotter
+	snapshotterBeta       snapshot.Snapshotter
+	snapshotterStable     snapshot.Snapshotter
+	cli                   kubernetes.Interface
+	dynCli                dynamic.Interface
+	snapshotClassAlpha    *string
+	snapshotClassBeta     *string
+	snapshotClassStable   *string
+	storageClassCSIAlpha  string
+	storageClassCSIBeta   string
+	storageClassCSIStable string
 }
 
 var _ = Suite(&SnapshotTestSuite{})
@@ -90,12 +94,16 @@ func (s *SnapshotTestSuite) SetUpSuite(c *C) {
 
 	s.snapshotterAlpha = snapshot.NewSnapshotAlpha(cli, dynCli)
 	s.snapshotterBeta = snapshot.NewSnapshotBeta(cli, dynCli)
+	s.snapshotterStable = snapshot.NewSnapshotStable(cli, dynCli)
 
 	// Find alpha VolumeSnapshotClass name
 	snapClassAlpha, driverAlpha := findSnapshotClassName(c, s.dynCli, v1alpha1.VolSnapClassGVR, v1alpha1.VolumeSnapshotClass{})
 	s.snapshotClassAlpha = &snapClassAlpha
 	snapClassBeta, driverBeta := findSnapshotClassName(c, s.dynCli, v1beta1.VolSnapClassGVR, v1beta1.VolumeSnapshotClass{})
 	s.snapshotClassBeta = &snapClassBeta
+	snapClassStable, driverStable := findSnapshotClassName(c, s.dynCli, snapshot.VolSnapClassGVR, snapv1.VolumeSnapshotClass{})
+	s.snapshotClassStable = &snapClassStable
+	fmt.Printf("snClass:: %+v\nDriver:: %+v\n", snapClassStable, driverStable)
 	storageClasses, err := cli.StorageV1().StorageClasses().List(context.TODO(), metav1.ListOptions{})
 	c.Assert(err, IsNil)
 	for _, class := range storageClasses.Items {
@@ -104,6 +112,9 @@ func (s *SnapshotTestSuite) SetUpSuite(c *C) {
 		}
 		if class.Provisioner == driverBeta {
 			s.storageClassCSIBeta = class.Name
+		}
+		if class.Provisioner == driverStable {
+			s.storageClassCSIStable = class.Name
 		}
 	}
 
@@ -145,6 +156,7 @@ func (s *SnapshotTestSuite) TestVolumeSnapshotFake(c *C) {
 	for _, fakeSs := range []snapshot.Snapshotter{
 		snapshot.NewSnapshotAlpha(fakeCli, dynfake.NewSimpleDynamicClient(scheme)),
 		snapshot.NewSnapshotBeta(fakeCli, dynfake.NewSimpleDynamicClient(scheme)),
+		snapshot.NewSnapshotStable(fakeCli, dynfake.NewSimpleDynamicClient(scheme)),
 	} {
 		err = fakeSs.Create(context.Background(), snapshotName, defaultNamespace, volName, &fakeClass, false)
 		c.Assert(err, IsNil)
@@ -185,9 +197,14 @@ func (s *SnapshotTestSuite) TestVolumeSnapshotClassCloneFake(c *C) {
 			snapshotter:         snapshot.NewSnapshotAlpha(fakeCli, dynCli),
 		},
 		{
-			sourceSnapClassSpec: snapshot.UnstructuredVolumeSnapshotClassBeta(fakeClass, fakeDriver, snapshot.DeletionPolicyDelete),
+			sourceSnapClassSpec: snapshot.UnstructuredVolumeSnapshotClass(v1beta1.VolSnapClassGVR, fakeClass, fakeDriver, snapshot.DeletionPolicyDelete),
 			snapClassGVR:        v1beta1.VolSnapClassGVR,
 			snapshotter:         snapshot.NewSnapshotBeta(fakeCli, dynCli),
+		},
+		{
+			sourceSnapClassSpec: snapshot.UnstructuredVolumeSnapshotClass(snapshot.VolSnapClassGVR, fakeClass, fakeDriver, snapshot.DeletionPolicyDelete),
+			snapClassGVR:        snapshot.VolSnapClassGVR,
+			snapshotter:         snapshot.NewSnapshotStable(fakeCli, dynCli),
 		},
 	} {
 		annotationKeyToKeep := "keepme"
@@ -251,15 +268,26 @@ func (s *SnapshotTestSuite) TestVolumeSnapshotCloneFake(c *C) {
 			fakeSs:            snapshot.NewSnapshotAlpha(nil, dynCli),
 		},
 		{
-			snapClassSpec: snapshot.UnstructuredVolumeSnapshotClassBeta(fakeClass, fakeDriver, deletionPolicy),
+			snapClassSpec: snapshot.UnstructuredVolumeSnapshotClass(v1beta1.VolSnapClassGVR, fakeClass, fakeDriver, deletionPolicy),
 			snapClassGVR:  v1beta1.VolSnapClassGVR,
-			contentSpec:   snapshot.UnstructuredVolumeSnapshotContentBeta(fakeContentName, fakeSnapshotName, defaultNamespace, deletionPolicy, fakeDriver, fakeSnapshotHandle, fakeClass),
+			contentSpec:   snapshot.UnstructuredVolumeSnapshotContent(v1beta1.VolSnapContentGVR, fakeContentName, fakeSnapshotName, defaultNamespace, deletionPolicy, fakeDriver, fakeSnapshotHandle, fakeClass),
 			contentGVR:    v1beta1.VolSnapContentGVR,
 
-			snapSpec:          snapshot.UnstructuredVolumeSnapshotBeta(fakeSnapshotName, defaultNamespace, "", fakeContentName, fakeClass),
+			snapSpec:          snapshot.UnstructuredVolumeSnapshot(v1beta1.VolSnapGVR, fakeSnapshotName, defaultNamespace, "", fakeContentName, fakeClass),
 			snapGVR:           v1beta1.VolSnapGVR,
 			snapContentObject: &v1beta1.VolumeSnapshotContent{},
 			fakeSs:            snapshot.NewSnapshotBeta(nil, dynCli),
+		},
+		{
+			snapClassSpec: snapshot.UnstructuredVolumeSnapshotClass(snapshot.VolSnapClassGVR, fakeClass, fakeDriver, deletionPolicy),
+			snapClassGVR:  snapshot.VolSnapClassGVR,
+			contentSpec:   snapshot.UnstructuredVolumeSnapshotContent(snapshot.VolSnapContentGVR, fakeContentName, fakeSnapshotName, defaultNamespace, deletionPolicy, fakeDriver, fakeSnapshotHandle, fakeClass),
+			contentGVR:    snapshot.VolSnapContentGVR,
+
+			snapSpec:          snapshot.UnstructuredVolumeSnapshot(snapshot.VolSnapGVR, fakeSnapshotName, defaultNamespace, "", fakeContentName, fakeClass),
+			snapGVR:           snapshot.VolSnapGVR,
+			snapContentObject: &snapv1.VolumeSnapshotContent{},
+			fakeSs:            snapshot.NewSnapshotStable(nil, dynCli),
 		},
 	} {
 		tc.contentSpec.Object["status"] = map[string]interface{}{
@@ -321,6 +349,17 @@ func (s *SnapshotTestSuite) TestVolumeSnapshotBeta(c *C) {
 	}
 	c.Logf("VolumeSnapshot test - source namespace: %s - target namespace: %s", s.sourceNamespace, s.targetNamespace)
 	s.testVolumeSnapshot(c, s.snapshotterBeta, s.storageClassCSIBeta, s.snapshotClassBeta)
+}
+
+func (s *SnapshotTestSuite) TestVolumeSnapshotStable(c *C) {
+	if s.snapshotClassStable == nil {
+		c.Skip("No Volumesnapshotclass in the cluster, create a volumesnapshotclass in the cluster")
+	}
+	if s.storageClassCSIStable == "" {
+		c.Skip("No Storageclass with CSI provisioner, install CSI and create a storageclass for it")
+	}
+	c.Logf("VolumeSnapshot test - source namespace: %s - target namespace: %s", s.sourceNamespace, s.targetNamespace)
+	s.testVolumeSnapshot(c, s.snapshotterStable, s.storageClassCSIStable, s.snapshotClassStable)
 }
 
 func (s *SnapshotTestSuite) testVolumeSnapshot(c *C, snapshotter snapshot.Snapshotter, storageClass string, snapshotClass *string) {
@@ -493,6 +532,17 @@ func (s *SnapshotTestSuite) TestNewSnapshotter(c *C) {
 			expected: "*snapshot.SnapshotBeta",
 			check:    IsNil,
 		},
+		{
+			apiResources: metav1.APIResourceList{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "VolumeSnapshot",
+					APIVersion: "v1",
+				},
+				GroupVersion: "snapshot.storage.k8s.io/v1",
+			},
+			expected: "*snapshot.SnapshotStable",
+			check:    IsNil,
+		},
 	} {
 		fakeCli.Resources = []*metav1.APIResourceList{&tc.apiResources}
 		ss, err := snapshot.NewSnapshotter(fakeCli, nil)
@@ -508,6 +558,7 @@ type snapshotClassTC struct {
 	storageClassName string
 	snapClassAlpha   *unstructured.Unstructured
 	snapClassBeta    *unstructured.Unstructured
+	snapClassStable  *unstructured.Unstructured
 	testKey          string
 	testValue        string
 	check            Checker
@@ -532,9 +583,12 @@ func (s *SnapshotTestSuite) TestGetVolumeSnapshotClassFake(c *C) {
 	)
 	fakeSsAlpha := snapshot.NewSnapshotAlpha(kubeCli, dynCli)
 	fakeSsBeta := snapshot.NewSnapshotBeta(kubeCli, dynCli)
+	fakeSsStable := snapshot.NewSnapshotStable(kubeCli, dynCli)
 	_, err := fakeSsAlpha.GetVolumeSnapshotClass("test-annotation", "value", fakeSC)
 	c.Assert(err, NotNil)
 	_, err = fakeSsBeta.GetVolumeSnapshotClass("test-annotation", "value", fakeSC)
+	c.Assert(err, NotNil)
+	_, err = fakeSsStable.GetVolumeSnapshotClass("test-annotation", "value", fakeSC)
 	c.Assert(err, NotNil)
 
 	for _, tc := range []snapshotClassTC{
@@ -544,7 +598,8 @@ func (s *SnapshotTestSuite) TestGetVolumeSnapshotClassFake(c *C) {
 			annotationValue:  "true",
 			storageClassName: fakeSC,
 			snapClassAlpha:   snapshot.UnstructuredVolumeSnapshotClassAlpha("test-1", fakeDriver, "Delete"),
-			snapClassBeta:    snapshot.UnstructuredVolumeSnapshotClassBeta("test-1", fakeDriver, "Delete"),
+			snapClassBeta:    snapshot.UnstructuredVolumeSnapshotClass(v1beta1.VolSnapClassGVR, "test-1", fakeDriver, "Delete"),
+			snapClassStable:  snapshot.UnstructuredVolumeSnapshotClass(v1beta1.VolSnapClassGVR, "test-1", fakeDriver, "Delete"),
 			testKey:          "test-1",
 			testValue:        "true",
 			check:            IsNil,
@@ -555,7 +610,8 @@ func (s *SnapshotTestSuite) TestGetVolumeSnapshotClassFake(c *C) {
 			annotationValue:  "",
 			storageClassName: fakeSC,
 			snapClassAlpha:   snapshot.UnstructuredVolumeSnapshotClassAlpha("test-2", fakeDriver, "Delete"),
-			snapClassBeta:    snapshot.UnstructuredVolumeSnapshotClassBeta("test-2", fakeDriver, "Delete"),
+			snapClassBeta:    snapshot.UnstructuredVolumeSnapshotClass(v1beta1.VolSnapClassGVR, "test-2", fakeDriver, "Delete"),
+			snapClassStable:  snapshot.UnstructuredVolumeSnapshotClass(snapshot.VolSnapClassGVR, "test-2", fakeDriver, "Delete"),
 			testKey:          "",
 			testValue:        "",
 			check:            IsNil,
@@ -566,7 +622,8 @@ func (s *SnapshotTestSuite) TestGetVolumeSnapshotClassFake(c *C) {
 			annotationValue:  "false",
 			storageClassName: fakeSC,
 			snapClassAlpha:   snapshot.UnstructuredVolumeSnapshotClassAlpha("test-2", fakeDriver, "Delete"),
-			snapClassBeta:    snapshot.UnstructuredVolumeSnapshotClassBeta("test-2", fakeDriver, "Delete"),
+			snapClassBeta:    snapshot.UnstructuredVolumeSnapshotClass(v1beta1.VolSnapClassGVR, "test-2", fakeDriver, "Delete"),
+			snapClassStable:  snapshot.UnstructuredVolumeSnapshotClass(snapshot.VolSnapClassGVR, "test-2", fakeDriver, "Delete"),
 			testKey:          "invalid",
 			testValue:        "false",
 			check:            NotNil,
@@ -577,7 +634,8 @@ func (s *SnapshotTestSuite) TestGetVolumeSnapshotClassFake(c *C) {
 			annotationValue:  "false",
 			storageClassName: fakeSC,
 			snapClassAlpha:   snapshot.UnstructuredVolumeSnapshotClassAlpha("test-4", fakeDriver, "Delete"),
-			snapClassBeta:    snapshot.UnstructuredVolumeSnapshotClassBeta("test-4", fakeDriver, "Delete"),
+			snapClassBeta:    snapshot.UnstructuredVolumeSnapshotClass(v1beta1.VolSnapClassGVR, "test-4", fakeDriver, "Delete"),
+			snapClassStable:  snapshot.UnstructuredVolumeSnapshotClass(snapshot.VolSnapClassGVR, "test-4", fakeDriver, "Delete"),
 			testKey:          "test-4",
 			testValue:        "true",
 			check:            NotNil,
@@ -588,7 +646,8 @@ func (s *SnapshotTestSuite) TestGetVolumeSnapshotClassFake(c *C) {
 			annotationValue:  "true",
 			storageClassName: "badStorageClass",
 			snapClassAlpha:   snapshot.UnstructuredVolumeSnapshotClassAlpha("test-5", fakeDriver, "Delete"),
-			snapClassBeta:    snapshot.UnstructuredVolumeSnapshotClassBeta("test-5", fakeDriver, "Delete"),
+			snapClassBeta:    snapshot.UnstructuredVolumeSnapshotClass(v1beta1.VolSnapClassGVR, "test-5", fakeDriver, "Delete"),
+			snapClassStable:  snapshot.UnstructuredVolumeSnapshotClass(snapshot.VolSnapClassGVR, "test-5", fakeDriver, "Delete"),
 			testKey:          "test-5",
 			testValue:        "true",
 			check:            NotNil,
@@ -599,7 +658,8 @@ func (s *SnapshotTestSuite) TestGetVolumeSnapshotClassFake(c *C) {
 			annotationValue:  "true",
 			storageClassName: fakeSC,
 			snapClassAlpha:   snapshot.UnstructuredVolumeSnapshotClassAlpha("test-6", "driverMismatch", "Delete"),
-			snapClassBeta:    snapshot.UnstructuredVolumeSnapshotClassBeta("test-6", "driverMismatch", "Delete"),
+			snapClassBeta:    snapshot.UnstructuredVolumeSnapshotClass(v1beta1.VolSnapClassGVR, "test-6", "driverMismatch", "Delete"),
+			snapClassStable:  snapshot.UnstructuredVolumeSnapshotClass(snapshot.VolSnapClassGVR, "test-6", "driverMismatch", "Delete"),
 			testKey:          "test-6",
 			testValue:        "true",
 			check:            NotNil,
@@ -629,6 +689,16 @@ func (s *SnapshotTestSuite) TestGetVolumeSnapshotClassFake(c *C) {
 					"deletionPolicy": "Delete",
 				},
 			},
+			snapClassStable: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": fmt.Sprintf("%s/%s", v1alpha1.GroupName, v1alpha1.Version),
+					"kind":       snapshot.VolSnapClassKind,
+					"metadata": map[string]interface{}{
+						"name": "test-7",
+					},
+					"deletionPolicy": "Delete",
+				},
+			},
 			testKey:   "test-7",
 			testValue: "true",
 			check:     NotNil,
@@ -649,6 +719,16 @@ func (s *SnapshotTestSuite) TestGetVolumeSnapshotClassFake(c *C) {
 				},
 			},
 			snapClassBeta: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": fmt.Sprintf("%s/%s", v1alpha1.GroupName, v1alpha1.Version),
+					"kind":       "bad kind",
+					"metadata": map[string]interface{}{
+						"name": "test-8",
+					},
+					"deletionPolicy": "Delete",
+				},
+			},
+			snapClassStable: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"apiVersion": fmt.Sprintf("%s/%s", v1alpha1.GroupName, v1alpha1.Version),
 					"kind":       "bad kind",
@@ -693,6 +773,19 @@ func (s *SnapshotTestSuite) TestGetVolumeSnapshotClassFake(c *C) {
 					},
 				},
 			},
+			snapClassStable: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": fmt.Sprintf("%s/%s", v1alpha1.GroupName, v1alpha1.Version),
+					"kind":       snapshot.VolSnapClassKind,
+					"metadata": map[string]interface{}{
+						"name": "test-9",
+					},
+					"deletionPolicy": "Delete",
+					"driver": map[string]interface{}{
+						"not": "string",
+					},
+				},
+			},
 			testKey:   "test-9",
 			testValue: "true",
 			check:     NotNil,
@@ -700,6 +793,7 @@ func (s *SnapshotTestSuite) TestGetVolumeSnapshotClassFake(c *C) {
 	} {
 		tc.testGetSnapshotClass(c, dynCli, fakeSsAlpha, tc.snapClassAlpha, v1alpha1.VolSnapClassGVR)
 		tc.testGetSnapshotClass(c, dynCli, fakeSsBeta, tc.snapClassBeta, v1beta1.VolSnapClassGVR)
+		tc.testGetSnapshotClass(c, dynCli, fakeSsStable, tc.snapClassStable, snapshot.VolSnapClassGVR)
 	}
 }
 
@@ -739,6 +833,7 @@ func findSnapshotClassName(c *C, dynCli dynamic.Interface, gvr schema.GroupVersi
 			c.Fail()
 		}
 		snapshotClass = usClass.GetName()
+		fmt.Println("snapshotClass GET", snapshotClass)
 		if vsc, ok := object.(v1alpha1.VolumeSnapshotClass); ok {
 			err := snapshot.TransformUnstructured(usClass, &vsc)
 			if err != nil {
@@ -748,6 +843,14 @@ func findSnapshotClassName(c *C, dynCli dynamic.Interface, gvr schema.GroupVersi
 			snapshotterName = vsc.Snapshotter
 		}
 		if vsc, ok := object.(v1beta1.VolumeSnapshotClass); ok {
+			err := snapshot.TransformUnstructured(usClass, &vsc)
+			if err != nil {
+				c.Logf("Failed to query VolumeSnapshotClass, skipping test. Error: %v", err)
+				c.Fail()
+			}
+			snapshotterName = vsc.Driver
+		}
+		if vsc, ok := object.(snapv1.VolumeSnapshotClass); ok {
 			err := snapshot.TransformUnstructured(usClass, &vsc)
 			if err != nil {
 				c.Logf("Failed to query VolumeSnapshotClass, skipping test. Error: %v", err)
@@ -802,13 +905,14 @@ func (s *SnapshotTestSuite) TestCreateFromSourceAlpha(c *C) {
 	err = snapshotterAlpha.UpdateVolumeSnapshotStatusAlpha(ctx, namespace, snapshotName, false)
 	c.Assert(err, NotNil)
 }
+
 func (s *SnapshotTestSuite) TestCreateFromSourceBeta(c *C) {
 	ctx := context.Background()
 	namespace := "namespace"
 	snapshotName := "snapname"
 	snapshotClass := "volSnapClass"
 
-	volSnap := snapshot.UnstructuredVolumeSnapshotBeta(snapshotName, namespace, "pvcName", "content", snapshotClass)
+	volSnap := snapshot.UnstructuredVolumeSnapshot(v1beta1.VolSnapGVR, snapshotName, namespace, "pvcName", "content", snapshotClass)
 	volSnap.Object["status"] = map[string]interface{}{
 		"readyToUse": false,
 	}
@@ -838,10 +942,54 @@ func (s *SnapshotTestSuite) TestCreateFromSourceBeta(c *C) {
 	c.Assert(status["readyToUse"], Equals, false)
 
 	// status not set
-	volSnap = snapshot.UnstructuredVolumeSnapshotBeta(snapshotName, namespace, "pvcName", "content", snapshotClass)
+	volSnap = snapshot.UnstructuredVolumeSnapshot(v1beta1.VolSnapGVR, snapshotName, namespace, "pvcName", "content", snapshotClass)
 	dynCli = dynfake.NewSimpleDynamicClient(scheme, volSnap)
 	snapshotterBeta, ok = snapshot.NewSnapshotBeta(kubeCli, dynCli).(*snapshot.SnapshotBeta)
 	c.Assert(ok, Equals, true)
 	err = snapshotterBeta.UpdateVolumeSnapshotStatusBeta(ctx, namespace, snapshotName, false)
+	c.Assert(err, NotNil)
+}
+
+func (s *SnapshotTestSuite) TestCreateFromSourceStable(c *C) {
+	ctx := context.Background()
+	namespace := "namespace"
+	snapshotName := "snapname"
+	snapshotClass := "volSnapClass"
+
+	volSnap := snapshot.UnstructuredVolumeSnapshot(snapshot.VolSnapGVR, snapshotName, namespace, "pvcName", "content", snapshotClass)
+	volSnap.Object["status"] = map[string]interface{}{
+		"readyToUse": false,
+	}
+	scheme := runtime.NewScheme()
+	dynCli := dynfake.NewSimpleDynamicClient(scheme, volSnap)
+	kubeCli := fake.NewSimpleClientset()
+
+	snapshotterStable, ok := snapshot.NewSnapshotStable(kubeCli, dynCli).(*snapshot.SnapshotStable)
+	c.Assert(ok, Equals, true)
+
+	// set true
+	err := snapshotterStable.UpdateVolumeSnapshotStatusStable(ctx, namespace, snapshotName, true)
+	c.Assert(err, IsNil)
+	us, err := dynCli.Resource(snapshot.VolSnapGVR).Namespace(namespace).Get(ctx, snapshotName, metav1.GetOptions{})
+	c.Assert(err, IsNil)
+	status, ok := us.Object["status"].(map[string]interface{})
+	c.Assert(ok, Equals, true)
+	c.Assert(status["readyToUse"], Equals, true)
+
+	// set false
+	err = snapshotterStable.UpdateVolumeSnapshotStatusStable(ctx, namespace, snapshotName, false)
+	c.Assert(err, IsNil)
+	us, err = dynCli.Resource(snapshot.VolSnapGVR).Namespace(namespace).Get(ctx, snapshotName, metav1.GetOptions{})
+	c.Assert(err, IsNil)
+	status, ok = us.Object["status"].(map[string]interface{})
+	c.Assert(ok, Equals, true)
+	c.Assert(status["readyToUse"], Equals, false)
+
+	// status not set
+	volSnap = snapshot.UnstructuredVolumeSnapshot(snapshot.VolSnapGVR, snapshotName, namespace, "pvcName", "content", snapshotClass)
+	dynCli = dynfake.NewSimpleDynamicClient(scheme, volSnap)
+	snapshotterStable, ok = snapshot.NewSnapshotStable(kubeCli, dynCli).(*snapshot.SnapshotStable)
+	c.Assert(ok, Equals, true)
+	err = snapshotterStable.UpdateVolumeSnapshotStatusStable(ctx, namespace, snapshotName, false)
 	c.Assert(err, NotNil)
 }

--- a/pkg/kube/snapshot/snapshot_test.go
+++ b/pkg/kube/snapshot/snapshot_test.go
@@ -286,7 +286,7 @@ func (s *SnapshotTestSuite) TestVolumeSnapshotCloneFake(c *C) {
 		clone, err := tc.fakeSs.Get(context.Background(), fakeClone, fakeTargetNamespace)
 		c.Assert(err, IsNil)
 
-		us, err := dynCli.Resource(tc.contentGVR).Get(context.TODO(), clone.Spec.SnapshotContentName, metav1.GetOptions{})
+		us, err := dynCli.Resource(tc.contentGVR).Get(context.TODO(), *clone.Spec.Source.VolumeSnapshotContentName, metav1.GetOptions{})
 		c.Assert(err, IsNil)
 		err = snapshot.TransformUnstructured(us, tc.snapContentObject)
 		c.Assert(err, IsNil)
@@ -363,7 +363,8 @@ func (s *SnapshotTestSuite) testVolumeSnapshot(c *C, snapshotter snapshot.Snapsh
 	snap, err := snapshotter.Get(ctx, snapshotName, s.sourceNamespace)
 	c.Assert(err, IsNil)
 	c.Assert(snap.Name, Equals, snapshotName)
-	c.Assert(snap.Status.ReadyToUse, Equals, true)
+	c.Assert(snap.Status.ReadyToUse, NotNil)
+	c.Assert(*snap.Status.ReadyToUse, Equals, true)
 
 	err = snapshotter.Create(ctx, snapshotName, s.sourceNamespace, pvc.Name, snapshotClass, wait)
 	c.Assert(err, NotNil)
@@ -378,7 +379,7 @@ func (s *SnapshotTestSuite) testVolumeSnapshot(c *C, snapshotter snapshot.Snapsh
 		DynCli:           s.dynCli,
 		Namespace:        s.targetNamespace,
 		VolumeName:       volumeCloneName,
-		StorageClassName: "",
+		StorageClassName: storageClass,
 		SnapshotName:     snapshotCloneName,
 		RestoreSize:      &sizeOriginal,
 		Labels:           nil,
@@ -401,7 +402,7 @@ func (s *SnapshotTestSuite) testVolumeSnapshot(c *C, snapshotter snapshot.Snapsh
 		DynCli:           s.dynCli,
 		Namespace:        s.targetNamespace,
 		VolumeName:       volumeCloneName,
-		StorageClassName: "",
+		StorageClassName: storageClass,
 		SnapshotName:     snapshotCloneName,
 		RestoreSize:      &sizeNew,
 		Labels: map[string]string{

--- a/pkg/kube/snapshot/snapshot_test.go
+++ b/pkg/kube/snapshot/snapshot_test.go
@@ -103,7 +103,6 @@ func (s *SnapshotTestSuite) SetUpSuite(c *C) {
 	s.snapshotClassBeta = &snapClassBeta
 	snapClassStable, driverStable := findSnapshotClassName(c, s.dynCli, snapshot.VolSnapClassGVR, snapv1.VolumeSnapshotClass{})
 	s.snapshotClassStable = &snapClassStable
-	fmt.Printf("snClass:: %+v\nDriver:: %+v\n", snapClassStable, driverStable)
 	storageClasses, err := cli.StorageV1().StorageClasses().List(context.TODO(), metav1.ListOptions{})
 	c.Assert(err, IsNil)
 	for _, class := range storageClasses.Items {
@@ -833,7 +832,6 @@ func findSnapshotClassName(c *C, dynCli dynamic.Interface, gvr schema.GroupVersi
 			c.Fail()
 		}
 		snapshotClass = usClass.GetName()
-		fmt.Println("snapshotClass GET", snapshotClass)
 		if vsc, ok := object.(v1alpha1.VolumeSnapshotClass); ok {
 			err := snapshot.TransformUnstructured(usClass, &vsc)
 			if err != nil {

--- a/pkg/kube/snapshot/snapshot_test.go
+++ b/pkg/kube/snapshot/snapshot_test.go
@@ -599,7 +599,7 @@ func (s *SnapshotTestSuite) TestGetVolumeSnapshotClassFake(c *C) {
 			storageClassName: fakeSC,
 			snapClassAlpha:   snapshot.UnstructuredVolumeSnapshotClassAlpha("test-1", fakeDriver, "Delete"),
 			snapClassBeta:    snapshot.UnstructuredVolumeSnapshotClass(v1beta1.VolSnapClassGVR, "test-1", fakeDriver, "Delete"),
-			snapClassStable:  snapshot.UnstructuredVolumeSnapshotClass(v1beta1.VolSnapClassGVR, "test-1", fakeDriver, "Delete"),
+			snapClassStable:  snapshot.UnstructuredVolumeSnapshotClass(snapshot.VolSnapClassGVR, "test-1", fakeDriver, "Delete"),
 			testKey:          "test-1",
 			testValue:        "true",
 			check:            IsNil,


### PR DESCRIPTION
Signed-off-by: Prasad Ghangal <prasad.ghangal@gmail.com>

## Change Overview

Add support for v1 k8s volume snapshot APIs

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test


## Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E

#### On cluster with Alpha snapshot APIs

```
$ go test -v -check.vv .
=== RUN   Test
START: snapshot_test.go:82: SnapshotTestSuite.SetUpSuite
snapshotClass GET do-block-storage
snClass:: 
Driver:: 
PASS: snapshot_test.go:82: SnapshotTestSuite.SetUpSuite 6.579s

START: snapshot_test.go:865: SnapshotTestSuite.TestCreateFromSourceAlpha
PASS: snapshot_test.go:865: SnapshotTestSuite.TestCreateFromSourceAlpha 0.003s

START: snapshot_test.go:909: SnapshotTestSuite.TestCreateFromSourceBeta
PASS: snapshot_test.go:909: SnapshotTestSuite.TestCreateFromSourceBeta  0.001s

START: snapshot_test.go:953: SnapshotTestSuite.TestCreateFromSourceStable
PASS: snapshot_test.go:953: SnapshotTestSuite.TestCreateFromSourceStable        0.001s

START: snapshot_test.go:567: SnapshotTestSuite.TestGetVolumeSnapshotClassFake
PASS: snapshot_test.go:567: SnapshotTestSuite.TestGetVolumeSnapshotClassFake    0.005s

START: snapshot_test.go:504: SnapshotTestSuite.TestNewSnapshotter
PASS: snapshot_test.go:504: SnapshotTestSuite.TestNewSnapshotter        0.001s

START: snapshot_test.go:332: SnapshotTestSuite.TestVolumeSnapshotAlpha
VolumeSnapshot test - source namespace: snapshot-test-source-59290 - target namespace: snapshot-test-target-59290
PASS: snapshot_test.go:332: SnapshotTestSuite.TestVolumeSnapshotAlpha   40.127s

START: snapshot_test.go:343: SnapshotTestSuite.TestVolumeSnapshotBeta
SKIP: snapshot_test.go:343: SnapshotTestSuite.TestVolumeSnapshotBeta (No Storageclass with CSI provisioner, install CSI and create a storageclass for it)

START: snapshot_test.go:177: SnapshotTestSuite.TestVolumeSnapshotClassCloneFake
PASS: snapshot_test.go:177: SnapshotTestSuite.TestVolumeSnapshotClassCloneFake  0.004s

START: snapshot_test.go:240: SnapshotTestSuite.TestVolumeSnapshotCloneFake
PASS: snapshot_test.go:240: SnapshotTestSuite.TestVolumeSnapshotCloneFake       0.005s

START: snapshot_test.go:133: SnapshotTestSuite.TestVolumeSnapshotFake
PASS: snapshot_test.go:133: SnapshotTestSuite.TestVolumeSnapshotFake    0.003s

START: snapshot_test.go:354: SnapshotTestSuite.TestVolumeSnapshotStable
SKIP: snapshot_test.go:354: SnapshotTestSuite.TestVolumeSnapshotStable (No Storageclass with CSI provisioner, install CSI and create a storageclass for it)

START: snapshot_test.go:128: SnapshotTestSuite.TearDownSuite
PASS: snapshot_test.go:128: SnapshotTestSuite.TearDownSuite     2.918s

OK: 9 passed, 2 skipped
--- PASS: Test (49.65s)
PASS
ok      github.com/kanisterio/kanister/pkg/kube/snapshot        49.675s

```

#### On cluster with Stable/Beta Snapshot APIs

```
$ go test -v -check.vv .
=== RUN   Test
START: snapshot_test.go:82: SnapshotTestSuite.SetUpSuite
snapshotClass GET csi-rbdplugin-snapclass
snapshotClass GET csi-rbdplugin-snapclass
snClass:: csi-rbdplugin-snapclass
Driver:: kube-rook-ceph.rbd.csi.ceph.com
PASS: snapshot_test.go:82: SnapshotTestSuite.SetUpSuite 11.787s

START: snapshot_test.go:865: SnapshotTestSuite.TestCreateFromSourceAlpha
PASS: snapshot_test.go:865: SnapshotTestSuite.TestCreateFromSourceAlpha 0.001s

START: snapshot_test.go:909: SnapshotTestSuite.TestCreateFromSourceBeta
PASS: snapshot_test.go:909: SnapshotTestSuite.TestCreateFromSourceBeta  0.001s

START: snapshot_test.go:953: SnapshotTestSuite.TestCreateFromSourceStable
PASS: snapshot_test.go:953: SnapshotTestSuite.TestCreateFromSourceStable        0.001s

START: snapshot_test.go:567: SnapshotTestSuite.TestGetVolumeSnapshotClassFake
PASS: snapshot_test.go:567: SnapshotTestSuite.TestGetVolumeSnapshotClassFake    0.005s

START: snapshot_test.go:504: SnapshotTestSuite.TestNewSnapshotter
PASS: snapshot_test.go:504: SnapshotTestSuite.TestNewSnapshotter        0.000s

START: snapshot_test.go:332: SnapshotTestSuite.TestVolumeSnapshotAlpha
SKIP: snapshot_test.go:332: SnapshotTestSuite.TestVolumeSnapshotAlpha (No Storageclass with CSI provisioner, install CSI and create a storageclass for it)

START: snapshot_test.go:343: SnapshotTestSuite.TestVolumeSnapshotBeta
VolumeSnapshot test - source namespace: snapshot-test-source-19461 - target namespace: snapshot-test-target-19461
PASS: snapshot_test.go:343: SnapshotTestSuite.TestVolumeSnapshotBeta    9.524s

START: snapshot_test.go:177: SnapshotTestSuite.TestVolumeSnapshotClassCloneFake
PASS: snapshot_test.go:177: SnapshotTestSuite.TestVolumeSnapshotClassCloneFake  0.003s

START: snapshot_test.go:240: SnapshotTestSuite.TestVolumeSnapshotCloneFake
PASS: snapshot_test.go:240: SnapshotTestSuite.TestVolumeSnapshotCloneFake       0.005s

START: snapshot_test.go:133: SnapshotTestSuite.TestVolumeSnapshotFake
PASS: snapshot_test.go:133: SnapshotTestSuite.TestVolumeSnapshotFake    0.002s

START: snapshot_test.go:354: SnapshotTestSuite.TestVolumeSnapshotStable
VolumeSnapshot test - source namespace: snapshot-test-source-19461 - target namespace: snapshot-test-target-19461
PASS: snapshot_test.go:354: SnapshotTestSuite.TestVolumeSnapshotStable  23.756s

START: snapshot_test.go:128: SnapshotTestSuite.TearDownSuite
Failed to list snapshots, Namespace: snapshot-test-source-19461, Error: the server could not find the requested resource
Skipping deleting the namespace, Namespace: snapshot-test-source-19461
Failed to list snapshots, Namespace: snapshot-test-target-19461, Error: the server could not find the requested resource
Skipping deleting the namespace, Namespace: snapshot-test-target-19461
PASS: snapshot_test.go:128: SnapshotTestSuite.TearDownSuite     4.130s

OK: 10 passed, 1 skipped
--- PASS: Test (49.22s)
PASS
ok      github.com/kanisterio/kanister/pkg/kube/snapshot        49.244s

```
