### PR TITLE
Add kubernetes 1.22 support, in helm RBAC templates

### DIFF
--- a/helm/kanister-operator/templates/rbac.yaml
+++ b/helm/kanister-operator/templates/rbac.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.rbac.create }}
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
 {{ include "kanister-operator.helmLabels" . | indent 4 }}
@@ -26,7 +26,7 @@ rules:
   - "*"
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
 {{ include "kanister-operator.helmLabels" . | indent 4 }}
@@ -41,7 +41,7 @@ subjects:
   namespace: {{ .Release.Namespace }}
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
 {{ include "kanister-operator.helmLabels" . | indent 4 }}
@@ -57,7 +57,7 @@ subjects:
 {{- end }}
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
 {{ include "kanister-operator.helmLabels" . | indent 4 }}


### PR DESCRIPTION
## Change Overview

We will not be able to install kanister as of now on k8s 1.22 because the RBAC related resources are being created from `apiVersion: rbac.authorization.k8s.io/v1beta1` which is not available in 1.22 version.
This updates that apiVersion to `v1` that was available since k8s version 1.8.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [x] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- https://github.com/kanisterio/kanister/issues/1173

## Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E

- Install published kanister version on k8s version 1.22 (RBAC `v1` version)
- Install published kanister version on k8s version less than 1.22 (RBAC `v1beta1` version) and then upgrade to fixed version
