### PR TITLE
Strictly match Group in ResourceTypeMatcher: K8s core group

### DIFF
--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -15,7 +15,7 @@
 package filter
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -28,9 +28,19 @@ type ResourceTypeRequirement struct {
 	Resource string `json:"resource,omitempty"`
 }
 
-// Matches returns true if group, version and resource values match or are empty
+// Matches returns true if group, version and resource values match or are all empty
+// Group must match exactly because K8s core group is ""
+// Version and resource requirement values of "" match any value
 func (r ResourceTypeRequirement) Matches(gvr schema.GroupVersionResource) bool {
-	return matches(r.Group, gvr.Group) && matches(r.Version, gvr.Version) && matches(r.Resource, gvr.Resource)
+	if r.Empty() {
+		return true
+	}
+	return r.Group == gvr.Group && matches(r.Version, gvr.Version) && matches(r.Resource, gvr.Resource)
+}
+
+// Empty returns true if ResourceTypeRequirement has no fields set
+func (rtr ResourceTypeRequirement) Empty() bool {
+	return rtr.Group == "" && rtr.Version == "" && rtr.Resource == ""
 }
 
 func matches(sel, val string) bool {

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 
 	. "gopkg.in/check.v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -337,12 +337,12 @@ func (s *FilterSuite) TestGroupVersionResourceIncludeExclude(c *C) {
 					Group:   "mygroup",
 					Version: "yourversion",
 				},
+			},
+			exclude: []schema.GroupVersionResource{
 				{
 					Group:   "yourgroup",
 					Version: "myversion",
 				},
-			},
-			exclude: []schema.GroupVersionResource{
 				{
 					Group:   "yourgroup",
 					Version: "yourversion",


### PR DESCRIPTION
## Change Overview

This PR supports strict matching of Group in ResourceTypeMatcher.

This allows use of K8s core resources (group == "") in filters without
accidentally matching resources with same name in other groups. Maintains
wildcard behavior for "" in version and resource so that matches can be
done for entire groups and all versions of a specific group:resource.

Note: the filter package has been contributed to Kanister in the hope that it
may be useful. It does not appear that the Matches() method that is modified
here is used by anything in Kanister other than test code. This package is
used by K10 and an additional unit test also exercises this change.

## Pull request type

Please check the type of change your PR introduces:
- [x] :bug: Bugfix


## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
