### PR TITLE
Remove `type` field from stable blueprints

### DIFF
--- a/examples/stable/cassandra/cassandra-blueprint.yaml
+++ b/examples/stable/cassandra/cassandra-blueprint.yaml
@@ -4,7 +4,6 @@ metadata:
   name: cassandra-blueprint
 actions:
   backup:
-    type: StatefulSet
     outputArtifacts:
       params:
         keyValue:
@@ -90,7 +89,6 @@ actions:
           - |
             rm -rf {{ .Phases.getBackupPrefixLocation.Output.localSnapshotPrefixLocation }}
   restore:
-    type: StatefulSet
     inputArtifactNames:
       - params
     phases:
@@ -173,9 +171,8 @@ actions:
                 cd ..
               done
             fi
-            rm -rf {{ .ArtifactsIn.params.KeyValue.snapshotPrefix }} 
+            rm -rf {{ .ArtifactsIn.params.KeyValue.snapshotPrefix }}
   delete:
-    type: Namespace
     inputArtifactNames:
       - params
     phases:

--- a/examples/stable/couchbase/blueprint-v2/couchbase-blueprint.yaml
+++ b/examples/stable/couchbase/blueprint-v2/couchbase-blueprint.yaml
@@ -80,7 +80,6 @@ actions:
               --force-updates
 
   delete:
-    type: Namespace
     inputArtifactNames:
     # The kopia snapshot info created in backup phase can be used here
     # Use the `--kopia-snapshot` flag in kando to pass in `cbBackup.KopiaSnapshot`

--- a/examples/stable/couchbase/couchbase-blueprint.yaml
+++ b/examples/stable/couchbase/couchbase-blueprint.yaml
@@ -74,7 +74,6 @@ actions:
               --force-updates
 
   delete:
-    type: Namespace
     phases:
     - func: KubeTask
       name: deleteBackup

--- a/examples/stable/elasticsearch/blueprint-v2/elasticsearch-blueprint.yaml
+++ b/examples/stable/elasticsearch/blueprint-v2/elasticsearch-blueprint.yaml
@@ -4,7 +4,6 @@ metadata:
   name: elasticsearch-blueprint
 actions:
   backup:
-    type: StatefulSet
     outputArtifacts:
       esBackup:
         # Capture the kopia snapshot information for subsequent actions
@@ -31,7 +30,6 @@ actions:
           gzip /backup
           kando location push --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --output-name "kopiaOutput" /backup.gz
   restore:
-    type: StatefulSet
     inputArtifactNames:
     # The kopia snapshot info created in backup phase can be used here
     # Use the `--kopia-snapshot` flag in kando to pass in `esBackup.KopiaSnapshot`
@@ -55,7 +53,6 @@ actions:
           kopia_snap='{{ .ArtifactsIn.esBackup.KopiaSnapshot }}'
           kando location pull --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --kopia-snapshot "${kopia_snap}" - | gunzip | elasticdump --bulk=true --input=$ --output=http://${host_name}:9200
   delete:
-    type: Namespace
     inputArtifactNames:
     # The kopia snapshot info created in backup phase can be used here
     # Use the `--kopia-snapshot` flag in kando to pass in `esBackup.KopiaSnapshot`

--- a/examples/stable/elasticsearch/elasticsearch-blueprint.yaml
+++ b/examples/stable/elasticsearch/elasticsearch-blueprint.yaml
@@ -4,7 +4,6 @@ metadata:
   name: elasticsearch-blueprint
 actions:
   backup:
-    type: StatefulSet
     outputArtifacts:
       cloudObject:
         keyValue:
@@ -30,7 +29,6 @@ actions:
           kando location push --profile '{{ toJson .Profile }}'  /backup.gz --path $BACKUP_LOCATION
           kando output backupLocation $BACKUP_LOCATION
   restore:
-    type: StatefulSet
     inputArtifactNames:
     - cloudObject
     phases:
@@ -50,7 +48,6 @@ actions:
           host_name="{{ .Object.spec.serviceName }}.{{ .StatefulSet.Namespace }}.svc.cluster.local"
           kando location pull --profile '{{ toJson .Profile }}' --path '{{ .ArtifactsIn.cloudObject.KeyValue.backupLocation }}' - | gunzip | elasticdump --bulk=true --input=$ --output=http://${host_name}:9200
   delete:
