### PR TITLE
Make the AWS session token duration a configurable setting

### DIFF
--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -78,7 +78,9 @@ func GetCredentials(ctx context.Context, config map[string]string) (*credentials
 		// If AccessKeys were provided - use those
 		creds = credentials.NewStaticCredentials(config[AccessKeyID], config[SecretAccessKey], "")
 	case os.Getenv(webIdentityTokenFilePathEnvKey) != "" && os.Getenv(roleARNEnvKey) != "":
-		sess, err := session.NewSessionWithOptions(session.Options{AssumeRoleDuration: assumeRoleDuration})
+		logLevel := aws.LogDebugWithHTTPBody
+		awsCfg := aws.Config{LogLevel: &logLevel}
+		sess, err := session.NewSessionWithOptions(session.Options{AssumeRoleDuration: assumeRoleDuration, Config: awsCfg})
 		if err != nil {
 			return nil, errors.Wrap(err, "Failed to create session to initialize Web Identify credentials")
 		}

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -26,6 +26,8 @@ import (
 	"github.com/pkg/errors"
 
 	awsrole "github.com/kanisterio/kanister/pkg/aws/role"
+	"github.com/kanisterio/kanister/pkg/field"
+	"github.com/kanisterio/kanister/pkg/log"
 )
 
 const (
@@ -69,6 +71,7 @@ func GetCredentials(ctx context.Context, config map[string]string) (*credentials
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to get assume role duration")
 	}
+	log.Info().Print("Assume Role Duration setup", field.M{"assumeRoleDuration": assumeRoleDuration})
 	switch {
 	case config[AccessKeyID] != "" && config[SecretAccessKey] != "":
 		// If AccessKeys were provided - use those

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -27,6 +27,8 @@ import (
 	"github.com/pkg/errors"
 
 	awsrole "github.com/kanisterio/kanister/pkg/aws/role"
+	"github.com/kanisterio/kanister/pkg/field"
+	"github.com/kanisterio/kanister/pkg/log"
 )
 
 const (
@@ -70,14 +72,13 @@ func GetCredentials(ctx context.Context, config map[string]string) (*credentials
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to get assume role duration")
 	}
+	log.Debug().Print("Assume Role Duration setup", field.M{"assumeRoleDuration": assumeRoleDuration})
 	switch {
 	case config[AccessKeyID] != "" && config[SecretAccessKey] != "":
 		// If AccessKeys were provided - use those
 		creds = credentials.NewStaticCredentials(config[AccessKeyID], config[SecretAccessKey], "")
 	case os.Getenv(webIdentityTokenFilePathEnvKey) != "" && os.Getenv(roleARNEnvKey) != "":
-		logLevel := aws.LogDebugWithHTTPBody
-		awsCfg := aws.Config{LogLevel: &logLevel}
-		sess, err := session.NewSessionWithOptions(session.Options{AssumeRoleDuration: assumeRoleDuration, Config: awsCfg})
+		sess, err := session.NewSessionWithOptions(session.Options{AssumeRoleDuration: assumeRoleDuration})
 		if err != nil {
 			return nil, errors.Wrap(err, "Failed to create session to initialize Web Identify credentials")
 		}

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -27,8 +27,6 @@ import (
 	"github.com/pkg/errors"
 
 	awsrole "github.com/kanisterio/kanister/pkg/aws/role"
-	"github.com/kanisterio/kanister/pkg/field"
-	"github.com/kanisterio/kanister/pkg/log"
 )
 
 const (
@@ -72,7 +70,6 @@ func GetCredentials(ctx context.Context, config map[string]string) (*credentials
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to get assume role duration")
 	}
-	log.Info().Print("Assume Role Duration setup", field.M{"assumeRoleDuration": assumeRoleDuration})
 	switch {
 	case config[AccessKeyID] != "" && config[SecretAccessKey] != "":
 		// If AccessKeys were provided - use those

--- a/pkg/blockstorage/gcepd/gcepd.go
+++ b/pkg/blockstorage/gcepd/gcepd.go
@@ -695,6 +695,12 @@ func staticRegionToZones(region string) ([]string, error) {
 			"northamerica-northeast1-b",
 			"northamerica-northeast1-c",
 		}, nil
+	case "northamerica-northeast2":
+		return []string{
+			"northamerica-northeast2-a",
+			"northamerica-northeast2-b",
+			"northamerica-northeast2-c",
+		}, nil
 	case "southamerica-east1":
 		return []string{
 			"southamerica-east1-a",

--- a/pkg/location/location.go
+++ b/pkg/location/location.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pkg/errors"
 
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
+	"github.com/kanisterio/kanister/pkg/aws"
 	"github.com/kanisterio/kanister/pkg/objectstore"
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/secrets"
@@ -229,7 +230,7 @@ func getAWSSecret(ctx context.Context, cred param.Credential) (*objectstore.Secr
 		}
 		return os, nil
 	case param.CredentialTypeSecret:
-		creds, err := secrets.ExtractAWSCredentials(ctx, cred.Secret)
+		creds, err := secrets.ExtractAWSCredentials(ctx, cred.Secret, aws.AssumeRoleDurationDefault)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/restic/restic.go
+++ b/pkg/restic/restic.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
+	"github.com/kanisterio/kanister/pkg/aws"
 	"github.com/kanisterio/kanister/pkg/consts"
 	"github.com/kanisterio/kanister/pkg/format"
 	"github.com/kanisterio/kanister/pkg/kube"
@@ -235,7 +236,7 @@ func resticS3CredentialArgs(creds param.Credential) ([]string, error) {
 }
 
 func resticS3CredentialSecretArgs(secret *v1.Secret) ([]string, error) {
-	creds, err := secrets.ExtractAWSCredentials(context.Background(), secret)
+	creds, err := secrets.ExtractAWSCredentials(context.Background(), secret, aws.AssumeRoleDurationDefault)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/secrets/aws.go
+++ b/pkg/secrets/aws.go
@@ -69,8 +69,13 @@ func ValidateAWSCredentials(secret *v1.Secret) error {
 // If the required types are not avaialable in the secrets, it returns an errror.
 //
 // ExtractAWSCredentials accepts an assumeRoleDuration which is used to set
-// the duration of the AWS session token provided by K10. AWS allows a maximum value of
-// 12 hours when no role chaining is involved.
+// the duration of the AWS session token provided by K10.
+// When this setting is not provided, the default duration of a token is 1h.
+// The minimum value allowed is 15 minutes (15m).
+// The maximum value depends on the max duration setting
+// of the IAM role - The setting can be viewed using instructions here
+// https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html#id_roles_use_view-role-max-session.
+// The IAM role's max duration setting can be modified between 1h to 12h.
 func ExtractAWSCredentials(ctx context.Context, secret *v1.Secret, assumeRoleDuration time.Duration) (*credentials.Value, error) {
 	if err := ValidateAWSCredentials(secret); err != nil {
 		return nil, err

--- a/pkg/secrets/aws.go
+++ b/pkg/secrets/aws.go
@@ -91,9 +91,7 @@ func ExtractAWSCredentials(ctx context.Context, secret *v1.Secret, assumeRoleDur
 	}
 	exp, err := creds.ExpiresAt()
 	if err == nil {
-		log.Info().Print("Credential expiration", field.M{"expirationTime": exp})
-	} else {
-		log.Info().Print("No expiration in credentials")
+		log.Debug().Print("Credential expiration", field.M{"expirationTime": exp})
 	}
 	return &val, nil
 }

--- a/pkg/secrets/aws.go
+++ b/pkg/secrets/aws.go
@@ -69,7 +69,7 @@ func ValidateAWSCredentials(secret *v1.Secret) error {
 // If the required types are not avaialable in the secrets, it returns an errror.
 //
 // ExtractAWSCredentials accepts an assumeRoleDuration which is used to set
-// the duration of the AWS session token provided by K10.
+// the duration of the AWS session token.
 // When this setting is not provided, the default duration of a token is 1h.
 // The minimum value allowed is 15 minutes (15m).
 // The maximum value depends on the max duration setting

--- a/pkg/secrets/aws.go
+++ b/pkg/secrets/aws.go
@@ -8,6 +8,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 
 	"github.com/kanisterio/kanister/pkg/aws"
+	"github.com/kanisterio/kanister/pkg/field"
+	"github.com/kanisterio/kanister/pkg/log"
 	"github.com/pkg/errors"
 )
 
@@ -86,6 +88,12 @@ func ExtractAWSCredentials(ctx context.Context, secret *v1.Secret, assumeRoleDur
 	val, err := creds.Get()
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to get AWS credentials")
+	}
+	exp, err := creds.ExpiresAt()
+	if err == nil {
+		log.Info().Print("Credential expiration", field.M{"expirationTime": exp})
+	} else {
+		log.Info().Print("No expiration in credentials")
 	}
 	return &val, nil
 }

--- a/pkg/secrets/aws_test.go
+++ b/pkg/secrets/aws_test.go
@@ -7,6 +7,7 @@ import (
 	. "gopkg.in/check.v1"
 	v1 "k8s.io/api/core/v1"
 
+	"github.com/kanisterio/kanister/pkg/aws"
 	"github.com/kanisterio/kanister/pkg/config"
 )
 
@@ -75,9 +76,9 @@ func (s *AWSSecretSuite) TestExtractAWSCredentials(c *C) {
 			errChecker: NotNil,
 		},
 	}
-	for _, tc := range tcs {
-		creds, err := ExtractAWSCredentials(context.Background(), tc.secret)
-		c.Check(creds, DeepEquals, tc.expected)
+	for testNum, tc := range tcs {
+		creds, err := ExtractAWSCredentials(context.Background(), tc.secret, aws.AssumeRoleDurationDefault)
+		c.Check(creds, DeepEquals, tc.expected, Commentf("test number:%d", testNum))
 		c.Check(err, tc.errChecker)
 	}
 }
@@ -110,7 +111,7 @@ func (s *AWSSecretSuite) TestExtractAWSCredentialsWithSessionToken(c *C) {
 			output: NotNil,
 		},
 	} {
-		_, err := ExtractAWSCredentials(context.Background(), tc.secret)
+		_, err := ExtractAWSCredentials(context.Background(), tc.secret, aws.AssumeRoleDurationDefault)
 		c.Check(err, tc.output)
 	}
 }

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
+	"github.com/kanisterio/kanister/pkg/aws"
 	"github.com/kanisterio/kanister/pkg/objectstore"
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/secrets"
@@ -312,7 +313,7 @@ func osSecretFromProfile(ctx context.Context, pType objectstore.ProviderType, p 
 		if err != nil {
 			return nil, errorf(err, "Could not fetch the secret specified in credential")
 		}
-		creds, err := secrets.ExtractAWSCredentials(ctx, s)
+		creds, err := secrets.ExtractAWSCredentials(ctx, s, aws.AssumeRoleDurationDefault)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Change Overview

- Make the AWS session token duration a configurable setting

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
