### PR TITLE
Spelling error in Azure zones

### DIFF
--- a/pkg/blockstorage/azure/azuredisk.go
+++ b/pkg/blockstorage/azure/azuredisk.go
@@ -753,7 +753,7 @@ func staticRegionToZones(region string) ([]string, error) {
 		return []string{"westus2-1", "westus2-2", "westus2-3"}, nil
 	case "westus2stage":
 		return nil, nil
-	case "westusstag":
+	case "westusstage":
 		return nil, nil
 	}
 	return nil, errors.New(fmt.Sprintf("cannot get availability zones for region %s", region))


### PR DESCRIPTION
## Change Overview

Spelling error, westusstag -> westusstage

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
