### PR TITLE
Update log.entry() To Not Use Global Logger

### DIFF
--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -111,6 +113,45 @@ func (s *LogSuite) TestLogPrintTo(c *C) {
 	c.Assert(entry["msg"], Equals, msg)
 }
 
+func (s *LogSuite) TestLogPrintToParallel(c *C) {
+	// this test ensures that the io.Writer passed to PrintTo() doesn't override
+	// that of the global logger.
+	// previously, the entry() function would return an entry bound to the global
+	// logger where changes made to the entry's logger yields a global effect.
+	// see https://github.com/kanisterio/kanister/issues/1523.
+
+	var (
+		msg     = "test log message"
+		buffers = []*bytes.Buffer{
+			{},
+			{},
+		}
+		wg = sync.WaitGroup{}
+	)
+
+	for i := 0; i < len(buffers); i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+
+			fields := map[string]interface{}{
+				"field1": "value1",
+				"field2": "value2",
+			}
+			PrintTo(buffers[i], fmt.Sprintf("%s %d", msg, i), fields)
+		}(i)
+	}
+	wg.Wait()
+
+	for i := 0; i < len(buffers); i++ {
+		actual := map[string]interface{}{}
+		err := json.Unmarshal(buffers[i].Bytes(), &actual)
+		c.Assert(err, IsNil)
+		c.Assert(actual, NotNil)
+		c.Assert(actual["msg"], Equals, fmt.Sprintf("%s %d", msg, i))
+	}
+}
+
 func testLogMessage(c *C, msg string, print func(string, ...field.M), fields ...field.M) map[string]interface{} {
 	log.SetFormatter(&logrus.JSONFormatter{TimestampFormat: time.RFC3339Nano})
 	var memLog bytes.Buffer
@@ -148,8 +189,44 @@ func (s *LogSuite) TestLogLevel(c *C) {
 	}()
 	initLogLevel()
 	Debug().WithContext(ctx).Print("Testing debug level")
+
 	cerr := json.Unmarshal(output.Bytes(), &entry)
 	c.Assert(cerr, IsNil)
 	c.Assert(entry, NotNil)
 	c.Assert(entry["msg"], Equals, "Testing debug level")
+}
+
+func (s *LogSuite) TestCloneGlobalLogger(c *C) {
+	actual := cloneGlobalLogger()
+	c.Assert(actual.Formatter, Equals, log.Formatter)
+	c.Assert(actual.ReportCaller, Equals, log.ReportCaller)
+	c.Assert(actual.Level, Equals, log.Level)
+	c.Assert(actual.Out, Equals, log.Out)
+	c.Assert(actual.Hooks, DeepEquals, log.Hooks)
+
+	// changing `actual` should not affect global logger
+	actual.SetFormatter(&logrus.TextFormatter{})
+	actual.SetReportCaller(true)
+	actual.SetLevel(logrus.ErrorLevel)
+	actual.SetOutput(&bytes.Buffer{})
+	actual.AddHook(&testLogHook{})
+
+	c.Assert(actual.Formatter, Not(Equals), log.Formatter)
+	c.Assert(actual.ReportCaller, Not(Equals), log.ReportCaller)
+	c.Assert(actual.Level, Not(Equals), log.Level)
+	c.Assert(actual.Out, Not(Equals), log.Out)
+	c.Assert(actual.Hooks, Not(DeepEquals), log.Hooks)
+}
+
+type testLogHook struct{}
+
+func (t *testLogHook) Levels() []logrus.Level {
+	return []logrus.Level{
+		logrus.InfoLevel,
+		logrus.DebugLevel,
+	}
+}
+
+func (t *testLogHook) Fire(*logrus.Entry) error {
+	return nil
 }


### PR DESCRIPTION
## Change Overview

This PR updates the `log.entry()` function to not bind new `logrus.Entry` instances to the global logger, to ensure that changes made to the entries' loggers do not escape to the global level. It ensures that all new entries are bound to clones of the global logger.

Without this change, if an entry is changed to output its log lines to a custom `io.Writer`, the global logger will also be changed to write logs the custom `io.Writer`. Also, when concurrent callers attempt to change the output target of their respective log entries, the global logger will end up with racey outputs.

Fixes #1532.

Signed-off-by: Ivan Sim <ivan.sim@kasten.io>

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #1532

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
