### PR TITLE
Fix kanister controller image vulnerability 

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -12,6 +12,7 @@ LABEL name=ARG_BIN \
 
 RUN microdnf update openssl-libs && \
     microdnf update cyrus-sasl && \
+    microdnf update cyrus-sasl-lib && \
     microdnf install git && \
     microdnf clean all
 

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -10,8 +10,8 @@ LABEL name=ARG_BIN \
       maintainer="Tom Manville<tom@kasten.io>" \
       description="Frameworks and utilities for application-specific data management, has updated openssl-libs."
 
-RUN microdnf install git && \
-    microdnf update openssl-libs && \
+RUN microdnf update openssl-libs && \
+    microdnf install git && \
     microdnf clean all
 
 COPY licenses /licenses/licenses

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -11,7 +11,6 @@ LABEL name=ARG_BIN \
       description="Frameworks and utilities for application-specific data management, has updated openssl-libs."
 
 RUN microdnf update openssl-libs && \
-    microdnf update cyrus-sasl && \
     microdnf update cyrus-sasl-lib && \
     microdnf install git && \
     microdnf clean all

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -11,6 +11,7 @@ LABEL name=ARG_BIN \
       description="Frameworks and utilities for application-specific data management, has updated openssl-libs."
 
 RUN microdnf update openssl-libs && \
+    microdnf update cyrus-sasl && \
     microdnf install git && \
     microdnf clean all
 


### PR DESCRIPTION
## Change Overview

Fixes https://access.redhat.com/security/cve/CVE-2022-24407 vulnerability in the controller image.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan


- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E

build the image and make sure we don't see `cyrus-sasl` related issue.