### PR TITLE
Add support for file target in kando pull command

### DIFF
--- a/pkg/kando/location_pull.go
+++ b/pkg/kando/location_pull.go
@@ -80,7 +80,7 @@ func runLocationPull(cmd *cobra.Command, args []string) error {
 
 func targetWriter(target string) (io.Writer, error) {
 	if target != usePipeParam {
-		return os.Open(target)
+		return os.OpenFile(target, os.O_RDWR|os.O_CREATE, 0755)
 	}
 	return os.Stdout, nil
 }


### PR DESCRIPTION
## Change Overview

- Add support for file target in kando location pull command
- Create the file if the target doesn't exist

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Test Plan

Tested the following cases:
- Test loc pull with file target where the file already exists and validate the file gets overridden 
- Test loc pull with file target where the file doesn't;t exist and validate that the new file gets created 

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
