### PR TITLE
Set log level using env variable

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -28,7 +28,7 @@ const (
 
 	// LevelVarName is the environment variable that controls
 	// init log levels
-	LevelVarName = "LOG_LEVEL"
+	LevelEnvName = "LOG_LEVEL"
 )
 
 // OutputSink describes the current output sink.
@@ -125,8 +125,11 @@ func SetFormatter(format OutputFormat) {
 func init() {
 	SetFormatter(TextFormat)
 	initEnvVarFields()
-	level, err := logrus.ParseLevel(os.Getenv(LevelVarName))
+	initLogLevel()
+}
 
+func initLogLevel() {
+	level, err := logrus.ParseLevel(os.Getenv(LevelEnvName))
 	if err != nil {
 		level = logrus.InfoLevel
 	}

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -25,6 +25,10 @@ const (
 	InfoLevel Level = Level(logrus.InfoLevel)
 	// ErrorLevel log level.
 	ErrorLevel Level = Level(logrus.ErrorLevel)
+
+	// LevelVarName is the environment variable that controls
+	// init log levels
+	LevelVarName = "LOG_LEVEL"
 )
 
 // OutputSink describes the current output sink.
@@ -121,6 +125,17 @@ func SetFormatter(format OutputFormat) {
 func init() {
 	SetFormatter(TextFormat)
 	initEnvVarFields()
+	level, err := logrus.ParseLevel(os.Getenv(LevelVarName))
+
+	if err != nil {
+		level = logrus.InfoLevel
+	}
+	SetLevel(Level(level))
+}
+
+// SetLevel sets the current log level.
+func SetLevel(level Level) {
+	log.SetLevel(logrus.Level(level))
 }
 
 func Info() Logger {

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"os"
 	"testing"
 	"time"
 
@@ -121,10 +122,12 @@ func (s *LogSuite) TestLogLevel(c *C) {
 	c.Assert(output.String(), HasLen, 0)
 
 	//Check if debug level log is printed when log level is debug
-	log.SetLevel(logrus.DebugLevel)
+	os.Setenv("LOG_LEVEL", "debug")
+	defer os.Unsetenv("LOG_LEVEL")
+	initLogLevel()
 	Debug().WithContext(ctx).Print("Testing debug level")
-	err = json.Unmarshal(output.Bytes(), &entry)
-	c.Assert(err, IsNil)
+	cerr := json.Unmarshal(output.Bytes(), &entry)
+	c.Assert(cerr, IsNil)
 	c.Assert(entry, NotNil)
 	c.Assert(entry["msg"], Equals, "Testing debug level")
 }

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -105,3 +105,26 @@ func testLogMessage(c *C, msg string, print func(string, ...field.M), fields ...
 	c.Assert(entry["msg"], Equals, msg)
 	return entry
 }
+
+func (s *LogSuite) TestLogLevel(c *C) {
+	log.SetFormatter(&logrus.JSONFormatter{TimestampFormat: time.RFC3339Nano})
+
+	var output bytes.Buffer
+	log.SetOutput(&output)
+	ctx := field.Context(context.Background(), "key", "value")
+	var entry map[string]interface{}
+	//Check if debug level log is printed when log level is info
+	Debug().WithContext(ctx).Print("Testing debug level")
+	err := json.Unmarshal(output.Bytes(), &entry)
+
+	c.Assert(err, NotNil)
+	c.Assert(output.String(), HasLen, 0)
+
+	//Check if debug level log is printed when log level is debug
+	log.SetLevel(logrus.DebugLevel)
+	Debug().WithContext(ctx).Print("Testing debug level")
+	err = json.Unmarshal(output.Bytes(), &entry)
+	c.Assert(err, IsNil)
+	c.Assert(entry, NotNil)
+	c.Assert(entry["msg"], Equals, "Testing debug level")
+}


### PR DESCRIPTION
Signed-off-by: Amruta Kale <amrutakale24.1991@gmail.com>

## Change Overview
Kanister by default logs at info level. This PR adds a way to change the log level setting

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [x] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
