### PR TITLE
Fix issue MySQL GPG check failed

### DIFF
--- a/docker/kanister-mysql/image/Dockerfile
+++ b/docker/kanister-mysql/image/Dockerfile
@@ -1,6 +1,11 @@
 ARG TOOLS_IMAGE
 FROM registry.access.redhat.com/ubi8/ubi:8.1 as builder
 RUN dnf install -y https://dev.mysql.com/get/mysql80-community-release-el8-1.noarch.rpm
+
+# GPG keys for MySQL have expired. Importing the new key below.
+# Please refer bug https://bugs.mysql.com/bug.php?id=106188 for more details
+RUN rpm --import https://repo.mysql.com/RPM-GPG-KEY-mysql-2022
+
 RUN dnf install -y mysql-community-client
 
 FROM $TOOLS_IMAGE


### PR DESCRIPTION
## Change Overview

Travis CI failed with following error log while building `ghcr.io/kanisterio/mysql-sidecar:v9.99.9-dev` image.
Please refer the bug logged at https://bugs.mysql.com/bug.php?id=106188 for more details.

```bash
⨯ release failed after 775.54s error=failed to build ghcr.io/kanisterio/mysql-sidecar:v9.99.9-dev: exit status 1: Sending build context to Docker daemon  48.37MB
Step 1/8 : ARG TOOLS_IMAGE
Step 2/8 : FROM registry.access.redhat.com/ubi8/ubi:8.1 as builder
8.1: Pulling from ubi8/ubi
ee2244abc66f: Pulling fs layer
befb03b11956: Pulling fs layer
befb03b11956: Verifying Checksum
befb03b11956: Download complete
ee2244abc66f: Verifying Checksum
ee2244abc66f: Download complete
ee2244abc66f: Pull complete
befb03b11956: Pull complete
Digest: sha256:1f0e6e1f451ff020b3b44c1c4c34d85db5ffa0fc1bb0490d6a32957a7a06b67f
Status: Downloaded newer image for registry.access.redhat.com/ubi8/ubi:8.1
 ---> 8121a9f5303b
Step 3/8 : RUN dnf install -y https://dev.mysql.com/get/mysql80-community-release-el8-1.noarch.rpm
 ---> Running in 63948fb830db
Updating Subscription Management repositories.
Unable to read consumer identity
This system is not registered to Red Hat Subscription Management. You can use subscription-manager to register.
Red Hat Universal Base Image 8 (RPMs) - BaseOS  2.0 MB/s | 796 kB     00:00    
Red Hat Universal Base Image 8 (RPMs) - AppStre  11 MB/s | 2.6 MB     00:00    
Red Hat Universal Base Image 8 (RPMs) - CodeRea 124 kB/s |  16 kB     00:00    
mysql80-community-release-el8-1.noarch.rpm       89 kB/s |  30 kB     00:00    
Dependencies resolved.
================================================================================
 Package                        Arch        Version     Repository         Size
================================================================================
Installing:
 mysql80-community-release      noarch      el8-1       @commandline       30 k
Transaction Summary
================================================================================
Install  1 Package
Total size: 30 k
Installed size: 29 k
Downloading Packages:
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                        1/1 
  Installing       : mysql80-community-release-el8-1.noarch                 1/1 
  Verifying        : mysql80-community-release-el8-1.noarch                 1/1 
Installed products updated.
Installed:
  mysql80-community-release-el8-1.noarch                                        
Complete!
Removing intermediate container 63948fb830db
 ---> d506cac92a2b
Step 4/8 : RUN dnf install -y mysql-community-client
 ---> Running in 092dfcd1373f
Updating Subscription Management repositories.
Unable to read consumer identity
This system is not registered to Red Hat Subscription Management. You can use subscription-manager to register.
MySQL 8.0 Community Server                       17 MB/s | 2.3 MB     00:00    
MySQL Connectors Community                      1.2 MB/s |  80 kB     00:00    
MySQL Tools Community                           3.6 MB/s | 432 kB     00:00    
Dependencies resolved.
================================================================================
 Package                         Arch    Version       Repository          Size
================================================================================
Installing:
 mysql-community-client          x86_64  8.0.28-1.el8  mysql80-community   14 M
Installing dependencies:
 mysql-community-client-plugins  x86_64  8.0.28-1.el8  mysql80-community  2.4 M
 mysql-community-common          x86_64  8.0.28-1.el8  mysql80-community  633 k
 mysql-community-libs            x86_64  8.0.28-1.el8  mysql80-community  1.5 M
Transaction Summary
================================================================================
Install  4 Packages
Total download size: 19 M
Installed size: 102 M
Downloading Packages:
(1/4): mysql-community-common-8.0.28-1.el8.x86_ 7.2 MB/s | 633 kB     00:00    
(2/4): mysql-community-client-plugins-8.0.28-1.  20 MB/s | 2.4 MB     00:00    
(3/4): mysql-community-libs-8.0.28-1.el8.x86_64  30 MB/s | 1.5 MB     00:00    
(4/4): mysql-community-client-8.0.28-1.el8.x86_  62 MB/s |  14 MB     00:00    
--------------------------------------------------------------------------------
Total                                            80 MB/s |  19 MB     00:00     
MySQL 8.0 Community Server                       27 MB/s |  27 kB     00:00    
warning: /var/cache/dnf/mysql80-community-b1f1ed5ba88ce0f8/packages/mysql-community-client-8.0.28-1.el8.x86_64.rpm: Header V4 RSA/SHA256 Signature, key ID 3a79bd29: NOKEY
Importing GPG key 0x5072E1F5:
 Userid     : "MySQL Release Engineering <mysql-build@oss.oracle.com>"
 Fingerprint: A4A9 4068 76FC BD3C 4567 70C8 8C71 8D3B 5072 E1F5
 From       : /etc/pki/rpm-gpg/RPM-GPG-KEY-mysql
Key imported successfully
Import of key(s) didn't help, wrong key(s)?
The downloaded packages were saved in cache until the next successful transaction.
You can remove cached packages by executing 'dnf clean packages'.
Public key for mysql-community-client-8.0.28-1.el8.x86_64.rpm is not installed. Failing package is: mysql-community-client-8.0.28-1.el8.x86_64
 GPG Keys are configured as: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-mysql
Public key for mysql-community-client-plugins-8.0.28-1.el8.x86_64.rpm is not installed. Failing package is: mysql-community-client-plugins-8.0.28-1.el8.x86_64
 GPG Keys are configured as: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-mysql
Public key for mysql-community-common-8.0.28-1.el8.x86_64.rpm is not installed. Failing package is: mysql-community-common-8.0.28-1.el8.x86_64
 GPG Keys are configured as: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-mysql
Public key for mysql-community-libs-8.0.28-1.el8.x86_64.rpm is not installed. Failing package is: mysql-community-libs-8.0.28-1.el8.x86_64
 GPG Keys are configured as: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-mysql
Error: GPG check FAILED
The command '/bin/sh -c dnf install -y mysql-community-client' returned a non-zero code: 1
```