### PR TITLE
Update helm version build image to 3.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ IMAGE_NAME := $(BIN)
 
 IMAGE := $(REGISTRY)/$(IMAGE_NAME)
 
-BUILD_IMAGE ?= ghcr.io/kanisterio/build:v0.0.17
+BUILD_IMAGE ?= ghcr.io/kanisterio/build:v0.0.18
 
 # tag 0.1.0 is, 0.0.1 (latest) + gh + aws + helm binary
 DOCS_BUILD_IMAGE ?= ghcr.io/kanisterio/docker-sphinx:0.2.0

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -12,7 +12,7 @@ COPY --from=bitnami/kubectl:1.17 /opt/bitnami/kubectl/bin/kubectl /usr/local/bin
 
 COPY --from=goreleaser/goreleaser:v1.2.4 /usr/local/bin/goreleaser /usr/local/bin/
 
-COPY --from=alpine/helm:3.1.0 /usr/bin/helm /usr/local/bin/
+COPY --from=alpine/helm:3.2.0 /usr/bin/helm /usr/local/bin/
 
 COPY --from=golangci/golangci-lint:v1.23.7 /usr/bin/golangci-lint /usr/local/bin/
 


### PR DESCRIPTION
## Change Overview

This change updates the helm version in the kanister build image to `3.2`. 

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #1285 

## Test Plan


Run 
```
make integration-test
```
to run the kanister integration test.
the logs can be found [here.](https://github.com/cli/cli/releases/tag/v2.6.0)