### PR TITLE
Update deferPhaes function to not mention image

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -480,17 +480,18 @@ from the output that is being generated from ``DeferPhase`` as shown below.
               - |
                 echo "Main Phase"
       deferPhase:
-        func: KubeTask
+        func: KubeExec
         name: saveBackupTime
         args:
-          image: ghcr.io/kanisterio/mysql-sidecar:0.74.0
           namespace: "{{ .Deployment.Namespace }}"
+          pod: "{{ index .Deployment.Pods 0 }}"
+          container: test-container
           command:
-          - sh
-          - -c
-          - |
-            echo "DeferPhase"
-            kando output bkpCompletedTime "10Minutes"
+            - sh
+            - -c
+            - |
+              echo "DeferPhase"
+              kando output bkpCompletedTime "10Minutes"
   EOF
 
 


### PR DESCRIPTION
## Change Overview

Image that we mentioned in the deferPhase example got stale because of merge order. Its better to use kubeexec instead and not mention the image.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

```
make docs
```

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
