### PR TITLE
Updated the doc for KubeTask function

### DIFF
--- a/docs/functions.rst
+++ b/docs/functions.rst
@@ -118,7 +118,7 @@ This allows you to run a new Pod from a Blueprint.
    :align: left
    :widths: 5,5,5,15
 
-   `namespace`, No, `string`, namespace in which to execute (if not specified, the pod will be created in controller's namespace)
+   `namespace`, No, `string`, namespace in which to execute (the pod will be created in controller's namespace if not specified)
    `image`, Yes, `string`, image to be used for executing the task
    `command`, Yes, `[]string`,  command list to execute
    `podOverride`, No, `map[string]interface{}`, specs to override default pod specs with

--- a/docs/functions.rst
+++ b/docs/functions.rst
@@ -118,7 +118,7 @@ This allows you to run a new Pod from a Blueprint.
    :align: left
    :widths: 5,5,5,15
 
-   `namespace`, Yes, `string`, namespace in which to execute
+   `namespace`, No, `string`, namespace in which to execute (if not mentioned will create pod under ``kanister`` namespace)
    `image`, Yes, `string`, image to be used for executing the task
    `command`, Yes, `[]string`,  command list to execute
    `podOverride`, No, `map[string]interface{}`, specs to override default pod specs with

--- a/docs/functions.rst
+++ b/docs/functions.rst
@@ -118,7 +118,7 @@ This allows you to run a new Pod from a Blueprint.
    :align: left
    :widths: 5,5,5,15
 
-   `namespace`, No, `string`, namespace in which to execute (if not mentioned will create pod under controller namespace)
+   `namespace`, No, `string`, namespace in which to execute (if not mentioned the pod will be created in controller's namespace)
    `image`, Yes, `string`, image to be used for executing the task
    `command`, Yes, `[]string`,  command list to execute
    `podOverride`, No, `map[string]interface{}`, specs to override default pod specs with

--- a/docs/functions.rst
+++ b/docs/functions.rst
@@ -118,7 +118,7 @@ This allows you to run a new Pod from a Blueprint.
    :align: left
    :widths: 5,5,5,15
 
-   `namespace`, No, `string`, namespace in which to execute (if not mentioned will create pod under ``kanister`` namespace)
+   `namespace`, No, `string`, namespace in which to execute (if not mentioned will create pod under controller namespace)
    `image`, Yes, `string`, image to be used for executing the task
    `command`, Yes, `[]string`,  command list to execute
    `podOverride`, No, `map[string]interface{}`, specs to override default pod specs with

--- a/docs/functions.rst
+++ b/docs/functions.rst
@@ -118,7 +118,7 @@ This allows you to run a new Pod from a Blueprint.
    :align: left
    :widths: 5,5,5,15
 
-   `namespace`, No, `string`, namespace in which to execute (if not mentioned the pod will be created in controller's namespace)
+   `namespace`, No, `string`, namespace in which to execute (if not specified, the pod will be created in controller's namespace)
    `image`, Yes, `string`, image to be used for executing the task
    `command`, Yes, `[]string`,  command list to execute
    `podOverride`, No, `map[string]interface{}`, specs to override default pod specs with


### PR DESCRIPTION
## Change Overview

In the documentation, KubeTask function had `namespace` as a required field, but at the back-end it's an optional argument. Updated the documentation to be in-sync with the function code-base.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [x] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