-    type: Namespace
     inputArtifactNames:
     - cloudObject
     phases:

--- a/examples/stable/foundationdb/blueprint-v2/foundationdb-blueprint.yaml
+++ b/examples/stable/foundationdb/blueprint-v2/foundationdb-blueprint.yaml
@@ -68,7 +68,6 @@ actions:
             fdbrestore start --dest_cluster_file /var/dynamic-conf/fdb.cluster -r file:///data/restored/fdbbackup/$backupname -w
             pkill -9 backup_agent
   delete:
-    type: Namespace
     inputArtifactNames:
     # The kopia snapshot info created in backup phase can be used here
     # Use the `--kopia-snapshot` flag in kando to pass in `fdbBackup.KopiaSnapshot`

--- a/examples/stable/foundationdb/foundationdb-blueprint.yaml
+++ b/examples/stable/foundationdb/foundationdb-blueprint.yaml
@@ -24,7 +24,7 @@ actions:
           - errexit
           - -c
           - |
-            #we are manually starting backup_aegnt here because fdb operator doesnt  have support for 
+            #we are manually starting backup_aegnt here because fdb operator doesnt  have support for
             # backup and restore right now. But they are planning to have it, going further.
             # Once they have the support for backup and restore we will change this to accommodate upstream changes
             /usr/bin/backup_agent -C /var/dynamic-conf/fdb.cluster  &
@@ -33,7 +33,7 @@ actions:
             fdbbackup start  -d file:///data/fdbbackup -w
             pkill -9 backup_agent
             tar zcvf - -C /data/ fdbbackup | kando location push --profile '{{ toJson .Profile }}' --path '/foundationdb-backups/{{ toDate "2006-01-02T15:04:05.999999999Z07:00" .Time  | date "2006-01-02T15-04-05" }}/backup.tgz' -
-            rm -rf /data/fdbbackup              
+            rm -rf /data/fdbbackup
   restore:
     kind: CustomResource
     inputArtifactNames:
@@ -48,7 +48,7 @@ actions:
         command:
           - bash
           - -o
-          - pipefail            
+          - pipefail
           - -o
           - errexit
           - -c
@@ -61,7 +61,6 @@ actions:
             fdbrestore start --dest_cluster_file /var/dynamic-conf/fdb.cluster -r file:///data/restored/fdbbackup/$backupname -w
             pkill -9 backup_agent
   delete:
-    type: Namespace
     phases:
     - func: KubeTask
       name: deleteBackup
@@ -78,4 +77,3 @@ actions:
           - |
             s3path='{{ .ArtifactsIn.fdbBackup.KeyValue.path }}'
             kando location delete --profile '{{ toJson .Profile }}' --path ${s3path}
-            

--- a/examples/stable/maria/blueprint-v2/maria-blueprint.yaml
+++ b/examples/stable/maria/blueprint-v2/maria-blueprint.yaml
@@ -4,7 +4,6 @@ metadata:
   name: maria-blueprint
 actions:
   backup:
-    type: StatefulSet
     outputArtifacts:
       mariaBackup:
         # Capture the kopia snapshot information for subsequent actions
@@ -41,7 +40,6 @@ actions:
           dump_cmd="mysqldump -u root --password=${root_password} -h {{ .StatefulSet.Name }} --column-statistics=0 --single-transaction --databases ${dump_databases}"
           ${dump_cmd} | gzip - | kando location push --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --output-name "kopiaOutput" -
   restore:
-    type: StatefulSet
     inputArtifactNames:
     # The kopia snapshot info created in backup phase can be used here
     # Use the `--kopia-snapshot` flag in kando to pass in `mariaBackup.KopiaSnapshot`
@@ -70,7 +68,6 @@ actions:
           root_password="{{ index .Phases.restoreFromStore.Secrets.mariaSecret.Data "mariadb-root-password" | toString }}"
           kando location pull --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --kopia-snapshot "${kopia_snap}" - | gunzip | mysql -u root --password=${root_password} -h {{ .StatefulSet.Name }}
   delete:
-    type: Namespace
     inputArtifactNames:
     # The kopia snapshot info created in backup phase can be used here
     # Use the `--kopia-snapshot` flag in kando to pass in `mariaBackup.KopiaSnapshot`

