### PR TITLE
Exclude frontend from bump version script

### DIFF
--- a/build/bump_version.sh
+++ b/build/bump_version.sh
@@ -33,7 +33,7 @@ main() {
             pkgs=( "$@" )
     fi
     # -F matches for exact words, not regular expression (-E), that is what required here
-    grep -F "${prev}" -Ir  "${pkgs[@]}" --exclude-dir={mod,bin,html} | cut -d ':' -f 1 | uniq | xargs sed -ri "s/${prev}/${next//./\\.}/g"
+    grep -F "${prev}" -Ir  "${pkgs[@]}" --exclude-dir={mod,bin,html,frontend} | cut -d ':' -f 1 | uniq | xargs sed -ri "s/${prev}/${next//./\\.}/g"
 }
 
 main $@

--- a/build/bump_version.sh
+++ b/build/bump_version.sh
@@ -33,7 +33,7 @@ main() {
             pkgs=( "$@" )
     fi
     # -F matches for exact words, not regular expression (-E), that is what required here
-    grep -F "${prev}" -Ir  "${pkgs[@]}" --exclude-dir={mod,bin,html,frontend} | cut -d ':' -f 1 | uniq | xargs sed -ri "s/${prev}/${next//./\\.}/g"
+    grep -F "${prev}" -Ir  "${pkgs[@]}" --exclude-dir={mod,bin,html,frontend} --exclude=\*.sum --exclude=\*.mod | cut -d ':' -f 1 | uniq | xargs sed -ri "s/${prev}/${next//./\\.}/g"
 }
 
 main $@


### PR DESCRIPTION
## Change Overview

We use the same script to bump kanister tools version in k10 as well. We should exclude frontend from the dirs.

## Pull request type

Please check the type of change your PR introduces:

- [x] :bug: Bugfix


## Issues

- #XXX

## Test Plan
NA