### PR TITLE
Adding checks for delete in progress for EFS snapshot deletes

### DIFF
--- a/pkg/blockstorage/awsefs/awsefs.go
+++ b/pkg/blockstorage/awsefs/awsefs.go
@@ -448,6 +448,9 @@ func (e *efs) SnapshotDelete(ctx context.Context, snapshot *blockstorage.Snapsho
 	if isResourceNotFoundException(err) {
 		return nil
 	}
+	if isDeleteInProgress(err) {
+		return nil
+	}
 	return err
 }
 

--- a/pkg/blockstorage/awsefs/error.go
+++ b/pkg/blockstorage/awsefs/error.go
@@ -15,6 +15,8 @@
 package awsefs
 
 import (
+	"strings"
+
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/backup"
 	awsefs "github.com/aws/aws-sdk-go/service/efs"
@@ -47,6 +49,16 @@ func isResourceNotFoundException(err error) bool {
 func isMountTargetNotFound(err error) bool {
 	if awsErr, ok := err.(awserr.Error); ok {
 		return awsErr.Code() == awsefs.ErrCodeMountTargetNotFound
+	}
+	return false
+}
+
+func isDeleteInProgress(err error) bool {
+	if awsErr, ok := err.(awserr.Error); ok {
+		if awsErr.Code() == backup.ErrCodeInvalidRequestException &&
+			strings.Contains(awsErr.Message(), "Recovery point already started the deletion process") {
+			return true
+		}
 	}
 	return false
 }


### PR DESCRIPTION
## Change Overview

EFS snapshot deletes now have a new errors saying that `Recovery point already started the deletion process` when a delete is in progress. This is a small change to ignore those errors.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

