### PR TITLE
Fix flaky Defer Phase tests

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -20,3 +20,5 @@ const (
 	ProfileResourceName         = "profile"
 	ProfileResourceNamePlural   = "profiles"
 )
+
+const LatestKanisterToolsImage = "ghcr.io/kanisterio/kanister-tools:v9.99.9-dev"

--- a/pkg/function/kube_task_test.go
+++ b/pkg/function/kube_task_test.go
@@ -26,6 +26,7 @@ import (
 
 	kanister "github.com/kanisterio/kanister/pkg"
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
+	"github.com/kanisterio/kanister/pkg/consts"
 	"github.com/kanisterio/kanister/pkg/kube"
 	"github.com/kanisterio/kanister/pkg/param"
 )
@@ -66,7 +67,7 @@ func outputPhase(namespace string) crv1alpha1.BlueprintPhase {
 		Func: KubeTaskFuncName,
 		Args: map[string]interface{}{
 			KubeTaskNamespaceArg: namespace,
-			KubeTaskImageArg:     "ghcr.io/kanisterio/kanister-tools:0.20.0",
+			KubeTaskImageArg:     consts.LatestKanisterToolsImage,
 			KubeTaskCommandArg: []string{
 				"sh",
 				"-c",

--- a/pkg/kube/exec_test.go
+++ b/pkg/kube/exec_test.go
@@ -27,8 +27,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-
-	"github.com/kanisterio/kanister/pkg/consts"
 )
 
 type ExecSuite struct {
@@ -123,7 +121,7 @@ func (s *ExecSuite) TestKopiaCommand(c *C) {
 			Containers: []v1.Container{
 				v1.Container{
 					Name:  "kanister-sidecar",
-					Image: consts.LatestKanisterToolsImage,
+					Image: "ghcr.io/kanisterio/kanister-tools:0.37.0",
 				},
 			},
 		},

--- a/pkg/kube/exec_test.go
+++ b/pkg/kube/exec_test.go
@@ -27,6 +27,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+
+	"github.com/kanisterio/kanister/pkg/consts"
 )
 
 type ExecSuite struct {
@@ -121,7 +123,7 @@ func (s *ExecSuite) TestKopiaCommand(c *C) {
 			Containers: []v1.Container{
 				v1.Container{
 					Name:  "kanister-sidecar",
-					Image: "ghcr.io/kanisterio/kanister-tools:0.37.0",
+					Image: consts.LatestKanisterToolsImage,
 				},
 			},
 		},

--- a/pkg/kube/pod_test.go
+++ b/pkg/kube/pod_test.go
@@ -43,9 +43,8 @@ type PodSuite struct {
 }
 
 const (
-	testSAName         = "test-sa"
-	controllerSA       = "controller-sa"
-	kanisterToolsImage = "ghcr.io/kanisterio/kanister-tools:v9.99.9-dev"
+	testSAName   = "test-sa"
+	controllerSA = "controller-sa"
 )
 
 var _ = Suite(&PodSuite{})
@@ -94,13 +93,13 @@ func (s *PodSuite) TestPod(c *C) {
 		{
 			Namespace:    s.namespace,
 			GenerateName: "test-",
-			Image:        kanisterToolsImage,
+			Image:        consts.LatestKanisterToolsImage,
 			Command:      []string{"sh", "-c", "tail -f /dev/null"},
 		},
 		{
 			Namespace:          s.namespace,
 			GenerateName:       "test-",
-			Image:              kanisterToolsImage,
+			Image:              consts.LatestKanisterToolsImage,
 			Command:            []string{"sh", "-c", "tail -f /dev/null"},
 			ServiceAccountName: testSAName,
 			RestartPolicy:      v1.RestartPolicyAlways,
@@ -108,14 +107,14 @@ func (s *PodSuite) TestPod(c *C) {
 		{
 			Namespace:     cns,
 			GenerateName:  "test-",
-			Image:         kanisterToolsImage,
+			Image:         consts.LatestKanisterToolsImage,
 			Command:       []string{"sh", "-c", "tail -f /dev/null"},
 			RestartPolicy: v1.RestartPolicyOnFailure,
 		},
 		{
 			Namespace:          cns,
 			GenerateName:       "test-",
-			Image:              kanisterToolsImage,
+			Image:              consts.LatestKanisterToolsImage,
 			Command:            []string{"sh", "-c", "tail -f /dev/null"},
 			ServiceAccountName: testSAName,
 			RestartPolicy:      v1.RestartPolicyNever,
@@ -123,7 +122,7 @@ func (s *PodSuite) TestPod(c *C) {
 		{
 			Namespace:    s.namespace,
 			GenerateName: "test-",
-			Image:        kanisterToolsImage,
+			Image:        consts.LatestKanisterToolsImage,
 			Command:      []string{"sh", "-c", "tail -f /dev/null"},
 			Annotations: map[string]string{
 				"test-annotation": "true",
@@ -132,7 +131,7 @@ func (s *PodSuite) TestPod(c *C) {
 		{
 			Namespace:    s.namespace,
 			GenerateName: "test-",
-			Image:        kanisterToolsImage,
+			Image:        consts.LatestKanisterToolsImage,
 			Command:      []string{"sh", "-c", "tail -f /dev/null"},
 			Labels: map[string]string{
 				"run": "pod",
@@ -141,7 +140,7 @@ func (s *PodSuite) TestPod(c *C) {
 		{
 			Namespace:    s.namespace,
 			GenerateName: "test-",
-			Image:        kanisterToolsImage,
+			Image:        consts.LatestKanisterToolsImage,
 			Command:      []string{"sh", "-c", "tail -f /dev/null"},
 			Resources: v1.ResourceRequirements{
 				Limits: v1.ResourceList{
@@ -157,7 +156,7 @@ func (s *PodSuite) TestPod(c *C) {
 		{
 			Namespace:     s.namespace,
 			GenerateName:  "test-",
-			Image:         kanisterToolsImage,
+			Image:         consts.LatestKanisterToolsImage,
 			ContainerName: "test-container",
 			Command:       []string{"sh", "-c", "tail -f /dev/null"},
 			Labels: map[string]string{
@@ -269,7 +268,7 @@ func (s *PodSuite) TestPodWithVolumes(c *C) {
 	pod, err := CreatePod(ctx, cli, &PodOptions{
 		Namespace:    s.namespace,
 		GenerateName: "test-",
-		Image:        "ghcr.io/kanisterio/kanister-tools:v9.99.9-dev",
+		Image:        consts.LatestKanisterToolsImage,
 		Command:      []string{"sh", "-c", "tail -f /dev/null"},
 		Volumes:      vols,
 	})
@@ -286,7 +285,7 @@ func (s *PodSuite) TestGetPodLogs(c *C) {
 	pod, err := CreatePod(context.Background(), s.cli, &PodOptions{
 		Namespace:    s.namespace,
 		GenerateName: "test-",
-		Image:        "ghcr.io/kanisterio/kanister-tools:latest",
+		Image:        consts.LatestKanisterToolsImage,
 		Command:      []string{"sh", "-c", "echo hello"},
 	})
 	c.Assert(err, IsNil)

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -102,7 +102,7 @@ func newTestPodTemplateSpec() v1.PodTemplateSpec {
 			Containers: []v1.Container{
 				v1.Container{
 					Name:    "test-container",
-					Image:   "ghcr.io/kanisterio/kanister-tools:v9.99.9-dev",
+					Image:   consts.LatestKanisterToolsImage,
 					Command: []string{"tail"},
 					Args:    []string{"-f", "/dev/null"},
 				},


### PR DESCRIPTION
## Change Overview

- Seems like the order of ActionSet status checks is incorrect in tests causing intermittent failures.
- Also refactored some older test to use latest kanister-tools image

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [x] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [x] :zap: Unit test
```
OK: 3 passed
--- PASS: Test (38.29s)
PASS
ok  	github.com/kanisterio/kanister/pkg/controller	38.874
```
- [ ] :green_heart: E2E
