### PR TITLE
Use latest tag for Unit and Integration test

### DIFF
--- a/pkg/app/cassandra.go
+++ b/pkg/app/cassandra.go
@@ -58,7 +58,7 @@ func NewCassandraInstance(name string) App {
 			Values: map[string]string{
 				"image.registry":       "ghcr.io",
 				"image.repository":     "kanisterio/cassandra",
-				"image.tag":            "0.61.0",
+				"image.tag":            "latest",
 				"image.pullPolicy":     "Always",
 				"cluster.replicaCount": "1",
 			},

--- a/pkg/app/mongodb.go
+++ b/pkg/app/mongodb.go
@@ -63,7 +63,7 @@ func NewMongoDB(name string) App {
 				"architecture":     "replicaset",
 				"image.registry":   "ghcr.io",
 				"image.repository": "kanisterio/mongodb",
-				"image.tag":        "0.61.0",
+				"image.tag":        "latest",
 			},
 		},
 	}

--- a/pkg/app/postgresql.go
+++ b/pkg/app/postgresql.go
@@ -52,7 +52,7 @@ func NewPostgresDB(name string, subPath string) App {
 			Values: map[string]string{
 				"image.registry":                        "ghcr.io",
 				"image.repository":                      "kanisterio/postgresql",
-				"image.tag":                             "0.61.0",
+				"image.tag":                             "latest",
 				"postgresqlPassword":                    "test@54321",
 				"postgresqlExtendedConf.archiveCommand": "envdir /bitnami/postgresql/data/env wal-e wal-push %p",
 				"postgresqlExtendedConf.archiveMode":    "true",

--- a/pkg/kube/pod_test.go
+++ b/pkg/kube/pod_test.go
@@ -44,7 +44,7 @@ type PodSuite struct {
 const (
 	testSAName         = "test-sa"
 	controllerSA       = "controller-sa"
-	kanisterToolsImage = "ghcr.io/kanisterio/kanister-tools:0.61.0"
+	kanisterToolsImage = "ghcr.io/kanisterio/kanister-tools:latest"
 )
 
 var _ = Suite(&PodSuite{})
@@ -268,7 +268,7 @@ func (s *PodSuite) TestPodWithVolumes(c *C) {
 	pod, err := CreatePod(ctx, cli, &PodOptions{
 		Namespace:    s.namespace,
 		GenerateName: "test-",
-		Image:        "ghcr.io/kanisterio/kanister-tools:0.61.0",
+		Image:        "ghcr.io/kanisterio/kanister-tools:latest",
 		Command:      []string{"sh", "-c", "tail -f /dev/null"},
 		Volumes:      vols,
 	})
@@ -285,7 +285,7 @@ func (s *PodSuite) TestGetPodLogs(c *C) {
 	pod, err := CreatePod(context.Background(), s.cli, &PodOptions{
 		Namespace:    s.namespace,
 		GenerateName: "test-",
-		Image:        "ghcr.io/kanisterio/kanister-tools:0.61.0",
+		Image:        "ghcr.io/kanisterio/kanister-tools:latest",
 		Command:      []string{"sh", "-c", "echo hello"},
 	})
 	c.Assert(err, IsNil)

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -97,7 +97,7 @@ func newTestPodTemplateSpec() v1.PodTemplateSpec {
 			Containers: []v1.Container{
 				v1.Container{
 					Name:    "test-container",
-					Image:   "ghcr.io/kanisterio/kanister-tools:0.61.0",
+					Image:   "ghcr.io/kanisterio/kanister-tools:latest",
 					Command: []string{"tail"},
 					Args:    []string{"-f", "/dev/null"},
 				},


### PR DESCRIPTION
## Change Overview

This PR is to add the latest tag to images instead of the released tag for unit and integration test.
The kanister apps included here are. `MongoDB`, `PostgreSQL`, `Cassandra`

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E

For testing used command `./build/bump_version.sh 0.61.0 0.62.0` on the changes
commit Id of the changes [https://github.com/kanisterio/kanister/pull/1034/commits/b3a52376f83175db75b3cfacdc6b95acd9c7aec9](https://github.com/kanisterio/kanister/pull/1034/commits/b3a52376f83175db75b3cfacdc6b95acd9c7aec9)
and the CI passed . [https://travis-ci.com/github/kanisterio/kanister/builds/230366827](https://travis-ci.com/github/kanisterio/kanister/builds/230366827)