### PR TITLE
Match all versions in CRDMatcher()

### DIFF
--- a/pkg/discovery/crd.go
+++ b/pkg/discovery/crd.go
@@ -37,8 +37,8 @@ func crdsToMatcher(crds []apiextensions.CustomResourceDefinition) filter.Resourc
 	gvrs := make(filter.ResourceTypeMatcher, 0, len(crds))
 	for _, crd := range crds {
 		gvr := filter.ResourceTypeRequirement{
-			Group:    crd.Spec.Group,
-			Version:  crd.Spec.Version,
+			Group: crd.Spec.Group,
+			// Omit Version-- match any version
 			Resource: crd.Spec.Names.Plural,
 		}
 		gvrs = append(gvrs, gvr)


### PR DESCRIPTION
## Change Overview

Omit version from CRDMatcher so it will match all versions given as input. Properly handle CRDs such as certificates.cert-manager.io where Version field is not the preferred version (at least as installed in some systems). 

## Pull request type

Please check the type of change your PR introduces:
- [x] :hamster: Trivial/Minor
- [x] :bug: Bugfix

