### PR TITLE
Update license-extractor to use image from ghcr instead of docker hub

### DIFF
--- a/build/package.sh
+++ b/build/package.sh
@@ -28,7 +28,7 @@ build_licenses_info_image() {
         mount_cmd="--volumes-from $(grep docker -m 1 /proc/self/cgroup|cut -d/ -f3)"
     fi
     docker run --rm ${mount_cmd} \
-        "kanisterio/license-extractor:4e0a91a" \
+        "ghcr.io/kanisterio/license-extractor:4e0a91a" \
         --mode merge \
         --source ${src_dir} \
         --target ${target_file}\

--- a/docker/license_extractor/build.sh
+++ b/docker/license_extractor/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-readonly IMAGE_TAG="kanisterio/license-extractor:$(git rev-parse --short=7 HEAD:docker/license_extractor)"
+readonly IMAGE_TAG="ghcr.io/kanisterio/license-extractor:$(git rev-parse --short=7 HEAD:docker/license_extractor)"
 
 docker build -t "${IMAGE_TAG}" .
 docker push "${IMAGE_TAG}"


### PR DESCRIPTION
## Change Overview

We have been using `license-extractor` image from docker hub to build license info image, this PR updates that to use the license extractor image from ghcr.

## Pull request type

Please check the type of change your PR introduces:

- [x] :hamster: Trivial/Minor

## Issues

- #XXX

## Test Plan

NA