### PR TITLE
Update Go v1.19.3 in build images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ IMAGE_NAME := $(BIN)
 
 IMAGE := $(REGISTRY)/$(IMAGE_NAME)
 
-BUILD_IMAGE ?= ghcr.io/kanisterio/build:v0.0.22
+BUILD_IMAGE ?= ghcr.io/kanisterio/build:v0.0.23
 
 # tag 0.1.0 is, 0.0.1 (latest) + gh + aws + helm binary
 DOCS_BUILD_IMAGE ?= ghcr.io/kanisterio/docker-sphinx:0.2.0

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-bullseye
+FROM golang:1.19.3-bullseye
 
 LABEL maintainer="Tom Manville<tom@kasten.io>"
 

--- a/docker/kopia-build/Dockerfile
+++ b/docker/kopia-build/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-bullseye AS builder
+FROM golang:1.19.3-bullseye AS builder
 
 ARG kopiaBuildCommit
 ARG kopiaRepoOrg


### PR DESCRIPTION
## Change Overview

This PR updates Go version in the build images to  v1.19.3

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [x] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E

Successfully build container images for build and kopia-build
