### PR TITLE
Use CONTAINER_NAME if set

### DIFF
--- a/build/package.sh
+++ b/build/package.sh
@@ -24,7 +24,10 @@ build_licenses_info_image() {
     local src_dir="$(pwd)"
     local target_file="$(pwd)/licenses"
     local mount_cmd="-v $(pwd):$(pwd)"
-    if grep docker /proc/1/cgroup -qa; then
+    # Checking if executed inside docker container
+    if [ -n "${CONTAINER_NAME:-}" ]; then
+        mount_cmd="--volumes-from ${CONTAINER_NAME}"
+    elif grep docker /proc/1/cgroup -qa; then
         mount_cmd="--volumes-from $(grep docker -m 1 /proc/self/cgroup|cut -d/ -f3)"
     fi
     docker run --rm ${mount_cmd} \


### PR DESCRIPTION

## Change Overview

Use CONTAINER_NAME if set instead of attempting to parse /proc/self/cgroup.

Supports cgroups v2 systems such as Docker Desktop for Mac 4.3+.

Approach of CONTAINER_NAME has been used successfully for K10. To maintain independence of Kanister from K10 in workflows that do not set CONTAINER_NAME, this change detects being in a container if either CONTAINER_NAME set or if detected from /proc/self/cgroup.

## Pull request type

Please check the type of change your PR introduces:
- [x] :hamster: Trivial/Minor

## Issues


## Test Plan
