### PR TITLE
Update script to always use latest version of hostpath CSI driver

### DIFF
--- a/build/local_kubernetes.sh
+++ b/build/local_kubernetes.sh
@@ -73,8 +73,8 @@ install_csi_hostpath_driver() {
     cd /tmp
     git clone https://github.com/kubernetes-csi/csi-driver-host-path.git
     cd csi-driver-host-path
-    sed -i 's/mountPropagation: Bidirectional/\#mountPropagation: Bidirectional/g' deploy/kubernetes-1.21/hostpath/csi-hostpath-plugin.yaml
-    ./deploy/kubernetes-1.21/deploy.sh
+    sed -i 's/mountPropagation: Bidirectional/\#mountPropagation: Bidirectional/g' deploy/kubernetes-latest/hostpath/csi-hostpath-plugin.yaml
+    ./deploy/kubernetes-latest/deploy.sh
 
     # Create StorageClass
     kubectl apply -f ./examples/csi-storageclass.yaml


### PR DESCRIPTION
## Change Overview

This PR updates the `./build/local_kubernetes.sh` CI script to always pull the latest version of the `hostpath` CSI driver. A number of PRs are failing at the integration test CI step because the 1.21 driver has been removed:

* https://github.com/kanisterio/kanister/runs/8003833267?check_suite_focus=true#step:5:108
* https://github.com/kanisterio/kanister/runs/8003198747?check_suite_focus=true#step:5:108

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Test Plan

- CI 