### PR TITLE
Update link to explanation of Operator pattern in Architecture Overview

### DIFF
--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -9,7 +9,7 @@ Kanister Architecture Overview
 The design of Kanister follows the operator pattern. This means
 Kanister defines its own resources and interacts with those resources
 through a controller. `This blog post
-<https://coreos.com/blog/introducing-operators.html>`_ describes the
+<https://www.redhat.com/en/blog/operators-over-easy-introduction-kubernetes-operators>`_ describes the
 pattern in detail.
 
 In particular, Kanister is composed of three main components: the


### PR DESCRIPTION


## Change Overview

In the [Kanister Architecture Overview Page](https://docs.kanister.io/architecture.html#architecture), in the first paragraph, there is a link to a blog post that explains the operator pattern. The link is out of date. Instead of taking you to a blog post, it just takes you to the main page for red hat's blog. After searching, i believe I've found a suitable blog post that serves as a good explanation of the operator pattern. I've updated the link in the docs/architecture.rst file. here is the new link: https://www.redhat.com/en/blog/operators-over-easy-introduction-kubernetes-operators

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [x] :world_map: Documentation
- [ ] :robot: Test

## Issues

no issue

## Test Plan

No tests needed

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
