### PR TITLE
update postgreSQL helm values to be compatible with latest chart version 10.3.15 

### DIFF
--- a/pkg/app/postgresql.go
+++ b/pkg/app/postgresql.go
@@ -40,7 +40,7 @@ type PostgresDB struct {
 	namespace string
 }
 
-// Last tested chart version "9.0.0"
+// Last tested chart version "10.3.15"
 func NewPostgresDB(name string, subPath string) App {
 	return &PostgresDB{
 		name: name,
@@ -54,7 +54,7 @@ func NewPostgresDB(name string, subPath string) App {
 				"image.repository":                      "kanisterio/postgresql",
 				"image.tag":                             "0.50.0",
 				"postgresqlPassword":                    "test@54321",
-				"postgresqlExtendedConf.archiveCommand": "'envdir /bitnami/postgresql/data/env wal-e wal-push %p'",
+				"postgresqlExtendedConf.archiveCommand": "envdir /bitnami/postgresql/data/env wal-e wal-push %p",
 				"postgresqlExtendedConf.archiveMode":    "true",
 				"postgresqlExtendedConf.archiveTimeout": "60",
 				"postgresqlExtendedConf.walLevel":       "archive",


### PR DESCRIPTION
## Change Overview

This PR update the helm option `postgresqlExtendedConf.archiveCommand` value to be compatible with latest postgreSQL chart version `10.3.15`

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- K10-6689

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->
`make integration-test`
- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
