### PR TITLE
Update restore cmd in postgres depconfig blueprint

### DIFF
--- a/examples/stable/postgresql-deploymentconfig/postgres-dep-config-blueprint.yaml
+++ b/examples/stable/postgresql-deploymentconfig/postgres-dep-config-blueprint.yaml
@@ -61,7 +61,7 @@ actions:
           export PGUSER='postgres'
           export PGPASSWORD='{{ index .Phases.pgRestore.Secrets.pgSecret.Data "postgresql_admin_password" | toString }}'
           BACKUP_LOCATION={{ .ArtifactsIn.cloudObject.KeyValue.backupLocation }}
-          kando location pull --profile '{{ toJson .Profile }}' --path "${BACKUP_LOCATION}" - | gunzip -c -f | psql -q -U "${PGUSER}"
+          kando location pull --profile '{{ toJson .Profile }}' --path "${BACKUP_LOCATION}" - | gunzip -c -f | sed 's/LOCALE/LC_COLLATE/' | psql -q -U "${PGUSER}"
   delete:
     inputArtifactNames:
       - cloudObject


### PR DESCRIPTION
## Change Overview

We recently figure out [an issue](https://github.com/kanisterio/kanister/pull/1116) where the restore command in our
blueprint was not working for postgres applications.
We fixed that for other application in the mentioned PR this
PR fixes the issue for the postgres application that gets
deployed as deployment config in OCP clusters.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

- [x] :muscle: Manual
