### PR TITLE
Add objectmeta override to ActionSpec

### DIFF
--- a/examples/stable/mongodb/mongo-blueprint.yaml
+++ b/examples/stable/mongodb/mongo-blueprint.yaml
@@ -32,10 +32,10 @@ actions:
             dbPassword='{{ index .Phases.takeConsistentBackup.Secrets.mongosecret.Data "mongodb-root-password" | toString }}'
             dump_cmd="mongodump --oplog --gzip --archive --host ${host} -u root -p ${dbPassword}"
             ${dump_cmd} | kando location push --profile '{{ toJson .Profile }}' --path '/mongodb-replicaset-backups/{{ .StatefulSet.Name }}/{{ toDate "2006-01-02T15:04:05.999999999Z07:00" .Time  | date "2006-01-02T15-04-05" }}/rs_backup.gz' -
-      objectMetaOverride:
-        labels:
-          name: ankit
-          id: 123
+        objectMetaOverride:
+          labels:
+            name: ankit
+            id: 123
   restore:
     type: StatefulSet
     inputArtifactNames:
@@ -63,10 +63,10 @@ actions:
             dbPassword='{{ index .Phases.pullFromBlobStore.Secrets.mongosecret.Data "mongodb-root-password" | toString }}'
             restore_cmd="mongorestore --gzip --archive --oplogReplay --drop --host ${host} -u root -p ${dbPassword}"
             kando location pull --profile '{{ toJson .Profile }}' --path '{{ .ArtifactsIn.cloudObject.KeyValue.path }}' - | ${restore_cmd}
-      objectMetaOverride:
-        labels:
-          name: ankit
-          id: 123
+        objectMetaOverride:
+          labels:
+            name: ankit
+            id: 123
   delete:
     type: Namespace
     inputArtifactNames:
@@ -87,7 +87,7 @@ actions:
           - |
             s3_path="{{ .ArtifactsIn.cloudObject.KeyValue.path }}"
             kando location delete --profile '{{ toJson .Profile }}' --path ${s3_path}
-      objectMetaOverride:
-        labels:
-          name: ankit
-          id: 123
+        objectMetaOverride:
+          labels:
+            name: ankit
+            id: 123

--- a/examples/stable/mongodb/mongo-blueprint.yaml
+++ b/examples/stable/mongodb/mongo-blueprint.yaml
@@ -32,6 +32,10 @@ actions:
             dbPassword='{{ index .Phases.takeConsistentBackup.Secrets.mongosecret.Data "mongodb-root-password" | toString }}'
             dump_cmd="mongodump --oplog --gzip --archive --host ${host} -u root -p ${dbPassword}"
             ${dump_cmd} | kando location push --profile '{{ toJson .Profile }}' --path '/mongodb-replicaset-backups/{{ .StatefulSet.Name }}/{{ toDate "2006-01-02T15:04:05.999999999Z07:00" .Time  | date "2006-01-02T15-04-05" }}/rs_backup.gz' -
+      objectMetaOverride:
+        labels:
+          name: ankit
+          id: 123
   restore:
     type: StatefulSet
     inputArtifactNames:
@@ -59,6 +63,10 @@ actions:
             dbPassword='{{ index .Phases.pullFromBlobStore.Secrets.mongosecret.Data "mongodb-root-password" | toString }}'
             restore_cmd="mongorestore --gzip --archive --oplogReplay --drop --host ${host} -u root -p ${dbPassword}"
             kando location pull --profile '{{ toJson .Profile }}' --path '{{ .ArtifactsIn.cloudObject.KeyValue.path }}' - | ${restore_cmd}
+      objectMetaOverride:
+        labels:
+          name: ankit
+          id: 123
   delete:
     type: Namespace
     inputArtifactNames:
@@ -79,3 +87,7 @@ actions:
           - |
             s3_path="{{ .ArtifactsIn.cloudObject.KeyValue.path }}"
             kando location delete --profile '{{ toJson .Profile }}' --path ${s3_path}
+      objectMetaOverride:
+        labels:
+          name: ankit
+          id: 123

