### PR TITLE
Add GitHub Actions Workflows To Manage Issues

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -4,10 +4,13 @@ on:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
     - uses: actions/stale@v5
       with:
-        repo-token: ${{ secrets.GH_TOKEN }}
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
         days-before-stale: 60
         days-before-close: 30
         close-issue-label: rotten

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -7,6 +7,7 @@ jobs:
     steps:
     - uses: actions/stale@v4
       with:
+        repo-token: ${{ secrets.GH_TOKEN }}
         days-before-stale: 60
         days-before-close: 30
         close-issue-label: rotten

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -5,7 +5,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v4
+    - uses: actions/stale@v5
       with:
         repo-token: ${{ secrets.GH_TOKEN }}
         days-before-stale: 60

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,21 @@
+on:
+  schedule:
+  - cron: "0 0 * * *"
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v4
+      with:
+        days-before-stale: 60
+        days-before-close: 30
+        close-issue-label: rotten
+        close-pr-label: rotten
+        stale-issue-label: stale
+        stale-pr-label: stale
+        exempt-issue-labels: frozen
+        exempt-pr-labels: frozen
+        close-issue-message: This issue is closed due to inactivity. Feel free to reopen it, if it's still relevant.
+        close-pr-message: This PR is closed due to inactivity. Feel free to reopen it, if it's still relevant.
+        stale-issue-message: This issue is marked as stale due to inactivity. Add a new comment to reactivate it.
+        stale-pr-message: This PR is marked as stale due to inactivity. Add a new comment to reactivate it.

--- a/.github/workflows/triage.yaml
+++ b/.github/workflows/triage.yaml
@@ -10,6 +10,8 @@ on:
 jobs:
   issues:
     if: github.event_name == 'issues'
+    permissions:
+      issues: write
     runs-on: ubuntu-latest
     steps:
     - uses: andymckay/labeler@1.0.2
@@ -32,8 +34,10 @@ jobs:
         repo-token: ${{ secrets.GH_TOKEN }} # must use a PAT here
         project: Kanister
         column: To Be Triaged
-  pull_requests:
+  pull-requests:
     if: github.event_name == 'pull_request'
+    permissions:
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
     - uses: peter-evans/create-or-update-comment@v2

--- a/.github/workflows/triage.yaml
+++ b/.github/workflows/triage.yaml
@@ -2,30 +2,51 @@ on:
   issues:
     types:
     - opened
+    - reopened
+  pull_request:
+    types:
+    - opened
+    - reopened
 jobs:
-  triage:
+  issues:
+    if: github.event_name == 'issues'
     runs-on: ubuntu-latest
     steps:
-    - id: get_issue_number
-      run: echo "::set-output name=output::${{ github.event.issue.number }}"
     - uses: andymckay/labeler@1.0.2
       with:
         add-labels: "triage"
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - uses: peter-evans/create-or-update-comment@v2
+      if: github.event.action == 'opened'
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        issue-number: ${{ steps.get_issue_number.outputs.output }}
+        issue-number: ${{ github.event.issue.number }}
         body: |
-          Thanks for opening this issue :+1:. The team will review it soon and get back to you.
+          Thanks for opening this issue :+1:. The team will review it shortly.
 