--- a/examples/stable/maria/maria-blueprint.yaml
+++ b/examples/stable/maria/maria-blueprint.yaml
@@ -4,7 +4,6 @@ metadata:
   name: maria-blueprint
 actions:
   backup:
-    type: StatefulSet
     outputArtifacts:
       mariaCloudDump:
         keyValue:
@@ -39,7 +38,6 @@ actions:
           mysqldump -u root --password=${root_password} -h {{ .StatefulSet.Name }} --column-statistics=0 --single-transaction --databases ${dump_databases} | gzip - | kando location push --profile '{{ toJson .Profile }}' --path ${s3_path} -
           kando output s3path ${s3_path}
   restore:
-    type: StatefulSet
     inputArtifactNames:
     - mariaCloudDump
     phases:
@@ -65,7 +63,6 @@ actions:
           root_password="{{ index .Phases.restoreFromBlobStore.Secrets.mariaSecret.Data "mariadb-root-password" | toString }}"
           kando location pull --profile '{{ toJson .Profile }}' --path ${s3_path} - | gunzip | mysql -u root --password=${root_password} -h {{ .StatefulSet.Name }}
   delete:
-    type: Namespace
     inputArtifactNames:
     - mariaCloudDump
     phases:

--- a/examples/stable/mongodb-deploymentconfig/blueprint-v2/mongo-dep-config-blueprint.yaml
+++ b/examples/stable/mongodb-deploymentconfig/blueprint-v2/mongo-dep-config-blueprint.yaml
@@ -4,7 +4,6 @@ metadata:
   name: mongodb-blueprint
 actions:
   backup:
-    type: DeploymentConfig
     outputArtifacts:
       mongoBackup:
         # Capture the kopia snapshot information for subsequent actions
@@ -37,7 +36,6 @@ actions:
             backup_file_path='rs_backup.gz'
             ${dump_cmd} | kando location push --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --output-name "kopiaOutput" -
   restore:
-    type: DeploymentConfig
     inputArtifactNames:
     # The kopia snapshot info created in backup phase can be used here
     # Use the `--kopia-snapshot` flag in kando to pass in `mongoBackup.KopiaSnapshot`
@@ -68,7 +66,6 @@ actions:
             kopia_snap='{{ .ArtifactsIn.mongoBackup.KopiaSnapshot }}'
             kando location pull --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --kopia-snapshot "${kopia_snap}" - | ${restore_cmd}
   delete:
-    type: Namespace
     inputArtifactNames:
     # The kopia snapshot info created in backup phase can be used here
     # Use the `--kopia-snapshot` flag in kando to pass in `mongoBackup.KopiaSnapshot`

--- a/examples/stable/mongodb-deploymentconfig/mongo-dep-config-blueprint.yaml
+++ b/examples/stable/mongodb-deploymentconfig/mongo-dep-config-blueprint.yaml
@@ -4,7 +4,6 @@ metadata:
   name: mongodb-blueprint
 actions:
   backup:
-    type: DeploymentConfig
     outputArtifacts:
       cloudObject:
         keyValue:
@@ -34,7 +33,6 @@ actions:
             echo $dump_cmd
             ${dump_cmd} | kando location push --profile '{{ toJson .Profile }}' --path '/mongodb-replicaset-backups/{{ .DeploymentConfig.Name }}/{{ toDate "2006-01-02T15:04:05.999999999Z07:00" .Time  | date "2006-01-02T15-04-05" }}/rs_backup.gz' -
   restore:
-    type: DeploymentConfig
     inputArtifactNames:
       - cloudObject
     phases:
@@ -61,7 +59,6 @@ actions:
             restore_cmd="mongorestore --gzip --archive --drop --host ${host} -u admin -p ${dbPassword}"
             kando location pull --profile '{{ toJson .Profile }}' --path '{{ .ArtifactsIn.cloudObject.KeyValue.path }}' - | ${restore_cmd}
   delete:
-    type: Namespace
     inputArtifactNames:
       - cloudObject
     phases:

--- a/examples/stable/mongodb-restic/mongodb-blueprint.yaml
+++ b/examples/stable/mongodb-restic/mongodb-blueprint.yaml
@@ -4,7 +4,6 @@ metadata:
   name: mongodb-blueprint
 actions:
   backup:
