### PR TITLE
Change duplicate flag

### DIFF
--- a/pkg/kanctl/profile.go
+++ b/pkg/kanctl/profile.go
@@ -140,7 +140,7 @@ func newAzureProfileCmd() *cobra.Command {
 
 	cmd.Flags().StringP(AzureStorageAccountFlag, "a", "", "Storage account name of the azure storage")
 	cmd.Flags().StringP(AzureStorageKeyFlag, "s", "", "Storage account key of the azure storage")
-	cmd.Flags().StringP(AzureStorageEnvFlag, "e", "", "The Azure cloud environment")
+	cmd.Flags().StringP(AzureStorageEnvFlag, "c", "", "The Azure cloud environment")
 
 	_ = cmd.MarkFlagRequired(AzureStorageAccountFlag)
 	_ = cmd.MarkFlagRequired(AzureStorageKeyFlag)


### PR DESCRIPTION
## Change Overview

The shorthand flag for setting the environment variable is a duplicate and conflicts with the `endpoint` variable.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
