### PR TITLE
Add `gh`, `aws` CLI in kanister docs build image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ IMAGE := $(REGISTRY)/$(IMAGE_NAME)
 
 BUILD_IMAGE ?= ghcr.io/kanisterio/build:v0.0.12
 
-# tag 0.1.0 is, 0.0.1 (latest) + gh binary
+# tag 0.1.0 is, 0.0.1 (latest) + gh + aws binary
 DOCS_BUILD_IMAGE ?= ghcr.io/kanisterio/docker-sphinx:0.1.0
 
 DOCS_RELEASE_BUCKET ?= s3://docs.kanister.io

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,8 @@ IMAGE := $(REGISTRY)/$(IMAGE_NAME)
 
 BUILD_IMAGE ?= ghcr.io/kanisterio/build:v0.0.12
 
-DOCS_BUILD_IMAGE ?= ghcr.io/kanisterio/docker-sphinx
+# tag 0.1.0 is, 0.0.1 (latest) + gh binary
+DOCS_BUILD_IMAGE ?= ghcr.io/kanisterio/docker-sphinx:0.1.0
 
 DOCS_RELEASE_BUCKET ?= s3://docs.kanister.io
 

--- a/docker/docs-build/Dockerfile
+++ b/docker/docs-build/Dockerfile
@@ -1,11 +1,12 @@
 FROM ghcr.io/kanisterio/docker-sphinx:0.0.1
 
 ARG GH_VERSION=1.9.2
+ARG AWS_VERSION=1.19.30
 # add gh (github CLI)
 RUN wget https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.deb && \
     dpkg -i gh_1.9.2_linux_amd64.deb
 
 # add aws CLI
-RUN curl "https://s3.amazonaws.com/aws-cli/awscli-bundle-1.16.312.zip" -o "awscli-bundle.zip" && \
+RUN curl "https://s3.amazonaws.com/aws-cli/awscli-bundle-${AWS_VERSION}.zip" -o "awscli-bundle.zip" && \
     unzip awscli-bundle.zip && \
     ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws

--- a/docker/docs-build/Dockerfile
+++ b/docker/docs-build/Dockerfile
@@ -1,0 +1,6 @@
+FROM ghcr.io/kanisterio/docker-sphinx:0.0.1
+
+ARG GH_VERSION=1.9.2
+# add gh (github CLI)
+RUN wget https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.deb && \
+    dpkg -i gh_1.9.2_linux_amd64.deb

--- a/docker/docs-build/Dockerfile
+++ b/docker/docs-build/Dockerfile
@@ -4,3 +4,8 @@ ARG GH_VERSION=1.9.2
 # add gh (github CLI)
 RUN wget https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.deb && \
     dpkg -i gh_1.9.2_linux_amd64.deb
+
+# add aws CLI
+RUN curl "https://s3.amazonaws.com/aws-cli/awscli-bundle-1.16.312.zip" -o "awscli-bundle.zip" && \
+    unzip awscli-bundle.zip && \
+    ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws


### PR DESCRIPTION
## Change Overview

Adding `gh` in the kanister docs build image because
this is the image that we are using to release kanister
and at the same place we are raising some PRs, to do
that we need gh.


## Pull request type

Please check the type of change your PR introduces:

- [x] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor

## Issues

- #XXX

## Test Plan

NA