### PR TITLE
Update 'triage' workflow to use the 'pull_request_target' event hook

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -2,7 +2,7 @@ on:
   push:
     branches:
     - master
-  pull_request:
+  pull_request_target:
     branches:
     - master
 jobs:


### PR DESCRIPTION
## Change Overview

This should fix the ongoing issue where PRs from forks are not getting added to the project board. See doc [here](https://github.com/alex-page/github-project-automation-plus#troubleshooting), under "Parameter token or opts.auth is required".

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
