### PR TITLE
TestBucketGetRegions fails intermittently 

### DIFF
--- a/pkg/objectstore/objectstore_test.go
+++ b/pkg/objectstore/objectstore_test.go
@@ -438,15 +438,21 @@ func (s *ObjectStoreProviderSuite) TestBucketGetRegions(c *C) {
 		c.Skip("Test only applicable to S3")
 	}
 	ctx := context.Background()
-	_, err := s.provider.ListBuckets(ctx)
+	origBucket, err := s.provider.GetBucket(ctx, testBucketName)
 	c.Assert(err, IsNil)
+	c.Assert(origBucket, NotNil)
+	ol, oerr := origBucket.ListObjects(ctx)
+	c.Assert(oerr, IsNil)
+	c.Assert(ol, NotNil)
+
 	b, err := GetOrCreateBucket(ctx, s.provider, testBucketName)
 	c.Assert(err, IsNil)
 	c.Assert(b, NotNil)
-
 	l, err := b.ListObjects(ctx)
 	c.Assert(err, IsNil)
 	c.Assert(l, NotNil)
+	c.Assert(len(l), Equals, len(ol))
+
 	objectName := s.suiteDirPrefix + "foo"
 	err = b.PutBytes(ctx, objectName, []byte("content"), nil)
 	c.Assert(err, IsNil)

--- a/pkg/objectstore/objectstore_test.go
+++ b/pkg/objectstore/objectstore_test.go
@@ -441,18 +441,29 @@ func (s *ObjectStoreProviderSuite) TestBucketGetRegions(c *C) {
 	origBucket, err := s.provider.GetBucket(ctx, testBucketName)
 	c.Assert(err, IsNil)
 	c.Assert(origBucket, NotNil)
-	ol, oerr := origBucket.ListObjects(ctx)
-	c.Assert(oerr, IsNil)
-	c.Assert(ol, NotNil)
+
+	//Creating an object in existing bucket to check it later when we call GetOrCreateBucket,
+	//to see if existing bucket was returned
+	orgBucketObjectName := s.suiteDirPrefix + "GetRegions"
+	err = origBucket.PutBytes(ctx, orgBucketObjectName, []byte("content-getRegions"), nil)
+	c.Assert(err, IsNil)
+	defer func() {
+		err = origBucket.Delete(ctx, orgBucketObjectName)
+		c.Assert(err, IsNil)
+	}()
 
 	b, err := GetOrCreateBucket(ctx, s.provider, testBucketName)
 	c.Assert(err, IsNil)
 	c.Assert(b, NotNil)
+
+	//Checking if same bucket was returned by checking if object
+	//that was created previously exists in newly retrieved bucket
+	_, _, err = b.Get(ctx, orgBucketObjectName)
+	c.Assert(err, IsNil)
+
 	l, err := b.ListObjects(ctx)
 	c.Assert(err, IsNil)
 	c.Assert(l, NotNil)
-	c.Assert(len(l), Equals, len(ol))
-
 	objectName := s.suiteDirPrefix + "foo"
 	err = b.PutBytes(ctx, objectName, []byte("content"), nil)
 	c.Assert(err, IsNil)

--- a/pkg/objectstore/objectstore_test.go
+++ b/pkg/objectstore/objectstore_test.go
@@ -438,15 +438,11 @@ func (s *ObjectStoreProviderSuite) TestBucketGetRegions(c *C) {
 		c.Skip("Test only applicable to S3")
 	}
 	ctx := context.Background()
-	buckets, err := s.provider.ListBuckets(ctx)
+	_, err := s.provider.ListBuckets(ctx)
 	c.Assert(err, IsNil)
 	b, err := GetOrCreateBucket(ctx, s.provider, testBucketName)
 	c.Assert(err, IsNil)
 	c.Assert(b, NotNil)
-	// Make sure no new bucket was created
-	newBuckets, err := s.provider.ListBuckets(ctx)
-	c.Assert(err, IsNil)
-	c.Assert(newBuckets, HasLen, len(buckets))
 
 	l, err := b.ListObjects(ctx)
 	c.Assert(err, IsNil)

--- a/pkg/objectstore/objectstore_test.go
+++ b/pkg/objectstore/objectstore_test.go
@@ -442,8 +442,8 @@ func (s *ObjectStoreProviderSuite) TestBucketGetRegions(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(origBucket, NotNil)
 
-	//Creating an object in existing bucket to check it later when we call GetOrCreateBucket,
-	//to see if existing bucket was returned
+	// Creating an object in existing bucket to check it later when we call GetOrCreateBucket,
+	// to see if existing bucket was returned
 	orgBucketObjectName := s.suiteDirPrefix + "GetRegions"
 	err = origBucket.PutBytes(ctx, orgBucketObjectName, []byte("content-getRegions"), nil)
 	c.Assert(err, IsNil)
@@ -456,8 +456,8 @@ func (s *ObjectStoreProviderSuite) TestBucketGetRegions(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(b, NotNil)
 
-	//Checking if same bucket was returned by checking if object
-	//that was created previously exists in newly retrieved bucket
+	// Checking if same bucket was returned by checking if object
+	// that was created previously exists in newly retrieved bucket
 	_, _, err = b.Get(ctx, orgBucketObjectName)
 	c.Assert(err, IsNil)
 


### PR DESCRIPTION
## Change Overview

ObjectStoreProviderSuite.TestBucketGetRegions breaks when a S3 bucket is created or deleted as its comparing the count of buckets returned at 2 different points in time. This makes the test flaky.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
