### PR TITLE
Add New ExecOutput Function To Support Custom Writers

### DIFF
--- a/pkg/format/format.go
+++ b/pkg/format/format.go
@@ -31,6 +31,23 @@ func Log(podName string, containerName string, output string) {
 	LogWithCtx(context.Background(), podName, containerName, output)
 }
 
+// LogTo prints output to w. The specified pod and container are added to the
+// log line as fields.
+func LogTo(w io.Writer, pod string, container string, output string) {
+	if output != "" {
+		for _, line := range regex.Split(output, -1) {
+			if line != "" {
+				fields := field.M{
+					"Pod":       pod,
+					"Container": container,
+					"Out":       line,
+				}
+				log.PrintTo(w, "action update", fields)
+			}
+		}
+	}
+}
+
 func LogStream(podName string, containerName string, output io.ReadCloser) chan string {
 	logCh := make(chan string, 100)
 	s := bufio.NewScanner(output)

--- a/pkg/format/writer.go
+++ b/pkg/format/writer.go
@@ -1,0 +1,18 @@
+package format
+
+import (
+	"io"
+)
+
+// Writer formats strings before writing them to its underlying writer.
+type Writer struct {
+	W         io.Writer
+	Pod       string
+	Container string
+}
+
+// Write formats p and write it to w's writer.
+func (w *Writer) Write(p []byte) (int, error) {
+	LogTo(w.W, w.Pod, w.Container, string(p))
+	return len(p), nil
+}

--- a/pkg/function/kube_exec.go
+++ b/pkg/function/kube_exec.go
@@ -21,8 +21,6 @@ import (
 	"github.com/pkg/errors"
 
 	kanister "github.com/kanisterio/kanister/pkg"
-	"github.com/kanisterio/kanister/pkg/consts"
-	"github.com/kanisterio/kanister/pkg/field"
 	"github.com/kanisterio/kanister/pkg/kube"
 	"github.com/kanisterio/kanister/pkg/output"
 	"github.com/kanisterio/kanister/pkg/param"
@@ -92,9 +90,6 @@ func (kef *kubeExecFunc) Exec(ctx context.Context, tp param.TemplateParams, args
 	if err = Arg(args, KubeExecCommandArg, &cmd); err != nil {
 		return nil, err
 	}
-	ctx = field.Context(ctx, consts.PodNameKey, pod)
-	_ = field.Context(ctx, consts.ContainerNameKey, container)
-
 	if err := kube.ExecAsync(cli, namespace, pod, container, cmd, nil); err != nil {
 		return nil, err
 	}

--- a/pkg/function/kube_exec.go
+++ b/pkg/function/kube_exec.go
@@ -21,7 +21,8 @@ import (
 	"github.com/pkg/errors"
 
 	kanister "github.com/kanisterio/kanister/pkg"
-	"github.com/kanisterio/kanister/pkg/format"
+	"github.com/kanisterio/kanister/pkg/consts"
+	"github.com/kanisterio/kanister/pkg/field"
 	"github.com/kanisterio/kanister/pkg/kube"
 	"github.com/kanisterio/kanister/pkg/output"
 	"github.com/kanisterio/kanister/pkg/param"
@@ -91,15 +92,14 @@ func (kef *kubeExecFunc) Exec(ctx context.Context, tp param.TemplateParams, args
 	if err = Arg(args, KubeExecCommandArg, &cmd); err != nil {
 		return nil, err
 	}
-	stdout, stderr, err := kube.Exec(cli, namespace, pod, container, cmd, nil)
-	format.LogWithCtx(ctx, pod, container, stdout)
-	format.LogWithCtx(ctx, pod, container, stderr)
-	if err != nil {
+	ctx = field.Context(ctx, consts.PodNameKey, pod)
+	_ = field.Context(ctx, consts.ContainerNameKey, container)
+
+	if err := kube.ExecAsync(cli, namespace, pod, container, cmd, nil); err != nil {
 		return nil, err
 	}
 
-	out, err := parseLogAndCreateOutput(stdout)
-	return out, errors.Wrap(err, "Failed to generate output")
+	return nil, errors.Wrap(err, "Failed to generate output")
 }
 
 func (*kubeExecFunc) RequiredArgs() []string {

--- a/pkg/function/kube_exec.go
+++ b/pkg/function/kube_exec.go
@@ -16,6 +16,7 @@ package function
 
 import (
 	"context"
+	"os"
 	"regexp"
 
 	"github.com/pkg/errors"
@@ -90,7 +91,7 @@ func (kef *kubeExecFunc) Exec(ctx context.Context, tp param.TemplateParams, args
 	if err = Arg(args, KubeExecCommandArg, &cmd); err != nil {
 		return nil, err
 	}
-	if err := kube.ExecAsync(cli, namespace, pod, container, cmd, nil); err != nil {
+	if err := kube.ExecOutput(cli, namespace, pod, container, cmd, nil, os.Stdout, os.Stderr); err != nil {
 		return nil, err
 	}
 

--- a/pkg/function/kube_exec_test.go
+++ b/pkg/function/kube_exec_test.go
@@ -180,9 +180,11 @@ func (s *KubeExecTest) TestParseLogAndCreateOutput(c *C) {
 		outChecker Checker
 	}{
 		{"###Phase-output###: {\"key\":\"version\",\"value\":\"0.78.0\"}", map[string]interface{}{"version": "0.78.0"}, IsNil, NotNil},
-		{"###Phase-output###: {\"key\":\"version\",\"value\":\"0.78.0\"}\n###Phase-output###: {\"key\":\"path\",\"value\":\"/backup/path\"}",
-			map[string]interface{}{"version": "0.78.0", "path": "/backup/path"}, IsNil, NotNil},
 		{"Random message ###Phase-output###: {\"key\":\"version\",\"value\":\"0.78.0\"}", map[string]interface{}{"version": "0.78.0"}, IsNil, NotNil},
+		{"###Phase-output###: {\"key\":\"version\",\"value\":\"0.78.0\"},Random message", map[string]interface{}{"version": "0.78.0"}, IsNil, NotNil},
+		{"Random message ###Phase-output###: {\"key\":\"version\",\"value\":\"0.78.0\"},Random message", map[string]interface{}{"version": "0.78.0"}, IsNil, NotNil},
+		{"{\"Out\":\"###Phase-output###: {\"key\":\"version\",\"value\":\"0.78.0\"}\"}", map[string]interface{}{"version": "0.78.0"}, IsNil, NotNil},
+		{"{\"Out\":\"###Phase-output###: {\"key\":\"version\",\"value\":\"0.78.0\"}\", \"Pod\":\"my-pod\"}", map[string]interface{}{"version": "0.78.0"}, IsNil, NotNil},
 		{"Random message with newline \n###Phase-output###: {\"key\":\"version\",\"value\":\"0.78.0\"}", map[string]interface{}{"version": "0.78.0"}, IsNil, NotNil},
 		{"###Phase-output###: Invalid message", nil, NotNil, IsNil},
 		{"Random message", nil, IsNil, IsNil},

--- a/pkg/kube/exec.go
+++ b/pkg/kube/exec.go
@@ -124,8 +124,8 @@ func execStream(kubeCli kubernetes.Interface, config *restclient.Config, options
 	go func() {
 		err := execute("POST", req.URL(), config, options.Stdin, pwo, pwe, tty)
 		errCh <- err
-		_ = pwo.CloseWithError(err)
-		_ = pwe.CloseWithError(err)
+		_ = pwo.Close()
+		_ = pwe.Close()
 	}()
 	return pro, pre, errCh
 }

--- a/pkg/kube/exec.go
+++ b/pkg/kube/exec.go
@@ -65,14 +65,17 @@ func ExecWithOptions(kubeCli kubernetes.Interface, options ExecOptions) (string,
 	if err != nil {
 		return "", "", err
 	}
-	o, e, errCh := execStream(kubeCli, config, options)
+	o, e := execStream(kubeCli, config, options)
 
 	var stdout []byte
-	var err error
+	var oerr error
 	wg := sync.WaitGroup{}
 	wg.Add(2)
 	go func() {
 		stdout, oerr = ioutil.ReadAll(o)
+		if oerr != nil {
+			log.Error("Failed to read stderr:", oerr.Error())
+		}
 		wg.Done()
 	}()
 

--- a/pkg/kube/exec.go
+++ b/pkg/kube/exec.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"io"
 	"net/url"
-	"os"
 	"strings"
 
 	"github.com/kanisterio/kanister/pkg/format"
@@ -56,28 +55,26 @@ func Exec(cli kubernetes.Interface, namespace, pod, container string, command []
 	return ExecWithOptions(cli, opts)
 }
 
-// ExecAsync is similar to Exec, except that inbound outputs are written to
-// stdout and stderr immediately. Unlike Exec, the outputs are not returned to
-// the caller.
-func ExecAsync(cli kubernetes.Interface, namespace, pod, container string, command []string, stdin io.Reader) error {
-	stdout := &format.Writer{
-		W:         os.Stdout,
-		Pod:       pod,
-		Container: container,
-	}
-	stderr := &format.Writer{
-		W:         os.Stderr,
-		Pod:       pod,
-		Container: container,
-	}
+// ExecOutput is similar to Exec, except that inbound outputs are written to the
+// provided stdout and stderr. Unlike Exec, the outputs are not returned to the
+// caller.
+func ExecOutput(cli kubernetes.Interface, namespace, pod, container string, command []string, stdin io.Reader, stdout, stderr io.Writer) error {
 	opts := ExecOptions{
 		Command:       command,
 		Namespace:     namespace,
 		PodName:       pod,
 		ContainerName: container,
 		Stdin:         stdin,
-		Stdout:        stdout,
-		Stderr:        stderr,
+		Stdout: &format.Writer{
+			W:         stdout,
+			Pod:       pod,
+			Container: container,
+		},
+		Stderr: &format.Writer{
+			W:         stderr,
+			Pod:       pod,
+			Container: container,
+		},
 	}
 
 	_, _, err := ExecWithOptions(cli, opts)

--- a/pkg/kube/exec.go
+++ b/pkg/kube/exec.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"net/url"
 	"os"
+	"strings"
 
 	"github.com/kanisterio/kanister/pkg/format"
 	"github.com/pkg/errors"
@@ -104,7 +105,7 @@ func ExecWithOptions(kubeCli kubernetes.Interface, options ExecOptions) (string,
 
 	errCh := execStream(kubeCli, config, options)
 	err = <-errCh
-	return outbuf.String(), errbuf.String(), errors.Wrap(err, "Failed to exec command in pod")
+	return strings.TrimSpace(outbuf.String()), strings.TrimSpace(errbuf.String()), errors.Wrap(err, "Failed to exec command in pod")
 }
 
 func execStream(kubeCli kubernetes.Interface, config *restclient.Config, options ExecOptions) chan error {

--- a/pkg/kube/exec.go
+++ b/pkg/kube/exec.go
@@ -128,7 +128,10 @@ func execStream(kubeCli kubernetes.Interface, config *restclient.Config, options
 
 	errCh := make(chan error, 1)
 	go func() {
-		err := execute("POST", req.URL(), config,
+		err := execute(
+			"POST",
+			req.URL(),
+			config,
 			options.Stdin,
 			options.Stdout,
 			options.Stderr,

--- a/pkg/kube/exec_test.go
+++ b/pkg/kube/exec_test.go
@@ -86,6 +86,22 @@ func (s *ExecSuite) TestStderr(c *C) {
 		c.Assert(stdout, Equals, "")
 		c.Assert(stderr, Equals, "hello")
 	}
+
+	cmd = []string{"sh", "-c", "echo -n hello && exit 1"}
+	for _, cs := range s.pod.Status.ContainerStatuses {
+		stdout, stderr, err := Exec(s.cli, s.pod.Namespace, s.pod.Name, cs.Name, cmd, nil)
+		c.Assert(err, NotNil)
+		c.Assert(stdout, Equals, "hello")
+		c.Assert(stderr, Equals, "")
+	}
+
+	cmd = []string{"sh", "-c", "count=0; while true; do printf $count; let count=$count+1; if [ $count -eq 6 ]; then exit 1; fi; done"}
+	for _, cs := range s.pod.Status.ContainerStatuses {
+		stdout, stderr, err := Exec(s.cli, s.pod.Namespace, s.pod.Name, cs.Name, cmd, nil)
+		c.Assert(err, NotNil)
+		c.Assert(stdout, Equals, "012345")
+		c.Assert(stderr, Equals, "")
+	}
 }
 
 func (s *ExecSuite) TestExecEcho(c *C) {

--- a/pkg/kube/exec_test.go
+++ b/pkg/kube/exec_test.go
@@ -78,6 +78,16 @@ func (s *ExecSuite) TearDownSuite(c *C) {
 	}
 }
 
+func (s *ExecSuite) TestStderr(c *C) {
+	cmd := []string{"sh", "-c", "echo -n hello >&2"}
+	for _, cs := range s.pod.Status.ContainerStatuses {
+		stdout, stderr, err := Exec(s.cli, s.pod.Namespace, s.pod.Name, cs.Name, cmd, nil)
+		c.Assert(err, IsNil)
+		c.Assert(stdout, Equals, "")
+		c.Assert(stderr, Equals, "hello")
+	}
+}
+
 func (s *ExecSuite) TestExecEcho(c *C) {
 	cmd := []string{"sh", "-c", "cat -"}
 	c.Assert(s.pod.Status.Phase, Equals, v1.PodRunning)

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -99,6 +99,22 @@ func (s *LogSuite) TestLogWithContextFieldsAndError(c *C) {
 	c.Assert(entry["key"], Equals, "value")
 }
 
+func (s *LogSuite) TestLogPrintTo(c *C) {
+	buf := &bytes.Buffer{}
+	msg := "test log message"
+	fields := map[string]interface{}{
+		"field1": "value1",
+		"field2": "value2",
+	}
+	PrintTo(buf, msg, fields)
+
+	entry := map[string]interface{}{}
+	err := json.Unmarshal(buf.Bytes(), &entry)
+	c.Assert(err, IsNil)
+	c.Assert(entry, NotNil)
+	c.Assert(entry["msg"], Equals, msg)
+}
+
 func testLogMessage(c *C, msg string, print func(string, ...field.M), fields ...field.M) map[string]interface{} {
 	log.SetFormatter(&logrus.JSONFormatter{TimestampFormat: time.RFC3339Nano})
 	var memLog bytes.Buffer

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -2,12 +2,14 @@ package log
 
 import (
 	"context"
+	"io"
 
 	"github.com/kanisterio/kanister/pkg/field"
 )
 
 type Logger interface {
 	Print(msg string, fields ...field.M)
+	PrintTo(w io.Writer, msg string, fields ...field.M)
 	WithContext(ctx context.Context) Logger
 	WithError(err error) Logger
 }

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -81,7 +81,17 @@ func fPrintOutput(w io.Writer, key, value string) error {
 	return nil
 }
 
-const reStr = PhaseOpString + `(.*)$`
+// reStr looks for phase output patterns from log lines.
+// it matches these patterns:
+//   case1: some-prefix###Phase-output###: {"foo":"bar"}
+//   case2: ###Phase-output###: {"foo":"bar","baz":"bazz"}some-suffix
+//   case3: ###Phase-output###: {"foo":"bar","baz":"bazz"}
+//   case4: ###Phase-output###: foo
+// See unit tests.
+// {.*?} ensures non-greedy evaluation so that the matching will stop at the
+// first curly bracket.
+// The Parse function return case4 as errors to the caller.
+const reStr = `(.*)` + PhaseOpString + `( *)({.*?}|.*)`
 
 var logRE = regexp.MustCompile(reStr)
 
@@ -91,9 +101,12 @@ func Parse(l string) (*Output, error) {
 	if len(match) == 0 {
 		return nil, nil
 	}
-	op, err := UnmarshalOutput(match[0][1])
+
+	stripped := strings.Replace(match[0][3], "\\", "", -1)
+	op, err := UnmarshalOutput(stripped)
 	if err != nil {
 		return nil, err
 	}
+
 	return op, nil
 }


### PR DESCRIPTION
## Change Overview

This PR introduces a new `kube.ExecOutput()` library function that can write `kube.Exec()` outputs to custom writers, allowing callers to provide either buffered writers or async (pipe) writers. This new function delegates the writes operation to a new `format.Writer` instance that formats the outputs to match the Kanister-style logs, before writing them to the custom writers.

The `KubeExec` Kanister function has been updated to use `kube.ExecOutput()`, with `os.Stdout` and `os.Stderr`. Other callers in the `pkg/app` and `pkg/function` packages remain untouched. By offering both `kube.Exec()` and `kube.ExecAsync()`, downstream has the flexibility to decide which output mechanism to use, based on their use cases.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [x] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

Follow-up of:
- https://github.com/kanisterio/kanister/pull/1194
- https://github.com/kanisterio/kanister/pull/1037

## Test Plan

Deploy this `timer` pod that has a script to tail the current datetime at one second interval:

```sh
cat <<EOF | k apply -f -
apiVersion: v1
kind: Pod
metadata:
  name: timer
spec:
  containers:
  - name: timer
    image: ubuntu
    command:
    - /bin/sh
    - "-c"
    - |
      cat <<EOF > /bin/tail_datetime.sh
      for i in \\\$(seq 0 20)
      do
        date +"%m-%d-%Y %H:%M:%S"
        sleep 1s
      done
      EOF

      chmod +x /bin/tail_datetime.sh
      sleep 7200s
EOF
```

Deploy this blueprint that uses `KubeExec` to invoke the remote script in the `timer` pod:

```sh
cat <<EOF | k apply -f -
apiVersion: cr.kanister.io/v1alpha1
kind: Blueprint
metadata:
  name: timer
  namespace: kanister
actions:
  tail:
    phases:
    - func: KubeExec
      name: tail
      args:
        namespace: default
        pod: timer
        container: timer
        command:
        - sh
        - "-c"
        - /bin/tail_datetime.sh
EOF
```

Creates the actionset to trigger the function call:
```sh
cat <<EOF | k create -f -
apiVersion: cr.kanister.io/v1alpha1
kind: ActionSet
metadata:
  generateName: timer-
  namespace: kanister
spec:
  actions:
  - name: tail
    blueprint: timer
    object:
      kind: Namespace
      name: default
EOF
```

Observe the datetime being streamed to the Kanister operator's logs:

```sh
$ k -n kanister logs -f kanister-kanister-operator-5964486449-xqv66
#...

{"Container":"timer","File":"pkg/log/log.go","Function":"github.com/kanisterio/kanister/pkg/log.PrintTo","Line":174,"Out":"03-25-2022 05:52:49","Pod":"timer","cluster_name":"8224a31e-876b-4ef2-98c2-ae9cbc5e96b0","hostname":"kanister-kanister-operator-5964486449-xqv66","level":"info","msg":"action update","time":"2022-03-25T05:52:49.060833604Z"}
{"Container":"timer","File":"pkg/log/log.go","Function":"github.com/kanisterio/kanister/pkg/log.PrintTo","Line":174,"Out":"03-25-2022 05:52:50","Pod":"timer","cluster_name":"8224a31e-876b-4ef2-98c2-ae9cbc5e96b0","hostname":"kanister-kanister-operator-5964486449-xqv66","level":"info","msg":"action update","time":"2022-03-25T05:52:50.063202873Z"}
{"ActionSet":"timer-2pkxw","File":"pkg/controller/controller.go","Function":"github.com/kanisterio/kanister/pkg/controller.(*Controller).logAndSuccessEvent","Line":510,"Phase":"tail","cluster_name":"8224a31e-876b-4ef2-98c2-ae9cbc5e96b0","hostname":"kanister-kanister-operator-5964486449-xqv66","level":"info","msg":"Completed phase tail","time":"2022-03-25T05:52:51.077562462Z"}
{"File":"pkg/controller/controller.go","Function":"github.com/kanisterio/kanister/pkg/controller.(*Controller).logAndSuccessEvent","Line":510,"cluster_name":"8224a31e-876b-4ef2-98c2-ae9cbc5e96b0","hostname":"kanister-kanister-operator-5964486449-xqv66","level":"info","msg":"Updated ActionSet 'timer-2pkxw' Status-\u003ecomplete","time":"2022-03-25T05:52:51.081930515Z"}
```

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
