### PR TITLE
Use latest tools images in test Blueprints

### DIFF
--- a/pkg/app/bp.go
+++ b/pkg/app/bp.go
@@ -82,6 +82,16 @@ func updateImageTags(bp *crv1alpha1.Blueprint) {
 
 			// ghcr.io/kanisterio/tools:v0.xx.x => ghcr.io/kanisterio/tools:latest
 			phase.Args["image"] = fmt.Sprintf("%s:latest", strings.Split(imageStr, ":")[0])
+
+			// Change imagePullPolicy to Always using podOverride config
+			phase.Args["podOverride"] = crv1alpha1.JSONMap{
+				"containers": []map[string]interface{}{
+					{
+						"name":            "container",
+						"imagePullPolicy": "Always",
+					},
+				},
+			}
 		}
 	}
 }

--- a/pkg/app/bp_test.go
+++ b/pkg/app/bp_test.go
@@ -1,0 +1,153 @@
+// Copyright 2021 The Kanister Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	. "gopkg.in/check.v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
+	"github.com/kanisterio/kanister/pkg/function"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) { TestingT(t) }
+
+type BlueprintSuite struct{}
+
+var _ = Suite(&BlueprintSuite{})
+
+func (bs *BlueprintSuite) TestUpdateImageTags(c *C) {
+	for _, bp := range []*crv1alpha1.Blueprint{
+		// BP with no phase with image arg
+		&crv1alpha1.Blueprint{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-blueprint-",
+			},
+			Actions: map[string]*crv1alpha1.BlueprintAction{
+				"test": &crv1alpha1.BlueprintAction{
+					Kind: "Deployment",
+					Phases: []crv1alpha1.BlueprintPhase{
+						crv1alpha1.BlueprintPhase{
+							Func: function.KubeExecFuncName,
+							Name: "test-kube-exec",
+							Args: map[string]interface{}{
+								"namespace": "{{ .Deployment.Namespace }}",
+								"pod":       "{{ index .Deployment.Pods 0 }}",
+								"container": "test-container",
+								"command":   []string{"echo", "hello"},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		// BP with multiple phases with image arg
+		&crv1alpha1.Blueprint{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-blueprint-",
+			},
+			Actions: map[string]*crv1alpha1.BlueprintAction{
+				"test": &crv1alpha1.BlueprintAction{
+					Kind: "Deployment",
+					Phases: []crv1alpha1.BlueprintPhase{
+						crv1alpha1.BlueprintPhase{
+							Func: function.KubeTaskFuncName,
+							Name: "test-kube-task",
+							Args: map[string]interface{}{
+								"namespace": "{{ .Deployment.Namespace }}",
+								"image":     "ghcr.io/image:v0.50.0",
+								"command":   []string{"echo", "hello"},
+							},
+						},
+						crv1alpha1.BlueprintPhase{
+							Func: function.KubeTaskFuncName,
+							Name: "test-kube-task2",
+							Args: map[string]interface{}{
+								"namespace": "{{ .Deployment.Namespace }}",
+								"image":     "ghcr.io/image2:v0.50.0",
+							},
+						},
+					},
+				},
+			},
+		},
+
+		// BP with multiple actions
+		&crv1alpha1.Blueprint{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-blueprint-",
+			},
+			Actions: map[string]*crv1alpha1.BlueprintAction{
+				"test": &crv1alpha1.BlueprintAction{
+					Kind: "Deployment",
+					Phases: []crv1alpha1.BlueprintPhase{
+						crv1alpha1.BlueprintPhase{
+							Func: function.KubeTaskFuncName,
+							Name: "test-kube-task",
+							Args: map[string]interface{}{
+								"namespace": "{{ .Deployment.Namespace }}",
+								"image":     "ghcr.io/image:v0.50.0",
+								"command":   []string{"echo", "hello"},
+							},
+						},
+						crv1alpha1.BlueprintPhase{
+							Func: function.KubeTaskFuncName,
+							Name: "test-kube-task2",
+							Args: map[string]interface{}{
+								"namespace": "{{ .Deployment.Namespace }}",
+								"image":     "ghcr.io/image2:v0.50.0",
+							},
+						},
+					},
+				},
+				"test2": &crv1alpha1.BlueprintAction{
+					Phases: []crv1alpha1.BlueprintPhase{
+						crv1alpha1.BlueprintPhase{
+							Func: function.PrepareDataFuncName,
+							Name: "test-prepare-data",
+							Args: map[string]interface{}{
+								"namespace": "{{ .Deployment.Namespace }}",
+								"image":     "ghcr.io/image/tools:v0.40.0",
+							},
+						},
+					},
+				},
+			},
+		},
+	} {
+		updateImageTags(bp)
+		validateImageTags(c, bp)
+	}
+}
+
+func validateImageTags(c *C, bp *crv1alpha1.Blueprint) {
+	for _, a := range bp.Actions {
+		for _, phase := range a.Phases {
+			image, ok := phase.Args["image"]
+			if !ok {
+				continue
+			}
+			// Verify if the tag is "latest"
+			c.Log(fmt.Sprintf("phase:%s, image:%s", phase.Name, image.(string)))
+			c.Assert(strings.Split(image.(string), ":")[1], Equals, "latest")
+		}
+	}
+}

--- a/pkg/app/bp_test.go
+++ b/pkg/app/bp_test.go
@@ -139,6 +139,14 @@ func (bs *BlueprintSuite) TestUpdateImageTags(c *C) {
 }
 
 func validateImageTags(c *C, bp *crv1alpha1.Blueprint) {
+	podOverride := crv1alpha1.JSONMap{
+		"containers": []map[string]interface{}{
+			{
+				"name":            "container",
+				"imagePullPolicy": "Always",
+			},
+		},
+	}
 	for _, a := range bp.Actions {
 		for _, phase := range a.Phases {
 			image, ok := phase.Args["image"]
@@ -148,6 +156,7 @@ func validateImageTags(c *C, bp *crv1alpha1.Blueprint) {
 			// Verify if the tag is "latest"
 			c.Log(fmt.Sprintf("phase:%s, image:%s", phase.Name, image.(string)))
 			c.Assert(strings.Split(image.(string), ":")[1], Equals, "latest")
+			c.Assert(phase.Args["podOverride"], DeepEquals, podOverride)
 		}
 	}
 }

--- a/pkg/testing/integration_register.go
+++ b/pkg/testing/integration_register.go
@@ -33,7 +33,7 @@ var _ = Suite(&PITRPostgreSQL{
 		name:      "pitr-postgres",
 		namespace: "pitr-postgres-test",
 		app:       app.NewPostgresDB("pitr-postgres", ""),
-		bp:        app.NewPITRBlueprint("pitr-postgres", ""),
+		bp:        app.NewPITRBlueprint("pitr-postgres", "", true),
 		profile:   newSecretProfile(),
 	},
 })
@@ -48,7 +48,7 @@ var _ = Suite(&PostgreSQL{
 		name:      "postgres",
 		namespace: "postgres-test",
 		app:       app.NewPostgresDB("postgres", ""),
-		bp:        app.NewBlueprint("postgres", ""),
+		bp:        app.NewBlueprint("postgres", "", true),
 		profile:   newSecretProfile(),
 	},
 })
@@ -63,7 +63,7 @@ var _ = Suite(&MySQL{
 		name:      "mysql",
 		namespace: "mysql-test",
 		app:       app.NewMysqlDB("mysql"),
-		bp:        app.NewBlueprint("mysql", ""),
+		bp:        app.NewBlueprint("mysql", "", true),
 		profile:   newSecretProfile(),
 	},
 })
@@ -78,7 +78,7 @@ var _ = Suite(&Maria{
 		name:      "mariadb",
 		namespace: "mariadb-test",
 		app:       app.NewMariaDB("maria"),
-		bp:        app.NewBlueprint("maria", ""),
+		bp:        app.NewBlueprint("maria", "", true),
 		profile:   newSecretProfile(),
 	},
 })
