### PR TITLE
Handle aurora db clusters in createRDSSnapshot and RestoreRDSSnapshot separately

### DIFF
--- a/docs/functions.rst
+++ b/docs/functions.rst
@@ -952,7 +952,7 @@ Arguments:
    :widths: 5,5,5,15
 
    `instanceID`, Yes, `string`, ID of RDS instance you want to create snapshot of
-   `dbEngine`, No, `String`, DB Engine that is running in RDS Aurora instance. Supported DB Engines: ``aurora`` ``aurora-mysql`` and ``aurora-postgresql``
+   `dbEngine`, No, `String`, Required in case of RDS Aurora instance. Supported DB Engines: ``aurora`` ``aurora-mysql`` and ``aurora-postgresql``
 
 
 Outputs:

--- a/docs/functions.rst
+++ b/docs/functions.rst
@@ -952,6 +952,7 @@ Arguments:
    :widths: 5,5,5,15
 
    `instanceID`, Yes, `string`, ID of RDS instance you want to create snapshot of
+   `dbEngine`, No, `String`, DB Engine that is running in RDS instance, it should be specified in case of Amazon Aurora DB
 
 
 Outputs:

--- a/docs/functions.rst
+++ b/docs/functions.rst
@@ -952,7 +952,7 @@ Arguments:
    :widths: 5,5,5,15
 
    `instanceID`, Yes, `string`, ID of RDS instance you want to create snapshot of
-   `dbEngine`, No, `String`, DB Engine that is running in RDS Aurora instance. Supported DB Engines: ``aurora``, ``aurora-mysql`` and ``aurora-postgresql``
+   `dbEngine`, No, `String`, DB Engine that is running in RDS Aurora instance. Supported DB Engines: ``aurora`` ``aurora-mysql`` and ``aurora-postgresql``
 
 
 Outputs:
@@ -1098,7 +1098,7 @@ Arguments:
    `backupID`, No, `string`, unique backup id generated during storing data into object storage
    `securityGroupID`, No, `[]string`, list of ``securityGroupID`` to be passed to temporary RDS instance
    `namespace`, No, `string`, namespace in which to execute. Required if ``snapshotID`` is nil
-   `dbEngine`, No, `string`, one of the RDS db engines. Supported engines: ``PostgreSQL``, ``aurora``, ``aurora-mysql`` and ``aurora-postgresql``. Required if ``snapshotID`` is nil or Aurora is run in RDS instance
+   `dbEngine`, No, `string`, one of the RDS db engines. Supported engines: ``PostgreSQL`` ``aurora`` ``aurora-mysql`` and ``aurora-postgresql``. Required if ``snapshotID`` is nil or Aurora is run in RDS instance
 
 .. note::
    - If ``snapshotID`` is not set, restore will be done from data dump. In that case ``backupID`` `arg` is required.

--- a/docs/functions.rst
+++ b/docs/functions.rst
@@ -952,7 +952,7 @@ Arguments:
    :widths: 5,5,5,15
 
    `instanceID`, Yes, `string`, ID of RDS instance you want to create snapshot of
-   `dbEngine`, No, `String`, DB Engine that is running in RDS instance. Supprted engine: ``Aurora``
+   `dbEngine`, No, `String`, DB Engine that is running in RDS instance. Supported DB Engine: ``Aurora``
 
 
 Outputs:

--- a/docs/functions.rst
+++ b/docs/functions.rst
@@ -952,7 +952,7 @@ Arguments:
    :widths: 5,5,5,15
 
    `instanceID`, Yes, `string`, ID of RDS instance you want to create snapshot of
-   `dbEngine`, No, `String`, DB Engine that is running in RDS instance, it should be specified in case of Amazon Aurora DB
+   `dbEngine`, No, `String`, DB Engine that is running in RDS instance. Supprted engine: ``Aurora``
 
 
 Outputs:

--- a/docs/functions.rst
+++ b/docs/functions.rst
@@ -952,7 +952,7 @@ Arguments:
    :widths: 5,5,5,15
 
    `instanceID`, Yes, `string`, ID of RDS instance you want to create snapshot of
-   `dbEngine`, No, `String`, DB Engine that is running in RDS instance. Supported DB Engine: ``Aurora``
+   `dbEngine`, No, `String`, DB Engine that is running in RDS Aurora instance. Supported DB Engines: ``aurora``, ``aurora-mysql`` and ``aurora-postgresql``
 
 
 Outputs:
@@ -1098,7 +1098,7 @@ Arguments:
    `backupID`, No, `string`, unique backup id generated during storing data into object storage
    `securityGroupID`, No, `[]string`, list of ``securityGroupID`` to be passed to temporary RDS instance
    `namespace`, No, `string`, namespace in which to execute. Required if ``snapshotID`` is nil
