### PR TITLE
Fix postgres application failure in integration test

### DIFF
--- a/build/integration-test.sh
+++ b/build/integration-test.sh
@@ -25,7 +25,7 @@ TEST_TIMEOUT="30m"
 # Set default options
 TEST_OPTIONS="-tags=integration -timeout ${TEST_TIMEOUT} -check.suitep ${DOP}"
 # Regex to match apps to run in short mode
-SHORT_APPS="^PostgreSQL$|^PITRPostgreSQL|^MySQL$|Elasticsearch|^MongoDB$|Maria|^MSSQL$"
+SHORT_APPS="^PostgreSQL$|^MySQL$|Elasticsearch|^MongoDB$|Maria|^MSSQL$"
 # OCAPPS has all the apps that are to be tested against openshift cluster
 OC_APPS3_11="MysqlDBDepConfig$|MongoDBDepConfig$|PostgreSQLDepConfig$"
 OC_APPS4_4="MysqlDBDepConfig4_4|MongoDBDepConfig4_4|PostgreSQLDepConfig4_4"

--- a/examples/stable/postgresql/postgres-blueprint.yaml
+++ b/examples/stable/postgresql/postgres-blueprint.yaml
@@ -30,7 +30,7 @@ actions:
         - |
           export PGHOST='{{ index .Object.metadata.labels "app.kubernetes.io/instance" }}-postgresql.{{ .StatefulSet.Namespace }}.svc.cluster.local'
           export PGUSER='postgres'
-          export PGPASSWORD='{{ index .Phases.pgDump.Secrets.pgSecret.Data "postgresql-password" | toString }}'
+          export PGPASSWORD='{{ index .Phases.pgDump.Secrets.pgSecret.Data "postgres-password" | toString }}'
           BACKUP_LOCATION=pg_backups/{{ .StatefulSet.Namespace }}/{{ .StatefulSet.Name }}/{{ toDate "2006-01-02T15:04:05.999999999Z07:00" .Time | date "2006-01-02T15:04:05Z07:00" }}/backup.sql.gz
           pg_dumpall --clean -U $PGUSER | gzip -c | kando location push --profile '{{ toJson .Profile }}' --path "${BACKUP_LOCATION}" -
           kando output backupLocation "${BACKUP_LOCATION}"
@@ -59,7 +59,7 @@ actions:
         - |
           export PGHOST='{{ index .Object.metadata.labels "app.kubernetes.io/instance" }}-postgresql.{{ .StatefulSet.Namespace }}.svc.cluster.local'
           export PGUSER='postgres'
-          export PGPASSWORD='{{ index .Phases.pgRestore.Secrets.pgSecret.Data "postgresql-password" | toString }}'
+          export PGPASSWORD='{{ index .Phases.pgRestore.Secrets.pgSecret.Data "postgres-password" | toString }}'
           BACKUP_LOCATION={{ .ArtifactsIn.cloudObject.KeyValue.backupLocation }}
           kando location pull --profile '{{ toJson .Profile }}' --path "${BACKUP_LOCATION}" - | gunzip -c -f | sed 's/LOCALE/LC_COLLATE/' | psql -q -U "${PGUSER}"
   delete:

--- a/examples/stable/postgresql/v10.16.2/postgres-blueprint.yaml
+++ b/examples/stable/postgresql/v10.16.2/postgres-blueprint.yaml
@@ -6,11 +6,9 @@ actions:
   backup:
     kind: StatefulSet
     outputArtifacts:
-      pgBackup:
-        # Capture the kopia snapshot information for subsequent actions
-        # The information includes the kopia snapshot ID which is essential for restore and delete to succeed
-        # `kopiaOutput` is the name provided to kando using `--output-name` flag
-        kopiaSnapshot: "{{ .Phases.pgDump.Output.kopiaOutput }}"
+      cloudObject:
+        keyValue:
+          backupLocation: "{{ .Phases.pgDump.Output.backupLocation }}"
     phases:
     - func: KubeTask
       name: pgDump
