### PR TITLE
Flush writes on kopia server after snapshot deletion

### DIFF
--- a/pkg/kopia/snapshot.go
+++ b/pkg/kopia/snapshot.go
@@ -100,7 +100,10 @@ func DeleteSnapshot(ctx context.Context, backupID, path string) error {
 	if err != nil {
 		return errors.Wrapf(err, "Failed to load kopia snapshot with ID: %v", backupID)
 	}
-	return rep.DeleteManifest(ctx, m.ID)
+	if err := rep.DeleteManifest(ctx, m.ID); err != nil {
+		return err
+	}
+	return rep.Flush(ctx)
 }
 
 // findPreviousSnapshotManifest returns the list of previous snapshots for a given source,


### PR DESCRIPTION
Signed-off-by: Prasad Ghangal <prasad.ghangal@gmail.com>

## Change Overview

This PR fixes an issue where the deleted kopia snapshots were not getting replicated on kopia server hence was causing conflicts 

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [x] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
