### PR TITLE
Make postgres PITR blueprint compatible with postgres 12+

### DIFF
--- a/build/integration-test.sh
+++ b/build/integration-test.sh
@@ -25,9 +25,7 @@ TEST_TIMEOUT="30m"
 # Set default options
 TEST_OPTIONS="-tags=integration -timeout ${TEST_TIMEOUT} -check.suitep ${DOP}"
 # Regex to match apps to run in short mode
-# TODO: PITRPostgreSQL app is incompatible with PostgreSQL:13.4.0`
-# Re-enable PITRPostgreSQL app once fixed
-SHORT_APPS="^PostgreSQL$|^MySQL$|Elasticsearch|^MongoDB$|Maria"
+SHORT_APPS="^PostgreSQL$|^PITRPostgreSQL|^MySQL$|Elasticsearch|^MongoDB$|Maria"
 # OCAPPS has all the apps that are to be tested against openshift cluster
 OC_APPS3_11="MysqlDBDepConfig$|MongoDBDepConfig$|PostgreSQLDepConfig$"
 OC_APPS4_4="MysqlDBDepConfig4_4|MongoDBDepConfig4_4|PostgreSQLDepConfig4_4"

--- a/examples/stable/postgresql-wale/postgresql-blueprint.yaml
+++ b/examples/stable/postgresql-wale/postgresql-blueprint.yaml
@@ -221,17 +221,6 @@ actions:
             mv ${PGDATA}/kanister-restore/* ${PGDATA}/
             rm -fr ${PGDATA}/kanister-restore
 
-            # Create the recovery file that will apply the WAL files.
-            cat << EOF > "${PGDATA}"/recovery.conf
-            restore_command = 'envdir "${PGDATA}/env" wal-e --s3-prefix ${old_wale_prefix} wal-fetch "%f" "%p"'
-            {{- if .Options }}
-            {{- if .Options.pitr }}
-            recovery_target_time = '{{ toDate "2006-01-02T15:04:05Z" .Options.pitr | date "2006-01-02 15:04:05 GMT" }}'
-            {{- end }}
-            {{- end }}
-            EOF
-            sync
-
             # Create required configuration dir/config files
             # Create empty conf.d directory
             if [ ! -d $PGDATA/conf.d ]; then
@@ -240,6 +229,19 @@ actions:
 
             # Create default postgresql.conf
             cp /opt/bitnami/postgresql/share/postgresql.conf.sample $PGDATA/postgresql.conf
+
+            # Create the recovery file that will apply the WAL files.
+            touch $PGDATA/recovery.signal
+            cat << EOF >> "${PGDATA}"/postgresql.conf
+            restore_command = 'envdir "${PGDATA}/env" wal-e --s3-prefix ${old_wale_prefix} wal-fetch "%f" "%p"'
+            hot_standby = off
+            {{- if .Options }}
+            {{- if .Options.pitr }}
+            recovery_target_time = '{{ toDate "2006-01-02T15:04:05Z" .Options.pitr | date "2006-01-02 15:04:05 GMT" }}'
+            {{- end }}
+            {{- end }}
+            EOF
+            sync
 
             # Create default pg_hba.conf
             cat << EOF > $PGDATA/pg_hba.conf
@@ -264,6 +266,7 @@ actions:
             timeline={{ toDate "2006-01-02T15:04:05.999999999Z07:00" .Time  | date "2006-01-02T15-04-05" }}
             wale_s3_prefix="s3://{{ .Profile.Location.Bucket }}/{{ .ArtifactsIn.manifest.KeyValue.prefix }}/${timeline}"
             echo "${wale_s3_prefix}" > "${env_wal_prefix}"
+            rm $PGDATA/recovery.signal
     - func: ScaleWorkload
       name: restartPod
       args:


### PR DESCRIPTION
Signed-off-by: Prasad Ghangal <prasad.ghangal@gmail.com>

## Change Overview

- Make postgres PITR blueprint compatible with postgres 12+
- Enable PITRPostgreSQL test app in integration test suite

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test


## Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [x] :green_heart: E2E

```
PITRPostgreSQL integration test passed locally
$ ./build/integration-test.sh ^PITRPostgreSQL$
```