### PR TITLE
Handle fatal errors while uploading data using kopia

### DIFF
--- a/pkg/stream/stream.go
+++ b/pkg/stream/stream.go
@@ -53,6 +53,8 @@ func Push(ctx context.Context, configFile, dirPath, filePath, password, sourceEn
 
 	// Setup kopia uploader
 	u := snapshotfs.NewUploader(rep)
+	// Fail full snapshot if errors are encountered during upload
+	u.FailFast = true
 
 	// Populate the source info with source path and file
 	sourceInfo := snapshot.SourceInfo{


### PR DESCRIPTION
## Change Overview

- Enable `FailFast` while creating kopia uploader.
- Handle failed entries in the manifest created for the snapshot.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
