### PR TITLE
Change to wait for storage byte status in GKE

### DIFF
--- a/pkg/blockstorage/gcepd/gcepd.go
+++ b/pkg/blockstorage/gcepd/gcepd.go
@@ -245,18 +245,7 @@ func (s *GpdStorage) SnapshotDelete(ctx context.Context, snapshot *blockstorage.
 
 // SnapshotGet is part of blockstorage.Provider
 func (s *GpdStorage) SnapshotGet(ctx context.Context, id string) (*blockstorage.Snapshot, error) {
-	var snap *compute.Snapshot
-	var err error
-	err = poll.Wait(ctx, func(ctx context.Context) (bool, error) {
-		snap, err = s.service.Snapshots.Get(s.project, id).Context(ctx).Do()
-		if err != nil {
-			return false, err
-		}
-		if snap.StorageBytesStatus != "UP_TO_DATE" {
-			return false, nil
-		}
-		return true, nil
-	})
+	snap, err := s.service.Snapshots.Get(s.project, id).Context(ctx).Do()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Change Overview

Currently we do not wait for GKE to update the size of the snapshots resulting in inconsistencies.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
