### PR TITLE
Fix Mergify conditions

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,29 +1,37 @@
 queue_rules:
   - name: default
     conditions:
-      - "#approved-reviews-by>=1"
-      - check-success=gomod
-      - check-success=lint
-      - check-success=test
-      - check-success=build
-      - check-success=docs
-      - check-success=release
-      - label=kueue
-      - label!="hold off merging"
+      - and:
+        - "#approved-reviews-by>=1"
+        - check-success=gomod
+        - check-success=lint
+        - check-success=test (test)
+        - check-success=test (integration-test)
+        - check-success=test (helm-test)
+        - check-success=build (controller)
+        - check-success=build (kanctl)
+        - check-success=build (kando)
+        - check-success=docs
+        - label=kueue
+        - label!="hold off merging"
 
 pull_request_rules:
   - name: Automatic merge
     conditions:
-      - base=master
-      - "#approved-reviews-by>=1"
-      - check-success=gomod
-      - check-success=lint
-      - check-success=test
-      - check-success=build
-      - check-success=docs
-      - check-success=release
-      - label=kueue
-      - label!="hold off merging"
+      - and:
+        - base=master
+        - "#approved-reviews-by>=1"
+        - check-success=gomod
+        - check-success=lint
+        - check-success=test (test)
+        - check-success=test (integration-test)
+        - check-success=test (helm-test)
+        - check-success=build (controller)
+        - check-success=build (kanctl)
+        - check-success=build (kando)
+        - check-success=docs
+        - label=kueue
+        - label!="hold off merging"
     actions:
       queue:
         name: default


### PR DESCRIPTION
## Change Overview

- Looks like Julio's hunch was right. We have to use the sub-jobs explicitly.
- Also, the release check is not necessary for merging changes as it runs only on the main merge.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [x] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
