### PR TITLE
Update kanister build to go1.19.2 buster

### DIFF
--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -3,7 +3,8 @@ FROM golang:1.19.2-buster
 LABEL maintainer="Tom Manville<tom@kasten.io>"
 
 RUN apt-get update && apt-get -y install ca-certificates bash git docker curl jq wget \
-    && update-ca-certificates
+    && update-ca-certificates \
+    && apt-get clean
 
 COPY --from=bitnami/kubectl:1.17 /opt/bitnami/kubectl/bin/kubectl /usr/local/bin/
 
@@ -15,8 +16,6 @@ COPY --from=golangci/golangci-lint:v1.23.7 /usr/bin/golangci-lint /usr/local/bin
 
 RUN wget -O /usr/local/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/v0.11.1/kind-linux-amd64 \
     && chmod +x /usr/local/bin/kind
-
-RUN apt-get clean
 
 ENV CGO_ENABLED=0 \
     GO111MODULE="on" \

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -1,12 +1,9 @@
-FROM alpine:3.10.5
+FROM golang:1.19.2-buster
 
 LABEL maintainer="Tom Manville<tom@kasten.io>"
 
-RUN apk add --update --no-cache ca-certificates bash git docker curl jq \
-    && update-ca-certificates \
-    && rm -rf /var/cache/apk/*
-
-COPY --from=golang:1.17.6-alpine3.15 /usr/local/go/ /usr/local/go/
+RUN apt-get update && apt-get -y install ca-certificates bash git docker curl jq wget \
+    && update-ca-certificates
 
 COPY --from=bitnami/kubectl:1.17 /opt/bitnami/kubectl/bin/kubectl /usr/local/bin/
 
@@ -18,6 +15,8 @@ COPY --from=golangci/golangci-lint:v1.23.7 /usr/bin/golangci-lint /usr/local/bin
 
 RUN wget -O /usr/local/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/v0.11.1/kind-linux-amd64 \
     && chmod +x /usr/local/bin/kind
+
+RUN apt-get clean
 
 ENV CGO_ENABLED=0 \
     GO111MODULE="on" \


### PR DESCRIPTION
## Change Overview

This PR updates the kanister build image to use go 1.19.2 and also debian instead of alpine, since alpine use musl libc.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [x] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
