### PR TITLE
Support for virtual hosting with S3 and S3-like object stores

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -36,7 +36,7 @@ This will install the Kanister controller in the ``kanister`` namespace
    $ helm repo add kanister https://charts.kanister.io/
 
    # Install the Kanister operator controller using helm
-   $ helm install --name myrelease --namespace kanister kanister/kanister-operator --set image.tag=|version|
+   $ helm install --name-template "myrelease-{{randAscii 6}}" --namespace kanister kanister/kanister-operator --set image.tag=|version|
 
    # Create an S3 Compliant Kanister profile using kanctl
    $ kanctl create profile s3compliant --bucket <bucket> --access-key ${AWS_ACCESS_KEY_ID} \

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 replace (
 	github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.4.1
-	github.com/graymeta/stow => github.com/kastenhq/stow v0.2.6-kasten.1
+	github.com/graymeta/stow => github.com/kastenhq/stow v0.2.6-kasten.3
 	github.com/rook/operator-kit => github.com/kastenhq/operator-kit v0.0.0-20180316185208-859e831cc18d
 	gopkg.in/check.v1 => github.com/kastenhq/check v0.0.0-20180626002341-0264cfcea734
 )

--- a/go.sum
+++ b/go.sum
@@ -650,6 +650,8 @@ github.com/kastenhq/check v0.0.0-20180626002341-0264cfcea734 h1:qulsCaCv+O2y9/sQ
 github.com/kastenhq/check v0.0.0-20180626002341-0264cfcea734/go.mod h1:rdqSnvOJuKCPFW/h2rVLuXOAkRnHHdp9PZcKx4HCoDM=
 github.com/kastenhq/stow v0.2.6-kasten.1 h1:QPJmo4T/cROplSfs4LDbpgPmPvR5S4aRCECATdl4pXU=
 github.com/kastenhq/stow v0.2.6-kasten.1/go.mod h1:+0vRL9oMECKjPMP7OeVWl8EIqRCpFwDlth3mrAeV2Kw=
+github.com/kastenhq/stow v0.2.6-kasten.3 h1:A3k6sBJj+6MybvnP90QcgQLFKj0LyDWu6MPyNTcSaH0=
+github.com/kastenhq/stow v0.2.6-kasten.3/go.mod h1:+0vRL9oMECKjPMP7OeVWl8EIqRCpFwDlth3mrAeV2Kw=
 github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=

--- a/pkg/objectstore/aws.go
+++ b/pkg/objectstore/aws.go
@@ -58,8 +58,9 @@ func awsConfig(ctx context.Context, pc ProviderConfig, s SecretAws) (*aws.Config
 	}
 	cfg = cfg.WithRegion(r)
 	if pc.Endpoint != "" {
-		cfg = cfg.WithEndpoint(pc.Endpoint).WithS3ForcePathStyle(true)
+		cfg = cfg.WithEndpoint(pc.Endpoint)
 	}
+	cfg = cfg.WithS3ForcePathStyle(false)
 	if pc.SkipSSLVerify {
 		h := &http.Client{
 			Transport: &http.Transport{

--- a/pkg/objectstore/bucket.go
+++ b/pkg/objectstore/bucket.go
@@ -254,10 +254,7 @@ func s3Endpoint(id string, c ProviderConfig) string {
 	return awsS3Endpoint(id, r)
 }
 
-// Stow uses path-style requests when specifying an endpoint.
-// https://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html#path-style-access
-// https://github.com/graymeta/stow/blob/master/s3/config.go#L159
-
+// https://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html
 const awsS3EndpointFmt = "https://%s.s3.%s.amazonaws.com"
 
 func awsS3Endpoint(id string, region string) string {

--- a/pkg/objectstore/bucket_test.go
+++ b/pkg/objectstore/bucket_test.go
@@ -60,7 +60,7 @@ func (s *BucketSuite) TestValidS3ClientBucketRegionMismatch(c *C) {
 
 	pc1 := ProviderConfig{
 		Type:     pt,
-		Endpoint: awsS3Endpoint(r1),
+		Endpoint: awsS3Endpoint(bn, r1),
 		Region:   r1,
 	}
 
@@ -71,7 +71,7 @@ func (s *BucketSuite) TestValidS3ClientBucketRegionMismatch(c *C) {
 
 	pc3 := ProviderConfig{
 		Type:     pt,
-		Endpoint: awsS3Endpoint(r2),
+		Endpoint: awsS3Endpoint(bn, r2),
 		Region:   r2,
 	}
 


### PR DESCRIPTION


## Change Overview

- Get the region for a bucket using GetBucketRegionWithClient with S3ForcePathStyle set to false (which means we are using the virtual host style).

- Set S3ForcePathStyle to false when building the aws config in awsConfig().


## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [x] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