-   `dbEngine`, No, `string`, one of the RDS db engines. Supported engines: ``PostgreSQL``. Required if ``snapshotID`` is nil
+   `dbEngine`, No, `string`, one of the RDS db engines. Supported engines: ``PostgreSQL``, ``aurora``, ``aurora-mysql`` and ``aurora-postgresql``. Required if ``snapshotID`` is nil or Aurora is run in RDS instance
 
 .. note::
    - If ``snapshotID`` is not set, restore will be done from data dump. In that case ``backupID`` `arg` is required.

--- a/examples/aws-rds/aurora-mysql/rds-aurora-snap-blueprint.yaml
+++ b/examples/aws-rds/aurora-mysql/rds-aurora-snap-blueprint.yaml
@@ -1,0 +1,37 @@
+apiVersion: cr.kanister.io/v1alpha1
+kind: Blueprint
+metadata:
+  name: rds-aurora-snapshot-bp
+actions:
+  backup:
+    outputArtifacts:
+      backupInfo:
+        keyValue:
+          snapshotID: "{{ .Phases.createSnapshot.Output.snapshotID }}"
+          instanceID: "{{ .Phases.createSnapshot.Output.instanceID }}"
+          securityGroupID: "{{ .Phases.createSnapshot.Output.securityGroupID }}"
+    phases:
+    - func: CreateRDSSnapshot
+      name: createSnapshot
+      args:
+        instanceID: '{{ index .Object.data "aurora.clusterID" }}'
+        dbEngine: "aurora-mysql"
+  restore:
+    inputArtifactNames:
+    - backupInfo
+    phases:
+    - func: RestoreRDSSnapshot
+      name: restoreSnapshots
+      args:
+        instanceID:  "{{ .ArtifactsIn.backupInfo.KeyValue.instanceID }}"
+        snapshotID:  "{{ .ArtifactsIn.backupInfo.KeyValue.snapshotID }}"
+        securityGroupID:  "{{ .ArtifactsIn.backupInfo.KeyValue.securityGroupID }}"
+        dbEngine: "aurora-mysql"
+  delete:
+    inputArtifactNames:
+    - backupInfo
+    phases:
+    - func: DeleteRDSSnapshot
+      name: deleteSnapshot
+      args:
+        snapshotID: "{{ .ArtifactsIn.backupInfo.KeyValue.snapshotID }}"

