### PR TITLE
fix pipleline failure for log test

### DIFF
--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -108,6 +108,8 @@ func testLogMessage(c *C, msg string, print func(string, ...field.M), fields ...
 }
 
 func (s *LogSuite) TestLogLevel(c *C) {
+	os.Unsetenv(LevelEnvName)
+	initLogLevel()
 	log.SetFormatter(&logrus.JSONFormatter{TimestampFormat: time.RFC3339Nano})
 
 	var output bytes.Buffer
@@ -122,8 +124,11 @@ func (s *LogSuite) TestLogLevel(c *C) {
 	c.Assert(output.String(), HasLen, 0)
 
 	//Check if debug level log is printed when log level is debug
-	os.Setenv("LOG_LEVEL", "debug")
-	defer os.Unsetenv("LOG_LEVEL")
+	os.Setenv(LevelEnvName, "debug")
+	defer func() {
+		os.Unsetenv(LevelEnvName)
+		initLogLevel()
+	}()
 	initLogLevel()
 	Debug().WithContext(ctx).Print("Testing debug level")
 	cerr := json.Unmarshal(output.Bytes(), &entry)


### PR DESCRIPTION
Signed-off-by: Amruta Kale <amrutakale24.1991@gmail.com>

## Change Overview

kanister test pipeline is failing for log test. This PR unsets the env variable at the start of the test and end of the test

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
