### PR TITLE
Refactor integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ DOCKER_CONFIG ?= "$(HOME)/.docker"
 # Mention the vm-driver that should be used to install OpenShift
 vm-driver ?= "kvm"
 # Default OCP version in which the OpenShift apps are going to run
-ocp_version ?= "4.7"
+ocp_version ?= "4.9"
 ###
 ### These variables should not need tweaking.
 ###
@@ -88,7 +88,7 @@ all-push: $(addprefix push-, $(ALL_ARCH))
 
 build: bin/$(ARCH)/$(BIN)
 
-build-controller: 
+build-controller:
 	@$(MAKE) run CMD='-c " \
 	goreleaser build --id $(BIN) --rm-dist --debug --snapshot \
 	&& cp dist/$(BIN)_linux_$(ARCH)/$(BIN) bin/$(ARCH)/$(BIN) \

--- a/build/integration-test.sh
+++ b/build/integration-test.sh
@@ -30,7 +30,7 @@ SHORT_APPS="^PostgreSQL$|^PITRPostgreSQL|^MySQL$|Elasticsearch|^MongoDB$|Maria"
 OC_APPS3_11="MysqlDBDepConfig$|MongoDBDepConfig$|PostgreSQLDepConfig$"
 OC_APPS4_4="MysqlDBDepConfig4_4|MongoDBDepConfig4_4|PostgreSQLDepConfig4_4"
 OC_APPS4_5="MysqlDBDepConfig4_5|MongoDBDepConfig4_5|PostgreSQLDepConfig4_5"
-# MongoDB is not provided as external DB template in release 4.9
+# MongoDB is not provided as external DB template in release 4.9 anymore
 # https://github.com/openshift/origin/commit/4ea9e6c5961eb815c200df933eee30c48a5c9166
 OC_APPS4_9="MysqlDBDepConfig4_9|PostgreSQLDepConfig4_9"
 

--- a/build/integration-test.sh
+++ b/build/integration-test.sh
@@ -30,7 +30,9 @@ SHORT_APPS="^PostgreSQL$|^PITRPostgreSQL|^MySQL$|Elasticsearch|^MongoDB$|Maria"
 OC_APPS3_11="MysqlDBDepConfig$|MongoDBDepConfig$|PostgreSQLDepConfig$"
 OC_APPS4_4="MysqlDBDepConfig4_4|MongoDBDepConfig4_4|PostgreSQLDepConfig4_4"
 OC_APPS4_5="MysqlDBDepConfig4_5|MongoDBDepConfig4_5|PostgreSQLDepConfig4_5"
-OC_APPS4_7="MysqlDBDepConfig4_7|MongoDBDepConfig4_7|PostgreSQLDepConfig4_7"
+# MongoDB is not provided as external DB template in release 4.9
+# https://github.com/openshift/origin/commit/4ea9e6c5961eb815c200df933eee30c48a5c9166
+OC_APPS4_9="MysqlDBDepConfig4_9|PostgreSQLDepConfig4_9"
 
 check_dependencies() {
     # Check if minio is already deployed
@@ -85,8 +87,8 @@ case "${1}" in
             "4.5")
                 TEST_APPS=${OC_APPS4_5}
                 ;;
-            "4.7")
-                TEST_APPS=${OC_APPS4_7}
+            "4.9")
+                TEST_APPS=${OC_APPS4_9}
                 ;;
             *)
                 usage

--- a/build/minio.sh
+++ b/build/minio.sh
@@ -63,7 +63,7 @@ usage() {
 Usage: ${0} <operation>
 Where operation is one of the following:
   install_minio: installs minio on k8s cluster
-  uninstall_minio: uninstalls minio 
+  uninstall_minio: uninstalls minio
 EOM
     exit 1
 }

--- a/pkg/testing/integration_register.go
+++ b/pkg/testing/integration_register.go
@@ -370,16 +370,15 @@ var _ = Suite(&Kafka{
 	},
 })
 
-// OpenShift apps for version 4.7
 // Mysql Instance that is deployed through DeploymentConfig on OpenShift cluster
-type MysqlDBDepConfig4_7 struct {
+type MysqlDBDepConfig4_9 struct {
 	IntegrationSuite
 }
 
-var _ = Suite(&MysqlDBDepConfig4_7{
+var _ = Suite(&MysqlDBDepConfig4_9{
 	IntegrationSuite{
 		name:      "mysqldc",
-		namespace: "mysqldc4-7-test",
+		namespace: "mysqldc4-9-test",
 		app:       app.NewMysqlDepConfig("mysqldeploymentconfig", app.TemplateVersionOCP4_9, app.EphemeralStorage, "8.0"),
 		bp:        app.NewBlueprint("mysql-dep-config", "", true),
 		profile:   newSecretProfile(),
@@ -387,14 +386,14 @@ var _ = Suite(&MysqlDBDepConfig4_7{
 })
 
 // MongoDB deployed on openshift cluster
-type MongoDBDepConfig4_7 struct {
+type MongoDBDepConfig4_9 struct {
 	IntegrationSuite
 }
 
-var _ = Suite(&MongoDBDepConfig4_7{
+var _ = Suite(&MongoDBDepConfig4_9{
 	IntegrationSuite{
 		name:      "mongodb",
-		namespace: "mongodb4-7-test",
+		namespace: "mongodb4-9-test",
 		app:       app.NewMongoDBDepConfig("mongodeploymentconfig", app.TemplateVersionOCP4_9, app.EphemeralStorage),
 		bp:        app.NewBlueprint("mongo-dep-config", "", true),
 		profile:   newSecretProfile(),
@@ -402,11 +401,11 @@ var _ = Suite(&MongoDBDepConfig4_7{
 })
 
 // PostgreSQL deployed on openshift cluster
-type PostgreSQLDepConfig4_7 struct {
+type PostgreSQLDepConfig4_9 struct {
 	IntegrationSuite
 }
 
-var _ = Suite(&PostgreSQLDepConfig4_7{
+var _ = Suite(&PostgreSQLDepConfig4_9{
 	IntegrationSuite{
 		name:      "postgresdepconf",
 		namespace: "postgresdepconf4-5-test",

--- a/pkg/testing/integration_test.go
+++ b/pkg/testing/integration_test.go
@@ -206,6 +206,9 @@ func (s *IntegrationSuite) TestRun(c *C) {
 		err = pingAppAndWait(ctx, a)
 		c.Assert(err, IsNil)
 
+		err = a.Reset(ctx)
+		c.Assert(err, IsNil)
+
 		err = a.Initialize(ctx)
 		c.Assert(err, IsNil)
 


### PR DESCRIPTION
## Change Overview

- Use OCP release version 4.9 for deployment config apps
- Remove MongoDB from OCP apps because this app is not dropped from
external templates
- Call `Reset` before calling `Initialize` for the application from `integration_test.go`

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E

Run 

```
make openshift-test
```
and 
```
make integration-test
```
to test the applications on openshift and normal k8s clusters respectively.

https://gist.github.com/viveksinghggits/227d8a54b31621f87605b71a82ec1488