### PR TITLE
Update controllers baseimage to version `ubi-minimal:8.4-200.1622548483`

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -1,4 +1,4 @@
-ARG base_image=registry.access.redhat.com/ubi8/ubi-minimal:8.3
+ARG base_image=registry.access.redhat.com/ubi8/ubi-minimal:8.4-200.1622548483
 FROM ${base_image}
 ARG kanister_version
 


### PR DESCRIPTION

## Change Overview

If we used the version `ubi-minimal:8.3`, certification of kanister
failed in the red hat certification pipeline.
This PR updated the version so that kanister image would pass the
red hat certification pipeline.


## Pull request type

Please check the type of change your PR introduces:

- [x] :hamster: Trivial/Minor

## Issues

- #XXX

## Test Plan

NA