### PR TITLE
Support delete operation in kubeops function

### DIFF
--- a/pkg/kube/kubectl.go
+++ b/pkg/kube/kubectl.go
@@ -15,57 +15,52 @@
 package kube
 
 import (
+	"context"
 	"io"
-	"strings"
 
-	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/resource"
+	"k8s.io/client-go/dynamic"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 )
 
+// Operation represents kubectl operation
 type Operation string
 
 const (
+	// CreateOperation represents kubectl create operation
 	CreateOperation Operation = "create"
+	// DeleteOperation represents kubectl delete operation
+	DeleteOperation Operation = "delete"
 )
 
 // KubectlOperation implements methods to perform kubectl operations
 type KubectlOperation struct {
-	factory   cmdutil.Factory
-	spec      io.Reader
-	namespace string
+	dynCli  dynamic.Interface
+	factory cmdutil.Factory
 }
 
 // NewKubectlOperations returns new KubectlOperations object
-func NewKubectlOperations(specString, namespace string) *KubectlOperation {
+func NewKubectlOperations(dynCli dynamic.Interface) *KubectlOperation {
 	return &KubectlOperation{
-		factory:   cmdutil.NewFactory(genericclioptions.NewConfigFlags(false)),
-		spec:      strings.NewReader(specString),
-		namespace: namespace,
+		dynCli:  dynCli,
+		factory: cmdutil.NewFactory(genericclioptions.NewConfigFlags(false)),
 	}
 }
 
-// Execute executes kubectl operation
-func (k *KubectlOperation) Execute(op Operation) (*crv1alpha1.ObjectReference, error) {
-	switch op {
-	case CreateOperation:
-		return k.create()
-	default:
-		return nil, errors.New("not implemented")
-	}
-}
-
-func (k *KubectlOperation) create() (*crv1alpha1.ObjectReference, error) {
+// Create k8s resource from spec manifest
+func (k *KubectlOperation) Create(spec io.Reader, namespace string) (*crv1alpha1.ObjectReference, error) {
 	// TODO: Create namespace if doesn't exist before creating an resource
 	result := k.factory.NewBuilder().
 		Unstructured().
-		NamespaceParam(k.namespace).
-		Stream(k.spec, "resource").
+		NamespaceParam(namespace).
+		Stream(spec, "resource").
 		Flatten().
 		Do()
 	err := result.Err()
@@ -77,7 +72,6 @@ func (k *KubectlOperation) create() (*crv1alpha1.ObjectReference, error) {
 		if err != nil {
 			return err
 		}
-		namespace := k.namespace
 		// Override namespace if the namespace is set in resource spec
 		if info.Namespace != "" {
 			namespace = info.Namespace
@@ -105,4 +99,16 @@ func (k *KubectlOperation) create() (*crv1alpha1.ObjectReference, error) {
 		return err
 	})
 	return objRef, err
+}
+
+// Delete k8s resource referred by objectReference
+func (k *KubectlOperation) Delete(objRef crv1alpha1.ObjectReference, namespace string) (*crv1alpha1.ObjectReference, error) {
+	if namespace == "" {
+		namespace = metav1.NamespaceDefault
+	}
+	if objRef.Namespace != "" {
+		namespace = objRef.Namespace
+	}
+	err := k.dynCli.Resource(schema.GroupVersionResource{Group: objRef.Group, Version: objRef.APIVersion, Resource: objRef.Resource}).Namespace(namespace).Delete(context.Background(), objRef.Name, metav1.DeleteOptions{})
+	return &objRef, err
 }

--- a/pkg/kube/kubectl.go
+++ b/pkg/kube/kubectl.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"io"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -110,5 +111,9 @@ func (k *KubectlOperation) Delete(objRef crv1alpha1.ObjectReference, namespace s
 		namespace = objRef.Namespace
 	}
 	err := k.dynCli.Resource(schema.GroupVersionResource{Group: objRef.Group, Version: objRef.APIVersion, Resource: objRef.Resource}).Namespace(namespace).Delete(context.Background(), objRef.Name, metav1.DeleteOptions{})
+	if apierrors.IsNotFound(err) {
+		return &objRef, nil
+	}
+
 	return &objRef, err
 }


### PR DESCRIPTION
Signed-off-by: Prasad Ghangal <prasad.ghangal@gmail.com>

## Change Overview

Add support for delete operation in kubeops function. The resource details can be provided as objectReference
```
    - func: KubeOps
      name: deleteDeploy
      args:
        operation: delete
        objectReference:
          apiVersion: "{{ .Phases.createDeploy.Output.apiVersion }}"
          group: "{{ .Phases.createDeploy.Output.group }}"
          resource: "{{ .Phases.createDeploy.Output.resource }}"
          name: "{{ .Phases.createDeploy.Output.name }}"
          namespace: "{{ .Phases.createDeploy.Output.namespace }}"
```

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [x] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Test Plan

$ go test -check.f="KubeOpsSuite" .
OK: 2 passed
PASS
ok      github.com/kanisterio/kanister/pkg/function     31.797s


- [x] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
