### PR TITLE
Update Makefile to build kopia image b9be9632a27751860c870732a74b076c2cd9d42a

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,8 @@ DOCKER_CONFIG ?= "$(HOME)/.docker"
 # Mention the vm-driver that should be used to install OpenShift
 vm-driver ?= "kvm"
 
-# Refers to https://github.com/kopia/kopia/commit/317cc36892707ab9bdc5f6e4dea567d1e638a070
-KOPIA_COMMIT_ID ?= "317cc36"
+# Refers to https://github.com/kopia/kopia/commit/b9be9632a27751860c870732a74b076c2cd9d42a
+KOPIA_COMMIT_ID ?= "b9be963"
 
 KOPIA_REPO ?= "kopia"
 # Default OCP version in which the OpenShift apps are going to run


### PR DESCRIPTION
## Change Overview

This PR updates kopia commit in Makefile to https://github.com/kopia/kopia/commit/b9be9632a27751860c870732a74b076c2cd9d42a. This will push the image and can be used in kanister-tools image.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
