### PR TITLE
Reduce dependabot concurrent requests to 2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,6 @@ version: 2
 updates:
   - package-ecosystem: gomod
     directory: "/"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 2
     schedule:
       interval: daily


### PR DESCRIPTION
## Change Overview

Reduce @dependabot concurrent requests to 2 to limit the amount of consumed CI cycles for @dependabot PRs.

Every time a @dependabot PR is merged, all the outstanding ones are rebased and go through CI as well.

Ideally, we'd have a rule to manage when CI gets to run for @dependabot PRs, as it does not make sense to run CI when there is another outstanding @dependabot PR for which CI is running or has succeeded. Until then, we will reduce the concurrency level.

## Pull request type

- [x] :hamster: Trivial/Minor

## Test Plan

- [x] CI