### PR TITLE
Change the default duration for assuming an AWS role from 90m to 60m 

### DIFF
--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -52,7 +52,7 @@ const (
 	roleARNEnvKey                  = "AWS_ROLE_ARN"
 
 	// TODO: Make this configurable via `config`
-	AssumeRoleDurationDefault = 90 * time.Minute
+	AssumeRoleDurationDefault = 60 * time.Minute
 	AssumeRoleDuration        = "assumeRoleDuration"
 )
 


### PR DESCRIPTION


## Change Overview

Change the default duration for assuming an AWS role from 90m to 60m  since newly created IAM role's have a default max duration of 60m.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
