### PR TITLE
Silence errors on integration test teardown

### DIFF
--- a/pkg/testing/integration_test.go
+++ b/pkg/testing/integration_test.go
@@ -419,13 +419,19 @@ func (s *IntegrationSuite) TearDownSuite(c *C) {
 	// Uninstall app
 	if !s.skip {
 		err := s.app.Uninstall(ctx)
-		c.Assert(err, IsNil)
+		if err != nil {
+			c.Log("Failed to uninstall app %s: %v", s.name, err.Error())
+		}
+
 	}
 
 	// Uninstall implementation of the apps doesn't delete namespace
 	// Delete the namespace separately
 	err := s.cli.CoreV1().Namespaces().Delete(ctx, s.namespace, metav1.DeleteOptions{})
 	c.Assert(err, IsNil)
+	if err != nil {
+		c.Log("Failed to delete namespace: %v", err.Error())
+	}
 }
 
 func pingAppAndWait(ctx context.Context, a app.DatabaseApp) error {


### PR DESCRIPTION
## Change Overview

There have been intermittent failures in the integration tests on teardown. This PR will make those failures log-only.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [x] :robot: Test

## Issues

- #XXX