--- a/pkg/aws/rds/rds.go
+++ b/pkg/aws/rds/rds.go
@@ -84,11 +84,10 @@ func (r RDS) WaitUntilDBInstanceAvailable(ctx context.Context, instanceID string
 func (r RDS) WaitUntilDBClusterAvailable(ctx context.Context, dbClusterID string) error {
 	timeoutCtx, waitCancel := context.WithTimeout(ctx, 10*time.Minute)
 	defer waitCancel()
-	poll.Wait(timeoutCtx, func(c context.Context) (bool, error) {
+	return poll.Wait(timeoutCtx, func(c context.Context) (bool, error) {
 		err := r.WaitOnDBCluster(ctx, dbClusterID, statusDBClusterAvailable)
 		return err == nil, nil
 	})
-	return nil
 }
 
 // WaitDBCluster waits for DB cluster with instanceID

--- a/pkg/aws/rds/rds.go
+++ b/pkg/aws/rds/rds.go
@@ -96,6 +96,13 @@ func (r RDS) DescribeDBClusters(ctx context.Context, instanceID string) (*rds.De
 	return r.DescribeDBClustersWithContext(ctx, dci)
 }
 
+func (r RDS) DescribeDBClustersSnapshot(ctx context.Context, snapshotID string) (*rds.DescribeDBClusterSnapshotsOutput, error) {
+	i := &rds.DescribeDBClusterSnapshotsInput{
+		DBClusterSnapshotIdentifier: &snapshotID,
+	}
+	return r.DescribeDBClusterSnapshotsWithContext(ctx, i)
+}
+
 func (r RDS) DeleteDBInstance(ctx context.Context, instanceID string) (*rds.DeleteDBInstanceOutput, error) {
 	skipSnapshot := true
 	dbi := &rds.DeleteDBInstanceInput{
@@ -173,13 +180,24 @@ func (r RDS) RestoreDBInstanceFromDBSnapshot(ctx context.Context, instanceID, sn
 	return r.RestoreDBInstanceFromDBSnapshotWithContext(ctx, rdbi)
 }
 
-func (r RDS) RestoreDBClusterFromDBSnapshot(ctx context.Context, instanceID, snapshotID string, sgIDs []string) (*rds.RestoreDBClusterFromSnapshotOutput, error) {
+func (r RDS) RestoreDBClusterFromDBSnapshot(ctx context.Context, instanceID, snapshotID string, version *string, sgIDs []string) (*rds.RestoreDBClusterFromSnapshotOutput, error) {
 	engine := "aurora"
-	rdi := &rds.RestoreDBClusterFromSnapshotInput{
-		Engine:              &engine,
-		DBClusterIdentifier: &instanceID,
-		SnapshotIdentifier:  &snapshotID,
-		VpcSecurityGroupIds: convertSGIDs(sgIDs),
+	var rdi *rds.RestoreDBClusterFromSnapshotInput
+	if sgIDs == nil {
+		rdi = &rds.RestoreDBClusterFromSnapshotInput{
+			Engine:              &engine,
+			EngineVersion:       version,
+			DBClusterIdentifier: &instanceID,
+			SnapshotIdentifier:  &snapshotID,
+		}
+	} else {
+		rdi = &rds.RestoreDBClusterFromSnapshotInput{
+			Engine:              &engine,
+			EngineVersion:       version,
+			DBClusterIdentifier: &instanceID,
+			SnapshotIdentifier:  &snapshotID,
+			VpcSecurityGroupIds: convertSGIDs(sgIDs),
+		}
 	}
 	return r.RestoreDBClusterFromSnapshotWithContext(ctx, rdi)
 }

--- a/pkg/function/create_rds_snapshot.go
+++ b/pkg/function/create_rds_snapshot.go
@@ -148,6 +148,5 @@ func (crs *createRDSSnapshotFunc) Exec(ctx context.Context, tp param.TemplatePar
 func (*createRDSSnapshotFunc) RequiredArgs() []string {
 	return []string{
 		CreateRDSSnapshotInstanceIDArg,
-		string(CreateRDSSnapshotDBEngine),
 	}
 }

--- a/pkg/function/create_rds_snapshot.go
+++ b/pkg/function/create_rds_snapshot.go
@@ -42,6 +42,8 @@ const (
 	CreateRDSSnapshotFuncName = "CreateRDSSnapshot"
 	// CreateRDSSnapshotInstanceIDArg provides rds instance ID
 	CreateRDSSnapshotInstanceIDArg = "instanceID"
+	// CreateRDSSnapshotDBEngine specifies the db engine of rds instance
+	CreateRDSSnapshotDBEngine RDSDBEngine = "dbEngine"
 	// CreateRDSSnapshotSnapshotID to set snapshotID in output artifact
 	CreateRDSSnapshotSnapshotID = "snapshotID"
 	// CreateRDSSnapshotSecurityGroupID to set securityGroupIDs in output artifact
@@ -54,7 +56,7 @@ func (*createRDSSnapshotFunc) Name() string {
 	return CreateRDSSnapshotFuncName
 }
 
-func createRDSSnapshot(ctx context.Context, instanceID string, profile *param.Profile) (map[string]interface{}, error) {
+func createRDSSnapshot(ctx context.Context, instanceID, dbEngine string, profile *param.Profile) (map[string]interface{}, error) {
 	// Validate profile
 	if err := ValidateProfile(profile); err != nil {
 		return nil, errors.Wrap(err, "Profile Validation failed")
@@ -67,7 +69,7 @@ func createRDSSnapshot(ctx context.Context, instanceID string, profile *param.Pr
 	}
 
 	// Create rds client
-	rdsCli, err := rds.NewClient(ctx, awsConfig, region)
+	rdsCli, err := rds.NewClient(ctx, awsConfig, region, dbEngine)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create RDS client")
 	}
@@ -108,12 +110,21 @@ func createRDSSnapshot(ctx context.Context, instanceID string, profile *param.Pr
 
 func (crs *createRDSSnapshotFunc) Exec(ctx context.Context, tp param.TemplateParams, args map[string]interface{}) (map[string]interface{}, error) {
 	var instanceID string
+	var dbEngine RDSDBEngine
 	if err := Arg(args, CreateRDSSnapshotInstanceIDArg, &instanceID); err != nil {
 		return nil, err
 	}
-	return createRDSSnapshot(ctx, instanceID, tp.Profile)
+
+	if err := OptArg(args, CreateRDSSnapshotDBEngine, &dbEngine); err != nil {
+		return nil, err
+	}
+
+	return createRDSSnapshot(ctx, instanceID, dbEngine, tp.Profile)
 }
 
 func (*createRDSSnapshotFunc) RequiredArgs() []string {
-	return []string{CreateRDSSnapshotInstanceIDArg}
+	return []string{
+		CreateRDSSnapshotInstanceIDArg,
+		string(CreateRDSSnapshotDBEngine),
+	}
 }

--- a/pkg/function/create_rds_snapshot.go
+++ b/pkg/function/create_rds_snapshot.go
@@ -52,7 +52,7 @@ const (
 	DBEngineAurora RDSDBEngine = "aurora"
 	// DBEngineAuroraMySQL has db engine for MySQL 5.7-compatible Aurora
 	DBEngineAuroraMySQL RDSDBEngine = "aurora-mysql"
-	// DBEngineAuroraPostgreSQL has db engine aurora postgresql
+	// DBEngineAuroraPostgreSQL has db engine for aurora postgresql
 	DBEngineAuroraPostgreSQL RDSDBEngine = "aurora-postgresql"
 )
 

--- a/pkg/function/utils.go
+++ b/pkg/function/utils.go
@@ -156,6 +156,19 @@ func findSecurityGroups(ctx context.Context, rdsCli *rds.RDS, instanceID string)
 	return sgIDs, err
 }
 
+func findAuroraSecurityGroups(ctx context.Context, rdsCli *rds.RDS, instanceID string) ([]string, error) {
+	desc, err := rdsCli.DescribeDBClusters(ctx, instanceID)
+	if err != nil {
+		return nil, err
+	}
+
+	var sgIDs []string
+	for _, vpc := range desc.DBClusters[0].VpcSecurityGroups {
+		sgIDs = append(sgIDs, *vpc.VpcSecurityGroupId)
+	}
+	return nil, nil
+}
+
 // findRDSEndpoint returns endpoint to access RDS instance
 func findRDSEndpoint(ctx context.Context, rdsCli *rds.RDS, instanceID string) (string, error) {
 	// Find host of the instance

--- a/pkg/function/utils.go
+++ b/pkg/function/utils.go
@@ -207,3 +207,12 @@ func createPostgresSecret(cli kubernetes.Interface, name, namespace, username, p
 func deletePostgresSecret(cli kubernetes.Interface, name, namespace string) error {
 	return cli.CoreV1().Secrets(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
 }
+
+func isAuroraCluster(engine string) bool {
+	for _, v := range []string{string(DBEngineAurora), string(DBEngineAuroraMySQL), string(DBEngineAuroraPostgreSQL)} {
+		if engine == v {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Change Overview

The backup mechanism as of now was db engine independent
and we simply used the API `CreateDBSnapshot` to create
the snapshot of the RDS instance that was provided in the
blueprint.
But in case of Aurora DB that seems to be a problem and
other API is suggested to be used.

```
InvalidParameterValue: The specified
      instance is a member of a cluster and a snapshot cannot be created
      directly. Please use the CreateDBClusterSnapshot API instead.
```
This PR tries to achive that by adding another optional argument in
the kanister function def.

## Pull request type

Please check the type of change your PR introduces:

- [x] :hamster: Trivial/Minor
- [x] :sunflower: Feature

## Issues

- #XXX

## Test Plan

- [x] :muscle: Manual

### Make sure postgres is not regressed 
Make sure we didn't break things with rds-postgres, create blueprint using [this blueprint](https://github.com/kanisterio/kanister/blob/master/examples/aws-rds/postgresql/rds-postgres-snap-blueprint.yaml) and create the actionset to take backup 
```
» cat pg-actionset.yaml 
apiVersion: cr.kanister.io/v1alpha1
kind: ActionSet
metadata:
  name: pg-backup
  namespace: kanister
spec:
  actions:
  - name: backup
    blueprint: rds-postgres-snapshot-bp 
    object:
      apiVersion: v1
      name: pg-details 
      namespace: pg-rds 
      resource: configmaps
    profile:
      name: s3-profile-s8dj5 
      namespace: pg-rds 
```
make sure snapshot of postgres instance is created successfully.
Create restore using command 
```
 kanctl create actionset --namespace kanister --action restore --from pg-backup        
actionset restore-pg-backup-n5nc4 created
```
The logs  can be found [here](https://gist.github.com/ec9f39c62ca64891be91096fca3e40e1).

### Test aurora db cluster with mysql engine 

```
» k apply -f rds-aurora-snap-blueprint.yaml -n kanister
blueprint.cr.kanister.io/rds-aurora-snapshot-bp configured

» k create configmap -n aurora-rds aurora-details --from-literal aurora.clusterID=aurora-mysq-engine
configmap/aurora-details created

```
create the actionset using 
```
» cat actionset.yaml 
apiVersion: cr.kanister.io/v1alpha1
kind: ActionSet
metadata:
  name: rds-aurora-backup
  namespace: kanister
spec:
  actions:
  - name: backup
    blueprint: rds-aurora-snapshot-bp 
    object:
      apiVersion: v1
      name: aurora-details 
      namespace: aurora-rds
      resource: configmaps
    profile:
      name: s3-profile-s8dj5 
      namespace: pg-rds 
```
create restore action using 
```
» kanctl create actionset --namespace kanister --action restore --from rds-aurora-backup
actionset restore-rds-aurora-backup-8f7wl created
```
the logs can be found [here](https://gist.github.com/de5b6bc3f0bb631e032cd2a45037f43c).