### PR TITLE
Boring kopia for kanister

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -265,7 +265,7 @@ release-snapshot:
 	@$(MAKE) run CMD='-c "GORELEASER_CURRENT_TAG=v9.99.9-dev goreleaser --debug release --rm-dist --snapshot"'
 
 update-kopia-image:
-	@/bin/bash ./build/update_kopia_image.sh $(KOPIA_COMMIT_ID) $(KOPIA_REPO)
+	@/bin/bash ./build/update_kopia_image.sh $(KOPIA_COMMIT_ID) $(KOPIA_REPO) $(KOPIA_BORING)
 
 go-mod-download:
 	@$(MAKE) run CMD='-c "go mod download"'

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,8 @@ vm-driver ?= "kvm"
 KOPIA_COMMIT_ID ?= "317cc36"
 
 KOPIA_REPO ?= "kopia"
+
+KOPIA_BORING ?= ""
 # Default OCP version in which the OpenShift apps are going to run
 ocp_version ?= "4.10"
 ###

--- a/Makefile
+++ b/Makefile
@@ -265,7 +265,7 @@ release-snapshot:
 	@$(MAKE) run CMD='-c "GORELEASER_CURRENT_TAG=v9.99.9-dev goreleaser --debug release --rm-dist --snapshot"'
 
 update-kopia-image:
-	@/bin/bash ./build/update_kopia_image.sh $(KOPIA_COMMIT_ID) $(KOPIA_REPO) $(KOPIA_BORING)
+	@/bin/bash ./build/update_kopia_image.sh -c $(KOPIA_COMMIT_ID) -r $(KOPIA_REPO) -b $(KOPIA_BORING)
 
 go-mod-download:
 	@$(MAKE) run CMD='-c "go mod download"'

--- a/build/update_kopia_image.sh
+++ b/build/update_kopia_image.sh
@@ -19,16 +19,24 @@ set -o nounset
 
 IMAGE_REGISTRY="ghcr.io/kanisterio"
 
-readonly COMMIT_ID=${1:?"Commit id to build kopia image not specified"}
-readonly KOPIA_REPO_ORG=${2-:"kopia"}
+while getopts c:r:b: flag
+do
+    case "${flag}" in
+        c) commitID=${OPTARG};;
+        r) repo=${OPTARG};;
+        b) boring=${OPTARG};;
+    esac
+done
+
+readonly COMMIT_ID=${commitID:?"Commit id to build kopia image not specified"}
+readonly KOPIA_REPO_ORG=${repo:-"kopia"}
 readonly IMAGE_TYPE=alpine
 readonly IMAGE_BUILD_VERSION="${COMMIT_ID}"
 readonly GH_PACKAGE_TARGET="${IMAGE_REGISTRY}/kopia"
 readonly TAG="${IMAGE_TYPE}-${IMAGE_BUILD_VERSION}"
-readonly KOPIA_BORING=$3
 
 KOPIA_IMAGE="kopia"
-if [[ -n KOPIA_BORING ]]; then
+if [[ -n $boring ]]; then
     KOPIA_IMAGE="kopia_boring"
 fi
 

--- a/build/update_kopia_image.sh
+++ b/build/update_kopia_image.sh
@@ -33,11 +33,12 @@ readonly KOPIA_REPO_ORG=${repo:-"kopia"}
 readonly IMAGE_TYPE=alpine
 readonly IMAGE_BUILD_VERSION="${COMMIT_ID}"
 readonly GH_PACKAGE_TARGET="${IMAGE_REGISTRY}/kopia"
-readonly TAG="${IMAGE_TYPE}-${IMAGE_BUILD_VERSION}"
+TAG="${IMAGE_TYPE}-${IMAGE_BUILD_VERSION}"
 
 KOPIA_IMAGE="kopia"
 if [[ -n $boring ]]; then
     KOPIA_IMAGE="kopia_boring"
+    TAG="${IMAGE_TYPE}-${IMAGE_BUILD_VERSION}-boring"
 fi
 
 

--- a/build/update_kopia_image.sh
+++ b/build/update_kopia_image.sh
@@ -25,12 +25,19 @@ readonly IMAGE_TYPE=alpine
 readonly IMAGE_BUILD_VERSION="${COMMIT_ID}"
 readonly GH_PACKAGE_TARGET="${IMAGE_REGISTRY}/kopia"
 readonly TAG="${IMAGE_TYPE}-${IMAGE_BUILD_VERSION}"
+readonly KOPIA_BORING=$3
+
+KOPIA_IMAGE="kopia"
+if [[ -n KOPIA_BORING ]]; then
+    KOPIA_IMAGE="kopia_boring"
+fi
 
 
 docker build \
     --tag "${GH_PACKAGE_TARGET}:${TAG}" \
     --build-arg "kopiaBuildCommit=${COMMIT_ID}" \
     --build-arg "kopiaRepoOrg=${KOPIA_REPO_ORG}" \
