### PR TITLE
Add AWS China availability zones mapping

### DIFF
--- a/pkg/blockstorage/awsebs/awsebs.go
+++ b/pkg/blockstorage/awsebs/awsebs.go
@@ -818,6 +818,17 @@ func staticRegionToZones(region string) ([]string, error) {
 			"ap-northeast-3b",
 			"ap-northeast-3c",
 		}, nil
+	case "cn-north-1":
+		return []string{
+			"cn-north-1a",
+			"cn-north-1b",
+		}, nil
+	case "cn-northwest-1":
+		return []string{
+			"cn-northwest-1a",
+			"cn-northwest-1b",
+			"cn-northwest-1c",
+		}, nil
 	}
 	return nil, errors.New("cannot get availability zones for region")
 }


### PR DESCRIPTION
## Change Overview

Snapshot restore actions to AWS China Regions currently fail due to "No provider zones for region (cn-north-1): cannot get availability zones for region". This patch updates the availability zone mappings for aws-cn.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