@@ -93,7 +93,7 @@ var _ = Suite(&Elasticsearch{
 		name:      "elasticsearch",
 		namespace: "es-test",
 		app:       app.NewElasticsearchInstance("elasticsearch"),
-		bp:        app.NewBlueprint("elasticsearch", ""),
+		bp:        app.NewBlueprint("elasticsearch", "", true),
 		profile:   newSecretProfile(),
 	},
 })
@@ -108,7 +108,7 @@ var _ = Suite(&MongoDB{
 		name:      "mongo",
 		namespace: "mongo-test",
 		app:       app.NewMongoDB("mongo"),
-		bp:        app.NewBlueprint("mongo", ""),
+		bp:        app.NewBlueprint("mongo", "", true),
 		profile:   newSecretProfile(),
 	},
 })
@@ -122,7 +122,7 @@ var _ = Suite(&Cassandra{IntegrationSuite{
 	name:      "cassandra",
 	namespace: "cassandra-test",
 	app:       app.NewCassandraInstance("cassandra"),
-	bp:        app.NewBlueprint("cassandra", ""),
+	bp:        app.NewBlueprint("cassandra", "", true),
 	profile:   newSecretProfile(),
 },
 })
@@ -137,7 +137,7 @@ var _ = Suite(&Couchbase{
 		name:      "couchbase",
 		namespace: "couchbase-test",
 		app:       app.NewCouchbaseDB("couchbase"),
-		bp:        app.NewBlueprint("couchbase", ""),
+		bp:        app.NewBlueprint("couchbase", "", true),
 		profile:   newSecretProfile(),
 	},
 })
