### PR TITLE
Direct passing WebIdentity token to AWS provider

### DIFF
--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -16,7 +16,6 @@ package aws
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"time"
 
@@ -105,7 +104,7 @@ func authenticateAWSCredentials(ctx context.Context, config map[string]string, a
 		}
 		assumedRole = os.Getenv(roleARNEnvKey)
 	default:
-		return nil, "", errors.New(fmt.Sprintf("%s and %s required to initialize AWS credentials", AccessKeyID, SecretAccessKey))
+		return nil, "", errors.Errorf("%s and %s required to initialize AWS credentials", AccessKeyID, SecretAccessKey)
 	}
 	return creds, assumedRole, nil
 }


### PR DESCRIPTION
## Change Overview

Allowing to pass Role ARN and Web Identity token for token-based AWS authentication. 

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [x] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
