### PR TITLE
Update docs to remove unused type field from example blueprints

### DIFF
--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -115,7 +115,6 @@ As a reference, below is an example of a BlueprintAction.
 
   actions:
     example-action:
-      type: Deployment
       phases:
       - func: KubeExec
         name: examplePhase

--- a/docs/functions.rst
+++ b/docs/functions.rst
@@ -309,7 +309,6 @@ Example:
 
   actions:
     backup:
-      type: Deployment
       outputArtifacts:
         backupInfo:
           keyValue:
@@ -367,7 +366,6 @@ Example:
 
   actions:
     backup:
-      type: Deployment
       outputArtifacts:
         params:
           keyValue:
@@ -729,7 +727,6 @@ of this phase is saved to an Artifact named ``backupInfo``, shown below:
 
   actions:
     backup:
-      type: Deployment
       outputArtifacts:
         backupInfo:
           keyValue:
@@ -870,7 +867,6 @@ Example:
 
   actions:
     backupStats:
-      type: Deployment
       outputArtifacts:
         backupStats:
           keyValue:
@@ -925,7 +921,6 @@ Example:
 
   actions:
     backupStats:
-      type: Deployment
       outputArtifacts:
         backupStats:
           keyValue:
@@ -973,7 +968,6 @@ Example:
 
   actions:
     backup:
-      type: Namespace
       outputArtifacts:
         backupInfo:
           keyValue:
@@ -1037,7 +1031,6 @@ Example:
 
   actions:
     backup:
-      type: Namespace
       outputArtifacts:
         backupInfo:
           keyValue:

--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -271,7 +271,6 @@ For example, with the following snippet from the time-log example Blueprint:
     namespace: kanister
   actions:
     backup:
-      type: Deployment
       configMapNames:
       - location
       secretNames:
@@ -283,7 +282,6 @@ For example, with the following snippet from the time-log example Blueprint:
 
       ...
     restore:
-      type: Deployment
       inputArtifactNames:
         - exampleArtifact
       ...

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -94,7 +94,6 @@ First Blueprint
     namespace: kanister
   actions:
     backup:
-      type: Deployment
       phases:
       - func: KubeExec
         name: backupToS3
@@ -229,7 +228,6 @@ stdout, but eventually we'll backup the time log to that path.
     namespace: kanister
   actions:
     backup:
-      type: Deployment
       configMapNames:
       - location
       phases:
@@ -330,7 +328,6 @@ For more on this templating, see :ref:`templates`
     namespace: kanister
   actions:
     backup:
-      type: Deployment
       configMapNames:
       - location
       secretNames:
@@ -413,7 +410,6 @@ ConfigMap.
     namespace: kanister
   actions:
     backup:
-      type: Deployment
       configMapNames:
       - location
       secretNames:
@@ -494,7 +490,6 @@ ConfigMap because the ``inputArtifact`` contains the fully specified path.
     namespace: kanister
   actions:
     backup:
-      type: Deployment
       configMapNames:
       - location
       secretNames:
@@ -518,7 +513,6 @@ ConfigMap because the ``inputArtifact`` contains the fully specified path.
                 AWS_SECRET_ACCESS_KEY={{ .Secrets.aws.Data.aws_secret_access_key | toString }} \
                 aws s3 cp /var/log/time.log {{ .ConfigMaps.location.Data.path }}/time-log/
     restore:
-      type: Deployment
       secretNames:
       - aws
       inputArtifactNames:


### PR DESCRIPTION
## Change Overview

After we removed `type` field from blueprints. we no longer need it in kanister docs as well. This PR removes the type field from docs.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [x] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