-          If this is a bug report, make sure to include clear instructions how on to reproduce the issue with [minimal reproducible examples](https://stackoverflow.com/help/minimal-reproducible-example), where possible. If this is a security report, please review our security policy as outlined in [SECURITY.md](https://github.com/ihcsim/kanister/blob/master/SECURITY.md).
+          If this is a bug report, make sure to include clear instructions how on to reproduce the problem with [minimal reproducible examples](https://stackoverflow.com/help/minimal-reproducible-example), where possible. If this is a security report, please review our security policy as outlined in [SECURITY.md](https://github.com/kanisterio/kanister/blob/master/SECURITY.md).
 
-          Also, take a look at our project [Code of Conduct](https://github.com/ihcsim/kanister/blob/master/CODE_OF_CONDUCT.md) document, if you haven't already.
-
-          Finally, consider giving Kanister a :star:!
+          If you haven't already, please take a moment to review our project's [Code of Conduct](https://github.com/kanisterio/kanister/blob/master/CODE_OF_CONDUCT.md) document.
     - uses: alex-page/github-project-automation-plus@v0.8.1
       with:
         repo-token: ${{ secrets.GH_TOKEN }} # must use a PAT here
         project: Kanister
         column: To Be Triaged
+  pull_requests:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: peter-evans/create-or-update-comment@v2
+      if: github.event.action == 'opened'
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        issue-number: ${{ github.event.number }}
+        body: |
+          Thanks for submitting this pull request :tada:. The team will review it soon and get back to you.
+
+          If you haven't already, please take a moment to review our project [contributing guideline](https://github.com/kanisterio/kanister/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kanisterio/kanister/blob/master/CODE_OF_CONDUCT.md) document.
+    - uses: alex-page/github-project-automation-plus@v0.8.1
+      with:
+        repo-token: ${{ secrets.GH_TOKEN }}
+        project: Kanister
+        column: In Progress

--- a/.github/workflows/triage.yaml
+++ b/.github/workflows/triage.yaml
@@ -14,15 +14,14 @@ jobs:
       issues: write
     runs-on: ubuntu-latest
     steps:
-    - uses: andymckay/labeler@1.0.2
+    - uses: actions-ecosystem/action-add-labels@v1.1.0
       with:
-        add-labels: "triage"
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-    - uses: peter-evans/create-or-update-comment@v2
+        labels: "triage"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: actions-ecosystem/action-create-comment@v1.0.0
       if: github.event.action == 'opened'
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        issue-number: ${{ github.event.issue.number }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
         body: |
           Thanks for opening this issue :+1:. The team will review it shortly.
 
@@ -40,11 +39,10 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - uses: peter-evans/create-or-update-comment@v2
+    - uses: actions-ecosystem/action-create-comment@v1.0.0
       if: github.event.action == 'opened'
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        issue-number: ${{ github.event.number }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
         body: |
           Thanks for submitting this pull request :tada:. The team will review it soon and get back to you.
 

--- a/.github/workflows/triage.yaml
+++ b/.github/workflows/triage.yaml
@@ -1,0 +1,30 @@
+on:
+  issues:
+    types:
+    - opened
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - id: get_issue_number
+      run: echo "::set-output name=output::${{ github.event.issue.number }}"
+    - uses: andymckay/labeler@1.0.2
+      with:
+        add-labels: "triage"
+        repo-token: ${{ secrets.GH_TOKEN }}
+    - uses: peter-evans/create-or-update-comment@v2
+      with:
+        issue-number: ${{ steps.get_issue_number.outputs.output }}
+        body: |
+          Thanks for opening this issue :+1:. The team will review it soon and get back to you.
+
+          If this is a bug report, make sure to include clear instructions how on to reproduce the issue with [minimal reproducible examples](https://stackoverflow.com/help/minimal-reproducible-example), where possible. If this is a security report, please review our security policy as outlined in [SECURITY.md](https://github.com/ihcsim/kanister/blob/master/SECURITY.md).
+
+          Also, take a look at our project [Code of Conduct](https://github.com/ihcsim/kanister/blob/master/CODE_OF_CONDUCT.md) document, if you haven't already.
+
+          Finally, consider giving Kanister a :star:!
+    - uses: alex-page/github-project-automation-plus@v0.8.1
+      with:
+        repo-token: ${{ secrets.GH_TOKEN }}
+        project: Kanister
+        column: To Be Triaged

--- a/.github/workflows/triage.yaml
+++ b/.github/workflows/triage.yaml
@@ -11,9 +11,10 @@ jobs:
     - uses: andymckay/labeler@1.0.2
       with:
         add-labels: "triage"
-        repo-token: ${{ secrets.GH_TOKEN }}
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - uses: peter-evans/create-or-update-comment@v2
       with:
+        token: ${{ secrets.GITHUB_TOKEN }}
         issue-number: ${{ steps.get_issue_number.outputs.output }}
         body: |
           Thanks for opening this issue :+1:. The team will review it soon and get back to you.
@@ -25,6 +26,6 @@ jobs:
           Finally, consider giving Kanister a :star:!
     - uses: alex-page/github-project-automation-plus@v0.8.1
       with:
-        repo-token: ${{ secrets.GH_TOKEN }}
+        repo-token: ${{ secrets.GH_TOKEN }} # must use a PAT here
         project: Kanister
         column: To Be Triaged


### PR DESCRIPTION
## Change Overview

This PR introduces 2 GitHub Actions workflows to manage new and stale issues. 

The `stale` workflow is scheduled to run nightly to identify issues that are older than 60 days as `stale`. Stale issues that have been inactive for more than 30 days are automatically closed. Issues that are labelled as `frozen` are exempted from this clean-up cycle.

The `triage` workflow automatically adds all new issues and pull requests to the Kanister project. New issues will be assigned to the "To Be Triaged" column, while pull requests go under the "In Progress" column. It also labels the issue as `triage` and adds an acknowledgement comment to the issues and pull requests. 

This is what a new issue looked like after the `triage` workflow has processed it:

![image](https://user-images.githubusercontent.com/1330522/164587537-717a1203-4463-42e9-b5df-7dd2fbf4ad41.png)

The issue has been automatically added to the project board:

![image](https://user-images.githubusercontent.com/1330522/164587643-f78c251d-5d55-4a89-b4f1-6c673ee8e6b0.png)