@@ -32,15 +30,14 @@ actions:
         - |
           export PGHOST='{{ index .Object.metadata.labels "app.kubernetes.io/instance" }}-postgresql.{{ .StatefulSet.Namespace }}.svc.cluster.local'
           export PGUSER='postgres'
-          export PGPASSWORD='{{ index .Phases.pgDump.Secrets.pgSecret.Data "postgres-password" | toString }}'
-          backup_file_path="backup.sql"
-          pg_dumpall --clean -U $PGUSER | kando location push --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --output-name "kopiaOutput" -
+          export PGPASSWORD='{{ index .Phases.pgDump.Secrets.pgSecret.Data "postgresql-password" | toString }}'
+          BACKUP_LOCATION=pg_backups/{{ .StatefulSet.Namespace }}/{{ .StatefulSet.Name }}/{{ toDate "2006-01-02T15:04:05.999999999Z07:00" .Time | date "2006-01-02T15:04:05Z07:00" }}/backup.sql.gz
+          pg_dumpall --clean -U $PGUSER | gzip -c | kando location push --profile '{{ toJson .Profile }}' --path "${BACKUP_LOCATION}" -
+          kando output backupLocation "${BACKUP_LOCATION}"
   restore:
     kind: StatefulSet
     inputArtifactNames:
-    # The kopia snapshot info created in backup phase can be used here
-    # Use the `--kopia-snapshot` flag in kando to pass in `pgBackup.KopiaSnapshot`
-    - pgBackup
+    - cloudObject
     phases:
     - func: KubeTask
       name: pgRestore
@@ -62,15 +59,12 @@ actions:
         - |
           export PGHOST='{{ index .Object.metadata.labels "app.kubernetes.io/instance" }}-postgresql.{{ .StatefulSet.Namespace }}.svc.cluster.local'
           export PGUSER='postgres'
-          export PGPASSWORD='{{ index .Phases.pgRestore.Secrets.pgSecret.Data "postgres-password" | toString }}'
-          backup_file_path="backup.sql"
-          kopia_snap='{{ .ArtifactsIn.pgBackup.KopiaSnapshot }}'
-          kando location pull --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --kopia-snapshot "${kopia_snap}" - | psql -q -U "${PGUSER}"
+          export PGPASSWORD='{{ index .Phases.pgRestore.Secrets.pgSecret.Data "postgresql-password" | toString }}'
+          BACKUP_LOCATION={{ .ArtifactsIn.cloudObject.KeyValue.backupLocation }}
+          kando location pull --profile '{{ toJson .Profile }}' --path "${BACKUP_LOCATION}" - | gunzip -c -f | sed 's/LOCALE/LC_COLLATE/' | psql -q -U "${PGUSER}"
   delete:
     inputArtifactNames:
-    # The kopia snapshot info created in backup phase can be used here
-    # Use the `--kopia-snapshot` flag in kando to pass in `pgBackup.KopiaSnapshot`
-      - pgBackup
+      - cloudObject
     phases:
     - func: KubeTask
       name: deleteDump
@@ -85,6 +79,5 @@ actions:
           - pipefail
           - -c
           - |
-            backup_file_path="backup.sql"
-            kopia_snap='{{ .ArtifactsIn.pgBackup.KopiaSnapshot }}'
-            kando location delete --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --kopia-snapshot "${kopia_snap}"
+            kando location delete --profile '{{ toJson .Profile }}' --path '{{ .ArtifactsIn.cloudObject.KeyValue.backupLocation }}'
+


### PR DESCRIPTION
## Change Overview

Postgres application that we run in our integration test has started failing recently because we use latest helm chart by default and there were some breaking changes pushed [into upstream](https://github.com/bitnami/charts/commit/2710baea1eb548209e9f97627f632987be5f5daf). 
PITR postgres application has also been failing but resolving that might take sometime, so I am removing that from the applications to make sure other PRs can get in, and would raise another PR when we fix that.


## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [x] :robot: Test

## Issues

- #XXX

## Test Plan

```
make integration-test
```
the logs can be found at https://gist.github.com/e59a1e0e4fa5842b7c0a941ed79d1741

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
