### PR TITLE
Expose EBS volume state through volume attributes

### DIFF
--- a/pkg/blockstorage/awsebs/awsebs.go
+++ b/pkg/blockstorage/awsebs/awsebs.go
@@ -144,6 +144,12 @@ func (s *EbsStorage) volumeParse(ctx context.Context, volume interface{}) *block
 	for _, tag := range vol.Tags {
 		tags = append(tags, &blockstorage.KeyValue{Key: aws.StringValue(tag.Key), Value: aws.StringValue(tag.Value)})
 	}
+	var attrs map[string]string
+	if vol.State != nil {
+		attrs = map[string]string{
+			"State": *vol.State,
+		}
+	}
 	return &blockstorage.Volume{
 		Type:         s.Type(),
 		ID:           aws.StringValue(vol.VolumeId),
@@ -151,6 +157,7 @@ func (s *EbsStorage) volumeParse(ctx context.Context, volume interface{}) *block
 		Encrypted:    aws.BoolValue(vol.Encrypted),
 		VolumeType:   aws.StringValue(vol.VolumeType),
 		SizeInBytes:  aws.Int64Value(vol.Size) * blockstorage.BytesInGi,
+		Attributes:   attrs,
 		Tags:         tags,
 		Iops:         aws.Int64Value(vol.Iops),
 		CreationTime: blockstorage.TimeStamp(aws.TimeValue(vol.CreateTime)),

--- a/pkg/blockstorage/awsebs/awsebs_test.go
+++ b/pkg/blockstorage/awsebs/awsebs_test.go
@@ -17,10 +17,14 @@ package awsebs
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/service/ec2"
 	. "gopkg.in/check.v1"
+
+	"github.com/kanisterio/kanister/pkg/blockstorage"
 )
 
 // Hook up gocheck into the "go test" runner.
@@ -40,4 +44,52 @@ func (s AWSEBSSuite) TestQueryRegionToZones(c *C) {
 	zs, err := provider.queryRegionToZones(ctx, region)
 	c.Assert(err, IsNil)
 	c.Assert(zs, DeepEquals, []string{"us-east-1a", "us-east-1b", "us-east-1c", "us-east-1d", "us-east-1e", "us-east-1f"})
+}
+
+func (s AWSEBSSuite) TestVolumeParse(c *C) {
+	expected := blockstorage.Volume{
+		Az:           "the-availability-zone",
+		CreationTime: blockstorage.TimeStamp(time.Date(2008, 8, 21, 5, 50, 0, 0, time.UTC)),
+		Encrypted:    true,
+		ID:           "the-volume-id",
+		Iops:         42,
+		SizeInBytes:  45097156608, // 42 * 1024 * 1024 * 1024
+		Tags: blockstorage.VolumeTags{
+			{Key: "a-tag", Value: "a-value"},
+			{Key: "another-tag", Value: "another-value"},
+		},
+		Type:       blockstorage.TypeEBS,
+		VolumeType: "the-volume-type",
+		Attributes: map[string]string{
+			"State": "the-state",
+		},
+	}
+
+	storage := EbsStorage{}
+	volume := storage.volumeParse(context.TODO(), &ec2.Volume{
+		AvailabilityZone: aws.String("the-availability-zone"),
+		CreateTime:       aws.Time(time.Date(2008, 8, 21, 5, 50, 0, 0, time.UTC)),
+		Encrypted:        aws.Bool(true),
+		Iops:             aws.Int64(42),
+		Size:             aws.Int64(42),
+		State:            aws.String("the-state"),
+		Tags: []*ec2.Tag{
+			{Key: aws.String("a-tag"), Value: aws.String("a-value")},
+			{Key: aws.String("another-tag"), Value: aws.String("another-value")},
+		},
+		VolumeId:   aws.String("the-volume-id"),
+		VolumeType: aws.String("the-volume-type"),
+	})
+
+	c.Assert(volume, Not(IsNil))
+	c.Check(volume.Az, Equals, expected.Az)
+	c.Check(volume.CreationTime, Equals, expected.CreationTime)
+	c.Check(volume.Encrypted, Equals, expected.Encrypted)
+	c.Check(volume.ID, Equals, expected.ID)
+	c.Check(volume.Iops, Equals, expected.Iops)
+	c.Check(volume.SizeInBytes, Equals, expected.SizeInBytes)
+	c.Check(volume.Tags, DeepEquals, expected.Tags)
+	c.Check(volume.Type, Equals, blockstorage.TypeEBS)
+	c.Check(volume.VolumeType, Equals, expected.VolumeType)
+	c.Check(volume.Attributes, DeepEquals, expected.Attributes)
 }


### PR DESCRIPTION
## Change Overview

An EBS volume's state is critical information denoting whether the volume is attached or not (among other things). However, this is provider-specific, so we'll expose it through the attributes.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [X] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- N/A

## Test Plan

- [ ] :muscle: Manual
- [X] :zap: Unit test
- [ ] :green_heart: E2E
