### PR TITLE
Run the triage workflow on primary repo only

### DIFF
--- a/.github/workflows/triage.yaml
+++ b/.github/workflows/triage.yaml
@@ -9,7 +9,7 @@ on:
     - reopened
 jobs:
   issues:
-    if: github.event_name == 'issues'
+    if: github.repository == 'kanisterio/kanister' && github.event_name == 'issues'
     permissions:
       issues: write
     runs-on: ubuntu-latest
@@ -34,7 +34,7 @@ jobs:
         project: Kanister
         column: To Be Triaged
   pull-requests:
-    if: github.event_name == 'pull_request'
+    if: github.repository == 'kanisterio/kanister' && github.event_name == 'pull_request'
     permissions:
       pull-requests: write
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Change Overview

The `triage` workflow will fail when a `contributor` submits a PR from a fork. This PR updates the CI to skip the `triage` workflow if a PR did not originate from the primary repo.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #1535

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
