### PR TITLE
Adding accessmode to Create PVCs and PVs

### DIFF
--- a/pkg/function/create_volume_from_snapshot.go
+++ b/pkg/function/create_volume_from_snapshot.go
@@ -106,11 +106,11 @@ func createVolumeFromSnapshot(ctx context.Context, cli kubernetes.Interface, nam
 		}
 
 		annotations := map[string]string{}
-		pvc, err := kubevolume.CreatePVC(ctx, cli, namespace, pvcName, vol.SizeInBytes, vol.ID, annotations)
+		pvc, err := kubevolume.CreatePVC(ctx, cli, namespace, pvcName, vol.SizeInBytes, vol.ID, annotations, nil)
 		if err != nil {
 			return nil, errors.Wrapf(err, "Unable to create PVC for volume %v", *vol)
 		}
-		pv, err := kubevolume.CreatePV(ctx, cli, vol, vol.Type, annotations)
+		pv, err := kubevolume.CreatePV(ctx, cli, vol, vol.Type, annotations, nil)
 		if err != nil {
 			return nil, errors.Wrapf(err, "Unable to create PV for volume %v", *vol)
 		}

--- a/pkg/kube/volume/volume.go
+++ b/pkg/kube/volume/volume.go
@@ -55,7 +55,7 @@ func CreatePVC(ctx context.Context, kubeCli kubernetes.Interface, ns string, nam
 	if err != nil {
 		return "", errors.Wrapf(err, "Unable to parse sizeFmt %s", sizeFmt)
 	}
-	if accessmodes == nil {
+	if len(accessmodes) == 0 {
 		accessmodes = []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}
 	}
 	pvc := v1.PersistentVolumeClaim{
@@ -138,7 +138,7 @@ func CreatePVCFromSnapshot(ctx context.Context, args *CreatePVCFromSnapshotArgs)
 		return "", fmt.Errorf("Restore size is empty and no restore size argument given, Volumesnapshot: %s", args.SnapshotName)
 	}
 
-	if args.AccessModes == nil {
+	if len(args.AccessModes) == 0 {
 		args.AccessModes = []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}
 	}
 	snapshotKind := "VolumeSnapshot"
@@ -198,7 +198,7 @@ func CreatePV(ctx context.Context, kubeCli kubernetes.Interface, vol *blockstora
 		return pvl.Items[0].Name, nil
 	}
 
-	if accessmodes == nil {
+	if len(accessmodes) == 0 {
 		accessmodes = []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}
 	}
 

--- a/pkg/kube/volume/volume_test.go
+++ b/pkg/kube/volume/volume_test.go
@@ -40,7 +40,7 @@ func (s *TestVolSuite) TestCreatePVC(c *C) {
 	targetVolID := "testVolID"
 	annotations := map[string]string{"a1": "foo"}
 	cli := fake.NewSimpleClientset()
-	pvcName, err := CreatePVC(ctx, cli, ns, NoPVCNameSpecified, pvcSize, targetVolID, annotations)
+	pvcName, err := CreatePVC(ctx, cli, ns, NoPVCNameSpecified, pvcSize, targetVolID, annotations, []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce})
 	c.Assert(err, IsNil)
 	pvc, err := cli.CoreV1().PersistentVolumeClaims(ns).Get(ctx, pvcName, metav1.GetOptions{})
 	c.Assert(err, IsNil)
@@ -56,4 +56,10 @@ func (s *TestVolSuite) TestCreatePVC(c *C) {
 	c.Assert(len(pvc.Spec.Selector.MatchLabels) >= 1, Equals, true)
 	label := pvc.Spec.Selector.MatchLabels[pvMatchLabelName]
 	c.Assert(label, Equals, filepath.Base(targetVolID))
+
+	_, err = CreatePVC(ctx, cli, ns, "pvc2", pvcSize, targetVolID, annotations, nil)
+	c.Assert(err, IsNil)
+	pvc2, err := cli.CoreV1().PersistentVolumeClaims(ns).Get(ctx, "pvc2", metav1.GetOptions{})
+	c.Assert(err, IsNil)
+	c.Assert(len(pvc2.Spec.AccessModes) >= 1, Equals, true)
 }


### PR DESCRIPTION
## Change Overview

Until now Accessmodes have been hardcoded. This change to the create methods allows the accessmode to be set.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [x] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