--- a/pkg/apis/cr/v1alpha1/types.go
+++ b/pkg/apis/cr/v1alpha1/types.go
@@ -23,6 +23,7 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	sp "k8s.io/apimachinery/pkg/util/strategicpatch"
@@ -111,6 +112,9 @@ type ActionSpec struct {
 	// PreferredVersion will be used to select the preferred version of Kanister functions
 	// to be executed for this action
 	PreferredVersion string `json:"preferredVersion"`
+	// ObjectMetaOverride is used to specify ObjectMeta that will override the
+	// default ObjectMeta
+	ObjectMetaOverride v1.ObjectMeta `json:"objectMetaOverride,omitempty"`
 }
 
 // ActionSetStatus is the status for the actionset. This should only be updated by the controller.

--- a/pkg/apis/cr/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/cr/v1alpha1/zz_generated.deepcopy.go
@@ -182,6 +182,7 @@ func (in *ActionSpec) DeepCopyInto(out *ActionSpec) {
 			(*out)[key] = val
 		}
 	}
+	in.ObjectMetaOverride.DeepCopyInto(&out.ObjectMetaOverride)
 	return
 }
 

--- a/pkg/function/args.go
+++ b/pkg/function/args.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	"github.com/kanisterio/kanister/pkg/kube"
@@ -68,6 +69,17 @@ func GetPodSpecOverride(tp param.TemplateParams, args map[string]interface{}, ar
 		}
 	}
 	return podOverride, nil
+}
+
+// GetObjectMetaOverride gets object meta override from args
+func GetObjectMetaOverride(tp param.TemplateParams, args map[string]interface{}, argName string) (*v1.ObjectMeta, error) {
+	var objectMeta v1.ObjectMeta
+	var err error
+	if err = OptArg(args, KubeTaskObjectMetaOverrideArg, &objectMeta, tp.ObjectMetaOverride); err != nil {
+		return nil, err
+	}
+
+	return &objectMeta, nil
 }
 
 // GetYamlList parses yaml formatted list arg and converts it into slice of string.

--- a/pkg/function/export_rds_snapshot_location.go
+++ b/pkg/function/export_rds_snapshot_location.go
@@ -218,7 +218,7 @@ func execDumpCommand(ctx context.Context, dbEngine RDSDBEngine, action RDSAction
 		}
 	}()
 
