### PR TITLE
Use current nodejs version for elasticsearch sidecar Image

### DIFF
--- a/docker/kanister-elasticsearch/image/Dockerfile
+++ b/docker/kanister-elasticsearch/image/Dockerfile
@@ -7,7 +7,9 @@ COPY --from=TOOLS_IMAGE /usr/local/bin/kopia /usr/local/bin/kopia
 ADD kando /usr/local/bin/
 
 RUN apt update
-RUN apt install -y nodejs npm bash curl
+RUN apt install -y npm bash curl
+RUN curl -fsSL https://deb.nodesource.com/setup_current.x | bash - && \
+ apt-get install -y nodejs
 RUN npm install -g npm yo grunt-cli bower express
 RUN npm install elasticdump -g
 


### PR DESCRIPTION
## Change Overview

We needed nodejs version >= 13 for npm version 9.1.1 that is being used in elastic sidecar image. This PR updates the docker file to use current version.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #1733

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [x] :green_heart: E2E

Build the image and use it in integration test
`make integration-test`

[Test logs](https://gist.github.com/akankshakumari393/66e9bf74aebff38b33e9b2ba055ca7b9)
