### PR TITLE
prefer GetBucketLocation() API for s3-compatible endpoints

### DIFF
--- a/pkg/objectstore/bucket.go
+++ b/pkg/objectstore/bucket.go
@@ -198,19 +198,19 @@ func s3BucketRegion(ctx context.Context, cfg ProviderConfig, sec Secret, bucketN
 	// s3-compatible stores may not support s3manager.GetBucketRegion() API, so
 	// prefer to use the get-bucket-location API instead
 	if cfg.Endpoint != "" {
-		if resp, err := svc.GetBucketLocation(&s3.GetBucketLocationInput{
+		resp, err := svc.GetBucketLocation(&s3.GetBucketLocationInput{
 			Bucket: aws.String(bucketName),
-		}); err == nil {
+		})
+		if err == nil {
 			if resp.LocationConstraint == nil { // per the AWS SDK doc a nil location means us-east-1
 				return "us-east-1", nil
 			}
 			return *resp.LocationConstraint, nil
-		} else {
-			log.Error().
-				WithContext(ctx).
-				WithError(err).
-				Print("GetBucketLocation() failed, falling back to GetBucketRegion()", field.M{"config": c})
 		}
+		log.Error().
+			WithContext(ctx).
+			WithError(err).
+			Print("GetBucketLocation() failed, falling back to GetBucketRegion()", field.M{"config": c})
 		// fallback to GetBucketRegion() API if we fail (could be due to
 		// access-denied or incorrect policies etc)
 	}


### PR DESCRIPTION
## Change Overview

The `GetBucketRegion()` API response from OVH Cloud is inconsistent with and without credentials (anonymous), so we make a change here to prefer `GetBucketLocation()` when possible for s3-compatible stores (explicit endpoint has been specified).

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
