### PR TITLE
Improve `IsResAvailableInGroupVersion` to handle non running api servers

### DIFF
--- a/pkg/kube/discover.go
+++ b/pkg/kube/discover.go
@@ -44,9 +44,14 @@ func IsOSRouteGroupAvailable(ctx context.Context, cli discovery.DiscoveryInterfa
 
 // IsResAvailableInGroupVersion takes a resource and checks if that exists in the passed group and version
 func IsResAvailableInGroupVersion(ctx context.Context, cli discovery.DiscoveryInterface, groupName, version, resource string) (bool, error) {
+	// This call is going to fail with error type `*discovery.ErrGroupDiscoveryFailed` if there are
+	// some api-resources that are served by agg. API server and the agg API server is not ready.
+	// So if this utility is being called for those api-resources, `false` would be returned
 	resList, err := cli.ServerPreferredResources()
 	if err != nil {
-		return false, err
+		if _, ok := err.(*discovery.ErrGroupDiscoveryFailed); !ok {
+			return false, err
+		}
 	}
 
 	gv := fmt.Sprintf(groupVersionFormat, groupName, version)

--- a/pkg/kube/discover.go
+++ b/pkg/kube/discover.go
@@ -45,7 +45,7 @@ func IsOSRouteGroupAvailable(ctx context.Context, cli discovery.DiscoveryInterfa
 // IsResAvailableInGroupVersion takes a resource and checks if that exists in the passed group and version
 func IsResAvailableInGroupVersion(ctx context.Context, cli discovery.DiscoveryInterface, groupName, version, resource string) (bool, error) {
 	// This call is going to fail with error type `*discovery.ErrGroupDiscoveryFailed` if there are
-	// some api-resources that are served by agg. API server and the agg API server is not ready.
+	// some api-resources that are served by aggregated API server and the aggregated API server is not ready.
 	// So if this utility is being called for those api-resources, `false` would be returned
 	resList, err := cli.ServerPreferredResources()
 	if err != nil {


### PR DESCRIPTION
## Change Overview

In the cases where there are some api resources that are being served by the agg api server and the api servers are not running, `IsResAvailableInGroupVersion` would fail with an error. That results into some problems if we are calling this for native resources or for the other resources that are being served correctly.
This PR makes sure that we are not failing in the cases where the agg api server is not able to serve some of the resources.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan


- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