-    type: StatefulSet
     outputArtifacts:
       backupInfo:
         keyValue:
@@ -18,7 +17,6 @@ actions:
         includePath: /bitnami/mongodb
         backupArtifactPrefix: "{{ .Profile.Location.Bucket }}/mongodb-backups/{{ .StatefulSet.Name }}/rs_backup"
   restore:
-    type: StatefulSet
     phases:
     # Scale down mongodb replicas
     - func: ScaleWorkload
@@ -77,7 +75,6 @@ actions:
         replicas: 1
 
   delete:
-    type: Namespace
     phases:
     - func: DeleteDataAll
       name: deleteSnapshots

--- a/examples/stable/mongodb/7.8.10/mongo-blueprint.yaml
+++ b/examples/stable/mongodb/7.8.10/mongo-blueprint.yaml
@@ -4,7 +4,6 @@ metadata:
   name: mongodb-blueprint
 actions:
   backup:
-    type: StatefulSet
     outputArtifacts:
       cloudObject:
         keyValue:
@@ -33,7 +32,6 @@ actions:
             dump_cmd="mongodump --oplog --gzip --archive --host ${host} -u root -p ${dbPassword}"
             ${dump_cmd} | kando location push --profile '{{ toJson .Profile }}' --path '/mongodb-replicaset-backups/{{ .StatefulSet.Name }}/{{ toDate "2006-01-02T15:04:05.999999999Z07:00" .Time  | date "2006-01-02T15-04-05" }}/rs_backup.gz' -
   restore:
-    type: StatefulSet
     inputArtifactNames:
       - cloudObject
     phases:
@@ -60,7 +58,6 @@ actions:
             restore_cmd="mongorestore --gzip --archive --oplogReplay --drop --host ${host} -u root -p ${dbPassword}"
             kando location pull --profile '{{ toJson .Profile }}' --path '{{ .ArtifactsIn.cloudObject.KeyValue.path }}' - | ${restore_cmd}
   delete:
-    type: Namespace
     inputArtifactNames:
       - cloudObject
     phases:

--- a/examples/stable/mongodb/blueprint-v2/mongo-blueprint.yaml
+++ b/examples/stable/mongodb/blueprint-v2/mongo-blueprint.yaml
@@ -4,7 +4,6 @@ metadata:
   name: mongodb-blueprint
 actions:
   backup:
-    type: StatefulSet
     outputArtifacts:
       mongoBackup:
         # Capture the kopia snapshot information for subsequent actions
@@ -36,7 +35,6 @@ actions:
             backup_file_path='rs_backup.gz'
             ${dump_cmd} | kando location push --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --output-name "kopiaOutput" -
   restore:
-    type: StatefulSet
     inputArtifactNames:
     # The kopia snapshot info created in backup phase can be used here
     # Use the `--kopia-snapshot` flag in kando to pass in `mongoBackup.KopiaSnapshot`
@@ -67,7 +65,6 @@ actions:
             kopia_snap='{{ .ArtifactsIn.mongoBackup.KopiaSnapshot }}'
             kando location pull --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --kopia-snapshot "${kopia_snap}" - | ${restore_cmd}
   delete:
-    type: Namespace
     inputArtifactNames:
     # The kopia snapshot info created in backup phase can be used here
     # Use the `--kopia-snapshot` flag in kando to pass in `mongoBackup.KopiaSnapshot`

--- a/examples/stable/mongodb/mongo-blueprint.yaml
+++ b/examples/stable/mongodb/mongo-blueprint.yaml
@@ -4,7 +4,6 @@ metadata:
   name: mongodb-blueprint
 actions:
   backup:
-    type: StatefulSet
     outputArtifacts:
       cloudObject:
         keyValue:
@@ -33,7 +32,6 @@ actions:
             dump_cmd="mongodump --oplog --gzip --archive --host ${host} -u root -p ${dbPassword}"
             ${dump_cmd} | kando location push --profile '{{ toJson .Profile }}' --path '/mongodb-replicaset-backups/{{ .StatefulSet.Name }}/{{ toDate "2006-01-02T15:04:05.999999999Z07:00" .Time  | date "2006-01-02T15-04-05" }}/rs_backup.gz' -
   restore:
