### PR TITLE
Log the Phase Output In Its Raw Form

### DIFF
--- a/pkg/format/format.go
+++ b/pkg/format/format.go
@@ -37,11 +37,16 @@ func Log(podName string, containerName string, output string) {
 func LogTo(w io.Writer, pod string, container string, output string) {
 	if output != "" {
 		for _, line := range regex.Split(output, -1) {
+			// retain the original format of phase outputs for ease
+			// of processing later.
 			if strings.Contains(line, pkgout.PhaseOpString) {
+				if _, err := w.Write([]byte(line + "\n")); err != nil {
+					log.PrintTo(w, err.Error())
+				}
 				continue
 			}
 
-			if line != "" {
+			if strings.TrimSpace(line) != "" {
 				fields := field.M{
 					"Pod":       pod,
 					"Container": container,

--- a/pkg/format/format_test.go
+++ b/pkg/format/format_test.go
@@ -1,0 +1,103 @@
+package format
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/kanisterio/kanister/pkg/output"
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type FormatTest struct{}
+
+var _ = Suite(&FormatTest{})
+
+func (s *FormatTest) TestLogToForPhaseOutputs(c *C) {
+	const (
+		pod       = "test-pod-logto"
+		container = "test-container-logto"
+	)
+
+	// invariant: format.LogTo() will not format phase outputs.
+
+	var testCases = []struct {
+		keys   []string
+		values []string
+	}{
+		{
+			keys:   []string{"key1"},
+			values: []string{"value1"},
+		},
+		{
+			keys:   []string{"key1", "key2"},
+			values: []string{"value1", "value2"},
+		},
+		{
+			keys:   []string{"key1", "key2", "key3"},
+			values: []string{"value1", "value2", "value3"},
+		},
+	}
+
+	for _, tc := range testCases {
+		expected := ""
+		input := &bytes.Buffer{}
+		actual := &bytes.Buffer{}
+
+		for i, key := range tc.keys {
+			// create the phase output for each pair of the given k/v
+			kv := &bytes.Buffer{}
+			err := output.PrintOutputTo(kv, key, tc.values[i])
+			c.Assert(err, IsNil)
+
+			kvRaw := fmt.Sprintf("%s\n", kv.String())
+			if _, err := input.WriteString(kvRaw); err != nil {
+				c.Assert(err, IsNil)
+			}
+
+			expected += fmt.Sprintf("%s {\"key\":\"%s\",\"value\":\"%s\"}\n", output.PhaseOpString, key, tc.values[i])
+		}
+		LogTo(actual, pod, container, input.String())
+		c.Check(expected, DeepEquals, actual.String())
+	}
+}
+
+func (s *FormatTest) TestLogToForNormalLogs(c *C) {
+	const (
+		pod       = "test-pod-logto"
+		container = "test-container-logto"
+	)
+
+	var testCases = []struct {
+		input    string
+		expected string
+		count    int // count represents how many "Out"s in the results
+	}{
+		{
+			input:    "",
+			expected: "",
+			count:    1,
+		},
+		{
+			input:    "test logs",
+			expected: `"Out":"test logs"`,
+			count:    1,
+		},
+		{
+			input:    "test logs\ntest logs",
+			expected: `"Out":"test logs"`,
+			count:    2, // the line break causes 2 log lines to be printed
+		},
+	}
+
+	for _, tc := range testCases {
+		actual := &bytes.Buffer{}
+		LogTo(actual, pod, container, tc.input)
+
+		c.Assert(strings.Contains(actual.String(), tc.expected), Equals, true)
+		c.Assert(strings.Count(actual.String(), tc.expected), Equals, tc.count)
+	}
+}

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -72,6 +72,11 @@ func PrintOutput(key, value string) error {
 	return fPrintOutput(os.Stdout, key, value)
 }
 
+// PrintOutput prints the output of the `kando output` command to w.
+func PrintOutputTo(w io.Writer, key, value string) error {
+	return fPrintOutput(w, key, value)
+}
+
 func fPrintOutput(w io.Writer, key, value string) error {
 	outString, err := marshalOutput(key, value)
 	if err != nil {


### PR DESCRIPTION
## Change Overview

This PR is a follow-up of a1d4240e598b13a9fe381fc603817bbbf3493520, where the `format.Writer()` was updated to skip the logging of all phase outputs encountered by `kube.ExecOutput()`. That change broke some output artifacts processing code due to the missing phase outputs. This PR adds the phase outputs back to the logs in its raw, unformatted form. The raw form ensures that later output parsing code doesn't have to handle any prefixed log metadata. This change aligns with the previous
implementation in `kube.Exec()` as seen at: https://github.com/kanisterio/kanister/blob/c3ee5854d48f63073012b924d3c793ddcb58ea49/pkg/function/kube_exec.go#L94-L101

With this change, the phase outputs will be logged in their raw format in the controller stdout. E.g.,

```
{"ActionSet":"echo-exec-8rtsc","File":"pkg/controller/controller.go","Function":"github.com/kanisterio/kanister/pkg/controller.(*Controller).onUpdateActionSet","Line":245,"Phase":"echoExec-\u003epending","Status":"running","cluster_name":"5d29f04c-5167-4925-9f83-fb8c748f8675","hostname":"kanister-kanister-operator-74cc54d475-fspq5","level":"info","msg":"Updated ActionSet","time":"2022-05-09T20:58:22.693359774Z"}
###Phase-output###: {"key":"bar1","value":"foo1"}
###Phase-output###: {"key":"bar2","value":"foo2"}
```

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Test Plan

Added new unit test in `pkg/format/format_test.go`. 

Also tested with these blueprints:

```yaml
  echoTask:
    outputArtifacts:
      output:
        keyValue:
          bar: "{{ .Phases.echoTask.Output.bar }}"
    phases:
    - func: KubeTask
      name: echoTask
      args:
        namespace: "{{ .Namespace.Name }}"
        image: ghcr.io/kanisterio/kanister-tools:v9.99.9-dev
        command:
        - sh
        - "-c"
        - kando output bar "foo"
  echoExec:
    outputArtifacts:
      output:
        keyValue:
          bar1: "{{ .Phases.echoExec.Output.bar1 }}"
          bar2: "{{ .Phases.echoExec.Output.bar2 }}"
    phases:
    - func: KubeExec
      name: echoExec
      args:
        namespace: default
        pod: timer
        container: timer
        command:
        - sh
        - "-c"
        - |
          kando output bar1 "foo1"
          kando output bar2 "foo2"
```

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
