### PR TITLE
Changes to pick largest Restore Size 

### DIFF
--- a/pkg/kube/volume/volume.go
+++ b/pkg/kube/volume/volume.go
@@ -170,6 +170,14 @@ func CreatePVCFromSnapshot(ctx context.Context, args *CreatePVCFromSnapshotArgs)
 func getPVCRestoreSize(ctx context.Context, args *CreatePVCFromSnapshotArgs) (*resource.Quantity, error) {
 	quantities := []*resource.Quantity{}
 
+	if args.RestoreSize != "" {
+		s, err := resource.ParseQuantity(args.RestoreSize)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to parse quantity (%s)", args.RestoreSize)
+		}
+		quantities = append(quantities, &s)
+	}
+
 	sns, err := snapshot.NewSnapshotter(args.KubeCli, args.DynCli)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to get snapshotter")
@@ -180,13 +188,6 @@ func getPVCRestoreSize(ctx context.Context, args *CreatePVCFromSnapshotArgs) (*r
 	}
 	if snap.Status != nil && snap.Status.RestoreSize != nil {
 		quantities = append(quantities, snap.Status.RestoreSize)
-	}
-	if args.RestoreSize != "" {
-		s, err := resource.ParseQuantity(args.RestoreSize)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to parse quantity (%s)", args.RestoreSize)
-		}
-		quantities = append(quantities, &s)
 	}
 
 	if len(quantities) == 0 {

--- a/pkg/kube/volume/volume_test.go
+++ b/pkg/kube/volume/volume_test.go
@@ -181,13 +181,13 @@ func (s *TestVolSuite) TestGetPVCRestoreSize(c *C) {
 	}
 }
 
