### PR TITLE
Export ActionSet Metrics for Kanister

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -155,6 +155,7 @@ func (c *Controller) onAdd(obj interface{}) {
 		} else {
 			// Ideally a function such a getStatus() should return the labels corresponding to the current status of the system.
 			// These labels will be passed to a function in the metrics package
+			// Also, a list of events to update metrics should be created and incremented.
 			if err := metrics.IncrementCounterVec(metrics.NewActionSetBackupCreated()); err != nil {
 				log.Error().WithError(err).Print("Metrics Incrementation failed")
 			}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -48,6 +48,7 @@ import (
 	"github.com/kanisterio/kanister/pkg/eventer"
 	"github.com/kanisterio/kanister/pkg/field"
 	"github.com/kanisterio/kanister/pkg/log"
+	"github.com/kanisterio/kanister/pkg/metrics"
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/progress"
 	"github.com/kanisterio/kanister/pkg/reconcile"
@@ -148,6 +149,9 @@ func (c *Controller) onAdd(obj interface{}) {
 	case *crv1alpha1.ActionSet:
 		if err := c.onAddActionSet(v); err != nil {
 			log.Error().WithError(err).Print("Callback onAddActionSet() failed")
+		} else {
+			//ideally a function such a getStatus() should return the labels corresponding to the current status of the system. These labels will be passed to a function in the metrics package
+			metrics.IncrementCounterVec(metrics.NewActionSetBackupCreated())
 		}
 	case *crv1alpha1.Blueprint:
 		c.onAddBlueprint(v)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -213,15 +213,6 @@ func (c *Controller) onAddActionSet(as *crv1alpha1.ActionSet) error {
 	if err := validate.ActionSet(as); err != nil {
 		return err
 	}
-	// ActionSet created
-	// Ideally a function such a getStatus() should return the labels corresponding to the current status of the system.
-	// These labels will be passed to a function in the metrics package
-	// Also, a list of events to update metrics should be created and incremented.
-	for _, a := range as.Spec.Actions {
-		if err := metrics.IncrementCounterVec(metrics.NewActionSetTotalCreated(a.Name, as.GetNamespace())); err != nil {
-			log.Error().WithError(err).Print("Metrics Incrementation failed")
-		}
-	}
 	return c.handleActionSet(as)
 }
 
@@ -377,6 +368,17 @@ func (c *Controller) handleActionSet(as *crv1alpha1.ActionSet) (err error) {
 	if as.Status.State != crv1alpha1.StatePending {
 		return nil
 	}
+
+	// ActionSet created
+	// Ideally a function such a getStatus() should return the labels corresponding to the current status of the system.
+	// These labels will be passed to a function in the metrics package
+	// Also, a list of events to update metrics should be created and incremented.
+	for _, a := range as.Spec.Actions {
+		if err := metrics.IncrementCounterVec(metrics.NewActionSetTotalCreated(a.Name, as.GetNamespace())); err != nil {
+			log.Error().WithError(err).Print("Metrics Incrementation failed")
+		}
+	}
+
 	as.Status.State = crv1alpha1.StateRunning
 	if as, err = c.crClient.CrV1alpha1().ActionSets(as.GetNamespace()).Update(context.TODO(), as, v1.UpdateOptions{}); err != nil {
 		return errors.WithStack(err)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -374,7 +374,7 @@ func (c *Controller) handleActionSet(as *crv1alpha1.ActionSet) (err error) {
 	// These labels will be passed to a function in the metrics package
 	// Also, a list of events to update metrics should be created and incremented.
 	for _, a := range as.Spec.Actions {
-		if err := metrics.IncrementCounterVec(metrics.NewActionSetTotalCreated(a.Name, as.GetNamespace())); err != nil {
+		if err := metrics.IncrementCounterVec(metrics.NewActionSetCreatedTotal(a.Name, as.GetNamespace())); err != nil {
 			log.Error().WithError(err).Print("Metrics Incrementation failed")
 		}
 	}

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -24,11 +24,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
-	"github.com/kanisterio/kanister/pkg/metrics"
 	"github.com/kanisterio/kanister/pkg/validatingwebhook"
 	"github.com/kanisterio/kanister/pkg/version"
 	"github.com/pkg/errors"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
@@ -85,7 +83,6 @@ func RunWebhookServer(c *rest.Config) error {
 }
 
 func NewServer() *http.Server {
-	metrics.InitAllCounterVecs(prometheus.DefaultRegisterer)
 	m := &http.ServeMux{}
 	m.Handle(healthCheckPath, &healthCheckHandler{})
 	m.Handle(metricsPath, promhttp.Handler())

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -24,9 +24,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
+	"github.com/kanisterio/kanister/pkg/metrics"
 	"github.com/kanisterio/kanister/pkg/validatingwebhook"
 	"github.com/kanisterio/kanister/pkg/version"
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
@@ -83,6 +85,7 @@ func RunWebhookServer(c *rest.Config) error {
 }
 
 func NewServer() *http.Server {
+	metrics.InitAllCounterVecs(prometheus.DefaultRegisterer)
 	m := &http.ServeMux{}
 	m.Handle(healthCheckPath, &healthCheckHandler{})
 	m.Handle(metricsPath, promhttp.Handler())

--- a/pkg/metrics/events.go
+++ b/pkg/metrics/events.go
@@ -147,19 +147,3 @@ func NewActionSetTotalCompleted(actionType string, namespace string, state strin
 		},
 	}
 }
-
-// func RecordMetrics() {
-// 	go func() {
-// 		for {
-// 			opsProcessed.Inc()
-// 			time.Sleep(2 * time.Second)
-// 		}
-// 	}()
-// }
-
-// var (
-// 	opsProcessed = promauto.NewCounter(prometheus.CounterOpts{
-// 		Name: "kanister_processed_ops_total",
-// 		Help: "Total number of processed events",
-// 	})
-// )

--- a/pkg/metrics/events.go
+++ b/pkg/metrics/events.go
@@ -1,6 +1,10 @@
 package metrics
 
-// MetricType will represent the type of the Prometheus metric.
+// This file contains wrapper functions that will map a Prometheus metric names to its
+// label field, help field and an associated Event.
+
+// MetricType will represent a Prometheus metric.
+// A variable of type MetricType will hold the name of the Prometheus metric as reported.
 type MetricType string
 
 const (
@@ -16,14 +20,18 @@ const (
 	ActionSetTotalCompletedType MetricType = "actionset_total_completed_count"
 )
 
-//MetricTypeOpt is a struct for a Prometheus metric
+// MetricTypeOpt is a struct for a Prometheus metric.
+// Help and LabelNames are passed directly to the Prometheus predefined functions.
+// EventFunc holds the constructor of the linked Event of a given MetricType.
 type MetricTypeOpt struct {
 	EventFunc  interface{}
 	Help       string
 	LabelNames []string
 }
 
-// Mapping a Prometheus metric name to the metric MetricTypeOpt struct
+// Mapping a Prometheus MetricType to the metric MetricTypeOpt struct.
+// Basically, a metric name is mapped to its associated Help and LabelName fields.
+// The linked event function (EventFunc) is also mapped to this metric name as a part of MetricTypeOpt.
 var MetricTypeOpts = map[MetricType]MetricTypeOpt{
 	SampleCountType: {
 		EventFunc:  NewSampleCount,
@@ -64,6 +72,8 @@ var MetricTypeOpts = map[MetricType]MetricTypeOpt{
 }
 
 // Event describes an individual event.
+// eventType is the MetricType with which the individial Event is associated.
+// Labels are the metric labels that will be passed to Prometheus.
 //
 // Note: The type and labels are private in order to force the use of the
 // event constructors below. This helps to prevent an event from being

--- a/pkg/metrics/events.go
+++ b/pkg/metrics/events.go
@@ -1,0 +1,165 @@
+package metrics
+
+// MetricType will represent the type of the Prometheus metric.
+type MetricType string
+
+const (
+	SampleCountType MetricType = "sample_count"
+
+	ActionSetBackupCreatedType   MetricType = "actionset_backup_created_count"
+	ActionSetBackupCompletedType MetricType = "actionset_backup_completed_count"
+
+	ActionSetRestoreCreatedType   MetricType = "actionset_restore_created_count"
+	ActionSetRestoreCompletedType MetricType = "actionset_restore_completed_count"
+
+	ActionSetTotalCreatedType   MetricType = "actionset_total_created_count"
+	ActionSetTotalCompletedType MetricType = "actionset_total_completed_count"
+)
+
+//MetricTypeOpt is a struct for a Prometheus metric
+type MetricTypeOpt struct {
+	EventFunc  interface{}
+	Help       string
+	LabelNames []string
+}
+
+// Mapping a Prometheus metric name to the metric MetricTypeOpt struct
+var MetricTypeOpts = map[MetricType]MetricTypeOpt{
+	SampleCountType: {
+		EventFunc:  NewSampleCount,
+		Help:       "Sample counter to remove later",
+		LabelNames: []string{"sample"},
+	},
+
+	ActionSetBackupCreatedType: {
+		EventFunc: NewActionSetBackupCreated,
+		Help:      "The count of backup ActionSets created",
+	},
+	ActionSetBackupCompletedType: {
+		EventFunc:  NewActionSetBackupCompleted,
+		Help:       "The count of backup ActionSets completed",
+		LabelNames: []string{"state"},
+	},
+
+	ActionSetRestoreCreatedType: {
+		EventFunc: NewActionSetRestoreCreated,
+		Help:      "The count of restore ActionSets created",
+	},
+	ActionSetRestoreCompletedType: {
+		EventFunc:  NewActionSetRestoreCompleted,
+		Help:       "The count of restore ActionSets completed",
+		LabelNames: []string{"state"},
+	},
+
+	ActionSetTotalCreatedType: {
+		EventFunc:  NewActionSetTotalCreated,
+		Help:       "The count of total ActionSets created",
+		LabelNames: []string{"actionType", "namespace"},
+	},
+	ActionSetTotalCompletedType: {
+		EventFunc:  NewActionSetTotalCompleted,
+		Help:       "The count of total ActionSets completed",
+		LabelNames: []string{"actionType", "namespace", "state"},
+	},
+}
+
+// Event describes an individual event.
+//
+// Note: The type and labels are private in order to force the use of the
+// event constructors below. This helps to prevent an event from being
+// accidentally misconstructed (e.g. with mismatching labels), which would
+// cause the Prometheus library to panic.
+type Event struct {
+	eventType MetricType
+	labels    map[string]string
+}
+
+// MetricType returns the event's type.
+func (e *Event) Type() MetricType {
+	return e.eventType
+}
+
+// Labels returns a copy of the event's labels.
+func (e *Event) Labels() map[string]string {
+	labels := make(map[string]string)
+	for k, v := range e.labels {
+		labels[k] = v
+	}
+	return labels
+}
+
+func NewSampleCount(sample string) Event {
+	return Event{
+		eventType: SampleCountType,
+		labels: map[string]string{
+			"sample": sample,
+		},
+	}
+}
+
+func NewActionSetBackupCreated() Event {
+	return Event{
+		eventType: ActionSetBackupCreatedType,
+	}
+}
+
+func NewActionSetBackupCompleted(state string) Event {
+	return Event{
+		eventType: ActionSetBackupCompletedType,
+		labels: map[string]string{
+			"state": state,
+		},
+	}
+}
+
+func NewActionSetRestoreCreated() Event {
+	return Event{
+		eventType: ActionSetRestoreCreatedType,
+	}
+}
+
+func NewActionSetRestoreCompleted(state string) Event {
+	return Event{
+		eventType: ActionSetRestoreCompletedType,
+		labels: map[string]string{
+			"state": state,
+		},
+	}
+}
+
+func NewActionSetTotalCreated(actionType string, namespace string) Event {
+	return Event{
+		eventType: ActionSetTotalCreatedType,
+		labels: map[string]string{
+			"actionType": actionType,
+			"namespace":  namespace,
+		},
+	}
+}
+
+func NewActionSetTotalCompleted(actionType string, namespace string, state string) Event {
+	return Event{
+		eventType: ActionSetTotalCompletedType,
+		labels: map[string]string{
+			"actionType": actionType,
+			"namespace":  namespace,
+			"state":      state,
+		},
+	}
+}
+
+// func RecordMetrics() {
+// 	go func() {
+// 		for {
+// 			opsProcessed.Inc()
+// 			time.Sleep(2 * time.Second)
+// 		}
+// 	}()
+// }
+
+// var (
+// 	opsProcessed = promauto.NewCounter(prometheus.CounterOpts{
+// 		Name: "kanister_processed_ops_total",
+// 		Help: "Total number of processed events",
+// 	})
+// )

--- a/pkg/metrics/events.go
+++ b/pkg/metrics/events.go
@@ -8,16 +8,9 @@ package metrics
 type MetricType string
 
 const (
-	SampleCountType MetricType = "sample_count"
-
-	ActionSetBackupCreatedType   MetricType = "actionset_backup_created_count"
-	ActionSetBackupCompletedType MetricType = "actionset_backup_completed_count"
-
-	ActionSetRestoreCreatedType   MetricType = "actionset_restore_created_count"
-	ActionSetRestoreCompletedType MetricType = "actionset_restore_completed_count"
-
-	ActionSetTotalCreatedType   MetricType = "actionset_total_created_count"
-	ActionSetTotalCompletedType MetricType = "actionset_total_completed_count"
+	ActionSetCreatedTotalType   MetricType = "kanister_actionset_created_total"
+	ActionSetCompletedTotalType MetricType = "kanister_actionset_completed_total"
+	ActionSetFailedTotalType    MetricType = "kanister_actionset_failed_total"
 )
 
 // MetricTypeOpt is a struct for a Prometheus metric.
@@ -32,42 +25,21 @@ type MetricTypeOpt struct {
 // Mapping a Prometheus MetricType to the metric MetricTypeOpt struct.
 // Basically, a metric name is mapped to its associated Help and LabelName fields.
 // The linked event function (EventFunc) is also mapped to this metric name as a part of MetricTypeOpt.
-var MetricTypeOpts = map[MetricType]MetricTypeOpt{
-	SampleCountType: {
-		EventFunc:  NewSampleCount,
-		Help:       "Sample counter to remove later",
-		LabelNames: []string{"sample"},
-	},
-
-	ActionSetBackupCreatedType: {
-		EventFunc: NewActionSetBackupCreated,
-		Help:      "The count of backup ActionSets created",
-	},
-	ActionSetBackupCompletedType: {
-		EventFunc:  NewActionSetBackupCompleted,
-		Help:       "The count of backup ActionSets completed",
-		LabelNames: []string{"state"},
-	},
-
-	ActionSetRestoreCreatedType: {
-		EventFunc: NewActionSetRestoreCreated,
-		Help:      "The count of restore ActionSets created",
-	},
-	ActionSetRestoreCompletedType: {
-		EventFunc:  NewActionSetRestoreCompleted,
-		Help:       "The count of restore ActionSets completed",
-		LabelNames: []string{"state"},
-	},
-
-	ActionSetTotalCreatedType: {
-		EventFunc:  NewActionSetTotalCreated,
+var MetricCounterOpts = map[MetricType]MetricTypeOpt{
+	ActionSetCreatedTotalType: {
+		EventFunc:  NewActionSetCreatedTotal,
 		Help:       "The count of total ActionSets created",
 		LabelNames: []string{"actionType", "namespace"},
 	},
-	ActionSetTotalCompletedType: {
-		EventFunc:  NewActionSetTotalCompleted,
+	ActionSetCompletedTotalType: {
+		EventFunc:  NewActionSetCompletedTotal,
 		Help:       "The count of total ActionSets completed",
-		LabelNames: []string{"actionType", "namespace", "state"},
+		LabelNames: []string{"actionName", "actionType", "blueprint", "namespace", "state"},
+	},
+	ActionSetFailedTotalType: {
+		EventFunc:  NewActionSetFailedTotal,
+		Help:       "The count of total ActionSets failed",
+		LabelNames: []string{"actionName", "actionType", "blueprint", "namespace", "state"},
 	},
 }
 
@@ -98,48 +70,9 @@ func (e *Event) Labels() map[string]string {
 	return labels
 }
 
-func NewSampleCount(sample string) Event {
+func NewActionSetCreatedTotal(actionType string, namespace string) Event {
 	return Event{
-		eventType: SampleCountType,
-		labels: map[string]string{
-			"sample": sample,
-		},
-	}
-}
-
-func NewActionSetBackupCreated() Event {
-	return Event{
-		eventType: ActionSetBackupCreatedType,
-	}
-}
-
-func NewActionSetBackupCompleted(state string) Event {
-	return Event{
-		eventType: ActionSetBackupCompletedType,
-		labels: map[string]string{
-			"state": state,
-		},
-	}
-}
-
-func NewActionSetRestoreCreated() Event {
-	return Event{
-		eventType: ActionSetRestoreCreatedType,
-	}
-}
-
-func NewActionSetRestoreCompleted(state string) Event {
-	return Event{
-		eventType: ActionSetRestoreCompletedType,
-		labels: map[string]string{
-			"state": state,
-		},
-	}
-}
-
-func NewActionSetTotalCreated(actionType string, namespace string) Event {
-	return Event{
-		eventType: ActionSetTotalCreatedType,
+		eventType: ActionSetCreatedTotalType,
 		labels: map[string]string{
 			"actionType": actionType,
 			"namespace":  namespace,
@@ -147,11 +80,26 @@ func NewActionSetTotalCreated(actionType string, namespace string) Event {
 	}
 }
 
-func NewActionSetTotalCompleted(actionType string, namespace string, state string) Event {
+func NewActionSetCompletedTotal(actionName string, actionType string, blueprint string, namespace string, state string) Event {
 	return Event{
-		eventType: ActionSetTotalCompletedType,
+		eventType: ActionSetCompletedTotalType,
 		labels: map[string]string{
+			"actionName": actionName,
 			"actionType": actionType,
+			"blueprint":  blueprint,
+			"namespace":  namespace,
+			"state":      state,
+		},
+	}
+}
+
+func NewActionSetFailedTotal(actionName string, actionType string, blueprint string, namespace string, state string) Event {
+	return Event{
+		eventType: ActionSetFailedTotalType,
+		labels: map[string]string{
+			"actionName": actionName,
+			"actionType": actionType,
+			"blueprint":  blueprint,
 			"namespace":  namespace,
 			"state":      state,
 		},

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,70 @@
+package metrics
+
+import (
+	"fmt"
+
+	"github.com/kanisterio/kanister/pkg/log"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var counterVecs map[MetricType]*prometheus.CounterVec
+
+// Initialize a Prometheus CounterVec for one metric and register it
+func initCounterVec(r prometheus.Registerer, t MetricType) (*prometheus.CounterVec, error) {
+	metricTypeOpts, ok := MetricTypeOpts[t]
+
+	if !ok {
+		panic(fmt.Sprintf("Event type %s is not defined", t))
+	}
+
+	opts := prometheus.CounterOpts{
+		Name: string(t),
+		Help: metricTypeOpts.Help,
+	}
+	counterVec := prometheus.NewCounterVec(opts, metricTypeOpts.LabelNames)
+
+	if err := r.Register(counterVec); err != nil {
+		return nil, fmt.Errorf("%s not registered: %s ", t, err)
+	}
+
+	return counterVec, nil
+}
+
+// Initialize a Prometheus GaugeVec for one metric and register it
+// func initGaugeVec(r prometheus.Registerer, t MetricType) (*prometheus.GaugeVec, error) {
+// 	metricTypeOpts, ok := MetricTypeOpts[t]
+
+// 	if !ok {
+// 		panic(fmt.Sprintf("Event type %s is not defined", t))
+// 	}
+
+// 	opts := prometheus.GaugeOpts{
+// 		Name: string(t),
+// 		Help: metricTypeOpts.Help,
+// 	}
+// 	gaugeVec := prometheus.NewGaugeVec(opts, metricTypeOpts.LabelNames)
+
+// 	if err := r.Register(gaugeVec); err != nil {
+// 		return nil, fmt.Errorf("%s not registered: %s ", t, err)
+// 	}
+
+// 	return gaugeVec, nil
+// }
+
+func InitAllCounterVecs(r prometheus.Registerer) {
+	for metricType := range MetricTypeOpts {
+		cv, err := initCounterVec(r, metricType)
+		if err != nil {
+			log.WithError(err).Print("Failed to register metric %s")
+			return
+		}
+		counterVecs[metricType] = cv
+	}
+}
+
+// Increment a Counter Vec metric
+func IncrementCounterVec(e Event) {
+	counterVecs[e.eventType].With(e.labels).Inc()
+}
+
+// on status change, create list of events to increment metrics for

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -39,6 +39,7 @@ func initCounterVec(r prometheus.Registerer, t MetricType) (*prometheus.CounterV
 }
 
 // Initialize a Prometheus GaugeVec for one metric and register it
+// nolint:all   // Function is for expanding on metrics to introduce Gauges
 func initGaugeVec(r prometheus.Registerer, t MetricType) (*prometheus.GaugeVec, error) {
 	metricTypeOpts, ok := MetricTypeOpts[t]
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -12,10 +12,10 @@ var counterVecs = make(map[MetricType]*prometheus.CounterVec)
 
 // Initialize a Prometheus CounterVec for one metric and register it
 func initCounterVec(r prometheus.Registerer, t MetricType) (*prometheus.CounterVec, error) {
-	metricTypeOpts, ok := MetricTypeOpts[t]
+	metricTypeOpts, ok := MetricCounterOpts[t]
 
 	if !ok {
-		panic(fmt.Sprintf("Event type %s is not defined", t))
+		return nil, fmt.Errorf("Event type %s is not defined", t)
 	}
 
 	opts := prometheus.CounterOpts{
@@ -32,7 +32,7 @@ func initCounterVec(r prometheus.Registerer, t MetricType) (*prometheus.CounterV
 	if errors.As(err, &alreadyRegisteredErr) {
 		counterVec = alreadyRegisteredErr.ExistingCollector.(*prometheus.CounterVec)
 	} else if err != nil {
-		panic(err)
+		return nil, fmt.Errorf("Error registering Counter Vecs : %s ", err)
 	}
 
 	return counterVec, nil
@@ -40,7 +40,7 @@ func initCounterVec(r prometheus.Registerer, t MetricType) (*prometheus.CounterV
 
 // Initialize all the Counter Vecs and save it in a map
 func InitAllCounterVecs(r prometheus.Registerer) map[MetricType]*prometheus.CounterVec {
-	for metricType := range MetricTypeOpts {
+	for metricType := range MetricCounterOpts {
 		cv, err := initCounterVec(r, metricType)
 		if err != nil {
 			log.WithError(err).Print("Failed to register metric %s")


### PR DESCRIPTION
## Change Overview

* Created a skeleton for a pipeline to export metrics.
* A sample Backup ActionSet Created metric is exposed. This is a counter that will increment every time an ActionSet of Backup type is created.
* Exposed Metrics are available at `/metrics`.
* Added Metric type definitions for future metrics to be exposed.
* Added functionality to initialize gauges for these additional metrics.

## Pull request type

Please check the type of change your PR introduces:
- [X] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [X] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #1602 

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
