### PR TITLE
Add GH Actions CI Workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -2,11 +2,9 @@ on:
   push:
     branches:
     - master
-    - ci-*
   pull_request:
     branches:
     - master
-    - ci-*
 jobs:
   gomod:
     runs-on: ubuntu-20.04

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,91 @@
+on:
+  push:
+    branches:
+    - master
+    - ci-*
+  pull_request:
+    branches:
+    - master
+    - ci-*
+jobs:
+  gomod:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - run: make gomod
+    - run: make go-mod-download
+    - run: tar -cvf ./src.tar.gz ./ # preserve file permissions
+    - uses: actions/upload-artifact@v3
+      with:
+        name: src
+        path: ./src.tar.gz
+  lint:
+    runs-on: ubuntu-20.04
+    needs: gomod
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: src
+    - run: tar -xvf ./src.tar.gz
+    - run: make golint
+  test:
+    runs-on: ubuntu-20.04
+    needs: [gomod, lint]
+    strategy:
+      fail-fast: false
+      matrix:
+        testSuite: [test, integration-test, helm-test]
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: src
+    - uses: AbsaOSS/k3d-action@v2
+      with:
+        cluster-name: "kanister-run-${{ matrix.testSuite }}"
+        args: >-
+          --agents 3
+          --no-lb
+          --k3s-arg "--no-deploy=traefik,servicelb@server:*"
+    - run: tar -xvf ./src.tar.gz
+    - run: |
+        make install-csi-hostpath-driver
+        make install-minio
+      if: matrix.testSuite == 'integration-test' || matrix.testSuite == 'helm-test'
+    - run: make ${{ matrix.testSuite }}
+  build:
+    runs-on: ubuntu-20.04
+    needs: [gomod, lint, test]
+    strategy:
+      matrix:
+        bin: [controller, kanctl, kando]
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: src
+    - run: tar -xvf ./src.tar.gz
+    - run: make build BIN=${{ matrix.bin }}
+  docs:
+    runs-on: ubuntu-20.04
+    needs: gomod
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: src
+    - run: tar -xvf ./src.tar.gz
+    - run: make docs
+  release:
+    runs-on: ubuntu-20.04
+    needs: [test, build]
+    if: github.ref_name == 'master' || startsWith(github.ref, 'refs/tags')
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: src
+    - uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ github.token }}
+    - run: tar -xvf ./src.tar.gz
+    - run: make release-snapshot
+    - run: ./build/push_images.sh

--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,7 @@ bin/$(ARCH)/$(BIN):
 		GOARCH=$(ARCH)       \
 		VERSION=$(VERSION) \
 		PKG=$(PKG)         \
+		BIN=$(BIN) \
 		./build/build.sh   \
 	"'
 # Example: make shell CMD="-c 'date > datefile'"
@@ -285,3 +286,6 @@ stop-kind:
 
 check:
 	@./build/check.sh
+
+gomod:
+	@$(MAKE) run CMD='-c "./build/gomod.sh"'

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 # Kanister
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/kanisterio/kanister)](https://goreportcard.com/report/github.com/kanisterio/kanister)
+[![GitHub Actions](https://github.com/kanisterio/actions/kanister/workflows/main.yaml/badge.svg)](https://github.com/kanisterio/kanister/actions)
 [![Build Status](https://travis-ci.com/kanisterio/kanister.svg?branch=master)](https://travis-ci.com/kanisterio/kanister)
-
 
 A framework for data management in Kubernetes.  It allows domain experts to
 define application-specific data management workflows through Kubernetes API

--- a/build/build.sh
+++ b/build/build.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Copyright 2019 The Kanister Authors.
-# 
+#
 # Copyright 2016 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,7 +29,7 @@ if [ -z "${VERSION}" ]; then
 fi
 
 export CGO_ENABLED=0
-go install -v                                                      \
+go build -v                                                      \
     -installsuffix "static"                                        \
     -ldflags "-X ${PKG}/pkg/version.VERSION=${VERSION}"            \
-    ./cmd/...
+    ./cmd/${BIN}/...

--- a/build/gomod.sh
+++ b/build/gomod.sh
@@ -1,6 +1,8 @@
-#!/bin/bash
+#!/bin/sh
 
 # Copyright 2019 The Kanister Authors.
+#
+# Copyright 2016 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,15 +19,9 @@
 set -o errexit
 set -o nounset
 
-SKIP_DIR_REGEX="pkg/client"
-TIMEOUT="10m"
-
-echo "Running golangci-lint..."
-
-golangci-lint run --timeout ${TIMEOUT} --skip-dirs ${SKIP_DIR_REGEX} -E maligned,whitespace,gocognit,unparam -e '`ctx` is unused'
-
-echo "PASS"
-echo
-
-echo "PASS"
-echo
+go mod tidy
+status=`git status --porcelain go.mod go.sum`
+if [ ! -z "$status" ]; then
+  echo 'stale go.mod and go.sum: please run `go mod tidy`'
+  exit 1
+fi

--- a/build/local_kubernetes.sh
+++ b/build/local_kubernetes.sh
@@ -73,6 +73,7 @@ install_csi_hostpath_driver() {
     cd /tmp
     git clone https://github.com/kubernetes-csi/csi-driver-host-path.git
     cd csi-driver-host-path
+    sed -i 's/mountPropagation: Bidirectional/\#mountPropagation: Bidirectional/g' deploy/kubernetes-1.21/hostpath/csi-hostpath-plugin.yaml
     ./deploy/kubernetes-1.21/deploy.sh
 
     # Create StorageClass


### PR DESCRIPTION
## Change Overview

This PR re-enables the GH Actions CI workflow. I would like to let it run in parallel to the current CI setup to compare the two CI solutions in terms of their speed, efficiency, responsiveness, flakiness and cost.

All the existing Travis CI jobs and stages have been added to the GH Actions `main.yaml` workflow. A completed successful CI run looks like this:

![github-actions-ci](https://user-images.githubusercontent.com/1330522/161804797-d075d511-7fe6-4bf4-bb9d-3a292d5b7ebf.png)

See https://github.com/kanisterio/kanister/actions/runs/2097423926.

Some highlights include:

* Parallel, independent jobs to run the `test`, `integration-test`, and `helm-test` suites
* Parallel, independent jobs to build the `controller`, `kanctl` and `kando` binaries
* Independent k3d clusters to run the test suites
* Run the `release` job only when there is a new merge into `master` or a new tag
* Takes about 25 minutes to complete compared to at least 30 mins on Travis (excluding the `make release-snapshot` target)
* Test flakes happen less frequently with the k3d setup

## Pull request type

Please check the type of change your PR introduces:
- CI/CD

## Issues

- Previously https://github.com/kanisterio/kanister/pull/917, https://github.com/kanisterio/kanister/pull/894