### PR TITLE
Harden Job Pod Service Account RBAC Settings

### DIFF
--- a/helm/fdb-operator/templates/manager/statefulset.yaml
+++ b/helm/fdb-operator/templates/manager/statefulset.yaml
@@ -24,6 +24,7 @@ spec:
           secret:
             secretName: {{ .Values.secret.name }}
       serviceAccountName: default
+      automountServiceAccountToken: false
       containers:
       - command:
         - /manager

--- a/helm/kanister-operator/templates/deployment.yaml
+++ b/helm/kanister-operator/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "kanister-operator.fullname" . }}
+  namespace: {{ template "kanister-operator.namespace" . }}
   labels:
 {{ include "kanister-operator.helmLabels" . | indent 4 }}
 spec:
@@ -15,6 +16,7 @@ spec:
 {{ include "kanister-operator.helmLabels" . | indent 8}}
     spec:
       serviceAccountName: {{ template "kanister-operator.serviceAccountName" . }}
+      automountServiceAccountToken: false
 {{- if .Values.bpValidatingWebhook.enabled }}
       volumes:
         - name: webhook-certs


### PR DESCRIPTION
## Change Overview

Adding automountServiceAccountToken: false for pod to not automatically mount service account credentials.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #1550 

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