+    --build-arg "kopiaImage=${KOPIA_IMAGE}" \
     --file ./docker/kopia-build/Dockerfile .
 
 docker push ${GH_PACKAGE_TARGET}:$TAG

--- a/docker/kopia-build/Dockerfile
+++ b/docker/kopia-build/Dockerfile
@@ -2,8 +2,9 @@ FROM golang:1.19.1-alpine3.16 AS builder
 
 ARG kopiaBuildCommit
 ARG kopiaRepoOrg
+ARG kopiaImage
 
-RUN apk add git
+RUN apk add git build-base
 
 WORKDIR /
 
@@ -19,6 +20,8 @@ RUN git checkout ${kopiaBuildCommit}
 COPY --from=docker.io/goreleaser/goreleaser@sha256:b13418f20019fffb29797aff3d03f5e9ca84cea93634f4169a7ed603a95ab198 \
   /usr/bin/goreleaser /usr/bin/goreleaser
 RUN goreleaser build --output=. --rm-dist --single-target
+
+RUN cp /kopia/dist/${kopiaImage}_linux_amd64_v1/${kopiaImage} /kopia/kopia
 
 RUN adduser -D kopia && addgroup kopia kopia
 USER kopia:kopia

--- a/docker/kopia-build/Dockerfile
+++ b/docker/kopia-build/Dockerfile
@@ -1,10 +1,10 @@
-FROM golang:1.19.1-alpine3.16 AS builder
+FROM golang:1.19.2-buster AS builder
 
 ARG kopiaBuildCommit
 ARG kopiaRepoOrg
 ARG kopiaImage
 
-RUN apk add git build-base
+RUN apt-get install git
 
 WORKDIR /
 
@@ -23,19 +23,19 @@ RUN goreleaser build --output=. --rm-dist --single-target
 
 RUN cp /kopia/dist/${kopiaImage}_linux_amd64_v1/${kopiaImage} /kopia/kopia
 
-RUN adduser -D kopia && addgroup kopia kopia
+RUN adduser kopia && addgroup kopia kopia
 USER kopia:kopia
 
 COPY --chown=kopia . /kopia
 
-FROM alpine:3.16
+FROM debian:buster
 
 WORKDIR /kopia
 
 # Add CA certs
-RUN apk add --no-cache --verbose ca-certificates && \
+RUN apt-get update && apt-get -y install ca-certificates && \
   rm -rf /var/cache/apk/* && \
-  adduser -D kopia && addgroup kopia kopia && \
+  adduser kopia && addgroup kopia kopia && \
   chown kopia /kopia
 
 USER kopia:kopia

--- a/docker/tools/Dockerfile
+++ b/docker/tools/Dockerfile
@@ -10,7 +10,7 @@ LABEL name="kanister-tools" \
 
 COPY --from=restic/restic:0.11.0 /usr/bin/restic /usr/local/bin/restic
 # ghcr.io/kanisterio/kopia:alpine-317cc36
-COPY --from=ghcr.io/kanisterio/kopia@sha256:87648ef24ce47f1d74ef5fa70bff96080f686b849dd0d787e1699d4c05807c4b \
+COPY --from=ghcr.io/kanisterio/kopia@sha256:bef192f29bfc321ea85ed615ea490a20711b9a1e7c1b9d5b63d6a3c8eafcb6f5 \
   /kopia/kopia /usr/local/bin/kopia
 COPY LICENSE /licenses/LICENSE
 

--- a/docker/tools/Dockerfile
+++ b/docker/tools/Dockerfile
@@ -10,7 +10,7 @@ LABEL name="kanister-tools" \
 
 COPY --from=restic/restic:0.11.0 /usr/bin/restic /usr/local/bin/restic
 # ghcr.io/kanisterio/kopia:alpine-317cc36
-COPY --from=ghcr.io/kanisterio/kopia@sha256:bef192f29bfc321ea85ed615ea490a20711b9a1e7c1b9d5b63d6a3c8eafcb6f5 \
+COPY --from=ghcr.io/kanisterio/kopia@sha256:87648ef24ce47f1d74ef5fa70bff96080f686b849dd0d787e1699d4c05807c4b \
   /kopia/kopia /usr/local/bin/kopia
 COPY LICENSE /licenses/LICENSE
 


### PR DESCRIPTION
## Change Overview

This PR introduces changes to build kopia with go boing enabled. 
It also changes the base of the kopia build from alpine to buster, since alpine builds boring-kopia with the musl-libc libraries.
Until upstream kopia changes merge and we have a new commit to build kopia from. This change will not affect the existing behaviour of the kansiter image.

## Pull request type

Please check the type of change your PR introduces:
- [x] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [x] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
