### PR TITLE
Make sure `kanctl` honors `KUBECONFIG` env and kubeconfig dir

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -53,16 +53,15 @@ func LoadConfig() (*rest.Config, error) {
 		return clientcmd.BuildConfigFromFlags("", kubeConfigEnv)
 	}
 
-	clientset, err := clientcmd.BuildConfigFromFlags("", clientcmd.RecommendedHomeFile)
-	if err != nil {
-		if c, err := rest.InClusterConfig(); err == nil {
-			return c, nil
-		} else {
-			return newClientConfig().ClientConfig()
-		}
+	if c, err := clientcmd.BuildConfigFromFlags("", clientcmd.RecommendedHomeFile); err == nil {
+		return c, nil
 	}
 
-	return clientset, nil
+	if c, err := rest.InClusterConfig(); err == nil {
+		return c, nil
+	}
+
+	return newClientConfig().ClientConfig()
 }
 
 // NewClient returns a k8 client configured by the kanister environment.


### PR DESCRIPTION
## Change Overview

kanctl in current implentation create kubeclient using `inClusterConfig`
it doesn't check if the `KUBECONFIG` env var is set or config file is
available at default location.
This has resulted into problem for some of the users. This PR makes the
change to prioritise creating kubeclient in below order

- KUBECONFIG env var
- kubeconfig file at deafult location `~/.kube/config`
- Use `inClusterConfig`

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #1111

## Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
