### PR TITLE
Bump base image for mongo app to 4.4.10

### DIFF
--- a/docker/mongodb/Dockerfile
+++ b/docker/mongodb/Dockerfile
@@ -1,9 +1,6 @@
-FROM bitnami/mongodb:4.4
+FROM bitnami/mongodb:4.4.10-debian-10-r70
 
 MAINTAINER "Tom Manville <tom@kasten.io>"
-
-# Install restic to take backups
-COPY --from=restic/restic:0.11.0 /usr/bin/restic /usr/local/bin/restic
 
 # Install kando
 ADD kando /usr/local/bin/

--- a/pkg/app/mongodb.go
+++ b/pkg/app/mongodb.go
@@ -64,6 +64,7 @@ func NewMongoDB(name string) App {
 				"image.registry":   "ghcr.io",
 				"image.repository": "kanisterio/mongodb",
 				"image.tag":        "latest",
+				"image.pullPolicy": "Always",
 			},
 		},
 	}


### PR DESCRIPTION
## Change Overview

- Bump baseimage for mongo app to 4.4.10-debian-10-r70
- Change imagePullPolicy of mongo test app to Always
- Remove restic from the base image - we no longer need it

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [x] :robot: Test


## Test Plan

Tested e2e integration test for MongoDB app

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
