### PR TITLE
examples/stable/mongodb: update README for mongo db example

### DIFF
--- a/examples/stable/mongodb/README.md
+++ b/examples/stable/mongodb/README.md
@@ -33,6 +33,9 @@ $ helm install bitnami/mongodb --name my-release --namespace mongo-test \
 
 The command deploys MongoDB on the Kubernetes cluster in the mongo-test namespace
 
+**NOTE:**
+
+If you are installing the chart with release name `mongodb`, some changes would be needed in the blueprint `mongo-blueprint.yaml`
 
 ## Integrating with Kanister
 


### PR DESCRIPTION
## Change Overview

If the mongodb chart is installed with chart name as release name, existing blueprint breaks, hence updating the documentation to avoid using chart name as release name

## Pull request type

Please check the type of change your PR introduces:
- [x] :world_map: Documentation


## Issues

- #XXX

## Test Plan
- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
