### PR TITLE
Adding better error message

### DIFF
--- a/pkg/blockstorage/awsefs/wait.go
+++ b/pkg/blockstorage/awsefs/wait.go
@@ -146,7 +146,7 @@ func (e *efs) waitUntilRestoreComplete(ctx context.Context, restoreJobID string)
 		case backup.RestoreJobStatusCompleted:
 			return true, nil
 		case backup.RestoreJobStatusAborted, backup.RestoreJobStatusFailed:
-			return false, errors.New("Restore job is not completed successfully")
+			return false, errors.Errorf("Restore job is not completed successfully (%s)\n", *resp.StatusMessage)
 		default:
 			return false, nil
 		}

--- a/pkg/blockstorage/awsefs/wait.go
+++ b/pkg/blockstorage/awsefs/wait.go
@@ -145,8 +145,10 @@ func (e *efs) waitUntilRestoreComplete(ctx context.Context, restoreJobID string)
 		switch *resp.Status {
 		case backup.RestoreJobStatusCompleted:
 			return true, nil
-		case backup.RestoreJobStatusAborted, backup.RestoreJobStatusFailed:
-			return false, errors.Errorf("Restore job is not completed successfully (%s)\n", *resp.StatusMessage)
+		case backup.RestoreJobStatusAborted:
+			return false, errors.Errorf("Restore job aborted (%s)\n", resp.String())
+		case backup.RestoreJobStatusFailed:
+			return false, errors.Errorf("Restore job failed (%s)\n", resp.String())
 		default:
 			return false, nil
 		}


### PR DESCRIPTION
## Change Overview

Aws integration tests fail intermittently with FileSystemAlreadyExists error. This should at least print a more useful error message going further. We will need to address this by ignoring such errors. 

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
