### PR TITLE
Removing checks for pods that are still running

### DIFF
--- a/pkg/kube/pod.go
+++ b/pkg/kube/pod.go
@@ -279,7 +279,7 @@ func checkPVCAndPVStatus(vol v1.Volume, p *v1.Pod, cli kubernetes.Interface, nam
 	return nil
 }
 
-// WaitForPodCompletion waits for a pod to reach a terminal state
+// WaitForPodCompletion waits for a pod to reach a terminal state, or timeout
 func WaitForPodCompletion(ctx context.Context, cli kubernetes.Interface, namespace, name string) error {
 	err := poll.Wait(ctx, func(ctx context.Context) (bool, error) {
 		p, err := cli.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})

--- a/pkg/kube/pod.go
+++ b/pkg/kube/pod.go
@@ -282,14 +282,8 @@ func WaitForPodCompletion(ctx context.Context, cli kubernetes.Interface, namespa
 			return true, err
 		}
 		switch p.Status.Phase {
-		case v1.PodRunning:
-			for _, con := range p.Status.ContainerStatuses {
-				if con.State.Terminated != nil {
-					return false, errors.Errorf("Container %v is terminated, while Pod %v is Running. Container termination status: %v. Pod details (%s)", con.Name, name, con.State.Terminated, p.String())
-				}
-			}
 		case v1.PodFailed:
-			return false, errors.Errorf("Pod %s failed", name)
+			return false, errors.Errorf("Pod %s failed. Pod details (%s)", name, p.String())
 		}
 		return p.Status.Phase == v1.PodSucceeded, nil
 	})

--- a/pkg/kube/pod.go
+++ b/pkg/kube/pod.go
@@ -55,6 +55,7 @@ type PodOptions struct {
 	Volumes            map[string]string
 	PodOverride        crv1alpha1.JSONMap
 	Resources          v1.ResourceRequirements
+	RestartPolicy      v1.RestartPolicy
 }
 
 // CreatePod creates a pod with a single container based on the specified image
@@ -79,6 +80,10 @@ func CreatePod(ctx context.Context, cli kubernetes.Interface, opts *PodOptions) 
 		}
 	}
 
+	if opts.RestartPolicy == "" {
+		opts.RestartPolicy = v1.RestartPolicyNever
+	}
+
 	volumeMounts, podVolumes := createVolumeSpecs(opts.Volumes)
 	defaultSpecs := v1.PodSpec{
 		Containers: []v1.Container{
@@ -95,7 +100,7 @@ func CreatePod(ctx context.Context, cli kubernetes.Interface, opts *PodOptions) 
 		// restarted.  The possible values include Always, OnFailure and Never
 		// with Always being the default.  OnFailure policy will result in
 		// failed containers being restarted with an exponential back-off delay.
-		RestartPolicy:      v1.RestartPolicyOnFailure,
+		RestartPolicy:      opts.RestartPolicy,
 		Volumes:            podVolumes,
 		ServiceAccountName: sa,
 	}

--- a/pkg/kube/pod.go
+++ b/pkg/kube/pod.go
@@ -98,7 +98,7 @@ func CreatePod(ctx context.Context, cli kubernetes.Interface, opts *PodOptions) 
 		},
 		// RestartPolicy dictates when the containers of the pod should be
 		// restarted.  The possible values include Always, OnFailure and Never
-		// with Always being the default.  OnFailure policy will result in
+		// with Never being the default.  OnFailure policy will result in
 		// failed containers being restarted with an exponential back-off delay.
 		RestartPolicy:      opts.RestartPolicy,
 		Volumes:            podVolumes,

--- a/pkg/kube/pod_test.go
+++ b/pkg/kube/pod_test.go
@@ -102,12 +102,14 @@ func (s *PodSuite) TestPod(c *C) {
 			Image:              kanisterToolsImage,
 			Command:            []string{"sh", "-c", "tail -f /dev/null"},
 			ServiceAccountName: testSAName,
+			RestartPolicy:      v1.RestartPolicyAlways,
 		},
 		{
-			Namespace:    cns,
-			GenerateName: "test-",
-			Image:        kanisterToolsImage,
-			Command:      []string{"sh", "-c", "tail -f /dev/null"},
+			Namespace:     cns,
+			GenerateName:  "test-",
+			Image:         kanisterToolsImage,
+			Command:       []string{"sh", "-c", "tail -f /dev/null"},
+			RestartPolicy: v1.RestartPolicyOnFailure,
 		},
 		{
 			Namespace:          cns,
@@ -115,6 +117,7 @@ func (s *PodSuite) TestPod(c *C) {
 			Image:              kanisterToolsImage,
 			Command:            []string{"sh", "-c", "tail -f /dev/null"},
 			ServiceAccountName: testSAName,
+			RestartPolicy:      v1.RestartPolicyNever,
 		},
 		{
 			Namespace:    s.namespace,
@@ -204,6 +207,13 @@ func (s *PodSuite) TestPod(c *C) {
 			c.Assert(pod.Spec.Containers[0].Name, Equals, po.ContainerName)
 		default:
 			c.Assert(pod.Spec.Containers[0].Name, Equals, defaultContainerName)
+		}
+
+		switch {
+		case po.RestartPolicy == "":
+			c.Assert(pod.Spec.RestartPolicy, Equals, v1.RestartPolicyNever)
+		default:
+			c.Assert(pod.Spec.RestartPolicy, Equals, po.RestartPolicy)
 		}
 
 		c.Assert(err, IsNil)


### PR DESCRIPTION
## Change Overview

WaitForPodCompletion initially returned an error when a container inside the pod failed. This behavior should be controlled by the pods RestartPolicy simplifying the logic. This function will now only return when a pod is in the terminal state of success or failure. Otherwise it exits when the context times out or keep restarting according to the policy.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
