### PR TITLE
Move docs image `docker-sphinx` to ghcr from docker hub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ IMAGE_NAME := $(BIN)
 IMAGE := $(REGISTRY)/$(IMAGE_NAME)
 
 BUILD_IMAGE ?= ghcr.io/kanisterio/build:v0.0.12
-DOCS_BUILD_IMAGE ?= kanisterio/docker-sphinx
+DOCS_BUILD_IMAGE ?= ghcr.io/kanisterio/docker-sphinx
 
 DOCS_RELEASE_BUCKET ?= s3://docs.kanister.io
 

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ IMAGE_NAME := $(BIN)
 IMAGE := $(REGISTRY)/$(IMAGE_NAME)
 
 BUILD_IMAGE ?= ghcr.io/kanisterio/build:v0.0.12
+
 DOCS_BUILD_IMAGE ?= ghcr.io/kanisterio/docker-sphinx
 
 DOCS_RELEASE_BUCKET ?= s3://docs.kanister.io


### PR DESCRIPTION

## Change Overview

It looks like when we moved kanister images from docker hub to
ghcr, we forgot about `docker-sphinx`.
Our pipeline fails a lot of times because of pull request limits
there and network issues.
Moving that image to ghcr where all of our other images are.


## Pull request type

Please check the type of change your PR introduces:

- [x] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :bug: Bugfix

## Issues

- #XXX

## Test Plan
NA