### PR TITLE
Add a check for permission to createVolume for EBS and creds validation for aws

### DIFF
--- a/pkg/aws/aws_test.go
+++ b/pkg/aws/aws_test.go
@@ -1,0 +1,49 @@
+// Copyright 2022 The Kanister Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aws
+
+import (
+	"context"
+	"testing"
+
+	"gopkg.in/check.v1"
+
+	envconfig "github.com/kanisterio/kanister/pkg/config"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) { check.TestingT(t) }
+
+type AWSSuite struct{}
+
+var _ = check.Suite(&AWSSuite{})
+
+func (s AWSSuite) TestValidCreds(c *check.C) {
+	ctx := context.Background()
+	config := map[string]string{}
+
+	config[AccessKeyID] = envconfig.GetEnvOrSkip(c, AccessKeyID)
+	config[SecretAccessKey] = envconfig.GetEnvOrSkip(c, SecretAccessKey)
+	config[ConfigRegion] = "us-west-2"
+
+	res, err := IsAwsCredsValid(ctx, config)
+	c.Assert(err, check.IsNil)
+	c.Assert(res, check.Equals, true)
+
+	config[AccessKeyID] = "fake-access-id"
+	res, err = IsAwsCredsValid(ctx, config)
+	c.Assert(err, check.NotNil)
+	c.Assert(res, check.Equals, false)
+}

--- a/pkg/blockstorage/awsebs/awsebs.go
+++ b/pkg/blockstorage/awsebs/awsebs.go
@@ -115,6 +115,40 @@ func (s *EbsStorage) VolumeCreate(ctx context.Context, volume blockstorage.Volum
 	return s.VolumeGet(ctx, volID, volume.Az)
 }
 
+// CheckVolumeCreate checks if client as permission to create volumes
+func (s *EbsStorage) CheckVolumeCreate(ctx context.Context) (bool, error) {
+	var zoneName *string
+	var err error
+	var size int64 = 1
+	var dryRun bool = true
+
+	ec2Cli, err := newEC2Client(*s.config.Region, s.config)
+	if err != nil {
+		return false, errors.Wrapf(err, "Could not get EC2 client")
+	}
+	dai := &ec2.DescribeAvailabilityZonesInput{}
+	az, err := ec2Cli.DescribeAvailabilityZones(dai)
+	if err != nil {
+		return false, err
+	}
+	if az != nil {
+		zoneName = az.AvailabilityZones[1].ZoneName
+	} else {
+		return false, errors.New("No zone avaialble for EC2 client")
+	}
+
+	cvi := &ec2.CreateVolumeInput{
+		AvailabilityZone: zoneName,
+		Size:             &size,
+		DryRun:           &dryRun,
+	}
+	_, err = s.Ec2Cli.CreateVolume(cvi)
+	if isDryRunErr(err) {
+		return true, nil
+	}
+	return false, errors.Wrapf(err, "Could not create volume with EC2 client")
+}
+
 // VolumeGet is part of blockstorage.Provider
 func (s *EbsStorage) VolumeGet(ctx context.Context, id string, zone string) (*blockstorage.Volume, error) {
 	volIDs := []*string{aws.String(id)}

--- a/pkg/blockstorage/awsebs/awsebs.go
+++ b/pkg/blockstorage/awsebs/awsebs.go
@@ -124,17 +124,17 @@ func (s *EbsStorage) CheckVolumeCreate(ctx context.Context) (bool, error) {
 
 	ec2Cli, err := newEC2Client(*s.config.Region, s.config)
 	if err != nil {
-		return false, errors.Wrapf(err, "Could not get EC2 client")
+		return false, errors.Wrap(err, "Could not get EC2 client")
 	}
 	dai := &ec2.DescribeAvailabilityZonesInput{}
 	az, err := ec2Cli.DescribeAvailabilityZones(dai)
 	if err != nil {
-		return false, err
+		return false, errors.New("Fail to get available zone for EC2 client")
 	}
 	if az != nil {
 		zoneName = az.AvailabilityZones[1].ZoneName
 	} else {
-		return false, errors.New("No zone avaialble for EC2 client")
+		return false, errors.New("No available zone for EC2 client")
 	}
 
 	cvi := &ec2.CreateVolumeInput{
@@ -143,10 +143,10 @@ func (s *EbsStorage) CheckVolumeCreate(ctx context.Context) (bool, error) {
 		DryRun:           &dryRun,
 	}
 	_, err = s.Ec2Cli.CreateVolume(cvi)
-	if isDryRunErr(err) {
-		return true, nil
+	if !isDryRunErr(err) {
+		return false, errors.Wrap(err, "Could not create volume with EC2 client")
 	}
-	return false, errors.Wrapf(err, "Could not create volume with EC2 client")
+	return true, nil
 }
 
 // VolumeGet is part of blockstorage.Provider


### PR DESCRIPTION
## Change Overview

This PR:

1. Add `CheckVolumeCreate` to check EC2 permission to perform VolumeCreate action
2. Add `IsAwsCredsValid` to check credibility of AWS creds 

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [x] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- [K10-10316](https://kasten.atlassian.net/browse/K10-10316)

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
