### PR TITLE
Upgrade kafka component version to 3.1.0

### DIFF
--- a/examples/kafka/adobe-s3-connector/kafka-cluster.yaml
+++ b/examples/kafka/adobe-s3-connector/kafka-cluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-cluster
 spec:
   kafka:
-    version: 2.8.0
+    version: 3.1.0
     replicas: 1
     listeners:
       - name: plain
@@ -15,6 +15,10 @@ spec:
         port: 9093
         type: internal
         tls: true
+    logging:
+      type: inline
+      loggers:
+        kafka.root.logger.level: "INFO"
     template:
       pod:
         securityContext:
@@ -24,8 +28,7 @@ spec:
       offsets.topic.replication.factor: 1
       transaction.state.log.replication.factor: 1
       transaction.state.log.min.isr: 1
-      log.message.format.version: "2.8"
-      inter.broker.protocol.version: "2.8"
+      inter.broker.protocol.version: "3.1"
     storage:
       type: jbod
       volumes:
@@ -40,6 +43,10 @@ spec:
         securityContext:
           runAsUser: 0
           fsGroup: 0
+    logging:
+      type: inline
+      loggers:
+        zookeeper.root.logger.level: "INFO"
     storage:
       type: persistent-claim
       size: 100Gi


### PR DESCRIPTION
## Change Overview

The helm chart that we use for kafka was recently upgraded to version [0.28.0](https://github.com/strimzi/strimzi-kafka-operator/releases/tag/0.28.0). In there we removed the support for Kafka `2.8.0`, that we were using earlier. In this PR we have upgraded the Kafka version to latest `3.1.0`

Reference : [https://strimzi.io/docs/operators/latest/configuring.html](https://strimzi.io/docs/operators/latest/configuring.html)

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E

`./build/integration-test.sh ^Kafka$`
[Logs can be found here](https://gist.github.com/A-kanksh-a/93e5701f8c66cefda8d770dda941eb8c)