### PR TITLE
Enable grpc for connecting to Kopia API Server

### DIFF
--- a/pkg/kopia/connect.go
+++ b/pkg/kopia/connect.go
@@ -55,8 +55,6 @@ func ConnectToAPIServer(
 	serverInfo := &repo.APIServerInfo{
 		BaseURL:                             serverAddress,
 		TrustedServerCertificateFingerprint: fingerprint,
-		// TODO(@pavan): Remove once GRPC support is added (kopia 0.8 release)
-		DisableGRPC: true,
 	}
 
 	opts := &repo.ConnectOptions{


### PR DESCRIPTION
## Change Overview

This PR stops setting `DisableGRPC` to `true`, thus allowing Kopa API client to connect to server using GRPC.
Note: The kopia API server also needs to be started with GRPC enabled.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
