### PR TITLE
Log output on failures in helm library

### DIFF
--- a/pkg/helm/client.go
+++ b/pkg/helm/client.go
@@ -141,6 +141,7 @@ func (h CliClient) Install(ctx context.Context, chart, version, release, namespa
 
 	out, err := RunCmdWithTimeout(ctx, h.helmBin, cmd)
 	if err != nil {
+		log.Error().Print("Error installing helm chart", field.M{"output": out})
 		return err
 	}
 	log.Debug().Print("Result", field.M{"output": out})


### PR DESCRIPTION
## Change Overview

This PR is to add an output log to the helm install function in case of failure.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- https://kasten.atlassian.net/browse/K10-7200

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E

A scenario where helm install would fail and output error log as well. Here helm install would fail because Kafka helm chart was already installed.
`./build/integration-test.sh Kafka`
```
Running integration tests:
~/KASTEN/kanister/pkg/testing ~/KASTEN/kanister
=== RUN   Test
INFO[2021-05-24T14:27:36.371277091+05:30] Running e2e integration test.                 File=reflect/value.go Function=reflect.Value.call Line=476 app=kafka testName=Kafka.TestRun
INFO[2021-05-24T14:27:36.435835746+05:30] Adding repo.                                  File=pkg/app/kafka.go Function="github.com/kanisterio/kanister/pkg/app.(*KafkaCluster).Install" Line=119 app=kafka
INFO[2021-05-24T14:27:40.196822748+05:30] Installing kafka operator using helm.         File=pkg/app/kafka.go Function="github.com/kanisterio/kanister/pkg/app.(*KafkaCluster).Install" Line=124 app=kafka
ERRO[2021-05-24T14:27:42.68865936+05:30] Error installing helm chart                   File=pkg/app/kafka.go Function="github.com/kanisterio/kanister/pkg/app.(*KafkaCluster).Install" Line=125 output="Error: rendered manifests contain a resource that already exists. Unable to continue with install: ClusterRole \"strimzi-cluster-operator-namespaced\" in namespace \"\" exists and cannot be imported into the current release: invalid ownership metadata; annotation validation error: key \"meta.helm.sh/release-name\" must equal \"kafka-65g5f\": current value is \"kafka-q4w87\""
----------------------------------------------------------------------
FAIL: <autogenerated>:1: Kafka.TestRun
integration_test.go:188:
    c.Assert(err, IsNil)
... value *errors.withStack = Error installing operator kafka through helm.: exit status 1 ("Error installing operator kafka through helm.: exit status 1")
```