### PR TITLE
Update base image for mongodb image

### DIFF
--- a/build/integration-test.sh
+++ b/build/integration-test.sh
@@ -25,7 +25,7 @@ TEST_TIMEOUT="30m"
 # Set default options
 TEST_OPTIONS="-tags=integration -timeout ${TEST_TIMEOUT} -check.suitep ${DOP}"
 # Regex to match apps to run in short mode
-SHORT_APPS="^PostgreSQL$|^MySQL$|Elasticsearch|^MongoDB$|Maria|^MSSQL$"
+SHORT_APPS="^PostgreSQL$|^MySQL$|Elasticsearch|Maria|^MSSQL$"
 # OCAPPS has all the apps that are to be tested against openshift cluster
 OC_APPS3_11="MysqlDBDepConfig$|MongoDBDepConfig$|PostgreSQLDepConfig$"
 OC_APPS4_4="MysqlDBDepConfig4_4|MongoDBDepConfig4_4|PostgreSQLDepConfig4_4"

--- a/docker/mongodb/Dockerfile
+++ b/docker/mongodb/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitnami/mongodb:4.4.10-debian-10-r70
+FROM bitnami/mongodb:4.4.13-debian-10-r52
 
 MAINTAINER "Tom Manville <tom@kasten.io>"
 


### PR DESCRIPTION
## Change Overview

This PR updates the mongo db base image that we use in the kanister-mongodb image to run the integration test. Tests have been failing if we tried to run the older image with updated chart.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E

Build and push this image, and change mongodb application to use that newly pushed image, run integration test.