-    type: StatefulSet
     inputArtifactNames:
       - cloudObject
     phases:
@@ -60,7 +58,6 @@ actions:
             restore_cmd="mongorestore --gzip --archive --oplogReplay --drop --host ${host} -u root -p ${dbPassword}"
             kando location pull --profile '{{ toJson .Profile }}' --path '{{ .ArtifactsIn.cloudObject.KeyValue.path }}' - | ${restore_cmd}
   delete:
-    type: Namespace
     inputArtifactNames:
       - cloudObject
     phases:

--- a/examples/stable/mysql-deploymentconfig/blueprint-v2/mysql-dep-config-blueprint.yaml
+++ b/examples/stable/mysql-deploymentconfig/blueprint-v2/mysql-dep-config-blueprint.yaml
@@ -4,7 +4,6 @@ metadata:
   name: mysql-dep-config-blueprint
 actions:
   backup:
-    type: DeploymentConfig
     outputArtifacts:
       mysqlBackup:
         # Capture the kopia snapshot information for subsequent actions
@@ -35,7 +34,6 @@ actions:
           dump_cmd="mysqldump --column-statistics=0 -u root --password=${root_password} -h {{ .DeploymentConfig.Name }} --single-transaction --all-databases"
           ${dump_cmd} | gzip - | kando location push --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --output-name "kopiaOutput" -
   restore:
-    type: DeploymentConfig
     inputArtifactNames:
     # The kopia snapshot info created in backup phase can be used here
     # Use the `--kopia-snapshot` flag in kando to pass in `mysqlBackup.KopiaSnapshot`
@@ -65,7 +63,6 @@ actions:
           restore_cmd="mysql -u root --password=${root_password} -h {{ .DeploymentConfig.Name }}"
           kando location pull --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --kopia-snapshot "${kopia_snap}" - | gunzip | ${restore_cmd}
   delete:
-    type: Namespace
     inputArtifactNames:
     # The kopia snapshot info created in backup phase can be used here
     # Use the `--kopia-snapshot` flag in kando to pass in `mysqlBackup.KopiaSnapshot`

--- a/examples/stable/mysql-deploymentconfig/mysql-dep-config-blueprint.yaml
+++ b/examples/stable/mysql-deploymentconfig/mysql-dep-config-blueprint.yaml
@@ -4,7 +4,6 @@ metadata:
   name: mysql-dep-config-blueprint
 actions:
   backup:
-    type: DeploymentConfig
     outputArtifacts:
       mysqlCloudDump:
         keyValue:
@@ -33,7 +32,6 @@ actions:
           mysqldump --column-statistics=0 -u root --password=${root_password} -h {{ .DeploymentConfig.Name }} --single-transaction --all-databases | gzip - | kando location push --profile '{{ toJson .Profile }}' --path ${s3_path} -
           kando output s3path ${s3_path}
   restore:
-    type: DeploymentConfig
     inputArtifactNames:
     - mysqlCloudDump
     phases:
@@ -59,7 +57,6 @@ actions:
           root_password="{{ index .Phases.restoreFromBlobStore.Secrets.mysqlsecret.Data "database-root-password" | toString }}"
           kando location pull --profile '{{ toJson .Profile }}' --path ${s3_path} - | gunzip | mysql -u root --password=${root_password} -h {{ .DeploymentConfig.Name }}
   delete:
-    type: Namespace
     inputArtifactNames:
     - mysqlCloudDump
     phases:

--- a/examples/stable/mysql/6.x/mysql-blueprint.yaml
+++ b/examples/stable/mysql/6.x/mysql-blueprint.yaml
@@ -4,7 +4,6 @@ metadata:
   name: mysql-blueprint
 actions:
   backup:
-    type: StatefulSet
     outputArtifacts:
       mysqlCloudDump:
         keyValue:
@@ -33,7 +32,6 @@ actions:
           mysqldump --column-statistics=0 -u root --password=${root_password} -h {{ index .Object.metadata.labels "release" | toString }} --single-transaction --all-databases | gzip - | kando location push --profile '{{ toJson .Profile }}' --path ${s3_path} -
           kando output s3path ${s3_path}
   restore:
-    type: StatefulSet
     inputArtifactNames:
     - mysqlCloudDump
     phases:
