### PR TITLE
Fix to wait for delete_mount_targets to complete

### DIFF
--- a/pkg/blockstorage/awsefs/awsefs.go
+++ b/pkg/blockstorage/awsefs/awsefs.go
@@ -133,6 +133,13 @@ func (e *efs) VolumeCreate(ctx context.Context, volume blockstorage.Volume) (*bl
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to get recently create EFS instance")
 	}
+	_, mountTargets, err := filterAndGetMountTargetsFromTags(blockstorage.KeyValueToMap(volume.Tags))
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to get filtered tags and mount targets")
+	}
+	if err = e.createMountTargets(ctx, vol.ID, mountTargets); err != nil {
+		return nil, errors.Wrap(err, "Failed to create mount targets")
+	}
 	return vol, nil
 }
 
@@ -254,12 +261,12 @@ func parseMountTargetValue(value string) (*mountTarget, error) {
 	// Example value:
 	// subnet-123+securityGroup-1+securityGroup-2
 	tokens := strings.Split(value, securityGroupSeperator)
-	if len(tokens) <= 1 {
+	if len(tokens) < 1 {
 		return nil, errors.New("Malformed string for mount target values")
 	}
 	subnetID := tokens[0]
 	sgs := make([]string, 0)
-	if len(tokens[1]) != 0 {
+	if len(tokens) > 1 {
 		sgs = append(sgs, tokens[1:]...)
 	}
 	return &mountTarget{

--- a/pkg/blockstorage/awsefs/awsefs.go
+++ b/pkg/blockstorage/awsefs/awsefs.go
@@ -349,6 +349,10 @@ func (e *efs) deleteMountTargets(ctx context.Context, mts []*awsefs.MountTargetD
 		if err != nil {
 			return err
 		}
+		err = e.waitUntilMountTargetIsDeleted(ctx, *mt.MountTargetId)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/blockstorage/awsefs/wait.go
+++ b/pkg/blockstorage/awsefs/wait.go
@@ -114,6 +114,22 @@ func (e *efs) waitUntilMountTargetReady(ctx context.Context, mountTargetID strin
 	})
 }
 
+func (e *efs) waitUntilMountTargetIsDeleted(ctx context.Context, mountTargetID string) error {
+	return poll.Wait(ctx, func(ctx context.Context) (bool, error) {
+		req := &awsefs.DescribeMountTargetsInput{}
+		req.SetMountTargetId(mountTargetID)
+
+		_, err := e.DescribeMountTargetsWithContext(ctx, req)
+		if isMountTargetNotFound(err) {
+			return true, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		return false, nil
+	})
+}
+
 func (e *efs) waitUntilRestoreComplete(ctx context.Context, restoreJobID string) error {
 	return poll.Wait(ctx, func(ctx context.Context) (bool, error) {
 		req := &backup.DescribeRestoreJobInput{}


### PR DESCRIPTION
## Change Overview

EFS volume delete fails because the Volume is still in use. This error occurs when the volume still has mount targets. We need to wait till these mount targets are completely deleted before deleting the efs volume.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
