### PR TITLE
Make check fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -285,7 +285,7 @@ stop-kind:
 	@$(MAKE) run CMD='-c "./build/local_kubernetes.sh stop_localkube"'
 
 check:
-	@./build/check.sh
+	@$(MAKE) run CMD='-c "./build/check.sh"'
 
 gomod:
 	@$(MAKE) run CMD='-c "./build/gomod.sh"'

--- a/build/check.sh
+++ b/build/check.sh
@@ -25,20 +25,10 @@ function output() {
 }
 
 function check_version_go() {
-  local expected=$(cat go.mod | grep "go [0-9]\.[0-9]*" | cut -d" " -f2)
   local result=""
-  local msg=""
 
   if command -v ${GO_BIN} > /dev/null 2>&1 ; then
-    local installed=$(go version | cut -d" " -f3)
-    installed=${installed:2}
-
-    if [ "${expected}" != "${installed}" ]; then
-      result="${warning}"
-      msg="version mismatched - got ${installed}, need ${expected}"
-    else
-      result="${ok}"
-    fi
+    result="${ok}"
   else
     result="${failed}"
     msg="${GO_BIN^} not installed"


### PR DESCRIPTION
## Change Overview

This PR modifies `make check` to run inside the build container and modifies the `go_version_check` function to check only for the existence of Go rather than the specific Go version.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #1531 
- #1530 

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

Run `make check`

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
