### PR TITLE
Compatible ResourceTypeMatcher with exact match for core

### DIFF
--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -28,14 +28,19 @@ type ResourceTypeRequirement struct {
 	Resource string `json:"resource,omitempty"`
 }
 
-// Matches returns true if group, version and resource values match or are all empty
-// Group must match exactly because K8s core group is ""
-// Version and resource requirement values of "" match any value
+// K8sCoreGroupExactMatch is sentinel value that only matches K8s core group of ""
+const K8sCoreGroupExactMatch = "core"
+
+// Matches returns true if group, version and resource values match or are empty
+// Group value of K8sCoreGroupExactMatch only matches K8s core group of ""
 func (r ResourceTypeRequirement) Matches(gvr schema.GroupVersionResource) bool {
-	if r.Empty() {
-		return true
+	var groupMatch bool
+	if r.Group == K8sCoreGroupExactMatch {
+		groupMatch = gvr.Group == ""
+	} else {
+		groupMatch = matches(r.Group, gvr.Group)
 	}
-	return r.Group == gvr.Group && matches(r.Version, gvr.Version) && matches(r.Resource, gvr.Resource)
+	return groupMatch && matches(r.Version, gvr.Version) && matches(r.Resource, gvr.Resource)
 }
 
 // Empty returns true if ResourceTypeRequirement has no fields set

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -337,15 +337,77 @@ func (s *FilterSuite) TestGroupVersionResourceIncludeExclude(c *C) {
 					Group:   "mygroup",
 					Version: "yourversion",
 				},
-			},
-			exclude: []schema.GroupVersionResource{
 				{
 					Group:   "yourgroup",
 					Version: "myversion",
 				},
+			},
+			exclude: []schema.GroupVersionResource{
 				{
 					Group:   "yourgroup",
 					Version: "yourversion",
+				},
+			},
+		},
+		{
+			m: ResourceTypeMatcher{
+				ResourceTypeRequirement{
+					Group:    "core",
+					Resource: "myresource",
+				},
+			},
+			gvrs: []schema.GroupVersionResource{
+				{
+					Group:    "",
+					Resource: "myresource",
+				},
+				{
+					Group:    "core",
+					Resource: "myresource",
+				},
+				{
+					Group:    "mygroup",
+					Resource: "myresource",
+				},
+				{
+					Group:    "",
+					Resource: "yourresource",
+				},
+				{
+					Group:    "core",
+					Resource: "yourresource",
+				},
+				{
+					Group:    "mygroup",
+					Resource: "yourresource",
+				},
+			},
+			include: []schema.GroupVersionResource{
+				{
+					Group:    "",
+					Resource: "myresource",
+				},
+			},
+			exclude: []schema.GroupVersionResource{
+				{
+					Group:    "core",
+					Resource: "myresource",
+				},
+				{
+					Group:    "mygroup",
+					Resource: "myresource",
+				},
+				{
+					Group:    "",
+					Resource: "yourresource",
+				},
+				{
+					Group:    "core",
+					Resource: "yourresource",
+				},
+				{
+					Group:    "mygroup",
+					Resource: "yourresource",
 				},
 			},
 		},


### PR DESCRIPTION
## Change Overview

This PR replaces #1390 to maintain compatibility for prior uses of empty group as matching
any group. This maintains consistency for empty values of G, V, or R. And it allows ResourceTypeRequirements with just a resource value to filter from GVR lists when it is unambiguous.

A new sentinel value of "core" is added that can be used to strictly match GVRs for K8s
core group resources.

## Pull request type

Please check the type of change your PR introduces:
- [x] :sunflower: Feature
- [x] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
