### PR TITLE
Fix kopia-snapshot arg typo

### DIFF
--- a/pkg/kando/location_pull.go
+++ b/pkg/kando/location_pull.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	kopiaSnapshotFlagName = "kopia-snaphot"
+	kopiaSnapshotFlagName = "kopia-snapshot"
 )
 
 func newLocationPullCommand() *cobra.Command {


### PR DESCRIPTION
## Change Overview

Fix arg "kopia-snapshot" typo in kando location commands

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test


## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
