### PR TITLE
Stream output from KubeExec

### DIFF
--- a/pkg/kube/exec.go
+++ b/pkg/kube/exec.go
@@ -124,8 +124,8 @@ func execStream(kubeCli kubernetes.Interface, config *restclient.Config, options
 	go func() {
 		err := execute("POST", req.URL(), config, options.Stdin, pwo, pwe, tty)
 		errCh <- err
-		_ = pwo.CloseWithError(err)
-		_ = pwe.CloseWithError(err)
+		_ = pwo.Close()
+		_ = pwe.Close()
 	}()
 	return pro, pre, errCh
 }

--- a/pkg/kube/exec.go
+++ b/pkg/kube/exec.go
@@ -65,14 +65,17 @@ func ExecWithOptions(kubeCli kubernetes.Interface, options ExecOptions) (string,
 	if err != nil {
 		return "", "", err
 	}
-	o, e, errCh := execStream(kubeCli, config, options)
+	o, e := execStream(kubeCli, config, options)
 
 	var stdout []byte
-	var err error
+	var oerr error
 	wg := sync.WaitGroup{}
 	wg.Add(2)
 	go func() {
 		stdout, oerr = ioutil.ReadAll(o)
+		if oerr != nil {
+			log.Error("Failed to read stderr:", oerr.Error())
+		}
 		wg.Done()
 	}()
 

--- a/pkg/kube/exec_test.go
+++ b/pkg/kube/exec_test.go
@@ -85,6 +85,22 @@ func (s *ExecSuite) TestStderr(c *C) {
 		c.Assert(stdout, Equals, "")
 		c.Assert(stderr, Equals, "hello")
 	}
+
+	cmd = []string{"sh", "-c", "echo -n hello && exit 1"}
+	for _, cs := range s.pod.Status.ContainerStatuses {
+		stdout, stderr, err := Exec(s.cli, s.pod.Namespace, s.pod.Name, cs.Name, cmd, nil)
+		c.Assert(err, NotNil)
+		c.Assert(stdout, Equals, "hello")
+		c.Assert(stderr, Equals, "")
+	}
+
+	cmd = []string{"sh", "-c", "count=0; while true; do printf $count; let count=$count+1; if [ $count -eq 6 ]; then exit 1; fi; done"}
+	for _, cs := range s.pod.Status.ContainerStatuses {
+		stdout, stderr, err := Exec(s.cli, s.pod.Namespace, s.pod.Name, cs.Name, cmd, nil)
+		c.Assert(err, NotNil)
+		c.Assert(stdout, Equals, "012345")
+		c.Assert(stderr, Equals, "")
+	}
 }
 
 func (s *ExecSuite) TestExecEcho(c *C) {

--- a/pkg/kube/exec_test.go
+++ b/pkg/kube/exec_test.go
@@ -77,6 +77,16 @@ func (s *ExecSuite) TearDownSuite(c *C) {
 	}
 }
 
+func (s *ExecSuite) TestStderr(c *C) {
+	cmd := []string{"sh", "-c", "echo -n hello >&2"}
+	for _, cs := range s.pod.Status.ContainerStatuses {
+		stdout, stderr, err := Exec(s.cli, s.pod.Namespace, s.pod.Name, cs.Name, cmd, nil)
+		c.Assert(err, IsNil)
+		c.Assert(stdout, Equals, "")
+		c.Assert(stderr, Equals, "hello")
+	}
+}
+
 func (s *ExecSuite) TestExecEcho(c *C) {
 	cmd := []string{"sh", "-c", "cat -"}
 	c.Assert(s.pod.Status.Phase, Equals, v1.PodRunning)


### PR DESCRIPTION
## Change Overview

This PR contains changes for streaming stdout and stderr output from kube exec commands. 
It contains refactoring done on top of https://github.com/kanisterio/kanister/pull/1037

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [x] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E

```
$ go test -check.f="TestStderr" -check.vv .
START: exec_test.go:39: ExecSuite.SetUpSuite
PASS: exec_test.go:39: ExecSuite.SetUpSuite     7.783s

START: exec_test.go:80: ExecSuite.TestStderr
PASS: exec_test.go:80: ExecSuite.TestStderr     11.821s

START: exec_test.go:73: ExecSuite.TearDownSuite
PASS: exec_test.go:73: ExecSuite.TearDownSuite  0.277s

OK: 1 passed
PASS
ok      github.com/kanisterio/kanister/pkg/kube 19.914s
```