### PR TITLE
Add infrastructure for user displayable errors

### DIFF
--- a/pkg/errors/user_errors.go
+++ b/pkg/errors/user_errors.go
@@ -34,7 +34,9 @@ func (ue *UserError) UserMessage() string {
 	return ue.msg
 }
 
-func (ue *UserError) Unwrap() error { return ue.error }
+func (ue *UserError) Unwrap() error {
+	return ue.error
+}
 
 // UserErrorWithMessage initializes the UserError with given error and a message.
 // Needs to accept error if we want to initialize the UserError in between the
@@ -49,7 +51,7 @@ func UserErrorWithMessage(err error, msg string) UserMessenger {
 // UserMessagesInError gets us messages of all the `UserError`s that are wrapped
 // in the passed error's chain
 func UserMessagesInError(err error) []string {
-	userMessages := []string{}
+	var userMessages []string
 	if err == nil {
 		return nil
 	}

--- a/pkg/errors/user_errors.go
+++ b/pkg/errors/user_errors.go
@@ -1,0 +1,63 @@
+// Copyright 2022 The Kanister Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errors
+
+import (
+	"errors"
+)
+
+type UserMessenger interface {
+	error
+	UserMessage() string
+}
+
+// UserError is an error type that be checked to be present in the
+// error chain. And if present, can be shown to the end users
+type UserError struct {
+	error
+	msg string
+}
+
+func (ue *UserError) UserMessage() string {
+	return ue.msg
+}
+
+func (ue *UserError) Unwrap() error { return ue.error }
+
+// UserErrorWithMessage initializes the UserError with given error and a message.
+// Needs to accept error if we want to initialize the UserError in between the
+// error chain
+func UserErrorWithMessage(err error, msg string) UserMessenger {
+	if err == nil {
+		err = errors.New(msg)
+	}
+	return &UserError{err, msg}
+}
+
+// UserMessagesInError gets us messages of all the `UserError`s that are wrapped
+// in the passed error's chain
+func UserMessagesInError(err error) []string {
+	userMessages := []string{}
+	if err == nil {
+		return nil
+	}
+	for err != nil {
+		if e, ok := err.(*UserError); ok {
+			userMessages = append(userMessages, e.UserMessage())
+		}
+		err = errors.Unwrap(err)
+	}
+	return userMessages
+}

--- a/pkg/errors/user_errors_test.go
+++ b/pkg/errors/user_errors_test.go
@@ -1,0 +1,56 @@
+// Copyright 2022 The Kanister Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errors
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type UserErrorSuite struct{}
+
+var _ = Suite(&UserErrorSuite{})
+
+func (u *UserErrorSuite) TestUserMessagesInError(c *C) {
+	expectedUserErrors := []string{"User Error Two", "User Error One"}
+	err1 := errors.New("error 1")
+	err2 := errors.Wrap(err1, "error2")
+
+	ue1 := UserErrorWithMessage(err2, expectedUserErrors[1])
+	err3 := errors.Wrap(ue1, "errro 3")
+
+	ue2 := UserErrorWithMessage(err3, expectedUserErrors[0])
+	err4 := errors.Wrap(ue2, "error 4")
+
+	c.Assert(UserMessagesInError(err4), DeepEquals, expectedUserErrors)
+}
+
+// The case where there are no `UserError`s in error chain
+func (u *UserErrorSuite) TestUserMessagesInErrorWithoutUserError(c *C) {
+	err1 := errors.New("error 1")
+	err2 := errors.Wrap(err1, "error 2")
+	err3 := errors.Wrap(err2, "error 3")
+	err4 := errors.Wrap(err3, "error 4")
+
+	c.Assert(len(UserMessagesInError(err4)), Equals, 0)
+}
+
+func (u *UserErrorSuite) TestUserMessagesInErrorNilError(c *C) {
+	c.Assert(UserMessagesInError(nil), Equals, nil)
+}

--- a/pkg/errors/user_errors_test.go
+++ b/pkg/errors/user_errors_test.go
@@ -52,5 +52,5 @@ func (u *UserErrorSuite) TestUserMessagesInErrorWithoutUserError(c *C) {
 }
 
 func (u *UserErrorSuite) TestUserMessagesInErrorNilError(c *C) {
-	c.Assert(UserMessagesInError(nil), Equals, nil)
+	c.Assert(UserMessagesInError(nil), IsNil)
 }


### PR DESCRIPTION
## Change Overview

This PR adds infrastructure to enable users to add errors that should be shown to the end users instead of showing them the entire stack trace. The usage can be figured out by looking at the test.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [x] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E

```
~/work/opensource/kanister/pkg/errors (user-errors*) » go test 
OK: 3 passed
PASS
ok  	github.com/kanisterio/kanister/pkg/errors	0.001s
```