### PR TITLE
Improve error message for undefined template key

### DIFF
--- a/pkg/param/render.go
+++ b/pkg/param/render.go
@@ -140,7 +140,7 @@ func newUndefinedKeyError(err string) error {
 	adjustedPos := pos + len(undefinedKeyErrorMsg)
 	key := err[adjustedPos:]
 	key = strings.Trim(key, "\"")
-	return errors.WithStack(errors.New("Error rendering template key: " + key + " is undefined"))
+	return errors.WithStack(errors.New("Can't render template: key <" + key + "> Not found"))
 }
 
 // RenderObjectRefs function renders object refs from TemplateParams

--- a/pkg/param/render.go
+++ b/pkg/param/render.go
@@ -140,7 +140,7 @@ func newUndefinedKeyError(err string) error {
 	pos := strings.LastIndex(err, undefinedKeyErrorMsg)
 	adjustedPos := pos + len(undefinedKeyErrorMsg)
 	key := strings.Trim(err[adjustedPos:], "\"")
-	return errors.WithStack(errors.New(fmt.Sprintf("Can't render template: \"%s\" Not found", key)))
+	return errors.WithStack(errors.New(fmt.Sprintf("Failed to render template: \"%s\" not found", key)))
 }
 
 // RenderObjectRefs function renders object refs from TemplateParams

--- a/pkg/param/render.go
+++ b/pkg/param/render.go
@@ -139,7 +139,7 @@ func newUndefinedKeyError(err string) error {
 	pos := strings.LastIndex(err, undefinedKeyErrorMsg)
 	adjustedPos := pos + len(undefinedKeyErrorMsg)
 	key = strings.Trim(err[adjustedPos:], "\"")
-	return errors.WithStack(errors.New("Can't render template: \"" + key + "\" Not found"))
+	return errors.WithStack(errors.New(fmt.Sprintf("Can't render template: \"%s\" Not found", key)))
 }
 
 // RenderObjectRefs function renders object refs from TemplateParams

--- a/pkg/param/render.go
+++ b/pkg/param/render.go
@@ -15,6 +15,7 @@
 package param
 
 import (
+	"fmt"
 	"bytes"
 	"reflect"
 	"strings"
@@ -138,7 +139,7 @@ func renderStringArg(arg string, tp TemplateParams) (string, error) {
 func newUndefinedKeyError(err string) error {
 	pos := strings.LastIndex(err, undefinedKeyErrorMsg)
 	adjustedPos := pos + len(undefinedKeyErrorMsg)
-	key = strings.Trim(err[adjustedPos:], "\"")
+	key := strings.Trim(err[adjustedPos:], "\"")
 	return errors.WithStack(errors.New(fmt.Sprintf("Can't render template: \"%s\" Not found", key)))
 }
 

--- a/pkg/param/render.go
+++ b/pkg/param/render.go
@@ -139,7 +139,7 @@ func newUndefinedKeyError(err string) error {
 	pos := strings.LastIndex(err, undefinedKeyErrorMsg)
 	adjustedPos := pos + len(undefinedKeyErrorMsg)
 	key = strings.Trim(err[adjustedPos:], "\"")
-	return errors.WithStack(errors.New("Can't render template: key <" + key + "> Not found"))
+	return errors.WithStack(errors.New("Can't render template: \"" + key + "\" Not found"))
 }
 
 // RenderObjectRefs function renders object refs from TemplateParams

--- a/pkg/param/render.go
+++ b/pkg/param/render.go
@@ -135,7 +135,7 @@ func renderStringArg(arg string, tp TemplateParams) (string, error) {
 func NewErrorMessage(err string, value string) string {
 	pos := strings.LastIndex(err, value)
 	adjustedPos := pos + len(value)
-	key := err[adjustedPos:len(err)]
+	key := err[adjustedPos:]
 	key = strings.Trim(key, "\"")
 	return "Error rendering template key: " + key + " is undefined"
 }

--- a/pkg/param/render.go
+++ b/pkg/param/render.go
@@ -15,8 +15,8 @@
 package param
 
 import (
-	"fmt"
 	"bytes"
+	"fmt"
 	"reflect"
 	"strings"
 	"text/template"

--- a/pkg/param/render.go
+++ b/pkg/param/render.go
@@ -138,8 +138,7 @@ func renderStringArg(arg string, tp TemplateParams) (string, error) {
 func newUndefinedKeyError(err string) error {
 	pos := strings.LastIndex(err, undefinedKeyErrorMsg)
 	adjustedPos := pos + len(undefinedKeyErrorMsg)
-	key := err[adjustedPos:]
-	key = strings.Trim(key, "\"")
+	key = strings.Trim(err[adjustedPos:], "\"")
 	return errors.WithStack(errors.New("Can't render template: key <" + key + "> Not found"))
 }
 


### PR DESCRIPTION
## Change Overview

Improve error message while rendering undefined template key. Currently, we get an error message `" map has no entry for key "`

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [x] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- K10-7240

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E

Error message when `'{{ .ArtifactsIn.cloudObject.KeyValue.paths }}' ` is being rendered and `paths` is undefined.

`time="2021-06-28T06:42:27.261951017Z" level=info msg="Failed to execute phase: v1alpha1.Phase{Name:\"pullFromBlobStore\", State:\"pending\", Output:map[string]interface {}(nil)}:" ActionSet=restore-backup-ggzfj-xbmgf File=pkg/controller/controller.go Function="github.com/kanisterio/kanister/pkg/controller.(*Controller).runAction.func1" Line=438 Phase=pullFromBlobStore cluster_name=6fe9c799-279c-4f46-bfda-c6e470080eaa error="Can't render template: key <paths> Not found" hostname=myrelease-kanister-operator-68ff8c8d54-tgp7v`