### PR TITLE
Add py-pip library to postgres-kanister-tools image

### DIFF
--- a/docker/postgres-kanister-tools/Dockerfile
+++ b/docker/postgres-kanister-tools/Dockerfile
@@ -5,7 +5,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 USER root
 
-RUN apk -v --update add --no-cache curl python3 groff less jq && \
+RUN apk -v --update add --no-cache curl python3 groff less jq py-pip && \
     pip3 install --upgrade pip && \
     pip3 install --upgrade awscli && \
     rm -f /var/cache/apk/*


### PR DESCRIPTION
## Change Overview

This PR fixes issue `/bin/sh: pip3: not found` while building `postgres-kanister-tools` image on `postgres:12.7-alpine` base image.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
