### PR TITLE
Functionality to call ingress operations after discovering APIVersion

### DIFF
--- a/pkg/kube/discover.go
+++ b/pkg/kube/discover.go
@@ -41,11 +41,12 @@ func IsOSRouteGroupAvailable(ctx context.Context, cli discovery.DiscoveryInterfa
 }
 
 func IsResAvailableInGroupVersion(ctx context.Context, cli discovery.DiscoveryInterface, groupName, version, resource string) (bool, error) {
-	gv := fmt.Sprintf("%s/%s", groupName, version)
 	resList, err := cli.ServerPreferredResources()
 	if err != nil {
 		return false, err
 	}
+
+	gv := fmt.Sprintf("%s/%s", groupName, version)
 	for _, res := range resList {
 		for _, r := range res.APIResources {
 			if r.Name == resource && gv == res.GroupVersion {

--- a/pkg/kube/discover.go
+++ b/pkg/kube/discover.go
@@ -41,13 +41,14 @@ func IsOSRouteGroupAvailable(ctx context.Context, cli discovery.DiscoveryInterfa
 }
 
 func IsResAvailableInGroupVersion(ctx context.Context, cli discovery.DiscoveryInterface, groupName, version, resource string) (bool, error) {
+	gv := fmt.Sprintf("%s/%s", groupName, version)
 	resList, err := cli.ServerPreferredResources()
 	if err != nil {
 		return false, err
 	}
 	for _, res := range resList {
 		for _, r := range res.APIResources {
-			if r.Name == resource && fmt.Sprintf("%s/%s", groupName, version) == res.GroupVersion {
+			if r.Name == resource && gv == res.GroupVersion {
 				return true, nil
 			}
 		}

--- a/pkg/kube/discover.go
+++ b/pkg/kube/discover.go
@@ -40,6 +40,21 @@ func IsOSRouteGroupAvailable(ctx context.Context, cli discovery.DiscoveryInterfa
 	return false, nil
 }
 
+func IsResAvailableInGroupVersion(ctx context.Context, cli discovery.DiscoveryInterface, groupName, version, resource string) (bool, error) {
+	resList, err := cli.ServerPreferredResources()
+	if err != nil {
+		return false, err
+	}
+	for _, res := range resList {
+		for _, r := range res.APIResources {
+			if r.Name == resource && fmt.Sprintf("%s/%s", groupName, version) == res.GroupVersion {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
 // IsGroupVersionAvailable returns true if given group/version is registered.
 func IsGroupVersionAvailable(ctx context.Context, cli discovery.DiscoveryInterface, groupName, version string) (bool, error) {
 	sgs, err := cli.ServerGroups()

--- a/pkg/kube/discover.go
+++ b/pkg/kube/discover.go
@@ -10,6 +10,8 @@ import (
 const (
 	osAppsGroupName  = `apps.openshift.io`
 	osRouteGroupName = `route.openshift.io`
+
+	groupVersionFormat = "%s/%s"
 )
 
 // IsOSAppsGroupAvailable returns true if the openshift apps group is registered in service discovery.
@@ -40,13 +42,14 @@ func IsOSRouteGroupAvailable(ctx context.Context, cli discovery.DiscoveryInterfa
 	return false, nil
 }
 
+// IsResAvailableInGroupVersion takes a resource and checks if that exists in the passed group and version
 func IsResAvailableInGroupVersion(ctx context.Context, cli discovery.DiscoveryInterface, groupName, version, resource string) (bool, error) {
 	resList, err := cli.ServerPreferredResources()
 	if err != nil {
 		return false, err
 	}
 
-	gv := fmt.Sprintf("%s/%s", groupName, version)
+	gv := fmt.Sprintf(groupVersionFormat, groupName, version)
 	for _, res := range resList {
 		for _, r := range res.APIResources {
 			if r.Name == resource && gv == res.GroupVersion {
@@ -66,7 +69,7 @@ func IsGroupVersionAvailable(ctx context.Context, cli discovery.DiscoveryInterfa
 
 	for _, g := range sgs.Groups {
 		for _, v := range g.Versions {
-			if fmt.Sprintf("%s/%s", groupName, version) == v.GroupVersion {
+			if fmt.Sprintf(groupVersionFormat, groupName, version) == v.GroupVersion {
 				return true, nil
 			}
 		}

--- a/pkg/kube/ingress/ingress_extbeta.go
+++ b/pkg/kube/ingress/ingress_extbeta.go
@@ -1,0 +1,41 @@
+// Copyright 2019 The Kanister Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ingress
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+)
+
+type IngressExtBeta struct {
+	kubeCli kubernetes.Interface
+}
+
+func NewIngressExtBeta(cli kubernetes.Interface) *IngressExtBeta {
+	return &IngressExtBeta{
+		kubeCli: cli,
+	}
+}
+
+func (i *IngressExtBeta) List(ctx context.Context, ns string) (runtime.Object, error) {
+	return i.kubeCli.ExtensionsV1beta1().Ingresses(ns).List(ctx, metav1.ListOptions{})
+}
+
+func (i *IngressExtBeta) Get(ctx context.Context, ns, name string) (runtime.Object, error) {
+	return i.kubeCli.ExtensionsV1beta1().Ingresses(ns).Get(ctx, name, metav1.GetOptions{})
+}

--- a/pkg/kube/ingress/ingress_extbeta.go
+++ b/pkg/kube/ingress/ingress_extbeta.go
@@ -36,16 +36,20 @@ func NewIngressExtBeta(cli kubernetes.Interface) *IngressExtBeta {
 	}
 }
 
+// List can be used to list all the ingress resources from `ns` namespace
 func (i *IngressExtBeta) List(ctx context.Context, ns string) (runtime.Object, error) {
 	return i.kubeCli.ExtensionsV1beta1().Ingresses(ns).List(ctx, metav1.ListOptions{})
 }
 
+// Get can be used to to get ingress resource with name `name` in `ns` namespace
 func (i *IngressExtBeta) Get(ctx context.Context, ns, name string) (runtime.Object, error) {
 	return i.kubeCli.ExtensionsV1beta1().Ingresses(ns).Get(ctx, name, metav1.GetOptions{})
 }
 
+// IngressPath can be used to get the backend path that is specified in the
+// ingress resource in `ns` namespace and name `releaseName-ingress`
 func (i *IngressExtBeta) IngressPath(ctx context.Context, ns, releaseName string) (string, error) {
-	obj, err := i.Get(ctx, ns, fmt.Sprintf("%s-ingress", releaseName))
+	obj, err := i.Get(ctx, ns, fmt.Sprintf("%s-%s", releaseName, ingressNameSuffix))
 	if apierrors.IsNotFound(err) {
 		// Try the release name if the ingress does not exist.
 		// This is possible if the user setup OIDC using the localhost IP
@@ -70,7 +74,7 @@ func (i *IngressExtBeta) IngressPath(ctx context.Context, ns, releaseName string
 	}
 	ingressPath := ""
 	for _, path := range ingressPaths {
-		if path.Backend.ServiceName == "gateway" {
+		if path.Backend.ServiceName == gatewaySvcName {
 			ingressPath = path.Path
 			break
 		}

--- a/pkg/kube/ingress/ingress_extbeta.go
+++ b/pkg/kube/ingress/ingress_extbeta.go
@@ -50,7 +50,7 @@ func (i *ExtensionsV1beta1) Get(ctx context.Context, ns, name string) (runtime.O
 // IngressPath can be used to get the backend path that is specified in the
 // ingress resource in `ns` namespace and name `releaseName-ingress`
 func (i *ExtensionsV1beta1) IngressPath(ctx context.Context, ns, releaseName string) (string, error) {
-	obj, err := i.Get(ctx, ns, fmt.Sprintf("%s-%s", releaseName, ingressNameSuffix))
+	obj, err := i.Get(ctx, ns, fmt.Sprintf(ingressNameFormat, releaseName, ingressNameSuffix))
 	if apierrors.IsNotFound(err) {
 		// Try the release name if the ingress does not exist.
 		// This is possible if the user setup OIDC using the localhost IP

--- a/pkg/kube/ingress/ingress_extbeta.go
+++ b/pkg/kube/ingress/ingress_extbeta.go
@@ -16,7 +16,11 @@ package ingress
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/pkg/errors"
+	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
@@ -38,4 +42,42 @@ func (i *IngressExtBeta) List(ctx context.Context, ns string) (runtime.Object, e
 
 func (i *IngressExtBeta) Get(ctx context.Context, ns, name string) (runtime.Object, error) {
 	return i.kubeCli.ExtensionsV1beta1().Ingresses(ns).Get(ctx, name, metav1.GetOptions{})
+}
+
+func (i *IngressExtBeta) IngressPath(ctx context.Context, ns, releaseName string) (string, error) {
+	obj, err := i.Get(ctx, ns, fmt.Sprintf("%s-ingress", releaseName))
+	if apierrors.IsNotFound(err) {
+		// Try the release name if the ingress does not exist.
+		// This is possible if the user setup OIDC using the localhost IP
+		// and has port forwarding turned on to access K10.
+		return releaseName, nil
+	}
+	if err != nil {
+		return "", err
+	}
+
+	ingress := obj.(*extensionsv1beta1.Ingress)
+	if len(ingress.Spec.Rules) == 0 {
+		return "", errors.Wrapf(err, "No ingress rules were found")
+	}
+	ingressHTTPRule := ingress.Spec.Rules[0].IngressRuleValue.HTTP
+	if ingressHTTPRule == nil {
+		return "", errors.Wrapf(err, "A HTTP ingress rule value is missing")
+	}
+	ingressPaths := ingressHTTPRule.Paths
+	if len(ingressPaths) == 0 {
+		return "", errors.Wrapf(err, "Failed to find HTTP paths in the ingress")
+	}
+	ingressPath := ""
+	for _, path := range ingressPaths {
+		if path.Backend.ServiceName == "gateway" {
+			ingressPath = path.Path
+			break
+		}
+	}
+	if ingressPath == "" {
+		return "", errors.Wrapf(err, "No path was set for K10's gateway service")
+	}
+
+	return ingressPath, nil
 }

--- a/pkg/kube/ingress/ingress_extbeta.go
+++ b/pkg/kube/ingress/ingress_extbeta.go
@@ -26,29 +26,30 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-type IngressExtBeta struct {
+// ExtensionsV1beta1 implements ingress.Manager interface
+type ExtensionsV1beta1 struct {
 	kubeCli kubernetes.Interface
 }
 
-func NewIngressExtBeta(cli kubernetes.Interface) *IngressExtBeta {
-	return &IngressExtBeta{
+func NewExtensionsV1beta1(cli kubernetes.Interface) *ExtensionsV1beta1 {
+	return &ExtensionsV1beta1{
 		kubeCli: cli,
 	}
 }
 
 // List can be used to list all the ingress resources from `ns` namespace
-func (i *IngressExtBeta) List(ctx context.Context, ns string) (runtime.Object, error) {
+func (i *ExtensionsV1beta1) List(ctx context.Context, ns string) (runtime.Object, error) {
 	return i.kubeCli.ExtensionsV1beta1().Ingresses(ns).List(ctx, metav1.ListOptions{})
 }
 
 // Get can be used to to get ingress resource with name `name` in `ns` namespace
-func (i *IngressExtBeta) Get(ctx context.Context, ns, name string) (runtime.Object, error) {
+func (i *ExtensionsV1beta1) Get(ctx context.Context, ns, name string) (runtime.Object, error) {
 	return i.kubeCli.ExtensionsV1beta1().Ingresses(ns).Get(ctx, name, metav1.GetOptions{})
 }
 
 // IngressPath can be used to get the backend path that is specified in the
 // ingress resource in `ns` namespace and name `releaseName-ingress`
-func (i *IngressExtBeta) IngressPath(ctx context.Context, ns, releaseName string) (string, error) {
+func (i *ExtensionsV1beta1) IngressPath(ctx context.Context, ns, releaseName string) (string, error) {
 	obj, err := i.Get(ctx, ns, fmt.Sprintf("%s-%s", releaseName, ingressNameSuffix))
 	if apierrors.IsNotFound(err) {
 		// Try the release name if the ingress does not exist.

--- a/pkg/kube/ingress/ingress_netbeta.go
+++ b/pkg/kube/ingress/ingress_netbeta.go
@@ -16,7 +16,11 @@ package ingress
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/pkg/errors"
+	netv1beta1 "k8s.io/api/networking/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
@@ -38,4 +42,42 @@ func (i *IngressNetBeta) List(ctx context.Context, ns string) (runtime.Object, e
 
 func (i *IngressNetBeta) Get(ctx context.Context, ns, name string) (runtime.Object, error) {
 	return i.kubeCli.NetworkingV1beta1().Ingresses(ns).Get(ctx, name, metav1.GetOptions{})
+}
+
+func (i *IngressNetBeta) IngressPath(ctx context.Context, ns, releaseName string) (string, error) {
+	obj, err := i.Get(ctx, ns, fmt.Sprintf("%s-ingress", releaseName))
+	if apierrors.IsNotFound(err) {
+		// Try the release name if the ingress does not exist.
+		// This is possible if the user setup OIDC using the localhost IP
+		// and has port forwarding turned on to access K10.
+		return releaseName, nil
+	}
+	if err != nil {
+		return "", err
+	}
+
+	ingress := obj.(*netv1beta1.Ingress)
+	if len(ingress.Spec.Rules) == 0 {
+		return "", errors.Wrapf(err, "No ingress rules were found")
+	}
+	ingressHTTPRule := ingress.Spec.Rules[0].IngressRuleValue.HTTP
+	if ingressHTTPRule == nil {
+		return "", errors.Wrapf(err, "A HTTP ingress rule value is missing")
+	}
+	ingressPaths := ingressHTTPRule.Paths
+	if len(ingressPaths) == 0 {
+		return "", errors.Wrapf(err, "Failed to find HTTP paths in the ingress")
+	}
+	ingressPath := ""
+	for _, path := range ingressPaths {
+		if path.Backend.ServiceName == "gateway" {
+			ingressPath = path.Path
+			break
+		}
+	}
+	if ingressPath == "" {
+		return "", errors.Wrapf(err, "No path was set for K10's gateway service")
+	}
+
+	return ingressPath, nil
 }

--- a/pkg/kube/ingress/ingress_netbeta.go
+++ b/pkg/kube/ingress/ingress_netbeta.go
@@ -1,0 +1,41 @@
+// Copyright 2019 The Kanister Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ingress
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+)
+
+type IngressNetBeta struct {
+	kubeCli kubernetes.Interface
+}
+
+func NewIngressNetBeta(cli kubernetes.Interface) *IngressNetBeta {
+	return &IngressNetBeta{
+		kubeCli: cli,
+	}
+}
+
+func (i *IngressNetBeta) List(ctx context.Context, ns string) (runtime.Object, error) {
+	return i.kubeCli.NetworkingV1beta1().Ingresses(ns).List(ctx, metav1.ListOptions{})
+}
+
+func (i *IngressNetBeta) Get(ctx context.Context, ns, name string) (runtime.Object, error) {
+	return i.kubeCli.NetworkingV1beta1().Ingresses(ns).Get(ctx, name, metav1.GetOptions{})
+}

--- a/pkg/kube/ingress/ingress_netbeta.go
+++ b/pkg/kube/ingress/ingress_netbeta.go
@@ -50,7 +50,7 @@ func (i *NetworkingV1beta1) Get(ctx context.Context, ns, name string) (runtime.O
 // IngressPath can be used to get the backend path that is specified in the
 // ingress resource in `ns` namespace and name `releaseName-ingress`
 func (i *NetworkingV1beta1) IngressPath(ctx context.Context, ns, releaseName string) (string, error) {
-	obj, err := i.Get(ctx, ns, fmt.Sprintf("%s-%s", releaseName, ingressNameSuffix))
+	obj, err := i.Get(ctx, ns, fmt.Sprintf(ingressNameFormat, releaseName, ingressNameSuffix))
 	if apierrors.IsNotFound(err) {
 		// Try the release name if the ingress does not exist.
 		// This is possible if the user setup OIDC using the localhost IP

--- a/pkg/kube/ingress/ingress_netbeta.go
+++ b/pkg/kube/ingress/ingress_netbeta.go
@@ -36,16 +36,20 @@ func NewIngressNetBeta(cli kubernetes.Interface) *IngressNetBeta {
 	}
 }
 
+// List can be used to list all the ingress resources from `ns` namespace
 func (i *IngressNetBeta) List(ctx context.Context, ns string) (runtime.Object, error) {
 	return i.kubeCli.NetworkingV1beta1().Ingresses(ns).List(ctx, metav1.ListOptions{})
 }
 
+// Get can be used to to get ingress resource with name `name` in `ns` namespace
 func (i *IngressNetBeta) Get(ctx context.Context, ns, name string) (runtime.Object, error) {
 	return i.kubeCli.NetworkingV1beta1().Ingresses(ns).Get(ctx, name, metav1.GetOptions{})
 }
 
+// IngressPath can be used to get the backend path that is specified in the
+// ingress resource in `ns` namespace and name `releaseName-ingress`
 func (i *IngressNetBeta) IngressPath(ctx context.Context, ns, releaseName string) (string, error) {
-	obj, err := i.Get(ctx, ns, fmt.Sprintf("%s-ingress", releaseName))
+	obj, err := i.Get(ctx, ns, fmt.Sprintf("%s-%s", releaseName, ingressNameSuffix))
 	if apierrors.IsNotFound(err) {
 		// Try the release name if the ingress does not exist.
 		// This is possible if the user setup OIDC using the localhost IP
@@ -70,7 +74,7 @@ func (i *IngressNetBeta) IngressPath(ctx context.Context, ns, releaseName string
 	}
 	ingressPath := ""
 	for _, path := range ingressPaths {
-		if path.Backend.ServiceName == "gateway" {
+		if path.Backend.ServiceName == gatewaySvcName {
 			ingressPath = path.Path
 			break
 		}

--- a/pkg/kube/ingress/ingress_netbeta.go
+++ b/pkg/kube/ingress/ingress_netbeta.go
@@ -26,29 +26,30 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-type IngressNetBeta struct {
+// NetworkingV1beta1 implements ingress.Manager interface
+type NetworkingV1beta1 struct {
 	kubeCli kubernetes.Interface
 }
 
-func NewIngressNetBeta(cli kubernetes.Interface) *IngressNetBeta {
-	return &IngressNetBeta{
+func NewNetworkingV1beta1(cli kubernetes.Interface) *NetworkingV1beta1 {
+	return &NetworkingV1beta1{
 		kubeCli: cli,
 	}
 }
 
 // List can be used to list all the ingress resources from `ns` namespace
-func (i *IngressNetBeta) List(ctx context.Context, ns string) (runtime.Object, error) {
+func (i *NetworkingV1beta1) List(ctx context.Context, ns string) (runtime.Object, error) {
 	return i.kubeCli.NetworkingV1beta1().Ingresses(ns).List(ctx, metav1.ListOptions{})
 }
 
 // Get can be used to to get ingress resource with name `name` in `ns` namespace
-func (i *IngressNetBeta) Get(ctx context.Context, ns, name string) (runtime.Object, error) {
+func (i *NetworkingV1beta1) Get(ctx context.Context, ns, name string) (runtime.Object, error) {
 	return i.kubeCli.NetworkingV1beta1().Ingresses(ns).Get(ctx, name, metav1.GetOptions{})
 }
 
 // IngressPath can be used to get the backend path that is specified in the
 // ingress resource in `ns` namespace and name `releaseName-ingress`
-func (i *IngressNetBeta) IngressPath(ctx context.Context, ns, releaseName string) (string, error) {
+func (i *NetworkingV1beta1) IngressPath(ctx context.Context, ns, releaseName string) (string, error) {
 	obj, err := i.Get(ctx, ns, fmt.Sprintf("%s-%s", releaseName, ingressNameSuffix))
 	if apierrors.IsNotFound(err) {
 		// Try the release name if the ingress does not exist.

--- a/pkg/kube/ingress/ingress_netv1.go
+++ b/pkg/kube/ingress/ingress_netv1.go
@@ -50,7 +50,7 @@ func (i *NetworkingV1) Get(ctx context.Context, ns, name string) (runtime.Object
 // IngressPath can be used to get the backend path that is specified in the
 // ingress resource in `ns` namespace and name `releaseName-ingress`
 func (i *NetworkingV1) IngressPath(ctx context.Context, ns, releaseName string) (string, error) {
-	obj, err := i.Get(ctx, ns, fmt.Sprintf("%s-%s", releaseName, ingressNameSuffix))
+	obj, err := i.Get(ctx, ns, fmt.Sprintf(ingressNameFormat, releaseName, ingressNameSuffix))
 	if apierrors.IsNotFound(err) {
 		// Try the release name if the ingress does not exist.
 		// This is possible if the user setup OIDC using the localhost IP

--- a/pkg/kube/ingress/ingress_netv1.go
+++ b/pkg/kube/ingress/ingress_netv1.go
@@ -36,16 +36,20 @@ func NewIngressNetV1(cli kubernetes.Interface) *IngressNetV1 {
 	}
 }
 
+// List can be used to list all the ingress resources from `ns` namespace
 func (i *IngressNetV1) List(ctx context.Context, ns string) (runtime.Object, error) {
 	return i.kubeCli.NetworkingV1().Ingresses(ns).List(ctx, metav1.ListOptions{})
 }
 
+// Get can be used to to get ingress resource with name `name` in `ns` namespace
 func (i *IngressNetV1) Get(ctx context.Context, ns, name string) (runtime.Object, error) {
 	return i.kubeCli.NetworkingV1().Ingresses(ns).Get(ctx, name, metav1.GetOptions{})
 }
 
+// IngressPath can be used to get the backend path that is specified in the
+// ingress resource in `ns` namespace and name `releaseName-ingress`
 func (i *IngressNetV1) IngressPath(ctx context.Context, ns, releaseName string) (string, error) {
-	obj, err := i.Get(ctx, ns, fmt.Sprintf("%s-ingress", releaseName))
+	obj, err := i.Get(ctx, ns, fmt.Sprintf("%s-%s", releaseName, ingressNameSuffix))
 	if apierrors.IsNotFound(err) {
 		// Try the release name if the ingress does not exist.
 		// This is possible if the user setup OIDC using the localhost IP
@@ -70,7 +74,7 @@ func (i *IngressNetV1) IngressPath(ctx context.Context, ns, releaseName string) 
 	}
 	ingressPath := ""
 	for _, path := range ingressPaths {
-		if path.Backend.Service.Name == "gateway" {
+		if path.Backend.Service.Name == gatewaySvcName {
 			ingressPath = path.Path
 			break
 		}

--- a/pkg/kube/ingress/ingress_netv1.go
+++ b/pkg/kube/ingress/ingress_netv1.go
@@ -26,29 +26,30 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-type IngressNetV1 struct {
+// NetworkingV1 implements ingress.Manager interface
+type NetworkingV1 struct {
 	kubeCli kubernetes.Interface
 }
 
-func NewIngressNetV1(cli kubernetes.Interface) *IngressNetV1 {
-	return &IngressNetV1{
+func NewNetworkingV1(cli kubernetes.Interface) *NetworkingV1 {
+	return &NetworkingV1{
 		kubeCli: cli,
 	}
 }
 
 // List can be used to list all the ingress resources from `ns` namespace
-func (i *IngressNetV1) List(ctx context.Context, ns string) (runtime.Object, error) {
+func (i *NetworkingV1) List(ctx context.Context, ns string) (runtime.Object, error) {
 	return i.kubeCli.NetworkingV1().Ingresses(ns).List(ctx, metav1.ListOptions{})
 }
 
 // Get can be used to to get ingress resource with name `name` in `ns` namespace
-func (i *IngressNetV1) Get(ctx context.Context, ns, name string) (runtime.Object, error) {
+func (i *NetworkingV1) Get(ctx context.Context, ns, name string) (runtime.Object, error) {
 	return i.kubeCli.NetworkingV1().Ingresses(ns).Get(ctx, name, metav1.GetOptions{})
 }
 
 // IngressPath can be used to get the backend path that is specified in the
 // ingress resource in `ns` namespace and name `releaseName-ingress`
-func (i *IngressNetV1) IngressPath(ctx context.Context, ns, releaseName string) (string, error) {
+func (i *NetworkingV1) IngressPath(ctx context.Context, ns, releaseName string) (string, error) {
 	obj, err := i.Get(ctx, ns, fmt.Sprintf("%s-%s", releaseName, ingressNameSuffix))
 	if apierrors.IsNotFound(err) {
 		// Try the release name if the ingress does not exist.

--- a/pkg/kube/ingress/ingress_netv1.go
+++ b/pkg/kube/ingress/ingress_netv1.go
@@ -1,0 +1,41 @@
+// Copyright 2019 The Kanister Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ingress
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+)
+
+type IngressNetV1 struct {
+	kubeCli kubernetes.Interface
+}
+
+func NewIngressNetV1(cli kubernetes.Interface) *IngressNetV1 {
+	return &IngressNetV1{
+		kubeCli: cli,
+	}
+}
+
+func (i *IngressNetV1) List(ctx context.Context, ns string) (runtime.Object, error) {
+	return i.kubeCli.NetworkingV1().Ingresses(ns).List(ctx, metav1.ListOptions{})
+}
+
+func (i *IngressNetV1) Get(ctx context.Context, ns, name string) (runtime.Object, error) {
+	return i.kubeCli.NetworkingV1().Ingresses(ns).Get(ctx, name, metav1.GetOptions{})
+}

--- a/pkg/kube/ingress/ingressmgr.go
+++ b/pkg/kube/ingress/ingressmgr.go
@@ -33,9 +33,9 @@ const (
 	ingressNameSuffix = "ingress"
 )
 
-// IngressMgr is an abstraction over the behaviour of the ingress resources that
-// depend on the APIVersion of the ingress resource
-type IngressMgr interface {
+// Manager is an abstraction over the behaviour of the ingress resources that
+// depends on the APIVersion of the ingress resource
+type Manager interface {
 	// List can be used to list all the ingress resources from `ns` namespace
 	List(ctx context.Context, ns string) (runtime.Object, error)
 	// Get can be used to to get ingress resource with name `name` in `ns` namespace
@@ -45,15 +45,15 @@ type IngressMgr interface {
 	IngressPath(ctx context.Context, ns, releaseName string) (string, error)
 }
 
-// NewIngressMgr can be used to get the IngressMgr based on the APIVersion of the ingress resources on the cluster
+// NewManager can be used to get the Manager based on the APIVersion of the ingress resources on the cluster
 // so that, respecitve methods from that APIVersion can be called
-func NewIngressMgr(ctx context.Context, kubeCli kubernetes.Interface) (IngressMgr, error) {
+func NewManager(ctx context.Context, kubeCli kubernetes.Interface) (Manager, error) {
 	exists, err := kube.IsResAvailableInGroupVersion(ctx, kubeCli.Discovery(), netv1.GroupName, netv1.SchemeGroupVersion.Version, ingressRes)
 	if err != nil {
 		return nil, errors.Errorf("Failed to call discovery APIs: %v", err)
 	}
 	if exists {
-		return NewIngressNetV1(kubeCli), nil
+		return NewNetworkingV1(kubeCli), nil
 	}
 
 	exists, err = kube.IsResAvailableInGroupVersion(ctx, kubeCli.Discovery(), extensionsv1beta1.GroupName, extensionsv1beta1.SchemeGroupVersion.Version, ingressRes)
@@ -61,7 +61,7 @@ func NewIngressMgr(ctx context.Context, kubeCli kubernetes.Interface) (IngressMg
 		return nil, errors.Errorf("Failed to call discovery APIs: %v", err)
 	}
 	if exists {
-		return NewIngressExtBeta(kubeCli), nil
+		return NewExtensionsV1beta1(kubeCli), nil
 	}
 
 	exists, err = kube.IsResAvailableInGroupVersion(ctx, kubeCli.Discovery(), netv1beta1.GroupName, netv1beta1.SchemeGroupVersion.Version, ingressRes)
@@ -69,7 +69,7 @@ func NewIngressMgr(ctx context.Context, kubeCli kubernetes.Interface) (IngressMg
 		return nil, errors.Errorf("Failed to call discovery APIs: %v", err)
 	}
 	if exists {
-		return NewIngressNetBeta(kubeCli), nil
+		return NewNetworkingV1beta1(kubeCli), nil
 	}
 	return nil, errors.New("Ingress resources are not available")
 }

--- a/pkg/kube/ingress/ingressmgr.go
+++ b/pkg/kube/ingress/ingressmgr.go
@@ -1,0 +1,64 @@
+// Copyright 2019 The Kanister Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ingress
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	netv1 "k8s.io/api/networking/v1"
+	netv1beta1 "k8s.io/api/networking/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/kanisterio/kanister/pkg/kube"
+)
+
+const (
+	ingressRes = "ingresses"
+)
+
+type IngressMgr interface {
+	List(ctx context.Context, ns string) (runtime.Object, error)
+	Get(ctx context.Context, ns, name string) (runtime.Object, error)
+}
+
+func NewIngressMgr(ctx context.Context, kubeCli kubernetes.Interface) (IngressMgr, error) {
+	exists, err := kube.IsResAvailableInGroupVersion(ctx, kubeCli.Discovery(), netv1.GroupName, netv1.SchemeGroupVersion.Version, ingressRes)
+	if err != nil {
+		return nil, errors.Errorf("Failed to call discovery APIs: %v", err)
+	}
+	if exists {
+		return NewIngressNetV1(kubeCli), nil
+	}
+
+	exists, err = kube.IsResAvailableInGroupVersion(ctx, kubeCli.Discovery(), extensionsv1beta1.GroupName, extensionsv1beta1.SchemeGroupVersion.Version, ingressRes)
+	if err != nil {
+		return nil, errors.Errorf("Failed to call discovery APIs: %v", err)
+	}
+	if exists {
+		return NewIngressExtBeta(kubeCli), nil
+	}
+
+	exists, err = kube.IsResAvailableInGroupVersion(ctx, kubeCli.Discovery(), netv1beta1.GroupName, netv1beta1.SchemeGroupVersion.Version, ingressRes)
+	if err != nil {
+		return nil, errors.Errorf("Failed to call discovery APIs: %v", err)
+	}
+	if exists {
+		return NewIngressNetBeta(kubeCli), nil
+	}
+	return nil, errors.New("Ingress resources are not available")
+}

--- a/pkg/kube/ingress/ingressmgr.go
+++ b/pkg/kube/ingress/ingressmgr.go
@@ -34,6 +34,7 @@ const (
 type IngressMgr interface {
 	List(ctx context.Context, ns string) (runtime.Object, error)
 	Get(ctx context.Context, ns, name string) (runtime.Object, error)
+	IngressPath(ctx context.Context, ns, releaseName string) (string, error)
 }
 
 func NewIngressMgr(ctx context.Context, kubeCli kubernetes.Interface) (IngressMgr, error) {

--- a/pkg/kube/ingress/ingressmgr.go
+++ b/pkg/kube/ingress/ingressmgr.go
@@ -28,15 +28,25 @@ import (
 )
 
 const (
-	ingressRes = "ingresses"
+	ingressRes        = "ingresses"
+	gatewaySvcName    = "gateway"
+	ingressNameSuffix = "ingress"
 )
 
+// IngressMgr is an abstraction over the behaviour of the ingress resources that
+// depend on the APIVersion of the ingress resource
 type IngressMgr interface {
+	// List can be used to list all the ingress resources from `ns` namespace
 	List(ctx context.Context, ns string) (runtime.Object, error)
+	// Get can be used to to get ingress resource with name `name` in `ns` namespace
 	Get(ctx context.Context, ns, name string) (runtime.Object, error)
+	// IngressPath can be used to get the backend path that is specified in the
+	// ingress resource in `ns` namespace and name `releaseName-ingress`
 	IngressPath(ctx context.Context, ns, releaseName string) (string, error)
 }
 
+// NewIngressMgr can be used to get the IngressMgr based on the APIVersion of the ingress resources on the cluster
+// so that, respecitve methods from that APIVersion can be called
 func NewIngressMgr(ctx context.Context, kubeCli kubernetes.Interface) (IngressMgr, error) {
 	exists, err := kube.IsResAvailableInGroupVersion(ctx, kubeCli.Discovery(), netv1.GroupName, netv1.SchemeGroupVersion.Version, ingressRes)
 	if err != nil {

--- a/pkg/kube/ingress/ingressmgr.go
+++ b/pkg/kube/ingress/ingressmgr.go
@@ -31,6 +31,7 @@ const (
 	ingressRes        = "ingresses"
 	gatewaySvcName    = "gateway"
 	ingressNameSuffix = "ingress"
+	ingressNameFormat = "%s-%s"
 )
 
 // Manager is an abstraction over the behaviour of the ingress resources that


### PR DESCRIPTION
## Change Overview

To support k8s version 1.17 and 1.22 we will have to make sure that we are getting the ingress resources from the api version that is present on the cluster, for example we can not get ingresses from api version networking/v1 on k8s versions 1.22.
This PR adds wrappers that can be used to figure out which api version ingresses are part and then call the helper methods to eventually call the verb methods (get/list) from respective apis.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [x] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->


- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
