### PR TITLE
Add configurable pod ready wait timeout

### DIFF
--- a/pkg/kube/pod.go
+++ b/pkg/kube/pod.go
@@ -42,9 +42,9 @@ const (
 	// DefaultPodReadyWaitTimeout is the time to wait for pod to be ready
 	DefaultPodReadyWaitTimeout = 15 * time.Minute
 	// PodReadyWaitTimeoutEnv is the env var to get pod ready wait timeout
-	PodReadyWaitTimeoutEnv   = "KANISTER_POD_READY_WAIT_TIMEOUT"
-	errAccessingNode     = "Failed to get node"
-	defaultContainerName = "container"
+	PodReadyWaitTimeoutEnv = "KANISTER_POD_READY_WAIT_TIMEOUT"
+	errAccessingNode       = "Failed to get node"
+	defaultContainerName   = "container"
 )
 
 // PodOptions specifies options for `CreatePod`

--- a/pkg/kube/pod.go
+++ b/pkg/kube/pod.go
@@ -41,8 +41,8 @@ import (
 const (
 	// defaultPodReadyWaitTimeout is the time to wait for pod to be ready
 	defaultPodReadyWaitTimeout = 15 * time.Minute
-	// podStartTimeoutEnv is the env var to get pod startup wait timeout
-	podStartTimeoutEnv   = "KANISTER_POD_START_TIMEOUT"
+	// podReadyWaitTimeoutEnv is the env var to get pod ready wait timeout
+	podReadyWaitTimeoutEnv   = "KANISTER_POD_READY_WAIT_TIMEOUT"
 	errAccessingNode     = "Failed to get node"
 	defaultContainerName = "container"
 )
@@ -180,7 +180,7 @@ func GetPodLogs(ctx context.Context, cli kubernetes.Interface, namespace, name s
 
 // WaitForPodReady waits for a pod to exit the pending state
 func WaitForPodReady(ctx context.Context, cli kubernetes.Interface, namespace, name string) error {
-	timeoutCtx, waitCancel := context.WithTimeout(ctx, getPodStartTimeout())
+	timeoutCtx, waitCancel := context.WithTimeout(ctx, getPodReadyWaitTimeout())
 	defer waitCancel()
 	err := poll.Wait(timeoutCtx, func(ctx context.Context) (bool, error) {
 		p, err := cli.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
@@ -355,10 +355,10 @@ func strategicMergeJsonPatch(original, override interface{}) ([]byte, error) {
 	return mergedPatch, nil
 }
 
-// getPodStartTimeout returns the pod ready wait timeout from ENV if configured
+// getPodReadyWaitTimeout returns the pod ready wait timeout from ENV if configured
 // returns the default of 15 minutes otherwise
-func getPodStartTimeout() time.Duration {
-	if v, ok := os.LookupEnv(podStartTimeoutEnv); ok {
+func getPodReadyWaitTimeout() time.Duration {
+	if v, ok := os.LookupEnv(podReadyWaitTimeoutEnv); ok {
 		iv, err := strconv.Atoi(v)
 		if err == nil {
 			return time.Duration(iv) * time.Minute

--- a/pkg/kube/pod.go
+++ b/pkg/kube/pod.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"io"
 	"io/ioutil"
+	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -31,13 +33,16 @@ import (
 
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	"github.com/kanisterio/kanister/pkg/consts"
+	"github.com/kanisterio/kanister/pkg/field"
 	"github.com/kanisterio/kanister/pkg/log"
 	"github.com/kanisterio/kanister/pkg/poll"
 )
 
 const (
-	// podReadyWaitTimeout is the time to wait for pod to be ready
-	podReadyWaitTimeout  = 15 * time.Minute
+	// defaultPodReadyWaitTimeout is the time to wait for pod to be ready
+	defaultPodReadyWaitTimeout = 15 * time.Minute
+	// podStartTimeoutEnv is the env var to get pod startup wait timeout
+	podStartTimeoutEnv   = "KANISTER_POD_START_TIMEOUT"
 	errAccessingNode     = "Failed to get node"
 	defaultContainerName = "container"
 )
@@ -175,7 +180,7 @@ func GetPodLogs(ctx context.Context, cli kubernetes.Interface, namespace, name s
 
 // WaitForPodReady waits for a pod to exit the pending state
 func WaitForPodReady(ctx context.Context, cli kubernetes.Interface, namespace, name string) error {
-	timeoutCtx, waitCancel := context.WithTimeout(ctx, podReadyWaitTimeout)
+	timeoutCtx, waitCancel := context.WithTimeout(ctx, getPodStartTimeout())
 	defer waitCancel()
 	err := poll.Wait(timeoutCtx, func(ctx context.Context) (bool, error) {
 		p, err := cli.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
@@ -203,7 +208,7 @@ func WaitForPodReady(ctx context.Context, cli kubernetes.Interface, namespace, n
 
 		return p.Status.Phase != v1.PodPending && p.Status.Phase != "", nil
 	})
-	return errors.Wrapf(err, "Pod did not transition into running state. Timeout:%v  Namespace:%s, Name:%s", podReadyWaitTimeout, namespace, name)
+	return errors.Wrapf(err, "Pod did not transition into running state. Timeout:%v  Namespace:%s, Name:%s", getPodStartTimeout(), namespace, name)
 }
 
 func checkNodesStatus(p *v1.Pod, cli kubernetes.Interface) error {
@@ -348,4 +353,18 @@ func strategicMergeJsonPatch(original, override interface{}) ([]byte, error) {
 		return nil, err
 	}
 	return mergedPatch, nil
+}
+
+// getPodStartTimeout returns the pod ready wait timeout from ENV if configured
+// returns the default of 15 minutes otherwise
+func getPodStartTimeout() time.Duration {
+	if v, ok := os.LookupEnv(podStartTimeoutEnv); ok {
+		iv, err := strconv.Atoi(v)
+		if err == nil {
+			return time.Duration(iv) * time.Minute
+		}
+		log.Debug().Print("Using default timeout value because of invalid environment variable", field.M{"envVar": v})
+	}
+
+	return defaultPodReadyWaitTimeout
 }

--- a/pkg/kube/pod_test.go
+++ b/pkg/kube/pod_test.go
@@ -687,10 +687,10 @@ func (s *PodSuite) TestPatchDefaultPodSpecs(c *C) {
 
 func (s *PodSuite) TestGetPodReadyWaitTimeout(c *C) {
 	// Setup ENV to change the default timeout
-	os.Setenv(podReadyWaitTimeoutEnv, "5")
-	c.Assert(getPodReadyWaitTimeout(), Equals, time.Minute*5)
-	os.Unsetenv(podReadyWaitTimeoutEnv)
+	os.Setenv(PodReadyWaitTimeoutEnv, "5")
+	c.Assert(GetPodReadyWaitTimeout(), Equals, time.Minute*5)
+	os.Unsetenv(PodReadyWaitTimeoutEnv)
 
 	// Check without ENV set
-	c.Assert(getPodReadyWaitTimeout(), Equals, defaultPodReadyWaitTimeout)
+	c.Assert(GetPodReadyWaitTimeout(), Equals, DefaultPodReadyWaitTimeout)
 }

--- a/pkg/kube/pod_test.go
+++ b/pkg/kube/pod_test.go
@@ -684,3 +684,13 @@ func (s *PodSuite) TestPatchDefaultPodSpecs(c *C) {
 		c.Assert(podSpec, DeepEquals, test.Expected)
 	}
 }
+
+func (s *PodSuite) TestGetPodStartTimeout(c *C) {
+	// Setup ENV to change the default timeout
+	os.Setenv(podStartTimeoutEnv, "5")
+	c.Assert(getPodStartTimeout(), Equals, time.Minute*5)
+	os.Unsetenv(podStartTimeoutEnv)
+
+	// Check without ENV set
+	c.Assert(getPodStartTimeout(), Equals, defaultPodReadyWaitTimeout)
+}

--- a/pkg/kube/pod_test.go
+++ b/pkg/kube/pod_test.go
@@ -685,12 +685,12 @@ func (s *PodSuite) TestPatchDefaultPodSpecs(c *C) {
 	}
 }
 
-func (s *PodSuite) TestGetPodStartTimeout(c *C) {
+func (s *PodSuite) TestGetPodReadyWaitTimeout(c *C) {
 	// Setup ENV to change the default timeout
-	os.Setenv(podStartTimeoutEnv, "5")
-	c.Assert(getPodStartTimeout(), Equals, time.Minute*5)
-	os.Unsetenv(podStartTimeoutEnv)
+	os.Setenv(podReadyWaitTimeoutEnv, "5")
+	c.Assert(getPodReadyWaitTimeout(), Equals, time.Minute*5)
+	os.Unsetenv(podReadyWaitTimeoutEnv)
 
 	// Check without ENV set
-	c.Assert(getPodStartTimeout(), Equals, defaultPodReadyWaitTimeout)
+	c.Assert(getPodReadyWaitTimeout(), Equals, defaultPodReadyWaitTimeout)
 }


### PR DESCRIPTION
## Change Overview

- Adding a way to configure the pod ready wait timeout. It is currently hard coded to 15 minutes
- This will help tweak it on platforms where binding PVCs to pods might take longer than 15 minutes

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [x] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