@@ -152,7 +152,7 @@ var _ = Suite(&RDSPostgreSQL{
 		name:      "rds-postgres",
 		namespace: "rds-postgres-test",
 		app:       app.NewRDSPostgresDB("rds-postgres", ""),
-		bp:        app.NewBlueprint("rds-postgres", ""),
+		bp:        app.NewBlueprint("rds-postgres", "", true),
 		profile:   newSecretProfile(),
 	},
 })
@@ -166,7 +166,7 @@ var _ = Suite(&FoundationDB{
 		name:      "foundationdb",
 		namespace: "fdb-test",
 		app:       app.NewFoundationDB("foundationdb"),
-		bp:        app.NewBlueprint("foundationdb", ""),
+		bp:        app.NewBlueprint("foundationdb", "", true),
 		profile:   newSecretProfile(),
 	},
 })
@@ -180,7 +180,7 @@ var _ = Suite(&RDSAuroraMySQL{
 		name:      "rds-aurora-mysql",
 		namespace: "rds-aurora-mysql-test",
 		app:       app.NewRDSAuroraMySQLDB("rds-aurora-dump", ""),
-		bp:        app.NewBlueprint("rds-aurora-snap", ""),
+		bp:        app.NewBlueprint("rds-aurora-snap", "", true),
 		profile:   newSecretProfile(),
 	},
 })
@@ -196,7 +196,7 @@ var _ = Suite(&RDSPostgreSQLDump{
 		name:      "rds-postgres-dump",
 		namespace: "rds-postgres-dump-test",
 		app:       app.NewRDSPostgresDB("rds-postgres-dump", ""),
-		bp:        app.NewBlueprint("rds-postgres-dump", ""),
+		bp:        app.NewBlueprint("rds-postgres-dump", "", true),
 		profile:   newSecretProfile(),
 	},
 })
@@ -212,7 +212,7 @@ var _ = Suite(&RDSPostgreSQLSnap{
 		name:      "rds-postgres-snap",
 		namespace: "rds-postgres-snap-test",
 		app:       app.NewRDSPostgresDB("rds-postgres-snap", ""),
-		bp:        app.NewBlueprint("rds-postgres-snap", ""),
+		bp:        app.NewBlueprint("rds-postgres-snap", "", true),
 		profile:   newSecretProfile(),
 	},
 })
