### PR TITLE
Don't use params field, if they are nil, while cloning volumesnapshotclass

### DIFF
--- a/pkg/kube/snapshot/snapshot_alpha.go
+++ b/pkg/kube/snapshot/snapshot_alpha.go
@@ -422,30 +422,22 @@ func UnstructuredVolumeSnapshotContentAlpha(name, snapshotName, snapshotNs, dele
 }
 
 func UnstructuredVolumeSnapshotClassAlpha(name, driver, deletionPolicy string, params map[string]string) *unstructured.Unstructured {
-	if params == nil {
-		return &unstructured.Unstructured{
-			Object: map[string]interface{}{
-				"apiVersion": fmt.Sprintf("%s/%s", v1alpha1.GroupName, v1alpha1.Version),
-				"kind":       VolSnapClassKind,
-				"metadata": map[string]interface{}{
-					"name": name,
-				},
-				VolSnapClassAlphaDriverKey: driver,
-				"deletionPolicy":           deletionPolicy,
-			},
-		}
-	}
-	return &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"apiVersion": fmt.Sprintf("%s/%s", v1alpha1.GroupName, v1alpha1.Version),
-			"kind":       VolSnapClassKind,
-			"metadata": map[string]interface{}{
-				"name": name,
-			},
-			VolSnapClassAlphaDriverKey: driver,
-			"deletionPolicy":           deletionPolicy,
-			"parameters":               Mss2msi(params),
+	obj := map[string]interface{}{
+		"apiVersion": fmt.Sprintf("%s/%s", v1alpha1.GroupName, v1alpha1.Version),
+		"kind":       VolSnapClassKind,
+		"metadata": map[string]interface{}{
+			"name": name,
 		},
+		VolSnapClassAlphaDriverKey: driver,
+		"deletionPolicy":           deletionPolicy,
+	}
+
+	if params != nil {
+		obj["parameters"] = Mss2msi(params)
+	}
+
+	return &unstructured.Unstructured{
+		Object: obj,
 	}
 }
 

--- a/pkg/kube/snapshot/snapshot_alpha.go
+++ b/pkg/kube/snapshot/snapshot_alpha.go
@@ -422,6 +422,19 @@ func UnstructuredVolumeSnapshotContentAlpha(name, snapshotName, snapshotNs, dele
 }
 
 func UnstructuredVolumeSnapshotClassAlpha(name, driver, deletionPolicy string, params map[string]string) *unstructured.Unstructured {
+	if params == nil {
+		return &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": fmt.Sprintf("%s/%s", v1alpha1.GroupName, v1alpha1.Version),
+				"kind":       VolSnapClassKind,
+				"metadata": map[string]interface{}{
+					"name": name,
+				},
+				VolSnapClassAlphaDriverKey: driver,
+				"deletionPolicy":           deletionPolicy,
+			},
+		}
+	}
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": fmt.Sprintf("%s/%s", v1alpha1.GroupName, v1alpha1.Version),

--- a/pkg/kube/snapshot/snapshot_beta.go
+++ b/pkg/kube/snapshot/snapshot_beta.go
@@ -402,30 +402,21 @@ func UnstructuredVolumeSnapshotContent(gvr schema.GroupVersionResource, name, sn
 }
 
 func UnstructuredVolumeSnapshotClass(gvr schema.GroupVersionResource, name, driver, deletionPolicy string, params map[string]string) *unstructured.Unstructured {
-	if params == nil {
-		return &unstructured.Unstructured{
-			Object: map[string]interface{}{
-				"apiVersion": fmt.Sprintf("%s/%s", gvr.Group, gvr.Version),
-				"kind":       VolSnapClassKind,
-				"metadata": map[string]interface{}{
-					"name": name,
-				},
-				VolSnapClassBetaDriverKey: driver,
-				"deletionPolicy":          deletionPolicy,
-			},
-		}
-	}
-	return &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"apiVersion": fmt.Sprintf("%s/%s", gvr.Group, gvr.Version),
-			"kind":       VolSnapClassKind,
-			"metadata": map[string]interface{}{
-				"name": name,
-			},
-			VolSnapClassBetaDriverKey: driver,
-			"deletionPolicy":          deletionPolicy,
-			"parameters":              Mss2msi(params),
+	obj := map[string]interface{}{
+		"apiVersion": fmt.Sprintf("%s/%s", gvr.Group, gvr.Version),
+		"kind":       VolSnapClassKind,
+		"metadata": map[string]interface{}{
+			"name": name,
 		},
+		VolSnapClassBetaDriverKey: driver,
+		"deletionPolicy":          deletionPolicy,
+	}
+	if params != nil {
+		obj["parameters"] = Mss2msi(params)
+	}
+
+	return &unstructured.Unstructured{
+		Object: obj,
 	}
 }
 

--- a/pkg/kube/snapshot/snapshot_beta.go
+++ b/pkg/kube/snapshot/snapshot_beta.go
@@ -402,6 +402,19 @@ func UnstructuredVolumeSnapshotContent(gvr schema.GroupVersionResource, name, sn
 }
 
 func UnstructuredVolumeSnapshotClass(gvr schema.GroupVersionResource, name, driver, deletionPolicy string, params map[string]string) *unstructured.Unstructured {
+	if params == nil {
+		return &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": fmt.Sprintf("%s/%s", gvr.Group, gvr.Version),
+				"kind":       VolSnapClassKind,
+				"metadata": map[string]interface{}{
+					"name": name,
+				},
+				VolSnapClassBetaDriverKey: driver,
+				"deletionPolicy":          deletionPolicy,
+			},
+		}
+	}
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": fmt.Sprintf("%s/%s", gvr.Group, gvr.Version),


### PR DESCRIPTION
## Change Overview

While cloning `VolumeSnapshotClass`, as part of https://github.com/kanisterio/kanister/pull/1128
we started passing params. But we should not pass params if the values
is `nil`, because in that case creation `VolumeSnapshotClass` fails with
`nil` not allowed.

## Pull request type

Please check the type of change your PR introduces:

- [x] :bug: Bugfix

## Issues

- #XXX

## Test Plan

- [x] :muscle: Manual

Updated *** with kanister commit id and then updated the image in the env where we have been facing problem to make sure things have been resolved.