### PR TITLE
Capture Task Pod's Most-Recent Error Logs As Output Artifacts

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -460,6 +460,9 @@ func (c *Controller) runAction(ctx context.Context, as *crv1alpha1.ActionSet, aI
 						Message: err.Error(),
 					}
 					ras.Status.Actions[aIDX].Phases[i].State = crv1alpha1.StateFailed
+					if output != nil {
+						ras.Status.Actions[aIDX].Phases[i].Output = output
+					}
 					return nil
 				}
 			} else {


### PR DESCRIPTION
## Change Overview

This PR updates `KubeTask` to capture the most-recent logs of a failed task pod as output artifacts in the ActionSet. This ensure that these logs are preserved after the pod is terminated to aid with debugging. The number of log lines to be captured is capped by the tail size parameter, which can be overridden by the new `KANISTER_TASK_LOGS_TAIL_SIZE` environment variable.

Although these logs are currently streamed to the Kanister controller, it may not always be easy to parse the controller's logs for specific task errors.

(The existing `status.error.message` which is normally filled with the **entire** pod spec is untouched. It can use some re-work in a separate PR.)

Test steps:

Deploy this blueprint:

```sh
cat<<EOF |  kubectl apply -f -
apiVersion: cr.kanister.io/v1alpha1
kind: Blueprint
metadata:
  name: task-errors
  namespace: kanister
actions:
  awscli:
    phases:
    - func: KubeTask
      name: echo
      args:
        namespace: "{{ .Namespace.Name }}"
        image: ghcr.io/kanisterio/kanister-tools:v9.99.9-dev
        command:
        - sh
        - "-c"
        - |
          aws -h
          exit 1
EOF
```

Deploy this ActionSet:

```sh
cat <<EOF | kubectl create -f -
apiVersion: cr.kanister.io/v1alpha1
kind: ActionSet
metadata:
  generateName: task-error-awscli-
  namespace: kanister
spec:
  actions:
  - name: awscli
    blueprint: task-errors
    object:
      kind: Namespace
      name: default
EOF
```

Check the ActionSet for recent logs:

```sh
$ kubectl -n kanister get actionset task-error-awscli-rtknm -ojsonpath='{.status.actions[?(@.name=="awscli")].phases}' | jq .
[
  {
    "name": "echo",
    "output": {
      "recentLogs": "sh: aws: command not found\n"
    },
    "state": "failed"
  }
]
```

Fixes https://github.com/kanisterio/kanister/discussions/1226.

## Pull request type

Please check the type of change your PR introduces:
- Improvement

## Issues

- https://github.com/kanisterio/kanister/discussions/1226

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
