### PR TITLE
Fix kafka E2E test uninstall function

### DIFF
--- a/pkg/app/kafka.go
+++ b/pkg/app/kafka.go
@@ -185,8 +185,6 @@ func (kc *KafkaCluster) Uninstall(ctx context.Context) error {
 	}
 
 	err = kc.cli.CoreV1().ConfigMaps(kc.namespace).Delete(ctx, configMapName, metav1.DeleteOptions{})
-	// deleteConfig := []string{"delete", "-n", kc.namespace, "configmap", configMapName}
-	// out, err := helm.RunCmdWithTimeout(ctx, "kubectl", deleteConfig)
 	if err != nil {
 		return errors.Wrapf(err, "Error deleting ConfigMap %s", kc.name)
 	}

--- a/pkg/app/kafka.go
+++ b/pkg/app/kafka.go
@@ -184,6 +184,12 @@ func (kc *KafkaCluster) Uninstall(ctx context.Context) error {
 		return errors.Wrap(err, "failed to create helm client")
 	}
 
+	deleteConfig := []string{"delete", "-n", kc.namespace, "configmap", configMapName}
+	out, err := helm.RunCmdWithTimeout(ctx, "kubectl", deleteConfig)
+	if err != nil {
+		return errors.Wrapf(err, "Error deleting ConfigMap %s, %s", kc.name, out)
+	}
+
 	err = cli.Uninstall(ctx, kc.chart.Release, kc.namespace)
 	if err != nil {
 		log.WithError(err).Print("Failed to uninstall app, you will have to uninstall it manually.", field.M{"app": kc.name})

--- a/pkg/app/kafka.go
+++ b/pkg/app/kafka.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/transport/spdy"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	"github.com/kanisterio/kanister/pkg/field"
@@ -185,7 +186,7 @@ func (kc *KafkaCluster) Uninstall(ctx context.Context) error {
 	}
 
 	err = kc.cli.CoreV1().ConfigMaps(kc.namespace).Delete(ctx, configMapName, metav1.DeleteOptions{})
-	if err != nil {
+	if err != nil && !apierrors.IsNotFound(err) {
 		return errors.Wrapf(err, "Error deleting ConfigMap %s", configMapName)
 	}
 

--- a/pkg/app/kafka.go
+++ b/pkg/app/kafka.go
@@ -186,7 +186,7 @@ func (kc *KafkaCluster) Uninstall(ctx context.Context) error {
 
 	err = kc.cli.CoreV1().ConfigMaps(kc.namespace).Delete(ctx, configMapName, metav1.DeleteOptions{})
 	if err != nil {
-		return errors.Wrapf(err, "Error deleting ConfigMap %s", kc.name)
+		return errors.Wrapf(err, "Error deleting ConfigMap %s", configMapName)
 	}
 
 	err = cli.Uninstall(ctx, kc.chart.Release, kc.namespace)

--- a/pkg/app/kafka.go
+++ b/pkg/app/kafka.go
@@ -184,10 +184,11 @@ func (kc *KafkaCluster) Uninstall(ctx context.Context) error {
 		return errors.Wrap(err, "failed to create helm client")
 	}
 
-	deleteConfig := []string{"delete", "-n", kc.namespace, "configmap", configMapName}
-	out, err := helm.RunCmdWithTimeout(ctx, "kubectl", deleteConfig)
+	err = kc.cli.CoreV1().ConfigMaps(kc.namespace).Delete(ctx, configMapName, metav1.DeleteOptions{})
+	// deleteConfig := []string{"delete", "-n", kc.namespace, "configmap", configMapName}
+	// out, err := helm.RunCmdWithTimeout(ctx, "kubectl", deleteConfig)
 	if err != nil {
-		return errors.Wrapf(err, "Error deleting ConfigMap %s, %s", kc.name, out)
+		return errors.Wrapf(err, "Error deleting ConfigMap %s", kc.name)
 	}
 
 	err = cli.Uninstall(ctx, kc.chart.Release, kc.namespace)

--- a/pkg/app/kafka.go
+++ b/pkg/app/kafka.go
@@ -26,11 +26,11 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/transport/spdy"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	"github.com/kanisterio/kanister/pkg/field"


### PR DESCRIPTION
## Change Overview

Add functionality to delete an annotated object {i.e Configmap } of Kafka application in uninstall function.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E

`./build/integration-test.sh Kafka`
Test log: [https://gist.github.com/A-kanksh-a/c635b96f90dc67a479c8ce2d0026a6c7](https://gist.github.com/A-kanksh-a/c635b96f90dc67a479c8ce2d0026a6c7)