### PR TITLE
Change regex that matches the restic stats cmd op

### DIFF
--- a/pkg/restic/restic.go
+++ b/pkg/restic/restic.go
@@ -414,7 +414,7 @@ func SnapshotStatsFromStatsLog(output string) (string, string, string) {
 func SnapshotStatsModeFromStatsLog(output string) string {
 	logs := regexp.MustCompile("[\n]").Split(output, -1)
 	// Log should contain "Stats for .... in  xx mode"
-	pattern := regexp.MustCompile(`Stats for.*in\s+(.*?)\s+mode:`)
+	pattern := regexp.MustCompile(`Stats in\s+(.*?)\s+mode:`)
 	for _, l := range logs {
 		match := pattern.FindAllStringSubmatch(l, 1)
 		if len(match) > 0 && len(match[0]) > 1 {

--- a/pkg/restic/restic_test.go
+++ b/pkg/restic/restic_test.go
@@ -250,10 +250,11 @@ func (s *ResticDataSuite) TestGetSnapshotStatsModeFromStatsLog(c *C) {
 		log      string
 		expected string
 	}{
-		{log: "Stats for all snapshots in restore-size mode:", expected: "restore-size"},
-		{log: "Stats for 7e17e764 in restore-size mode:", expected: "restore-size"},
-		{log: "Stats for all snapshots in raw-data mode:", expected: "raw-data"},
-		{log: "Stats for all snapshots in blobs-per-file mode:", expected: "blobs-per-file"},
+		// after updating restic to 0.11.0 this format is changed
+		{log: "Stats in restore-size mode:", expected: "restore-size"},
+		{log: "Stats in restore-size mode:", expected: "restore-size"},
+		{log: "Stats in raw-data mode:", expected: "raw-data"},
+		{log: "Stats in blobs-per-file mode:", expected: "blobs-per-file"},
 		{log: "sudhufehfuijbfjbruifhoiwhf", expected: ""},
 	} {
 		mode := SnapshotStatsModeFromStatsLog(tc.log)


### PR DESCRIPTION
## Change Overview

`restic stats` returned the output in below format

```
repository 8b4484dd opened successfully, password is correct
created new cache in /root/.cache/restic
scanning...
Stats for all snapshots in raw-data mode:
  Total Blob Count:   194
        Total Size:   1.786 MiB
```

but after release of kanister `0.49.0` as part of this PR (https://github.com/kanisterio/kanister/pull/826)
we upgraded restic to version 0.11.0 and after the output of `restic stats` has been
changed to

```
repository 5cbbd926 opened successfully, password is correct
created new cache in /root/.cache/restic
scanning...
Stats in raw-data mode:
Snapshots processed:   1
   Total Blob Count:   194
         Total Size:   1.786 MiB
```

This PR changes the regex that matched the line to figure
out the stats mode.


## Pull request type

Please check the type of change your PR introduces:

- [x] :hamster: Trivial/Minor

## Issues

- #XXX

## Test Plan

- [x] :zap: Unit test

`DataSuite.TestDescribeBackups` that was failing

```
» go test -check.f "DataSuite.TestDescribeBackups"
```
the logs can be found [here](https://gist.github.com/268836d41cb113318a63ca3312a154c5).

`ResticDataSuite`
```
» go test -check.f "ResticDataSuite"
```
the logs can be found [here](https://gist.github.com/a84dffd8c05a828f5a69d83f5edc9af0).

