### PR TITLE
Make RDSPostgres/Aurora DBSnapshot delete operation Idempotent

### DIFF
--- a/pkg/function/delete_rds_snapshot.go
+++ b/pkg/function/delete_rds_snapshot.go
@@ -94,7 +94,7 @@ func deleteRDSSnapshot(ctx context.Context, snapshotID string, profile *param.Pr
 		if err, ok := err.(awserr.Error); ok {
 			switch err.Code() {
 			case awsrds.ErrCodeDBClusterSnapshotNotFoundFault:
-				log.Info().Print("DB Cluster Snapshot already deleted", field.M{"SnapshotId": snapshotID})
+				log.Info().Print("Could not find matching Aurora DB cluster snapshot; might have been deleted previously", field.M{"SnapshotId": snapshotID})
 				return nil, nil
 			default:
 				return nil, errors.Wrap(err, "Error deleting Aurora DB cluster snapshot")

--- a/pkg/function/delete_rds_snapshot.go
+++ b/pkg/function/delete_rds_snapshot.go
@@ -17,9 +17,9 @@ package function
 import (
 	"context"
 
-	"github.com/pkg/errors"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	awsrds "github.com/aws/aws-sdk-go/service/rds"
+	"github.com/pkg/errors"
 
 	kanister "github.com/kanisterio/kanister/pkg"
 	"github.com/kanisterio/kanister/pkg/aws/rds"

--- a/pkg/function/delete_rds_snapshot.go
+++ b/pkg/function/delete_rds_snapshot.go
@@ -74,7 +74,7 @@ func deleteRDSSnapshot(ctx context.Context, snapshotID string, profile *param.Pr
 			if err, ok := err.(awserr.Error); ok {
 				switch err.Code() {
 				case awsrds.ErrCodeDBSnapshotNotFoundFault:
-					log.Info().Print("DB Snapshot already deleted", field.M{"SnapshotId": snapshotID})
+					log.Info().Print("Could not find matching RDS snapshot; might have been deleted previously", field.M{"SnapshotId": snapshotID})
 					return nil, nil
 				default:
 					return nil, errors.Wrap(err, "Failed to delete snapshot")

--- a/pkg/function/delete_rds_snapshot.go
+++ b/pkg/function/delete_rds_snapshot.go
@@ -89,7 +89,7 @@ func deleteRDSSnapshot(ctx context.Context, snapshotID string, profile *param.Pr
 
 	// delete Aurora DB cluster snapshot
 	log.Print("Deleting Aurora DB cluster snapshot")
-	_, err := rdsCli.DeleteDBClusterSnapshot(ctx, snapshotID)
+	_, err = rdsCli.DeleteDBClusterSnapshot(ctx, snapshotID)
 	if err != nil {
 		if err, ok := err.(awserr.Error); ok {
 			switch err.Code() {


### PR DESCRIPTION
## Change Overview

This PR makes the delete operation for RDS DB snapshot Idempotent. It looks for the `DB snapshot Not Found` error in the case of PostgreSQL or `DBClusterSnapshotNotFoundFault` in the case of Aurora DBCluster and prints the message in the log. 

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E

`./build/integration-test.sh RDSPostgreSQLSnap` 
[https://gist.github.com/A-kanksh-a/f56f06825b42c43653b2678bfde324b1](https://gist.github.com/A-kanksh-a/f56f06825b42c43653b2678bfde324b1)