### PR TITLE
Update release for OCP application to `4.9` from `4.7`

### DIFF
--- a/pkg/app/utils.go
+++ b/pkg/app/utils.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	dbTemplateURI = "https://raw.githubusercontent.com/openshift/origin/%s/examples/db-templates/%s-%s-template.json"
-	// PersistentStorage can be used if we want to deploy database with Persistent
+	// PersistentStorage can be used if we want to deploy database with Persistent Volumes
 	PersistentStorage storage = "persistent" // nolint:varcheck
 
 	// EphemeralStorage can be used if we don't want to deploy database with Persistent

--- a/pkg/app/utils.go
+++ b/pkg/app/utils.go
@@ -31,10 +31,10 @@ const (
 	TemplateVersionOCP3_11 DBTemplate = "release-3.11"
 	// TemplateVersionOCP4_4 stores version of db template 4.4
 	TemplateVersionOCP4_4 DBTemplate = "release-4.4"
-	// TemplateVersionOCP4_5 stored version of db template 4.5
+	// TemplateVersionOCP4_5 stores version of db template 4.5
 	TemplateVersionOCP4_5 DBTemplate = "release-4.5"
-	// TemplateVersionOCP4_7 stoted version of db template 4.7
-	TemplateVersionOCP4_7 DBTemplate = "release-4.7"
+	// TemplateVersionOCP4_9 stores version of db template 4.9
+	TemplateVersionOCP4_9 DBTemplate = "release-4.9"
 )
 
 type storage string

--- a/pkg/testing/integration_register.go
+++ b/pkg/testing/integration_register.go
@@ -380,7 +380,7 @@ var _ = Suite(&MysqlDBDepConfig4_7{
 	IntegrationSuite{
 		name:      "mysqldc",
 		namespace: "mysqldc4-7-test",
-		app:       app.NewMysqlDepConfig("mysqldeploymentconfig", app.TemplateVersionOCP4_7, app.EphemeralStorage, "8.0"),
+		app:       app.NewMysqlDepConfig("mysqldeploymentconfig", app.TemplateVersionOCP4_9, app.EphemeralStorage, "8.0"),
 		bp:        app.NewBlueprint("mysql-dep-config", "", true),
 		profile:   newSecretProfile(),
 	},
@@ -395,7 +395,7 @@ var _ = Suite(&MongoDBDepConfig4_7{
 	IntegrationSuite{
 		name:      "mongodb",
 		namespace: "mongodb4-7-test",
-		app:       app.NewMongoDBDepConfig("mongodeploymentconfig", app.TemplateVersionOCP4_7, app.EphemeralStorage),
+		app:       app.NewMongoDBDepConfig("mongodeploymentconfig", app.TemplateVersionOCP4_9, app.EphemeralStorage),
 		bp:        app.NewBlueprint("mongo-dep-config", "", true),
 		profile:   newSecretProfile(),
 	},
@@ -410,7 +410,7 @@ var _ = Suite(&PostgreSQLDepConfig4_7{
 	IntegrationSuite{
 		name:      "postgresdepconf",
 		namespace: "postgresdepconf4-5-test",
-		app:       app.NewPostgreSQLDepConfig("postgresdepconf", app.TemplateVersionOCP4_7, app.EphemeralStorage),
+		app:       app.NewPostgreSQLDepConfig("postgresdepconf", app.TemplateVersionOCP4_9, app.EphemeralStorage),
 		bp:        app.NewBlueprint("postgres-dep-config", "", true),
 		profile:   newSecretProfile(),
 	},


### PR DESCRIPTION
## Change Overview

Since its been sometime the OCP 4.9 is out, this PR updates the OCP application in our integration test to 4.9 from 4.7.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
