### PR TITLE
Add a new PodOption to override default container name

### DIFF
--- a/pkg/kube/pod.go
+++ b/pkg/kube/pod.go
@@ -37,14 +37,16 @@ import (
 
 const (
 	// podReadyWaitTimeout is the time to wait for pod to be ready
-	podReadyWaitTimeout = 15 * time.Minute
-	errAccessingNode    = "Failed to get node"
+	podReadyWaitTimeout  = 15 * time.Minute
+	errAccessingNode     = "Failed to get node"
+	defaultContainerName = "container"
 )
 
 // PodOptions specifies options for `CreatePod`
 type PodOptions struct {
 	Annotations        map[string]string
 	Command            []string
+	ContainerName      string
 	GenerateName       string
 	Image              string
 	Labels             map[string]string
@@ -81,7 +83,7 @@ func CreatePod(ctx context.Context, cli kubernetes.Interface, opts *PodOptions) 
 	defaultSpecs := v1.PodSpec{
 		Containers: []v1.Container{
 			{
-				Name:            "container",
+				Name:            defaultContainerName,
 				Image:           opts.Image,
 				Command:         opts.Command,
 				ImagePullPolicy: v1.PullPolicy(v1.PullIfNotPresent),
@@ -112,6 +114,11 @@ func CreatePod(ctx context.Context, cli kubernetes.Interface, opts *PodOptions) 
 			},
 		},
 		Spec: patchedSpecs,
+	}
+
+	// Override default container name if applicable
+	if opts.ContainerName != "" {
+		pod.Spec.Containers[0].Name = opts.ContainerName
 	}
 
 	// Add Annotations and Labels, if specified

--- a/pkg/kube/pod_test.go
+++ b/pkg/kube/pod_test.go
@@ -150,6 +150,16 @@ func (s *PodSuite) TestPod(c *C) {
 				},
 			},
 		},
+		{
+			Namespace:     s.namespace,
+			GenerateName:  "test-",
+			Image:         kanisterToolsImage,
+			ContainerName: "test-container",
+			Command:       []string{"sh", "-c", "tail -f /dev/null"},
+			Labels: map[string]string{
+				"run": "pod",
+			},
+		},
 	}
 
 	for _, po := range podOptions {
@@ -187,6 +197,13 @@ func (s *PodSuite) TestPod(c *C) {
 		if po.Resources.Requests != nil {
 			c.Assert(pod.Spec.Containers[0].Resources.Requests, NotNil)
 			c.Assert(pod.Spec.Containers[0].Resources.Requests, DeepEquals, po.Resources.Requests)
+		}
+
+		switch {
+		case po.ContainerName != "":
+			c.Assert(pod.Spec.Containers[0].Name, Equals, po.ContainerName)
+		default:
+			c.Assert(pod.Spec.Containers[0].Name, Equals, defaultContainerName)
 		}
 
 		c.Assert(err, IsNil)


### PR DESCRIPTION
## Change Overview

Add a new PodOption to override default container name

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [x] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E

```
$ go test -v -check.f="PodSuite" .
=== RUN   Test
found pod
OK: 4 passed
--- PASS: Test (41.18s)
PASS
ok      github.com/kanisterio/kanister/pkg/kube 41.188s
```