### PR TITLE
Update docs to specify that we support k8s version 1.16 and higher

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -11,7 +11,7 @@ Prerequisites
 =============
 
 * Kubernetes ``1.16`` or higher. For cluster version lower than ``1.16``,
-  we recommend installing Kanister version lower than ``0.63.0``
+  we recommend installing Kanister version ``0.62.0`` or lower.
 
 * `kubectl <https://kubernetes.io/docs/tasks/tools/install-kubectl/>`_ installed
   and setup

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -10,7 +10,8 @@ Installing Kanister
 Prerequisites
 =============
 
-* Kubernetes 1.16 or higher
+* Kubernetes ``1.16`` or higher. For cluster version lower than ``1.16``,
+  we recommend installing Kanister version lower than ``0.63.0``
 
 * `kubectl <https://kubernetes.io/docs/tasks/tools/install-kubectl/>`_ installed
   and setup

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -10,7 +10,7 @@ Installing Kanister
 Prerequisites
 =============
 
-* Kubernetes 1.8 or higher with Beta APIs enabled
+* Kubernetes 1.16 or higher
 
 * `kubectl <https://kubernetes.io/docs/tasks/tools/install-kubectl/>`_ installed
   and setup

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -13,7 +13,8 @@ of Kanister's features to manage the application's data.
 Prerequisites
 =============
 
-* Kubernetes 1.16 or higher
+* Kubernetes ``1.16`` or higher. For cluster version lower than ``1.16``,
+  we recommend installing Kanister version lower than ``0.63.0``
 
 * `kubectl <https://kubernetes.io/docs/tasks/tools/install-kubectl/>`_ installed
   and setup

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -13,7 +13,7 @@ of Kanister's features to manage the application's data.
 Prerequisites
 =============
 
-* Kubernetes 1.8 or higher with Beta APIs enabled
+* Kubernetes 1.16 or higher
 
 * `kubectl <https://kubernetes.io/docs/tasks/tools/install-kubectl/>`_ installed
   and setup

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -14,7 +14,7 @@ Prerequisites
 =============
 
 * Kubernetes ``1.16`` or higher. For cluster version lower than ``1.16``,
-  we recommend installing Kanister version lower than ``0.63.0``
+  we recommend installing Kanister version ``0.62.0`` or lower.
 
 * `kubectl <https://kubernetes.io/docs/tasks/tools/install-kubectl/>`_ installed
   and setup


### PR DESCRIPTION
## Change Overview

Since we recently upgraded the CRD APIs to `v1` from `v1beta1` and `v1` APIs are not available in Kubernetes versions lower than 1.16; we will have to update our docs as well because they still said we support k8s version 1.8.

## Pull request type

Please check the type of change your PR introduces:

- [x] :world_map: Documentation


## Issues

- #XXX

## Test Plan

```
make docs
```
