### PR TITLE
Update helm version in build image and move build image to ghcr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ IMAGE_NAME := $(BIN)
 
 IMAGE := $(REGISTRY)/$(IMAGE_NAME)
 
-BUILD_IMAGE ?= kanisterio/build:v0.0.11
+BUILD_IMAGE ?= ghcr.io/kanisterio/build:v0.0.12
 DOCS_BUILD_IMAGE ?= kanisterio/docker-sphinx
 
 DOCS_RELEASE_BUCKET ?= s3://docs.kanister.io

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -12,7 +12,7 @@ COPY --from=bitnami/kubectl:1.17 /opt/bitnami/kubectl/bin/kubectl /usr/local/bin
 
 COPY --from=goreleaser/goreleaser:v0.127.0 /bin/goreleaser /usr/local/bin/
 
-COPY --from=alpine/helm:3.0.0 /usr/bin/helm /usr/local/bin/
+COPY --from=alpine/helm:3.1.0 /usr/bin/helm /usr/local/bin/
 
 COPY --from=golangci/golangci-lint:v1.23.7 /usr/bin/golangci-lint /usr/local/bin/
 


### PR DESCRIPTION
## Change Overview

MySQL helm chart has now helm v3.1.0 as prerequisites which is causing integration-test to fail. This PR is to update helm version in build image from v3.0.0 to v3.1.0 and move the build image to ghcr.io.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [x] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E

Created test image with updated Dockerfile and used the image to run integration to verify it was passing.