### PR TITLE
Add ability to configure MysqlDB app via Options

### DIFF
--- a/pkg/app/mysql.go
+++ b/pkg/app/mysql.go
@@ -44,9 +44,9 @@ type MysqlDB struct {
 
 type MysqlDBOptions func(*MysqlDB)
 
-func MysqlDBWithChart(chart map[string]string) MysqlDBOptions {
+func MysqlDBChartValues(values map[string]string) MysqlDBOptions {
 	return func(db *MysqlDB) {
-		for k, v := range chart {
+		for k, v := range values {
 			db.chart.Values[k] = v
 		}
 	}

--- a/pkg/app/mysql.go
+++ b/pkg/app/mysql.go
@@ -42,9 +42,19 @@ type MysqlDB struct {
 	chart     helm.ChartInfo
 }
 
+type MysqlDBOptions func(*MysqlDB)
+
+func MysqlDBWithChart(chart map[string]string) MysqlDBOptions {
+	return func(db *MysqlDB) {
+		for k, v := range chart {
+			db.chart.Values[k] = v
+		}
+	}
+}
+
 // Last tested working version "6.14.11"
-func NewMysqlDB(name string) App {
-	return &MysqlDB{
+func NewMysqlDB(name string, opts ...MysqlDBOptions) App {
+	m := MysqlDB{
 		name: name,
 		chart: helm.ChartInfo{
 			Release:  appendRandString(name),
@@ -57,6 +67,10 @@ func NewMysqlDB(name string) App {
 			},
 		},
 	}
+	for _, opt := range opts {
+		opt(&m)
+	}
+	return &m
 }
 
 func (mdb *MysqlDB) Init(ctx context.Context) error {


### PR DESCRIPTION
## Change Overview

This PR add ability to configure MysqlDB app via options + added function that help us configure chart values for that app.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [x] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