@@ -59,7 +57,6 @@ actions:
           root_password="{{ index .Phases.restoreFromBlobStore.Secrets.mysqlSecret.Data "mysql-root-password" | toString }}"
           kando location pull --profile '{{ toJson .Profile }}' --path ${s3_path} - | gunzip | mysql -u root --password=${root_password} -h {{ index .Object.metadata.labels "release" | toString }}
   delete:
-    type: Namespace
     inputArtifactNames:
     - mysqlCloudDump
     phases:

--- a/examples/stable/mysql/blueprint-v2/mysql-blueprint.yaml
+++ b/examples/stable/mysql/blueprint-v2/mysql-blueprint.yaml
@@ -4,7 +4,6 @@ metadata:
   name: mysql-blueprint
 actions:
   backup:
-    type: StatefulSet
     outputArtifacts:
       mysqlBackup:
         # Capture the kopia snapshot information for subsequent actions
@@ -35,7 +34,6 @@ actions:
           dump_cmd="mysqldump --column-statistics=0 -u root --password=${root_password} -h {{ index .Object.metadata.labels "app.kubernetes.io/instance" }} --single-transaction --all-databases"
           ${dump_cmd} | gzip - | kando location push --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --output-name "kopiaOutput" -
   restore:
-    type: StatefulSet
     inputArtifactNames:
     # The kopia snapshot info created in backup phase can be used here
     # Use the `--kopia-snapshot` flag in kando to pass in `mysqlBackup.KopiaSnapshot`
@@ -65,7 +63,6 @@ actions:
           restore_cmd="mysql -u root --password=${root_password} -h {{ index .Object.metadata.labels "app.kubernetes.io/instance" }}"
           kando location pull --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --kopia-snapshot "${kopia_snap}" - | gunzip | ${restore_cmd}
   delete:
-    type: Namespace
     inputArtifactNames:
     # The kopia snapshot info created in backup phase can be used here
     # Use the `--kopia-snapshot` flag in kando to pass in `mysqlBackup.KopiaSnapshot`

--- a/examples/stable/mysql/mysql-blueprint.yaml
+++ b/examples/stable/mysql/mysql-blueprint.yaml
@@ -4,7 +4,6 @@ metadata:
   name: mysql-blueprint
 actions:
   backup:
-    type: StatefulSet
     outputArtifacts:
       mysqlCloudDump:
         keyValue:
@@ -33,7 +32,6 @@ actions:
           mysqldump --column-statistics=0 -u root --password=${root_password} -h {{ index .Object.metadata.labels "app.kubernetes.io/instance" }} --single-transaction --all-databases | gzip - | kando location push --profile '{{ toJson .Profile }}' --path ${s3_path} -
           kando output s3path ${s3_path}
   restore:
-    type: StatefulSet
     inputArtifactNames:
     - mysqlCloudDump
     phases:
@@ -59,7 +57,6 @@ actions:
           root_password="{{ index .Phases.restoreFromBlobStore.Secrets.mysqlSecret.Data "mysql-root-password" | toString }}"
           kando location pull --profile '{{ toJson .Profile }}' --path ${s3_path} - | gunzip | mysql -u root --password=${root_password} -h {{ index .Object.metadata.labels "app.kubernetes.io/instance" }}
   delete:
-    type: Namespace
     inputArtifactNames:
     - mysqlCloudDump
     phases:

--- a/examples/stable/postgresql-deploymentconfig/blueprint-v2/postgres-dep-config-blueprint.yaml
+++ b/examples/stable/postgresql-deploymentconfig/blueprint-v2/postgres-dep-config-blueprint.yaml
@@ -67,7 +67,6 @@ actions:
           kopia_snap='{{ .ArtifactsIn.pgBackup.KopiaSnapshot }}'
           kando location pull --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --kopia-snapshot "${kopia_snap}" - | gunzip -c -f | psql -q -U "${PGUSER}"
   delete:
-    type: Namespace
     inputArtifactNames:
     # The kopia snapshot info created in backup phase can be used here
     # Use the `--kopia-snapshot` flag in kando to pass in `pgBackup.KopiaSnapshot`

