### PR TITLE
Add Resources field to PodOptions to allow resource configuration

### DIFF
--- a/pkg/kube/pod.go
+++ b/pkg/kube/pod.go
@@ -52,6 +52,7 @@ type PodOptions struct {
 	ServiceAccountName string
 	Volumes            map[string]string
 	PodOverride        crv1alpha1.JSONMap
+	Resources          v1.ResourceRequirements
 }
 
 // CreatePod creates a pod with a single container based on the specified image
@@ -85,6 +86,7 @@ func CreatePod(ctx context.Context, cli kubernetes.Interface, opts *PodOptions) 
 				Command:         opts.Command,
 				ImagePullPolicy: v1.PullPolicy(v1.PullIfNotPresent),
 				VolumeMounts:    volumeMounts,
+				Resources:       opts.Resources,
 			},
 		},
 		// RestartPolicy dictates when the containers of the pod should be

--- a/pkg/kube/pod_test.go
+++ b/pkg/kube/pod_test.go
@@ -134,6 +134,22 @@ func (s *PodSuite) TestPod(c *C) {
 				"run": "pod",
 			},
 		},
+		{
+			Namespace:    s.namespace,
+			GenerateName: "test-",
+			Image:        kanisterToolsImage,
+			Command:      []string{"sh", "-c", "tail -f /dev/null"},
+			Resources: v1.ResourceRequirements{
+				Limits: v1.ResourceList{
+					"memory": resource.MustParse("100Mi"),
+					"cpu":    resource.MustParse("100m"),
+				},
+				Requests: v1.ResourceList{
+					"memory": resource.MustParse("100Mi"),
+					"cpu":    resource.MustParse("100m"),
+				},
+			},
+		},
 	}
 
 	for _, po := range podOptions {
@@ -162,6 +178,15 @@ func (s *PodSuite) TestPod(c *C) {
 		c.Check(pod.ObjectMeta.Labels[consts.LabelKeyCreatedBy], Equals, consts.LabelValueKanister)
 		for key, value := range po.Labels {
 			c.Check(pod.ObjectMeta.Labels[key], Equals, value)
+		}
+
+		if po.Resources.Limits != nil {
+			c.Assert(pod.Spec.Containers[0].Resources.Limits, NotNil)
+			c.Assert(pod.Spec.Containers[0].Resources.Limits, DeepEquals, po.Resources.Limits)
+		}
+		if po.Resources.Requests != nil {
+			c.Assert(pod.Spec.Containers[0].Resources.Requests, NotNil)
+			c.Assert(pod.Spec.Containers[0].Resources.Requests, DeepEquals, po.Resources.Requests)
 		}
 
 		c.Assert(err, IsNil)


### PR DESCRIPTION
## Change Overview

This PR adds Resource field to PodOptions so that pods can be configured with resource requests and limits.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [x] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
