### PR TITLE
Add new flag to override actionset name

### DIFF
--- a/pkg/kanctl/actionset_test.go
+++ b/pkg/kanctl/actionset_test.go
@@ -76,3 +76,32 @@ func (k *KanctlTestSuite) TestParseGenericObjectReference(c *C) {
 		c.Assert(a, DeepEquals, tc.expected)
 	}
 }
+
+func (k *KanctlTestSuite) TestGenerateActionSetName(c *C) {
+	var testCases = []struct {
+		actionName    string
+		actionSetName string
+		parentName    string
+		expected      string
+		expectedErr   error
+	}{
+		{actionName: "", actionSetName: "", parentName: "", expected: "", expectedErr: errMissingFieldActionName},
+		{actionName: "my-action", actionSetName: "", parentName: "", expected: "my-action-"},
+		{actionName: "my-action", actionSetName: "", parentName: "parent", expected: "my-action-parent-"},
+		{actionName: "", actionSetName: "", parentName: "parent", expected: "parent-"},
+		{actionName: "my-action", actionSetName: "my-override", parentName: "parent", expected: "my-override-"},
+		{actionName: "", actionSetName: "my-override", parentName: "", expected: "my-override-"},
+	}
+
+	for _, tc := range testCases {
+		params := &PerformParams{
+			ActionName:    tc.actionName,
+			ActionSetName: tc.actionSetName,
+			ParentName:    tc.parentName,
+		}
+
+		actual, err := generateActionSetName(params)
+		c.Assert(err, DeepEquals, tc.expectedErr)
+		c.Assert(actual, DeepEquals, tc.expected)
+	}
+}


### PR DESCRIPTION
## Change Overview

This PR adds a new flag called `--actionset-name` to the `kanctl create actionset` command. The current mechanism to auto-generate the new actionset name based on the provided action name (with `--action`) and parent actionset name (with `--from`) is unreliable. The resource creation will fail if the auto-generated name doesn't comply with the K8s resource [naming constraints](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names). See #1414.

The new flag allows user to override the auto-generation mechanism to use one provided by the user.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #1414

## Test Plan

Deploy this blueprint where the action's name is in the camel case format:
```sh
cat <<EOF | kubectl apply -f -
apiVersion: cr.kanister.io/v1alpha1
kind: Blueprint
metadata:
  name: remote-outputs
  namespace: kanister
actions:
  echoTask:
    outputArtifacts:
      output:
        keyValue:
          bar: "{{ .Phases.echoTask.Output.bar }}"
    phases:
    - func: KubeTask
      name: echoTask
      args:
        namespace: "{{ .Namespace.Name }}"
        image: ghcr.io/kanisterio/kanister-tools:v9.99.9-dev
        command:
        - sh
        - "-c"
        - |
         kando output bar "foo"
```

Deploy this actionset to execute the `echoTask` action:

```sh
cat <<EOF | kubectl create -f -
apiVersion: cr.kanister.io/v1alpha1
kind: ActionSet
metadata:
  generateName: echo-task-
  namespace: kanister
spec:
  actions:
  - name: echoTask
    blueprint: remote-outputs
    object:
      kind: Namespace
      name: default
```

Use `kanctl` to create an actionset, using the previous actionset as its parent:

```sh
kanctl -n kanister create actionset --action echoTask --from echo-task-q552d -T default 
```

Expect the above command to fail:

```sh
Error: ActionSet.cr.kanister.io "echoTask-echo-task-q552d-sdkqd" is invalid: [metadata.generateName: Invalid value: "echoTask-echo-task-q552d-": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'), metadata.name: Invalid value: "echoTask-echo-task-q552d-sdkqd": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')]
```

Re-run the command again with the `-A` / `--actionset-name` flag:

```sh
kanctl -n kanister create actionset --action echoTask --from echo-task-q552d -T default -A myactionset     
```

Expect the actionset to be created successfully:

```sh
kubectl -n kanister get actionset myactionset-tcrth                                                                           
NAME                AGE
myactionset-tcrth   17s
```