### PR TITLE
Add label to pods created by Kanister

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -6,4 +6,6 @@ const (
 	ContainerNameKey         = "Container"
 	PhaseNameKey             = "Phase"
 	GoogleCloudCredsFilePath = "/tmp/creds.txt"
+	LabelKeyCreatedBy        = "createdBy"
+	LabelValueKanister       = "kanister"
 )

--- a/pkg/kube/pod.go
+++ b/pkg/kube/pod.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
+	"github.com/kanisterio/kanister/pkg/consts"
 	"github.com/kanisterio/kanister/pkg/log"
 	"github.com/kanisterio/kanister/pkg/poll"
 )
@@ -104,6 +105,9 @@ func CreatePod(ctx context.Context, cli kubernetes.Interface, opts *PodOptions) 
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: opts.GenerateName,
+			Labels: map[string]string{
+				consts.LabelKeyCreatedBy: consts.LabelValueKanister,
+			},
 		},
 		Spec: patchedSpecs,
 	}
@@ -112,8 +116,8 @@ func CreatePod(ctx context.Context, cli kubernetes.Interface, opts *PodOptions) 
 	if opts.Annotations != nil {
 		pod.ObjectMeta.Annotations = opts.Annotations
 	}
-	if opts.Labels != nil {
-		pod.ObjectMeta.Labels = opts.Labels
+	for key, value := range opts.Labels {
+		pod.ObjectMeta.Labels[key] = value
 	}
 
 	pod, err = cli.CoreV1().Pods(ns).Create(ctx, pod, metav1.CreateOptions{})

--- a/pkg/kube/pod.go
+++ b/pkg/kube/pod.go
@@ -116,6 +116,9 @@ func CreatePod(ctx context.Context, cli kubernetes.Interface, opts *PodOptions) 
 	if opts.Annotations != nil {
 		pod.ObjectMeta.Annotations = opts.Annotations
 	}
+	if pod.ObjectMeta.Labels == nil {
+		pod.ObjectMeta.Labels = map[string]string{}
+	}
 	for key, value := range opts.Labels {
 		pod.ObjectMeta.Labels[key] = value
 	}

--- a/pkg/kube/pod_test.go
+++ b/pkg/kube/pod_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/client-go/testing"
 
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
+	"github.com/kanisterio/kanister/pkg/consts"
 )
 
 type PodSuite struct {
@@ -157,9 +158,10 @@ func (s *PodSuite) TestPod(c *C) {
 			c.Check(pod.ObjectMeta.Annotations, DeepEquals, po.Annotations)
 		}
 
-		if po.Labels != nil {
-			c.Check(pod.ObjectMeta.Labels, NotNil)
-			c.Check(pod.ObjectMeta.Labels, DeepEquals, po.Labels)
+		c.Check(len(pod.ObjectMeta.Labels), Equals, len(po.Labels)+1)
+		c.Check(pod.ObjectMeta.Labels[consts.LabelKeyCreatedBy], Equals, consts.LabelValueKanister)
+		for key, value := range po.Labels {
+			c.Check(pod.ObjectMeta.Labels[key], Equals, value)
 		}
 
 		c.Assert(err, IsNil)


### PR DESCRIPTION
## Change Overview

Add "createdBy" label to all pods created by Kanister so users can easily find all pods that were created by Kanister.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [x] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
