### PR TITLE
Fix `gzip` not found issue on kanister-kubectl image

### DIFF
--- a/docker/tools/Dockerfile
+++ b/docker/tools/Dockerfile
@@ -15,7 +15,7 @@ COPY --from=ghcr.io/kastenhq/kopia@sha256:ad987e7062686fb1c2485e7c1a942687086821
 COPY LICENSE /licenses/LICENSE
 
 ADD kando /usr/local/bin/
-RUN microdnf update && microdnf install shadow-utils httpd-tools && \
+RUN microdnf update && microdnf install shadow-utils httpd-tools gzip && \
   adduser -U kanister -u 1000 && \
   microdnf remove shadow-utils && \
   microdnf clean all


### PR DESCRIPTION

## Change Overview

In the recent release (`0.70.0`) of kanister we changed the
base image of kanister-tools image that resulted into a failure
in kanister-kubectl image.
It started failing with `gzip` command not found, and the reason
is when we run `microdnf update` on previous rh base image it
install gzip but not in the newere rh base image.
This commit install gzip manually.


## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

Build the image and make sure gzip is present.