### PR TITLE
Add CoC, DCO and Security documents

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,41 @@
+# Community Code of Conduct
+
+## Contributor Code of Conduct
+
+As contributors and maintainers of this project, and in the interest of
+fostering an open and welcoming community, we pledge to respect all people who
+contribute through reporting issues, posting feature requests, updating
+documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free
+experience for everyone, regardless of level of experience, gender, gender
+identity and expression, sexual orientation, disability, personal appearance,
+body size, race, ethnicity, age, religion, or nationality.
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery
+* Personal attacks
+* Trolling or insulting/derogatory comments
+* Public or private harassment
+* Publishing others' private information, such as physical or electronic addresses, without explicit permission
+* Other unethical or unprofessional conduct.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct. By adopting this Code of Conduct,
+project maintainers commit themselves to fairly and consistently applying these
+principles to every aspect of managing this project. Project maintainers who do
+not follow or enforce the Code of Conduct may be permanently removed from the
+project team.
+
+This code of conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting a project maintainer listed in the
+[MAINTAINERS.md](MAINTAINERS.md) file.
+
+This Code of Conduct is adapted from the Contributor Covenant
+(http://contributor-covenant.org), version 1.2.0, available at
+http://contributor-covenant.org/version/1/2/0/

--- a/DCO
+++ b/DCO
@@ -1,0 +1,35 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+660 York Street, Suite 102,
+San Francisco, CA 94110 USA
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,15 @@ We hold public community meetings, for roadmap and other design discussions, onc
 - To get yourself added into the regular Community meetings invite, please drop a mail to vivek@kasten.io.
 - Meeting joining details can be found in the meeting invite itself.
 
+## Code of Conduct
+
+Kanister is for everyone. We ask that our users and contributors take a few
+minutes to review our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Security
+
+See [SECURITY.md](SECURITY.md) for our security policy, including how to report
+vulnerabilities.
 
 ## Resources
 
@@ -77,4 +86,5 @@ issue](https://github.com/kanisterio/kanister/issues).
 - [Percona Live 2018](https://www.youtube.com/watch?v=dS0kv0k8D_E)
 
 ## License
+
 Apache License 2.0, see [LICENSE](https://github.com/kanisterio/kanister/blob/master/LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,30 @@
+# Security Policy
+
+## Supported Versions
+
+To be confirmed.
+
+## Reporting a Vulnerability
+
+To report a security problem in Kanister, please contact the maintainers listed
+in the [MAINTAINERS.md](MAINTAINERS.md) file.
+
+The maintainers will help diagnose the severity of the issue and determine how
+to address the issue. Issues deemed to be non-critical will be filed as GitHub
+issues. Critical issues will receive immediate attention and be fixed as quickly
+as possible. The maintainers will then coordinate a release date with you.
+
+## Security Advisories
+
+When serious security problems in Kanister are discovered and corrected, the
+maintainers issue a security advisory, describing the problem and containing a
+pointer to the fix. These will be announced on the Kanister's mailing list and
+websites.
+
+Security issues are fixed as soon as possible, and the fixes are propagated to
+the stable branches as fast as possible. However, when a vulnerability is found
+during a code audit, or when several other issues are likely to be spotted and
+fixed in the near future, the maintainers may delay the release of a Security
+Advisory, so that one unique, comprehensive Security Advisory covering several
+vulnerabilities can be issued. Communication with vendors and other
+distributions shipping the same code may also cause these delays.


### PR DESCRIPTION
## Change Overview

This PR adds the Code of Conduct, DCO and [security](https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository) documents to the repo.

Resolves https://github.com/kanisterio/kanister/issues/1233 
Resolves https://github.com/kanisterio/kanister/issues/1241

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [x] :world_map: Documentation
- [ ] :robot: Test