@@ -228,7 +228,7 @@ var _ = Suite(&MysqlDBDepConfig{
 		name:      "mysqldc",
 		namespace: "mysqldc-test",
 		app:       app.NewMysqlDepConfig("mysqldeploymentconfig", app.TemplateVersionOCP3_11, app.EphemeralStorage, "5.7"),
-		bp:        app.NewBlueprint("mysql-dep-config", ""),
+		bp:        app.NewBlueprint("mysql-dep-config", "", true),
 		profile:   newSecretProfile(),
 	},
 })
@@ -243,7 +243,7 @@ var _ = Suite(&MongoDBDepConfig{
 		name:      "mongodb",
 		namespace: "mongodb-test",
 		app:       app.NewMongoDBDepConfig("mongodeploymentconfig", app.TemplateVersionOCP3_11, app.EphemeralStorage),
-		bp:        app.NewBlueprint("mongo-dep-config", ""),
+		bp:        app.NewBlueprint("mongo-dep-config", "", true),
 		profile:   newSecretProfile(),
 	},
 })
@@ -258,7 +258,7 @@ var _ = Suite(&PostgreSQLDepConfig{
 		name:      "postgresdepconf",
 		namespace: "postgresdepconf-test",
 		app:       app.NewPostgreSQLDepConfig("postgresdepconf", app.TemplateVersionOCP3_11, app.EphemeralStorage),
-		bp:        app.NewBlueprint("postgres-dep-config", ""),
+		bp:        app.NewBlueprint("postgres-dep-config", "", true),
 		profile:   newSecretProfile(),
 	},
 })
@@ -274,7 +274,7 @@ var _ = Suite(&MysqlDBDepConfig4_4{
 		name:      "mysqldc",
 		namespace: "mysqldc4-4-test",
 		app:       app.NewMysqlDepConfig("mysqldeploymentconfig", app.TemplateVersionOCP4_4, app.EphemeralStorage, "5.7"),
-		bp:        app.NewBlueprint("mysql-dep-config", ""),
+		bp:        app.NewBlueprint("mysql-dep-config", "", true),
 		profile:   newSecretProfile(),
 	},
 })
@@ -289,7 +289,7 @@ var _ = Suite(&MongoDBDepConfig4_4{
 		name:      "mongodb",
 		namespace: "mongodb4-4-test",
 		app:       app.NewMongoDBDepConfig("mongodeploymentconfig", app.TemplateVersionOCP4_4, app.EphemeralStorage),
-		bp:        app.NewBlueprint("mongo-dep-config", ""),
+		bp:        app.NewBlueprint("mongo-dep-config", "", true),
 		profile:   newSecretProfile(),
 	},
 })
@@ -304,7 +304,7 @@ var _ = Suite(&PostgreSQLDepConfig4_4{
 		name:      "postgresdepconf",
 		namespace: "postgresdepconf4-4-test",
 		app:       app.NewPostgreSQLDepConfig("postgresdepconf", app.TemplateVersionOCP4_4, app.EphemeralStorage),
-		bp:        app.NewBlueprint("postgres-dep-config", ""),
+		bp:        app.NewBlueprint("postgres-dep-config", "", true),
 		profile:   newSecretProfile(),
 	},
 })
@@ -320,7 +320,7 @@ var _ = Suite(&MysqlDBDepConfig4_5{
 		name:      "mysqldc",
 		namespace: "mysqldc4-5-test",
 		app:       app.NewMysqlDepConfig("mysqldeploymentconfig", app.TemplateVersionOCP4_5, app.EphemeralStorage, "5.7"),
-		bp:        app.NewBlueprint("mysql-dep-config", ""),
+		bp:        app.NewBlueprint("mysql-dep-config", "", true),
 		profile:   newSecretProfile(),
 	},
 })
