### PR TITLE
Fix podOverride not being persisted on etcd

### DIFF
--- a/pkg/customresource/actionset-crd.go
+++ b/pkg/customresource/actionset-crd.go
@@ -114,6 +114,7 @@ spec:
                       type: object
                     podOverride:
                       type: object
+                      x-kubernetes-preserve-unknown-fields: true
                       description: PodOverride is used to specify pod specs that will
                         override the default pod specs
                     preferredVersion:


### PR DESCRIPTION

## Change Overview

podOverride field was not being persisted because
of data type mismatch in the CRD. Thid PR resolves
that by adding perserveUnknownfields in the CRD.


## Pull request type

Please check the type of change your PR introduces:

- [x] :bug: Bugfix

## Issues

- #XXX

## Test Plan


- [x] :muscle: Manual

Created the CR to make sure podOverride field is being persisted.