### PR TITLE
Update Profile Bucket Validation Code To Account For Custom S3 Endpoint

### DIFF
--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -195,6 +195,11 @@ func ProfileBucket(ctx context.Context, p *crv1alpha1.Profile, cli kubernetes.In
 		Type:   pType,
 		Region: p.Location.Region,
 	}
+
+	if p.Location.Endpoint != "" {
+		pc.Endpoint = p.Location.Endpoint
+	}
+
 	secret, err := osSecretFromProfile(ctx, pType, p, cli)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Change Overview

This PR updates the `validate.ProfileBucket()` method to use custom S3 endpoint, if provided, for its validation steps. Without this change, `stow` will default back to using the `s3.<region>.amazonaws.com` domain, even though the custom endpoint is provided.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #1590

## Test Plan

Use the latest `kanctl` CLI to reproduce the issue:
```sh
$ kanctl create profile s3compliant --access-key "test" --secret-key "test" --endpoint https://s3.cern.ch/  --bucket my-bucket --region cern --namespace default --verbose
```

The validation code ignores the `s3.cern.ch` endpoint:
```sh
secret 's3-secret-ggiorh' created
Failed the 'Validate bucket region specified in profile' check.. ❌
validation failed, deleting secret 's3-secret-ggiorh'
secret 's3-secret-ggiorh' deleted
Error: profile validation failed: failed to get bucket my-bucket: GetBucketLocation: RequestError: send request failed
caused by: Get "https://s3.cern.amazonaws.com/my-bucket?location=": dial tcp: lookup s3.cern.amazonaws.com on 127.0.0.53:53: no such host
```

Run `kanctl` with this change:
```sh
go run ./cmd/kanctl create profile s3compliant --access-key "test" --secret-key "test" --endpoint https://s3.cern.ch/  --bucket my-buclet --region cern --namespace default --verbose
```

The right endpoint is used:
```sh
secret 's3-secret-ijj2lv' created
Failed to obtain reader, failed to marshal fields to JSON, json: unsupported type: func(time.Duration)
Failed the 'Validate bucket region specified in profile' check.. ❌
validation failed, deleting secret 's3-secret-ijj2lv'
secret 's3-secret-ijj2lv' deleted
Error: profile validation failed: failed to get bucket my-bucket: GetBucketLocation: InvalidAccessKeyId: 
        status code: 403, request id: tx000000000000049299681-00631bb733-2af9b497-default, host id: 
{"File":"pkg/kanctl/kanctl.go","Function":"github.com/kanisterio/kanister/pkg/kanctl.Execute","Line":48,"error":"profile validation failed: failed to get bucket my-bucket: GetBucketLocation: InvalidAccessKeyId: \n\tstatus code: 403, request id: tx000000000000049299681-00631bb733-2af9b497-default, host id: ","level":"info","msg":"Kanctl failed to execute","time":"2022-09-09T14:59:15.597305194-07:00"}
exit status 1
```


- [x] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
