### PR TITLE
Make check fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -285,7 +285,7 @@ stop-kind:
 	@$(MAKE) run CMD='-c "./build/local_kubernetes.sh stop_localkube"'
 
 check:
-	@./build/check.sh
+	@$(MAKE) run CMD='-c "./build/check.sh"'
 
 gomod:
 	@$(MAKE) run CMD='-c "./build/gomod.sh"'

--- a/Makefile
+++ b/Makefile
@@ -285,7 +285,7 @@ stop-kind:
 	@$(MAKE) run CMD='-c "./build/local_kubernetes.sh stop_localkube"'
 
 check:
-	@$(MAKE) run CMD='-c "./build/check.sh"'
+	@./build/check.sh
 
 gomod:
 	@$(MAKE) run CMD='-c "./build/gomod.sh"'

--- a/build/check.sh
+++ b/build/check.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 GO_BIN=go
 DOCKER_BIN=docker
@@ -11,12 +11,12 @@ failed="❌"
 pad=$(printf '%0.1s' "."{1..25})
 pad_len=25
 
-function output() {
-  local bin=$1
+output() {
+  local bin=$(echo "$1" | awk '{print toupper(substr( $0, 1, 1 )) substr($0, 2)}')
   local result=$2
-  local msg=$3
+  local msg=$(echo "$3" | awk '{print toupper(substr( $0, 1, 1 )) substr($0, 2)}')
 
-  printf "* need %s" "${bin^}"
+  printf "* need %s" "${bin}"
   printf "%*.*s %s" 0 $((pad_len - ${#bin})) "${pad}" "${result}"
   if [ ! -z "${msg}" ]; then
     printf "\n → %s" "${msg}"
@@ -24,33 +24,33 @@ function output() {
   printf "\n"
 }
 
-function check_version_go() {
+check_version_go() {
   local result=""
 
   if command -v ${GO_BIN} > /dev/null 2>&1 ; then
     result="${ok}"
   else
     result="${failed}"
-    msg="${GO_BIN^} not installed"
+    msg="${GO_BIN} not installed"
   fi
 
   output "${GO_BIN}" "${result}" "${msg}"
 }
 
 
-function check_version_docker() {
+check_version_docker() {
   local result=""
   if command -v ${DOCKER_BIN} > /dev/null 2>&1 ; then
     result="${ok}"
   else
     result="${failed}"
-    msg="${DOCKER_BIN^} not installed"
+    msg="${DOCKER_BIN} not installed"
   fi
 
   output "${DOCKER_BIN}" "${result}" "${msg}"
 }
 
-function check_version_kubectl() {
+check_version_kubectl() {
   local result=""
   if command -v ${KUBECTL_BIN} > /dev/null 2>&1 ; then
     result="${ok}"
@@ -59,7 +59,7 @@ function check_version_kubectl() {
     msg="${KUBECTL_BIN} not installed"
   fi
 
-  output "${KUBECTL_BIN^}" "${result}" "${msg}"
+  output "${KUBECTL_BIN}" "${result}" "${msg}"
 }
 
 check_version_go

--- a/build/check.sh
+++ b/build/check.sh
@@ -25,20 +25,10 @@ function output() {
 }
 
 function check_version_go() {
-  local expected=$(cat go.mod | grep "go [0-9]\.[0-9]*" | cut -d" " -f2)
   local result=""
-  local msg=""
 
   if command -v ${GO_BIN} > /dev/null 2>&1 ; then
-    local installed=$(go version | cut -d" " -f3)
-    installed=${installed:2}
-
-    if [ "${expected}" != "${installed}" ]; then
-      result="${warning}"
-      msg="version mismatched - got ${installed}, need ${expected}"
-    else
-      result="${ok}"
-    fi
+    result="${ok}"
   else
     result="${failed}"
     msg="${GO_BIN^} not installed"
@@ -46,6 +36,7 @@ function check_version_go() {
 
   output "${GO_BIN}" "${result}" "${msg}"
 }
+
 
 function check_version_docker() {
   local result=""


### PR DESCRIPTION
## Change Overview

This PR modifies `make check` to run inside the build container and modifies the `go_version_check` function to check only for the existence of Go rather than the specific Go version.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #1530 
- #1531

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
