### PR TITLE
Update RH base image for controller and tools image to `ubi-minimal:8.4-208`

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -1,4 +1,4 @@
-ARG base_image=registry.access.redhat.com/ubi8/ubi-minimal:8.4-205
+ARG base_image=registry.access.redhat.com/ubi8/ubi-minimal:8.4-208
 FROM ${base_image}
 ARG kanister_version
 

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -8,7 +8,7 @@ LABEL name=ARG_BIN \
       release="${kanister_version}" \
       summary="Microservice for application-specific data management" \
       maintainer="Tom Manville<tom@kasten.io>" \
-      description="Framework and utilities for application-specific data management, has updated openssl-libs."
+      description="Frameworks and utilities for application-specific data management, has updated openssl-libs."
 
 RUN microdnf install git && \
     microdnf update openssl-libs && \

--- a/docker/tools/Dockerfile
+++ b/docker/tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4-205
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4-208
 ARG kan_tools_version="test-version"
 LABEL name="kanister-tools" \
     vendor="Kanister" \


### PR DESCRIPTION
## Change Overview

This PR updates the base image for `controller` and `kanister-tools` to `8.4-208` to resolve the RH certification pipeline issues.

## Pull request type

Please check the type of change your PR introduces:

- [x] :hamster: Trivial/Minor

## Issues

- #XXX

## Test Plan

NA