### PR TITLE
Stream output from KubeExec

### DIFF
--- a/pkg/kube/exec_test.go
+++ b/pkg/kube/exec_test.go
@@ -77,6 +77,16 @@ func (s *ExecSuite) TearDownSuite(c *C) {
 	}
 }
 
+func (s *ExecSuite) TestStderr(c *C) {
+	cmd := []string{"sh", "-c", "echo -n hello >&2"}
+	for _, cs := range s.pod.Status.ContainerStatuses {
+		stdout, stderr, err := Exec(s.cli, s.pod.Namespace, s.pod.Name, cs.Name, cmd, nil)
+		c.Assert(err, IsNil)
+		c.Assert(stdout, Equals, "")
+		c.Assert(stderr, Equals, "hello")
+	}
+}
+
 func (s *ExecSuite) TestExecEcho(c *C) {
 	cmd := []string{"sh", "-c", "cat -"}
 	c.Assert(s.pod.Status.Phase, Equals, v1.PodRunning)


### PR DESCRIPTION
## Change Overview

Re-implementation of https://github.com/kanisterio/kanister/pull/257/files, but correctly handles stderr-only output. That PR would hang if only stderr was returned and stdout was empty.

In follow-ups, we'll plumb the reader to the caller so it can be parsed.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Test Plan
Added test times out on original change https://github.com/kanisterio/kanister/pull/257/files

```
~/src/kanister/pkg/kube/ go test -v -check.v -check.f TestStderr
=== RUN   Test
PASS: exec_test.go:80: ExecSuite.TestStderr     0.360s
OK: 1 passed
--- PASS: Test (4.11s)
PASS
ok      github.com/kanisterio/kanister/pkg/kube 4.123s
```
<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
