### PR TITLE
Add github `CLI` in build image

### DIFF
--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -16,13 +16,15 @@ COPY --from=alpine/helm:3.1.0 /usr/bin/helm /usr/local/bin/
 
 COPY --from=golangci/golangci-lint:v1.23.7 /usr/bin/golangci-lint /usr/local/bin/
 
-RUN wget -O /usr/local/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/v0.7.0/kind-linux-amd64 \
-    && chmod +x /usr/local/bin/kind
+RUN wget -O /usr/local/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/v0.7.0/kind-linux-amd64 && \
+    chmod +x /usr/local/bin/kind && \
+    wget https://github.com/cli/cli/releases/download/v1.9.2/gh_1.9.2_linux_386.tar.gz -O ghcli.tar.gz && \
+    tar --strip-components=1 -xf ghcli.tar.gz
 
 ENV CGO_ENABLED=0 \
     GO111MODULE="on" \
     GOROOT="/usr/local/go" \
     GOCACHE=/go/.cache/go-build \
     GO_EXTLINK_ENABLED=0 \
-    PATH="/usr/local/go/bin:${PATH}" 
-  
+    PATH="/usr/local/go/bin:${PATH}"
+

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -1,7 +1,5 @@
 FROM alpine:3.10.5
 
-MAINTAINER Tom Manville <tom@kasten.io>
-
 RUN apk add --update --no-cache ca-certificates bash git docker jq \
     && update-ca-certificates \
     && rm -rf /var/cache/apk/*
@@ -20,6 +18,8 @@ RUN wget -O /usr/local/bin/kind https://github.com/kubernetes-sigs/kind/releases
     chmod +x /usr/local/bin/kind && \
     wget https://github.com/cli/cli/releases/download/v1.9.2/gh_1.9.2_linux_386.tar.gz -O ghcli.tar.gz && \
     tar --strip-components=1 -xf ghcli.tar.gz
+
+LABEL Author="Tom Manville <tom@kasten.io>"
 
 ENV CGO_ENABLED=0 \
     GO111MODULE="on" \


### PR DESCRIPTION
## Change Overview

While moving the pipeline to codefresh, I think using `gh CLI` instead of hub would be a good idea. 

## Pull request type

Please check the type of change your PR introduces:

- [x] :hamster: Trivial/Minor

## Issues

- #XXX

## Test Plan

- [x] :muscle: Manual

build the docker image and make sure gh CLI is available.

```
» docker run --rm -it ghcr.io/kanisterio/build:v0.0.13 sh
/ # gh --version 
gh version 1.9.2 (2021-04-20)
https://github.com/cli/cli/releases/tag/v1.9.2

```