### PR TITLE
Trim trailing '-' sign

### DIFF
--- a/pkg/blockstorage/tags/tags.go
+++ b/pkg/blockstorage/tags/tags.go
@@ -86,9 +86,9 @@ func SanitizeValueForGCP(value string) string {
 	if len(sanitizedVal) > 63 {
 		sanitizedVal = sanitizedVal[0:63]
 	}
-	sanitizedVal = strings.TrimRight(sanitizedVal, "-")
 	sanitizedVal = strings.ToLower(sanitizedVal)
 	sanitizedVal = re.ReplaceAllString(sanitizedVal, "_")
+	sanitizedVal = strings.TrimRight(sanitizedVal, "_-")
 	return sanitizedVal
 }
 

--- a/pkg/blockstorage/tags/tags.go
+++ b/pkg/blockstorage/tags/tags.go
@@ -86,9 +86,9 @@ func SanitizeValueForGCP(value string) string {
 	if len(sanitizedVal) > 63 {
 		sanitizedVal = sanitizedVal[0:63]
 	}
+	sanitizedVal = strings.TrimRight(sanitizedVal, "_-")
 	sanitizedVal = strings.ToLower(sanitizedVal)
 	sanitizedVal = re.ReplaceAllString(sanitizedVal, "_")
-	sanitizedVal = strings.TrimRight(sanitizedVal, "_-")
 	return sanitizedVal
 }
 

--- a/pkg/blockstorage/tags/tags.go
+++ b/pkg/blockstorage/tags/tags.go
@@ -86,9 +86,9 @@ func SanitizeValueForGCP(value string) string {
 	if len(sanitizedVal) > 63 {
 		sanitizedVal = sanitizedVal[0:63]
 	}
-	sanitizedVal = strings.TrimRight(sanitizedVal, "_-")
 	sanitizedVal = strings.ToLower(sanitizedVal)
 	sanitizedVal = re.ReplaceAllString(sanitizedVal, "_")
+	sanitizedVal = strings.TrimRight(sanitizedVal, "_-")
 	return sanitizedVal
 }
 

--- a/pkg/blockstorage/tags/tags.go
+++ b/pkg/blockstorage/tags/tags.go
@@ -86,6 +86,7 @@ func SanitizeValueForGCP(value string) string {
 	if len(sanitizedVal) > 63 {
 		sanitizedVal = sanitizedVal[0:63]
 	}
+	sanitizedVal = strings.TrimRight(sanitizedVal, "-")
 	sanitizedVal = strings.ToLower(sanitizedVal)
 	sanitizedVal = re.ReplaceAllString(sanitizedVal, "_")
 	return sanitizedVal

--- a/pkg/blockstorage/tags/tags_test.go
+++ b/pkg/blockstorage/tags/tags_test.go
@@ -35,7 +35,7 @@ func (s *TagsSuite) TestSanitizeValueForGCP(c *C) {
 		},
 		{
 			input:  "kasten__snapshot-wordpress! ?*()",
-			output: "kasten__snapshot-wordpress______",
+			output: "kasten__snapshot-wordpress",
 		},
 		{
 			input:  "kasten__snapshot-wordpress-on-rbd-ceph-ns-__",

--- a/pkg/blockstorage/tags/tags_test.go
+++ b/pkg/blockstorage/tags/tags_test.go
@@ -38,6 +38,14 @@ func (s *TagsSuite) TestSanitizeValueForGCP(c *C) {
 			output: "kasten__snapshot-wordpress______",
 		},
 		{
+			input:  "kasten__snapshot-wordpress-on-rbd-ceph-ns-__",
+			output: "kasten__snapshot-wordpress-on-rbd-ceph-ns",
+		},
+		{
+			input:  "kasten__snapshot-wordpress-on-rbd-ceph-ns__--",
+			output: "kasten__snapshot-wordpress-on-rbd-ceph-ns",
+		},
+		{
 			input:  "ALLCAPS",
 			output: "allcaps",
 		},

--- a/pkg/blockstorage/tags/tags_test.go
+++ b/pkg/blockstorage/tags/tags_test.go
@@ -1,0 +1,44 @@
+package tags
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type TagsSuite struct{}
+
+var _ = Suite(&TagsSuite{})
+
+func (s *TagsSuite) TestSanitizeValueForGCP(c *C) {
+	for _, tc := range []struct {
+		input  string
+		output string
+	}{
+		{
+			input:  "abcd",
+			output: "abcd",
+		},
+		{
+			input:  "kasten__snapshot-wordpress-on-rbd-ceph-ns-2021-04-15t18-11-27z-abcd",
+			output: "kasten__snapshot-wordpress-on-rbd-ceph-ns-2021-04-15t18-11-27z",
+		},
+		{
+			input:  "kasten__snapshot-wordpress-on-rbd-ceph-ns-",
+			output: "kasten__snapshot-wordpress-on-rbd-ceph-ns",
+		},
+		{
+			input:  "kasten__snapshot-wordpress! ?*()",
+			output: "kasten__snapshot-wordpress______",
+		},
+		{
+			input:  "ALLCAPS",
+			output: "allcaps",
+		},
+	} {
+		out := SanitizeValueForGCP(tc.input)
+		c.Assert(out, Equals, tc.output)
+	}
+}

--- a/pkg/blockstorage/tags/tags_test.go
+++ b/pkg/blockstorage/tags/tags_test.go
@@ -30,6 +30,10 @@ func (s *TagsSuite) TestSanitizeValueForGCP(c *C) {
 			output: "kasten__snapshot-wordpress-on-rbd-ceph-ns",
 		},
 		{
+			input:  "kasten__snapshot-wordpress-on-rbd-ceph-ns---",
+			output: "kasten__snapshot-wordpress-on-rbd-ceph-ns",
+		},
+		{
 			input:  "kasten__snapshot-wordpress! ?*()",
 			output: "kasten__snapshot-wordpress______",
 		},


### PR DESCRIPTION
## Change Overview

This changes the sanitization function to trim any trailing '-' signs. These cause malformed labels.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- K10-5868

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
