### PR TITLE
Fallback to `extensions/v1beta1` for ingress APIs in case of fake CLI

### DIFF
--- a/pkg/kube/ingress/ingressmgr.go
+++ b/pkg/kube/ingress/ingressmgr.go
@@ -58,7 +58,7 @@ func NewManager(ctx context.Context, kubeCli kubernetes.Interface) (Manager, err
 	if err != nil {
 		return nil, errors.New("Error finding if the CLI was fake CLI")
 	}
-	if len(list) == 0 {
+	if list == nil {
 		return nil, nil
 	}
 

--- a/pkg/kube/ingress/ingressmgr.go
+++ b/pkg/kube/ingress/ingressmgr.go
@@ -53,15 +53,6 @@ type Manager interface {
 // NewManager can be used to get the Manager based on the APIVersion of the ingress resources on the cluster
 // so that, respecitve methods from that APIVersion can be called
 func NewManager(ctx context.Context, kubeCli kubernetes.Interface) (Manager, error) {
-	// Kubernetes fake CLI doesn't implement `ServerPreferredResources`. Return early when used.
-	// list, err := kubeCli.Discovery().ServerPreferredResources()
-	// if err != nil {
-	// 	return nil, errors.Wrap(err, "Failed to discover the server preferred resources")
-	// }
-	// if list == nil {
-	// 	return nil, nil
-	// }
-
 	exists, err := kube.IsResAvailableInGroupVersion(ctx, kubeCli.Discovery(), netv1.GroupName, netv1.SchemeGroupVersion.Version, ingressRes)
 	if err != nil {
 		return nil, errors.Errorf("Failed to call discovery APIs: %v", err)
@@ -86,7 +77,7 @@ func NewManager(ctx context.Context, kubeCli kubernetes.Interface) (Manager, err
 		return NewNetworkingV1beta1(kubeCli), nil
 	}
 
-	// We were not able to figure out which groupVersion resource is available in
-	// most probably its because fake CLI was used, default to extensions/v1beta1
+	// We were not able to figure out which groupVersion, resource is available in.
+	// Most probably its because fake CLI was used, fallback to extensions/v1beta1
 	return NewExtensionsV1beta1(kubeCli), nil
 }


### PR DESCRIPTION
## Change Overview

While creating ingress manager to interact with ingress resources based on apiVersion, we were failing when fake kubeclient was passed.
This PR tries to default to `extensions/v1beta1` in that case.

## Pull request type

Please check the type of change your PR introduces:

- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
