### PR TITLE
Do not set default namespace

### DIFF
--- a/pkg/function/kubeops.go
+++ b/pkg/function/kubeops.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
 
 	kanister "github.com/kanisterio/kanister/pkg"
@@ -67,7 +66,7 @@ func (crs *kubeops) Exec(ctx context.Context, tp param.TemplateParams, args map[
 	if err := Arg(args, KubeOpsOperationArg, &op); err != nil {
 		return nil, err
 	}
-	if err := OptArg(args, KubeOpsNamespaceArg, &namespace, metav1.NamespaceDefault); err != nil {
+	if err := OptArg(args, KubeOpsNamespaceArg, &namespace, nil); err != nil {
 		return nil, err
 	}
 	if ArgExists(args, KubeOpsObjectReferenceArg) {

--- a/pkg/kube/kubectl.go
+++ b/pkg/kube/kubectl.go
@@ -29,6 +29,8 @@ import (
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
+	"github.com/kanisterio/kanister/pkg/field"
+	"github.com/kanisterio/kanister/pkg/log"
 	"github.com/kanisterio/kanister/pkg/poll"
 )
 
@@ -105,12 +107,10 @@ func (k *KubectlOperation) Create(spec io.Reader, namespace string) (*crv1alpha1
 
 // Delete k8s resource referred by objectReference. Waits for the resource to be deleted
 func (k *KubectlOperation) Delete(ctx context.Context, objRef crv1alpha1.ObjectReference, namespace string) (*crv1alpha1.ObjectReference, error) {
-	if namespace == "" {
-		namespace = metav1.NamespaceDefault
-	}
 	if objRef.Namespace != "" {
 		namespace = objRef.Namespace
 	}
+	log.Print("Deleting object.", field.M{"namespace": namespace, "objRef": objRef})
 	err := k.dynCli.Resource(schema.GroupVersionResource{Group: objRef.Group, Version: objRef.APIVersion, Resource: objRef.Resource}).Namespace(namespace).Delete(ctx, objRef.Name, metav1.DeleteOptions{})
 	if err != nil {
 		return &objRef, err


### PR DESCRIPTION
## Change Overview

Currently, it is not possible to delete objects that do not have a namespace, like VolumeSnapshotContent or PersistentVolume. 
```
{"ActionSet":"staging-server-delete-nwvg6","File":"pkg/controller/controller.go","Function":"github.com/kanisterio/kanister/pkg/controller.(*Controller).runAction.func1","Line":438,"Phase":"deleteSnapshotContent","cluster_name":"684f75d4-1734-4ec3-84b2-a56c001e71cf","error":"the server could not find the requested resource","hostname":"kanister-kanister-operator-646cd44d8f-zdc77","level":"info","msg":"Failed to execute phase: v1alpha1.Phase{Name:\"deleteSnapshotContent\", State:\"pending\", Output:map[string]interface {}(nil)}:","time":"2022-02-14T14:28:36.055688239Z"}
```
My blueprint:
```
apiVersion: cr.kanister.io/v1alpha1
kind: Blueprint
metadata:
  name: staging-server
  namespace: kanister
actions:
  delete:
    phases:
      - func: KubeOps
        name: deleteSnapshotContent
        args:
          operation: delete
          objectReference:
            apiVersion: v1
            group: snapshot.storage.k8s.io
            resource: volumesnapshotcontents
            name: snapshot-content-test
```

This PR removes the setting of a default namespace, which allows these kind of operations.

Unfortunately, removing this default behaviour feels pretty dangerous, cause other users might already rely on that. 


Thread in Slack: https://kanisterio.slack.com/archives/C85C8V22J/p1643919326058139

## Pull request type

Please check the type of change your PR introduces:
- [x] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- n/a

## Test Plan



- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