@@ -335,7 +335,7 @@ var _ = Suite(&MongoDBDepConfig4_5{
 		name:      "mongodb",
 		namespace: "mongodb4-5-test",
 		app:       app.NewMongoDBDepConfig("mongodeploymentconfig", app.TemplateVersionOCP4_5, app.EphemeralStorage),
-		bp:        app.NewBlueprint("mongo-dep-config", ""),
+		bp:        app.NewBlueprint("mongo-dep-config", "", true),
 		profile:   newSecretProfile(),
 	},
 })
@@ -350,7 +350,7 @@ var _ = Suite(&PostgreSQLDepConfig4_5{
 		name:      "postgresdepconf",
 		namespace: "postgresdepconf4-5-test",
 		app:       app.NewPostgreSQLDepConfig("postgresdepconf", app.TemplateVersionOCP4_5, app.EphemeralStorage),
-		bp:        app.NewBlueprint("postgres-dep-config", ""),
+		bp:        app.NewBlueprint("postgres-dep-config", "", true),
 		profile:   newSecretProfile(),
 	},
 })
@@ -365,7 +365,7 @@ var _ = Suite(&Kafka{
 		name:      "kafka",
 		namespace: "kafka-test",
 		app:       app.NewKafkaCluster("kafka", ""),
-		bp:        app.NewBlueprint("kafka", ""),
+		bp:        app.NewBlueprint("kafka", "", true),
 		profile:   newSecretProfile(),
 	},
 })
@@ -381,7 +381,7 @@ var _ = Suite(&MysqlDBDepConfig4_7{
 		name:      "mysqldc",
 		namespace: "mysqldc4-7-test",
 		app:       app.NewMysqlDepConfig("mysqldeploymentconfig", app.TemplateVersionOCP4_7, app.EphemeralStorage, "8.0"),
-		bp:        app.NewBlueprint("mysql-dep-config", ""),
+		bp:        app.NewBlueprint("mysql-dep-config", "", true),
 		profile:   newSecretProfile(),
 	},
 })
@@ -396,7 +396,7 @@ var _ = Suite(&MongoDBDepConfig4_7{
 		name:      "mongodb",
 		namespace: "mongodb4-7-test",
 		app:       app.NewMongoDBDepConfig("mongodeploymentconfig", app.TemplateVersionOCP4_7, app.EphemeralStorage),
-		bp:        app.NewBlueprint("mongo-dep-config", ""),
+		bp:        app.NewBlueprint("mongo-dep-config", "", true),
 		profile:   newSecretProfile(),
 	},
 })
@@ -411,7 +411,7 @@ var _ = Suite(&PostgreSQLDepConfig4_7{
 		name:      "postgresdepconf",
 		namespace: "postgresdepconf4-5-test",
 		app:       app.NewPostgreSQLDepConfig("postgresdepconf", app.TemplateVersionOCP4_7, app.EphemeralStorage),
-		bp:        app.NewBlueprint("postgres-dep-config", ""),
+		bp:        app.NewBlueprint("postgres-dep-config", "", true),
 		profile:   newSecretProfile(),
 	},
 })


### PR DESCRIPTION
## Change Overview

Use latest tag for all the images used in Kanister test BPs to test against development revision of source code.
The latest images expected to be built on every PR merge to master

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [x] :robot: Test

## Issues

- #814

## Test Plan

```
$ go test -v ./pkg/app/... -check.vv -count=1
=== RUN   Test
START: bp_test.go:36: BlueprintSuite.TestUpdateImageTags
phase:test-kube-task, image:ghcr.io/image:latest
phase:test-kube-task2, image:ghcr.io/image2:latest
phase:test-kube-task, image:ghcr.io/image:latest
phase:test-kube-task2, image:ghcr.io/image2:latest
phase:test-prepare-data, image:ghcr.io/image/tools:latest
PASS: bp_test.go:36: BlueprintSuite.TestUpdateImageTags 0.000s

OK: 1 passed
--- PASS: Test (0.00s)
PASS
ok      github.com/kanisterio/kanister/pkg/app  0.016s
```

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
