### PR TITLE
Support blueprint resource for validate sub command to `kanctl`

### DIFF
--- a/pkg/app/bp.go
+++ b/pkg/app/bp.go
@@ -23,6 +23,7 @@ import (
 	bp "github.com/kanisterio/kanister/pkg/blueprint"
 	"github.com/kanisterio/kanister/pkg/field"
 	"github.com/kanisterio/kanister/pkg/log"
+	"k8s.io/apimachinery/pkg/util/rand"
 )
 
 const (
@@ -59,6 +60,12 @@ func (b AppBlueprint) Blueprint() *crv1alpha1.Blueprint {
 	if err != nil {
 		log.Error().WithError(err).Print("Failed to read Blueprint", field.M{"app": b.App})
 	}
+
+	// set the name to a dynamically generated value
+	// so that the name wont conflict with the same application
+	// installed using other ways
+	bpr.ObjectMeta.Name = fmt.Sprintf("%s-%s", bpr.ObjectMeta.Name, rand.String(5))
+
 	if b.UseDevImages {
 		updateImageTags(bpr)
 	}

--- a/pkg/blueprint/blueprint.go
+++ b/pkg/blueprint/blueprint.go
@@ -25,10 +25,8 @@ package blueprint
 
 import (
 	"bytes"
-	"fmt"
 	"io/ioutil"
 
-	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/yaml"
 
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
@@ -46,11 +44,6 @@ func ReadFromFile(path string) (*crv1alpha1.Blueprint, error) {
 	if err := dec.Decode(&bp); err != nil {
 		return nil, err
 	}
-
-	// set the name to a dynamically generated value
-	// so that the name wont conflict with the same application
-	// installed as part of k10
-	bp.ObjectMeta.Name = fmt.Sprintf("%s-%s", bp.ObjectMeta.Name, rand.String(5))
 
 	return &bp, err
 }

--- a/pkg/blueprint/validate/validate.go
+++ b/pkg/blueprint/validate/validate.go
@@ -1,0 +1,22 @@
+package validate
+
+import (
+	kanister "github.com/kanisterio/kanister/pkg"
+	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
+	"github.com/kanisterio/kanister/pkg/param"
+)
+
+func Do(bp *crv1alpha1.Blueprint) error {
+	for _, action := range bp.Actions {
+		phases, err := kanister.GetPhases(*bp, action.Name, kanister.DefaultVersion, param.TemplateParams{})
+		if err != nil {
+			return err
+		}
+
+		for _, phase := range phases {
+			return phase.Validate()
+		}
+	}
+
+	return nil
+}

--- a/pkg/kanctl/blueprint.go
+++ b/pkg/kanctl/blueprint.go
@@ -1,0 +1,22 @@
+package kanctl
+
+import (
+	"errors"
+
+	"github.com/kanisterio/kanister/pkg/blueprint"
+	"github.com/kanisterio/kanister/pkg/blueprint/validate"
+)
+
+func performBlueprintValidation(p *validateParams) error {
+	if p.filename == "" {
+		return errors.New("Name is not supported for blueprint resources, please specify blueprint manfiest using -f.")
+	}
+
+	// read blueprint from specified file
+	bp, err := blueprint.ReadFromFile(p.filename)
+	if err != nil {
+		return err
+	}
+
+	return validate.Do(bp)
+}

--- a/pkg/kanctl/validate.go
+++ b/pkg/kanctl/validate.go
@@ -16,6 +16,7 @@ package kanctl
 
 import (
 	"fmt"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -69,6 +70,8 @@ func performValidation(cmd *cobra.Command, args []string) error {
 	switch p.resourceKind {
 	case "profile":
 		return performProfileValidation(p)
+	case "blueprint":
+		return performBlueprintValidation(p)
 	default:
 		return errors.Errorf("expected profile.. got %s. Not supported", p.resourceKind)
 	}

--- a/pkg/phase.go
+++ b/pkg/phase.go
@@ -114,6 +114,10 @@ func GetPhases(bp crv1alpha1.Blueprint, action, version string, tp param.Templat
 	return phases, nil
 }
 
+func (p *Phase) Validate() error {
+	return checkRequiredArgs(p.f.RequiredArgs(), p.args)
+}
+
 func checkRequiredArgs(reqArgs []string, args map[string]interface{}) error {
 	for _, a := range reqArgs {
 		if _, ok := args[a]; !ok {


### PR DESCRIPTION
## Change Overview

`kanctl` command didn't support blueprint resource to get validated. This PR add support for blueprint resource as `kanctl validate` sub command.
These are some of the validation that we are planning to achieve 
- Make sure function names are correct 
- Make sure all the mandatory arguments are provided to phase function
- If possible make sure if the go template syntax is correct

## Pull request type

Please check the type of change your PR introduces:
- [x] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #1183

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