--- a/examples/stable/postgresql-deploymentconfig/postgres-dep-config-blueprint.yaml
+++ b/examples/stable/postgresql-deploymentconfig/postgres-dep-config-blueprint.yaml
@@ -63,7 +63,6 @@ actions:
           BACKUP_LOCATION={{ .ArtifactsIn.cloudObject.KeyValue.backupLocation }}
           kando location pull --profile '{{ toJson .Profile }}' --path "${BACKUP_LOCATION}" - | gunzip -c -f | psql -q -U "${PGUSER}"
   delete:
-    type: Namespace
     inputArtifactNames:
       - cloudObject
     phases:

--- a/examples/stable/postgresql-wale/postgresql-blueprint.yaml
+++ b/examples/stable/postgresql-wale/postgresql-blueprint.yaml
@@ -4,7 +4,6 @@ metadata:
   name: postgresql-blueprint
 actions:
   backup:
-    type: StatefulSet
     outputArtifacts:
       manifest:
         keyValue:
@@ -120,7 +119,6 @@ actions:
             wale_s3_prefix=$(cat "${env_wal_prefix}")
             EOF
   restore:
-    type: StatefulSet
     inputArtifactNames:
       - manifest
     phases:
@@ -274,7 +272,6 @@ actions:
         namespace: '{{ .StatefulSet.Namespace }}'
         replicas: 1
   delete:
-    type: Namespace
     inputArtifactNames:
       - manifest
     phases:

--- a/examples/stable/postgresql/blueprint-v2/postgres-blueprint.yaml
+++ b/examples/stable/postgresql/blueprint-v2/postgres-blueprint.yaml
@@ -67,7 +67,6 @@ actions:
           kopia_snap='{{ .ArtifactsIn.pgBackup.KopiaSnapshot }}'
           kando location pull --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --kopia-snapshot "${kopia_snap}" - | gunzip -c -f | psql -q -U "${PGUSER}"
   delete:
-    type: Namespace
     inputArtifactNames:
     # The kopia snapshot info created in backup phase can be used here
     # Use the `--kopia-snapshot` flag in kando to pass in `pgBackup.KopiaSnapshot`

--- a/examples/stable/postgresql/postgres-blueprint.yaml
+++ b/examples/stable/postgresql/postgres-blueprint.yaml
@@ -63,7 +63,6 @@ actions:
           BACKUP_LOCATION={{ .ArtifactsIn.cloudObject.KeyValue.backupLocation }}
           kando location pull --profile '{{ toJson .Profile }}' --path "${BACKUP_LOCATION}" - | gunzip -c -f | psql -q -U "${PGUSER}"
   delete:
-    type: Namespace
     inputArtifactNames:
       - cloudObject
     phases:

--- a/examples/stable/postgresql/v8.6.4/postgres-blueprint.yaml
+++ b/examples/stable/postgresql/v8.6.4/postgres-blueprint.yaml
@@ -63,7 +63,6 @@ actions:
           BACKUP_LOCATION={{ .ArtifactsIn.cloudObject.KeyValue.backupLocation }}
           kando location pull --profile '{{ toJson .Profile }}' --path "${BACKUP_LOCATION}" - | gunzip -c -f | psql -q -U "${PGUSER}"
   delete:
-    type: Namespace
     inputArtifactNames:
       - cloudObject
     phases:


### PR DESCRIPTION
## Change Overview

Since we are upgrading the CRDs to `v1` from `v1beta1`, and we
don't actually specify `type` field in our `types.go` we wont
have `types` field in the CR schema. And because of that if
we create a blueprint with `types` in it, the validation would
failed.

I see there would be a problem when these applications are being
called from k10, because it looks like k10 needs type for `delete`
action.

I still am looking into if we really need that or we can change that.

## Pull request type

Please check the type of change your PR introduces:
- [x] :construction: Work in Progress
- [x] :rainbow: Refactoring (no functional changes, no api changes)

## Issues

- #XXX

## Test Plan

Changed blueprint to remove `type` field from it and ran mysql integration test.

```
» make integration-test
```
the logs can be found [here](https://gist.github.com/6043fefec8f22f5565a004d64320000b)

I have tested the change with k10 as well, I created a blueprint without `type` field and then did backup and restore of application. And have tested e2e as well. The logs of e2e can be found [here]().https://gist.github.com/fdd0fe3032f2736e8e88376150389c48