-func (s *TestVolSuite) fakeUnstructuredSnasphotWSize(name, namespace, size string) *unstructured.Unstructured {
+func (s *TestVolSuite) fakeUnstructuredSnasphotWSize(vsName, namespace, size string) *unstructured.Unstructured {
 	gvr := schema.GroupVersionResource{Group: "snapshot.storage.k8s.io", Version: "v1", Resource: "volumesnapshots"}
 	Object := map[string]interface{}{
 		"apiVersion": fmt.Sprintf("%s/%s", gvr.Group, gvr.Version),
 		"kind":       "VolumeSnapshot",
 		"metadata": map[string]interface{}{
-			"name":      name,
+			"name":      vsName,
 			"namespace": namespace,
 		},
 	}

--- a/pkg/kube/volume/volume_test.go
+++ b/pkg/kube/volume/volume_test.go
@@ -138,9 +138,9 @@ func (s *TestVolSuite) TestGetPVCRestoreSize(c *C) {
 			args: &CreatePVCFromSnapshotArgs{
 				KubeCli: fakeCli,
 				DynCli: dynfake.NewSimpleDynamicClient(scheme,
-					s.fakeUnstructuredSnasphotWSize("vsName1", "vsNamespace", "9Gi")),
+					s.fakeUnstructuredSnasphotWSize("vsName1", "vsNamespace1", "9Gi")),
 				SnapshotName: "vsName1",
-				Namespace:    "vsNamespace",
+				Namespace:    "vsNamespace1",
 				RestoreSize:  "10Gi",
 			},
 			sizeValue:  10737418240,

--- a/pkg/kube/volume/volume_test.go
+++ b/pkg/kube/volume/volume_test.go
@@ -146,17 +146,6 @@ func (s *TestVolSuite) TestGetPVCRestoreSize(c *C) {
 			sizeValue:  10737418240,
 			errChecker: IsNil,
 		},
-		{ // bad args restore size
-			args: &CreatePVCFromSnapshotArgs{
-				KubeCli: fakeCli,
-				DynCli: dynfake.NewSimpleDynamicClient(scheme,
-					s.fakeUnstructuredSnasphotWSize("vsName", "vsNamespace", "")),
-				SnapshotName: "vsName",
-				Namespace:    "vsNamespace",
-				RestoreSize:  "10wut",
-			},
-			errChecker: NotNil,
-		},
 		{ // Failed to find snapshot
 			args: &CreatePVCFromSnapshotArgs{
 				KubeCli:      fakeCli,
@@ -172,6 +161,14 @@ func (s *TestVolSuite) TestGetPVCRestoreSize(c *C) {
 				DynCli:       dynfake.NewSimpleDynamicClient(scheme),
 				SnapshotName: "vsName",
 				Namespace:    "vsNamespace",
+			},
+			errChecker: NotNil,
+		},
+		{ // bad args restore size
+			args: &CreatePVCFromSnapshotArgs{
+				SnapshotName: "vsName",
+				Namespace:    "vsNamespace",
+				RestoreSize:  "10wut",
 			},
 			errChecker: NotNil,
 		},

--- a/pkg/kube/volume/volume_test.go
+++ b/pkg/kube/volume/volume_test.go
@@ -16,13 +16,19 @@ package volume
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"reflect"
 	"testing"
 
 	. "gopkg.in/check.v1"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
@@ -64,4 +70,135 @@ func (s *TestVolSuite) TestCreatePVC(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(len(pvc2.Spec.AccessModes) >= 1, Equals, true)
 	c.Assert(*pvc2.Spec.VolumeMode, Equals, v1.PersistentVolumeBlock)
+}
+
+func (s *TestVolSuite) TestGetPVCRestoreSize(c *C) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: "snapshot.storage.k8s.io", Version: "v1", Kind: "VolumeSnapshotList"}, &unstructured.UnstructuredList{})
+	fakeCli := fake.NewSimpleClientset()
+	fakeCli.Resources = []*metav1.APIResourceList{{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "VolumeSnapshot",
+			APIVersion: "v1",
+		},
+		GroupVersion: "snapshot.storage.k8s.io/v1",
+	}}
+	for _, tc := range []struct {
+		args       *CreatePVCFromSnapshotArgs
+		sizeValue  int64
+		errChecker Checker
+	}{
+		{ // only snapshot restore size
+			args: &CreatePVCFromSnapshotArgs{
+				KubeCli: fakeCli,
+				DynCli: dynfake.NewSimpleDynamicClient(scheme,
+					s.fakeUnstructuredSnasphotWSize("vsName", "vsNamespace", "10Gi")),
+				SnapshotName: "vsName",
+				Namespace:    "vsNamespace",
+			},
+			sizeValue:  10737418240,
+			errChecker: IsNil,
+		},
+		{ // only args restore size
+			args: &CreatePVCFromSnapshotArgs{
+				KubeCli: fakeCli,
+				DynCli: dynfake.NewSimpleDynamicClient(scheme,
+					s.fakeUnstructuredSnasphotWSize("vsName", "vsNamespace", "")),
+				SnapshotName: "vsName",
+				Namespace:    "vsNamespace",
+				RestoreSize:  "10Gi",
+			},
+			sizeValue:  10737418240,
+			errChecker: IsNil,
+		},
+		{ // neither
+			args: &CreatePVCFromSnapshotArgs{
+				KubeCli: fakeCli,
+				DynCli: dynfake.NewSimpleDynamicClient(scheme,
+					s.fakeUnstructuredSnasphotWSize("vsName", "vsNamespace", "")),
+				SnapshotName: "vsName",
+				Namespace:    "vsNamespace",
+			},
+			errChecker: NotNil,
+		},
+		{ // both, snapshot size is bigger
+			args: &CreatePVCFromSnapshotArgs{
+				KubeCli: fakeCli,
+				DynCli: dynfake.NewSimpleDynamicClient(scheme,
+					s.fakeUnstructuredSnasphotWSize("vsName", "vsNamespace", "10Gi")),
+				SnapshotName: "vsName",
+				Namespace:    "vsNamespace",
+				RestoreSize:  "9Gi",
+			},
+			sizeValue:  10737418240,
+			errChecker: IsNil,
+		},
+		{ // both, args size is bigger
+			args: &CreatePVCFromSnapshotArgs{
+				KubeCli: fakeCli,
+				DynCli: dynfake.NewSimpleDynamicClient(scheme,
+					s.fakeUnstructuredSnasphotWSize("vsName", "vsNamespace", "9Gi")),
+				SnapshotName: "vsName",
+				Namespace:    "vsNamespace",
+				RestoreSize:  "10Gi",
+			},
+			sizeValue:  10737418240,
+			errChecker: IsNil,
+		},
+		{ // bad args restore size
+			args: &CreatePVCFromSnapshotArgs{
+				KubeCli: fakeCli,
+				DynCli: dynfake.NewSimpleDynamicClient(scheme,
+					s.fakeUnstructuredSnasphotWSize("vsName", "vsNamespace", "")),
+				SnapshotName: "vsName",
+				Namespace:    "vsNamespace",
+				RestoreSize:  "10wut",
+			},
+			errChecker: NotNil,
+		},
+		{ // Failed to find snapshot
+			args: &CreatePVCFromSnapshotArgs{
+				KubeCli:      fakeCli,
+				DynCli:       dynfake.NewSimpleDynamicClient(scheme),
+				SnapshotName: "vsName",
+				Namespace:    "vsNamespace",
+			},
+			errChecker: NotNil,
+		},
+		{ // Failed to create snapshotter
+			args: &CreatePVCFromSnapshotArgs{
+				KubeCli:      fake.NewSimpleClientset(), // fails to find dynamic api
+				DynCli:       dynfake.NewSimpleDynamicClient(scheme),
+				SnapshotName: "vsName",
+				Namespace:    "vsNamespace",
+			},
+			errChecker: NotNil,
+		},
+	} {
+		q, err := getPVCRestoreSize(ctx, tc.args)
+		c.Assert(err, tc.errChecker)
+		if tc.errChecker == IsNil {
+			c.Assert(q.Value(), Equals, tc.sizeValue)
+		}
+	}
+}
+
+func (s *TestVolSuite) fakeUnstructuredSnasphotWSize(name, namespace, size string) *unstructured.Unstructured {
+	gvr := schema.GroupVersionResource{Group: "snapshot.storage.k8s.io", Version: "v1", Resource: "volumesnapshots"}
+	Object := map[string]interface{}{
+		"apiVersion": fmt.Sprintf("%s/%s", gvr.Group, gvr.Version),
+		"kind":       "VolumeSnapshot",
+		"metadata": map[string]interface{}{
+			"name":      name,
+			"namespace": namespace,
+		},
+	}
+	if size != "" {
+		q := resource.MustParse(size)
+		Object["status"] = map[string]interface{}{
+			"restoreSize": q.ToUnstructured(),
+		}
+	}
+	return &unstructured.Unstructured{Object: Object}
 }

--- a/pkg/kube/volume/volume_test.go
+++ b/pkg/kube/volume/volume_test.go
@@ -138,8 +138,8 @@ func (s *TestVolSuite) TestGetPVCRestoreSize(c *C) {
 			args: &CreatePVCFromSnapshotArgs{
 				KubeCli: fakeCli,
 				DynCli: dynfake.NewSimpleDynamicClient(scheme,
-					s.fakeUnstructuredSnasphotWSize("vsName", "vsNamespace", "9Gi")),
-				SnapshotName: "vsName",
+					s.fakeUnstructuredSnasphotWSize("vsName1", "vsNamespace", "9Gi")),
+				SnapshotName: "vsName1",
 				Namespace:    "vsNamespace",
 				RestoreSize:  "10Gi",
 			},


### PR DESCRIPTION
## Change Overview

When creating a PVC from a Snapshot, if the restoreSize is specified we use it instead of the Snapshots restore size. 
This leads to issues if the specified restoreSize is less than the snapshots restore size.

This change picks the greater of both and uses that to create the resulting PVC.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
