### PR TITLE
Fix the example of `KubeExecAll` kanister function

### DIFF
--- a/docs/functions.rst
+++ b/docs/functions.rst
@@ -76,8 +76,10 @@ Example:
 KubeExecAll
 -----------
 
-KubeExecAll is similar to running KubeExec on multiple containers on
-multiple pods (all specified containers on all pods) in parallel.
+KubeExecAll is similar to running KubeExec on specified containers of
+given pods (all specified containers on given pods) in parallel. In below
+example, the command is going to be executed in both the containers of
+given pods.
 
 .. csv-table::
    :header: "Argument", "Required", "Type", "Description"
@@ -98,12 +100,8 @@ Example:
     name: examplePhase
     args:
       namespace: "{{ .Deployment.Namespace }}"
-      pods:
-        - "{{ index .Deployment.Pods 0 }}"
-        - "{{ index .Deployment.Pods 1 }}"
-      containers:
-        - kanister-sidecar1
-        - kanister-sidecar2
+      pods: "{{ index .Deployment.Pods 0 }} {{ index .Deployment.Pods 1 }}"
+      containers: "container1 container2"
       command:
         - sh
         - -c

--- a/docs/functions.rst
+++ b/docs/functions.rst
@@ -77,9 +77,9 @@ KubeExecAll
 -----------
 
 KubeExecAll is similar to running KubeExec on specified containers of
-given pods (all specified containers on given pods) in parallel. In below
-example, the command is going to be executed in both the containers of
-given pods.
+given pods (all specified containers on given pods) in parallel. In the
+below example, the command is going to be executed in both the containers
+of the given pods.
 
 .. csv-table::
    :header: "Argument", "Required", "Type", "Description"

--- a/docs/functions.rst
+++ b/docs/functions.rst
@@ -87,8 +87,8 @@ given pods.
    :widths: 5,5,5,15
 
    `namespace`, Yes, `string`, namespace in which to execute
-   `pods`, Yes, `[]string`, list of names of pods in which to execute
-   `containers`, Yes, `[]string`, list of names of the containers in which to execute
+   `pods`, Yes, `string`, space separated list of names of pods in which to execute
+   `containers`, Yes, `string`, space separated list of names of the containers in which to execute
    `command`, Yes, `[]string`,  command list to execute
 
 Example:


### PR DESCRIPTION
## Change Overview

The example in the `KubeExecAll` was incorrect. This corrects that.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E

Create a blueprint with below manifest and run the action 

```
apiVersion: cr.kanister.io/v1alpha1
kind: Blueprint
metadata:
  name: cassandra-blueprint
actions:
  backup:
    phases:
    - func: KubeExecAll
      name: examplePhase
      args:
        namespace: "{{ .Deployment.Namespace }}"
        pods: "{{ index .Deployment.Pods 0 }} {{ index .Deployment.Pods 1 }}"
        containers: "nginx"
        command:
          - sh
          - -c
          - |
            echo "Example"
```