### PR TITLE
Bump the timeout for goreleaser command

### DIFF
--- a/build/gorelease.sh
+++ b/build/gorelease.sh
@@ -25,4 +25,4 @@ then
 	echo "You can generate a token here: https://github.com/settings/tokens/new"
 	exit 1
 fi
-goreleaser release --parallelism=1 --rm-dist --debug
+goreleaser release --parallelism=1 --rm-dist --debug --timeout 120m


### PR DESCRIPTION

## Change Overview

We faced an issue of timeout while releasing kanister, it looks
like goreleaser times out after 30mins.
This PR increases that timeout to 120m.


## Pull request type

Please check the type of change your PR introduces:

- [x] :bug: Bugfix

## Issues

- #XXX

## Test Plan

NA