### PR TITLE
Extend the defer phase state checks in the unit test

### DIFF
--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -182,17 +182,14 @@ func (s *ControllerSuite) waitOnDeferPhaseState(c *C, as *crv1alpha1.ActionSet, 
 		}
 
 		if as.Status == nil {
-			return false, nil
+			return false, fmt.Errorf("unexpected error: actionset status shouldn't be nil")
 		}
 
 		if as.Status.Actions[0].DeferPhase.State == state {
 			return true, nil
 		}
-		// These are non-terminal states.
-		if as.Status.Actions[0].DeferPhase.State == crv1alpha1.StatePending || as.Status.Actions[0].DeferPhase.State == crv1alpha1.StateRunning {
-			return false, nil
-		}
-		return false, errors.New(fmt.Sprintf("Unexpected state: %s", as.Status.Actions[0].DeferPhase.State))
+
+		return false, nil
 	})
 	if err == nil {
 		return nil


### PR DESCRIPTION
## Change Overview

This PR attempts to fix the flakiness around the defer phase unit tests by extending the defer phase checks in the unit test to account for states with empty string value. 

Following this log from one of the failed CI runs, notice that the defer phase of the `test-actionset-sg4qq` actionset is set to completed after the test has failed:

```
[36m[2022-04-21T20:11:25.785Z][0m {"ActionSet":"test-actionset-sg4qq","Container":"container","File":"pkg/output/stream.go","Function":"github.com/kanisterio/kanister/pkg/output.splitLines","Line":46,"Phase":"backupPhaseTwo","Pod":"kanister-job-v4jx8","Pod_Out":"###Phase-output###: {\"key\":\"value\",\"value\":\"mainValueTwo\"}","hostname":"a48311680e48","level":"info","msg":"","time":"2022-04-21T19:54:52.857077971Z"}
[36m[2022-04-21T20:11:25.785Z][0m {"ActionSet":"test-actionset-sg4qq","File":"pkg/controller/controller.go","Function":"github.com/kanisterio/kanister/pkg/controller.(*Controller).runAction.func1","Line":493,"Phase":"backupPhaseTwo","hostname":"a48311680e48","level":"info","msg":"Completed phase backupPhaseTwo","time":"2022-04-21T19:54:52.926249989Z"}
[36m[2022-04-21T20:11:25.785Z][0m {"ActionSet":"test-actionset-sg4qq","File":"pkg/controller/controller.go","Function":"github.com/kanisterio/kanister/pkg/controller.(*Controller).executeDeferPhase","Line":516,"Phase":"deferPhase","hostname":"a48311680e48","level":"info","msg":"Executing deferPhase deferPhase","time":"2022-04-21T19:54:52.926303491Z"}

[36m[2022-04-21T20:11:25.785Z][0m ----------------------------------------------------------------------
[36m[2022-04-21T20:11:25.785Z][0m FAIL: controller_test.go:656: ControllerSuite.TestDeferPhase

[36m[2022-04-21T20:11:25.785Z][0m controller_test.go:674:
[36m[2022-04-21T20:11:25.786Z][0m     c.Assert(err, IsNil)
[36m[2022-04-21T20:11:25.786Z][0m ... value *errors.withStack = State 'complete' never reached: Unexpected state:  ("State 'complete' never reached: Unexpected state: ")

[36m[2022-04-21T20:11:25.786Z][0m {"File":"pkg/controller/controller.go","Function":"github.com/kanisterio/kanister/pkg/controller.(*Controller).onAddBlueprint","Line":215,"hostname":"a48311680e48","level":"info","msg":"Added blueprint test-blueprint-defer-d5hlk","time":"2022-04-21T19:54:53.740559764Z"}

# ....
[36m[2022-04-21T20:11:25.786Z][0m {"Container":"container","File":"pkg/output/stream.go","Function":"github.com/kanisterio/kanister/pkg/output.splitLines","Line":46,"Pod":"kanister-job-4qk5f","Pod_Out":"###Phase-output###: {\"key\":\"value\",\"value\":\"deferValue\"}","hostname":"a48311680e48","level":"info","msg":"","time":"2022-04-21T19:54:59.564795915Z"}
[36m[2022-04-21T20:11:25.786Z][0m {"ActionSet":"test-actionset-sg4qq","File":"pkg/controller/controller.go","Function":"github.com/kanisterio/kanister/pkg/controller.(*Controller).executeDeferPhase","Line":553,"Phase":"deferPhase","hostname":"a48311680e48","level":"info","msg":"Completed deferPhase deferPhase","time":"2022-04-21T19:54:59.62929645Z"}
```

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [x] :robot: Test

## Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