-	return kubeTask(ctx, cli, namespace, image, command, injectPostgresSecrets(secretName))
+	return kubeTask(ctx, cli, namespace, image, command, injectPostgresSecrets(secretName), nil)
 }
 
 func prepareCommand(ctx context.Context, dbEngine RDSDBEngine, action RDSAction, dbEndpoint, username, password string, dbList []string, backupPrefix, backupID string, profile *param.Profile) ([]string, string, error) {

--- a/pkg/function/kube_task.go
+++ b/pkg/function/kube_task.go
@@ -16,7 +16,6 @@ package function
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
@@ -35,11 +34,12 @@ import (
 const (
 	jobPrefix = "kanister-job-"
 	// KubeTaskFuncName gives the function name
-	KubeTaskFuncName       = "KubeTask"
-	KubeTaskNamespaceArg   = "namespace"
-	KubeTaskImageArg       = "image"
-	KubeTaskCommandArg     = "command"
-	KubeTaskPodOverrideArg = "podOverride"
+	KubeTaskFuncName              = "KubeTask"
+	KubeTaskNamespaceArg          = "namespace"
+	KubeTaskImageArg              = "image"
+	KubeTaskCommandArg            = "command"
+	KubeTaskPodOverrideArg        = "podOverride"
+	KubeTaskObjectMetaOverrideArg = "objectMetaOverride"
 )
 
 func init() {
@@ -113,14 +113,16 @@ func (ktf *kubeTaskFunc) Exec(ctx context.Context, tp param.TemplateParams, args
 		return nil, err
 	}
 
-	fmt.Println("omo", tp.ObjectMetaOverride)
-	objectMetaOverride := tp.ObjectMetaOverride
+	objectMetaOverride, err := GetObjectMetaOverride(tp, args, KubeTaskPodOverrideArg)
+	if err != nil {
+		return nil, err
+	}
 
 	cli, err := kube.NewClient()
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed to create Kubernetes client")
 	}
-	return kubeTask(ctx, cli, namespace, image, command, podOverride, &objectMetaOverride)
+	return kubeTask(ctx, cli, namespace, image, command, podOverride, objectMetaOverride)
 }
 
 func (*kubeTaskFunc) RequiredArgs() []string {

--- a/pkg/param/param.go
+++ b/pkg/param/param.go
@@ -16,7 +16,6 @@ package param
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -154,8 +153,6 @@ func New(ctx context.Context, cli kubernetes.Interface, dynCli dynamic.Interface
 		return nil, err
 	}
 	now := time.Now().UTC()
-	fmt.Println("AS :: ", as)
-	fmt.Println("1OMO : ", as.ObjectMetaOverride)
 	tp := TemplateParams{
 		ArtifactsIn:        as.Artifacts,
 		ConfigMaps:         cms,

--- a/pkg/param/param.go
+++ b/pkg/param/param.go
@@ -16,6 +16,7 @@ package param
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -39,20 +40,21 @@ const timeFormat = time.RFC3339Nano
 
 // TemplateParams are the values that will change between separate runs of Phases.
 type TemplateParams struct {
-	StatefulSet      *StatefulSetParams
-	DeploymentConfig *DeploymentConfigParams
-	Deployment       *DeploymentParams
-	PVC              *PVCParams
-	Namespace        *NamespaceParams
-	ArtifactsIn      map[string]crv1alpha1.Artifact
-	ConfigMaps       map[string]v1.ConfigMap
-	Secrets          map[string]v1.Secret
-	Time             string
-	Profile          *Profile
-	Options          map[string]string
-	Object           map[string]interface{}
-	Phases           map[string]*Phase
-	PodOverride      crv1alpha1.JSONMap
+	StatefulSet        *StatefulSetParams
+	DeploymentConfig   *DeploymentConfigParams
+	Deployment         *DeploymentParams
+	PVC                *PVCParams
+	Namespace          *NamespaceParams
+	ArtifactsIn        map[string]crv1alpha1.Artifact
+	ConfigMaps         map[string]v1.ConfigMap
+	Secrets            map[string]v1.Secret
+	Time               string
+	Profile            *Profile
+	Options            map[string]string
+	Object             map[string]interface{}
+	Phases             map[string]*Phase
+	PodOverride        crv1alpha1.JSONMap
+	ObjectMetaOverride metav1.ObjectMeta
 }
 
 // DeploymentConfigParams are params for deploymentconfig, will be used if working on open shift cluster
@@ -152,14 +154,17 @@ func New(ctx context.Context, cli kubernetes.Interface, dynCli dynamic.Interface
 		return nil, err
 	}
 	now := time.Now().UTC()
+	fmt.Println("AS :: ", as)
+	fmt.Println("1OMO : ", as.ObjectMetaOverride)
 	tp := TemplateParams{
-		ArtifactsIn: as.Artifacts,
-		ConfigMaps:  cms,
-		Secrets:     secrets,
-		Profile:     prof,
-		Time:        now.Format(timeFormat),
-		Options:     as.Options,
-		PodOverride: as.PodOverride,
+		ArtifactsIn:        as.Artifacts,
+		ConfigMaps:         cms,
+		Secrets:            secrets,
+		Profile:            prof,
+		Time:               now.Format(timeFormat),
+		Options:            as.Options,
+		PodOverride:        as.PodOverride,
+		ObjectMetaOverride: as.ObjectMetaOverride,
 	}
 	var gvr schema.GroupVersionResource
 	namespace := as.Object.Namespace


### PR DESCRIPTION
## Change Overview

This PR adds handling to allow override objectMeta for kanister pods by specifying as args while creating actionsets.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [x] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E

- After setting labels in args as:
```
      args:
        objectMetaOverride:
          labels:
            name: ankit
            id: 123
```
- Verified in kanister-job pod launched that the labels were present:
```
apiVersion: v1
kind: Pod
metadata:
  creationTimestamp: "2021-02-26T13:34:34Z"
  generateName: kanister-job-
  labels:
    createdBy: kanister
    id: "123"
    name: ankit
```