### PR TITLE
updated kafdrop broker environment variable

### DIFF
--- a/examples/kafka/adobe-s3-connector/kafdrop.yaml
+++ b/examples/kafka/adobe-s3-connector/kafdrop.yaml
@@ -13,4 +13,4 @@ spec:
       protocol: TCP
     env:
     - name: KAFKA_BROKERCONNECT
-      value: PLAINTEXT://my-cluster-kafka-external-bootstrap:9094
+      value: PLAINTEXT://my-cluster-kafka-bootstrap:9092


### PR DESCRIPTION
## Change Overview

Updated kafdrop environment variable to use correct address port of kafka broker `my-cluster-kafka-bootstrap:9092`

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
