### PR TITLE
Replace yum command with microdnf

### DIFF
--- a/docker/kafka-adobes3Connector/image/adobeSink.Dockerfile
+++ b/docker/kafka-adobes3Connector/image/adobeSink.Dockerfile
@@ -2,16 +2,16 @@ FROM confluentinc/cp-kafka-connect:6.1.0
 
 USER root
 
-RUN yum install -y lsof
+RUN microdnf install -y lsof
 
 # copy the jar files
 
-RUN yum install -y \
+RUN microdnf install -y \
    java-1.8.0-openjdk \
    java-1.8.0-openjdk-devel
 
 ENV JAVA_HOME /usr/lib/jvm/java-1.8.0-openjdk/
-RUN yum install git -y
+RUN microdnf install git -y
 RUN java -version
 RUN git clone https://github.com/adobe/kafka-connect-s3.git
 RUN cd kafka-connect-s3 && ./gradlew shadowJar

--- a/docker/kafka-adobes3Connector/image/adobeSource.Dockerfile
+++ b/docker/kafka-adobes3Connector/image/adobeSource.Dockerfile
@@ -3,12 +3,12 @@ FROM confluentinc/cp-kafka-connect:6.1.0
 USER root
 # copy the jar files
 
-RUN yum install -y \
+RUN microdnf install -y \
    java-1.8.0-openjdk \
    java-1.8.0-openjdk-devel
 
 ENV JAVA_HOME /usr/lib/jvm/java-1.8.0-openjdk/
-RUN yum install git -y
+RUN microdnf install git -y
 RUN java -version
 RUN git clone https://github.com/adobe/kafka-connect-s3.git
 RUN cd kafka-connect-s3 && ./gradlew shadowJar


### PR DESCRIPTION
## Change Overview

In this PR, we have replaced the `yum` command with `microdnf` to install utilities for Kafka adobe s3 source and sink connector docker image. 

**Note:** we had to do this as CI failed to build the image for kafka osurce and sink connector with the error while using yum commands
```
Error: Failed to download metadata for repo 'Confluent.dist': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried
```
## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E

Build the source and sink connector image locally with 
`goreleaser release --skip-publish --snapshot --rm-dist
`
Run Integration test for kafka
`./build/integration-test.sh Kafka
`
output - [https://gist.github.com/A-kanksh-a/7c2f38ed601940731b73a9b8d2db100e](https://gist.github.com/A-kanksh-a/7c2f38ed601940731b73a9b8d2db100e)
