### PR TITLE
Fix `unable to redefine shorthand`, prob in `create profile azure`

### DIFF
--- a/pkg/kanctl/profile.go
+++ b/pkg/kanctl/profile.go
@@ -140,7 +140,7 @@ func newAzureProfileCmd() *cobra.Command {
 
 	cmd.Flags().StringP(AzureStorageAccountFlag, "a", "", "Storage account name of the azure storage")
 	cmd.Flags().StringP(AzureStorageKeyFlag, "s", "", "Storage account key of the azure storage")
-	cmd.Flags().StringP(AzureStorageEnvFlag, "e", "", "The Azure cloud environment")
+	cmd.Flags().String(AzureStorageEnvFlag, "", "The Azure cloud environment")
 
 	_ = cmd.MarkFlagRequired(AzureStorageAccountFlag)
 	_ = cmd.MarkFlagRequired(AzureStorageKeyFlag)


### PR DESCRIPTION
## Change Overview

Fixes #1333 

We can try to come up with the shorthand flag but I think we its ok if we don't provide the shorthand here. The other thing is should we try to check the same problem with other flag combinations. I still see some other instances of same characters being used as shorthand flag.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #1333 

## Test Plan

Build the binary and run the same command again

```
» ./kanctl create profile azure
Error: required flag(s) "storage-account", "storage-key" not set
Usage:
  kanctl create profile azure [flags]

Flags:
  -h, --help                     help for azure
  -a, --storage-account string   Storage account name of the azure storage
      --storage-env string       The Azure cloud environment
  -s, --storage-key string       Storage account key of the azure storage

Global Flags:
  -b, --bucket string           object store bucket name
      --dry-run                 if set, resource YAML will be printed but not created
  -e, --endpoint string         endpoint URL of the object store bucket
  -n, --namespace string        Override namespace obtained from kubectl context
  -p, --prefix string           prefix URL of the object store bucket
  -r, --region string           region of the object store bucket
      --skip-SSL-verification   if set, SSL verification is disabled for the profile
      --skip-validation         if set, resource is not validated before creation
      --verbose                 Display verbose output


```