### PR TITLE
Removing dead code in tests

### DIFF
--- a/pkg/function/scale_test.go
+++ b/pkg/function/scale_test.go
@@ -224,16 +224,8 @@ func (s *ScaleSuite) TestScaleStatefulSet(c *C) {
 		c.Assert(ok, Equals, true)
 	}
 
-	pods, err := s.cli.CoreV1().Pods(s.namespace).List(ctx, metav1.ListOptions{})
+	_, err = s.cli.CoreV1().Pods(s.namespace).List(ctx, metav1.ListOptions{})
 	c.Assert(err, IsNil)
-
-	// This check can flake on underprovisioned clusters so we exit early.
-	c.SucceedNow()
-	for _, pod := range pods.Items {
-		for _, cs := range pod.Status.ContainerStatuses {
-			c.Assert(cs.State.Terminated, NotNil)
-		}
-	}
 }
 
 func (s *ScaleSuite) TestGetArgs(c *C) {


### PR DESCRIPTION
## Change Overview

The PR removes some dead code in `pkg/function/scale_test.go`. The reasons for this proposed change are center around the idea that the use of `SucceedNow()` should be avoided. A few reasons for this are:
1. It creates dead code. This results in a more complicated codebase without any benefit.
2. It passes all assertions made by the `c.Check()` but not assertions made by `c.Assert()`. This is not very clear in the check.v1 documentation. This doesn't affect this case, but can result in inadvertent passing of a test. 
3. It's difficult to mock this behavior if a custom implementation of the `check.v1` is used. This also makes it difficult to incrementally migrate away from `check.v1`.


## Pull request type

Please check the type of change your PR introduces:
- [x] :robot: Test

## Issues

- None

## Test Plan

No functional change is made. Unit tests will be relied upon for validation.

- [x] :zap: Unit test