### PR TITLE
Update goreleaser to use boring

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,6 +12,7 @@ builds:
     -X github.com/kanisterio/kanister/pkg/version.GIT_COMMIT={{.Commit}}
     -X github.com/kanisterio/kanister/pkg/version.BUILD_DATE={{.Date}}
   env: &env
+  - GO111MODULE=on
   - CGO_ENABLED=1
   - GOEXPERIMENT=boringcrypto
   - CC=gcc

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,7 +7,8 @@ builds:
   binary: kanctl
   main: cmd/kanctl/main.go
   ldflags: &ldflags
-  - -X github.com/kanisterio/kanister/pkg/version.VERSION={{.Version}}
+  - -extldflags "-static"
+    -X github.com/kanisterio/kanister/pkg/version.VERSION={{.Version}}
     -X github.com/kanisterio/kanister/pkg/version.GIT_COMMIT={{.Commit}}
     -X github.com/kanisterio/kanister/pkg/version.BUILD_DATE={{.Date}}
   env: &env

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,16 +7,17 @@ builds:
   binary: kanctl
   main: cmd/kanctl/main.go
   ldflags: &ldflags
-  - -s -w
+  - -w
     -X github.com/kanisterio/kanister/pkg/version.VERSION={{.Version}}
     -X github.com/kanisterio/kanister/pkg/version.GIT_COMMIT={{.Commit}}
     -X github.com/kanisterio/kanister/pkg/version.BUILD_DATE={{.Date}}
   env: &env
-  - GO111MODULE=on
-  - CGO_ENABLED=0
+  - CGO_ENABLED=1
+  - GOEXPERIMENT=boringcrypto
+  - CC=gcc
+  - CXX=g++
   - GO_EXTLINK_ENABLED=0
   goos:
-  - darwin
   - linux
   goarch: &goarch
   - amd64

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,8 +7,7 @@ builds:
   binary: kanctl
   main: cmd/kanctl/main.go
   ldflags: &ldflags
-  - -w
-    -X github.com/kanisterio/kanister/pkg/version.VERSION={{.Version}}
+  - -X github.com/kanisterio/kanister/pkg/version.VERSION={{.Version}}
     -X github.com/kanisterio/kanister/pkg/version.GIT_COMMIT={{.Commit}}
     -X github.com/kanisterio/kanister/pkg/version.BUILD_DATE={{.Date}}
   env: &env

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ IMAGE_NAME := $(BIN)
 
 IMAGE := $(REGISTRY)/$(IMAGE_NAME)
 
-BUILD_IMAGE ?= ghcr.io/kanisterio/build:v0.0.21
+BUILD_IMAGE ?= ghcr.io/kanisterio/build:v0.0.22
 
 # tag 0.1.0 is, 0.0.1 (latest) + gh + aws + helm binary
 DOCS_BUILD_IMAGE ?= ghcr.io/kanisterio/docker-sphinx:0.2.0

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get -y install apt-transport-https ca-certificates bas
 
 COPY --from=bitnami/kubectl:1.17 /opt/bitnami/kubectl/bin/kubectl /usr/local/bin/
 
-COPY --from=goreleaser/goreleaser:v1.2.4 /usr/local/bin/goreleaser /usr/local/bin/
+COPY --from=goreleaser/goreleaser:v1.12.3 /usr/bin/goreleaser /usr/local/bin/
 
 COPY --from=alpine/helm:3.2.0 /usr/bin/helm /usr/local/bin/
 


### PR DESCRIPTION
## Change Overview

This PR updates goreleaser to build boring versions of kanister tools

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [x] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
