### PR TITLE
Update baseimage to ubi-minimal 8.3

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -1,4 +1,4 @@
-ARG base_image=registry.access.redhat.com/ubi8/ubi-minimal:8.1
+ARG base_image=registry.access.redhat.com/ubi8/ubi-minimal:8.3
 FROM ${base_image}
 ARG kanister_version
 

--- a/docker/controller/Dockerfile
+++ b/docker/controller/Dockerfile
@@ -1,4 +1,5 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3
+
 MAINTAINER Tom Manville<tom@kasten.io>
 
 ADD controller /controller

--- a/docker/controller/Dockerfile
+++ b/docker/controller/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3
 MAINTAINER Tom Manville<tom@kasten.io>
 
 ADD controller /controller


### PR DESCRIPTION
## Change Overview

This PR changes the baseimage version of kanister to red hat ubi-minimal 8.3 instead of 8.1

## Pull request type

Please check the type of change your PR introduces:

- [x] :hamster: Trivial/Minor

## Issues

- #XXX

## Test Plan

NA