### PR TITLE
gofmt issue fixes as per goreportcard (#1274)

### DIFF
--- a/build/golint.sh
+++ b/build/golint.sh
@@ -24,6 +24,13 @@ echo "Running golangci-lint..."
 
 golangci-lint run --timeout ${TIMEOUT} --skip-dirs ${SKIP_DIR_REGEX} -E maligned,whitespace,gocognit,unparam -e '`ctx` is unused'
 
+# gofmt should run everywhere, including
+#   1. Skipped directories in previous step
+#   2. Build exempted files using build tags
+#      Note: Future build tags should be included.
+echo "Running gofmt..."
+golangci-lint run --timeout ${TIMEOUT} --disable-all --enable gofmt --build-tags integration
+
 echo "PASS"
 echo
 

--- a/pkg/app/bp_test.go
+++ b/pkg/app/bp_test.go
@@ -36,15 +36,15 @@ var _ = Suite(&BlueprintSuite{})
 func (bs *BlueprintSuite) TestUpdateImageTags(c *C) {
 	for _, bp := range []*crv1alpha1.Blueprint{
 		// BP with no phase with image arg
-		&crv1alpha1.Blueprint{
+		{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "test-blueprint-",
 			},
 			Actions: map[string]*crv1alpha1.BlueprintAction{
-				"test": &crv1alpha1.BlueprintAction{
+				"test": {
 					Kind: "Deployment",
 					Phases: []crv1alpha1.BlueprintPhase{
-						crv1alpha1.BlueprintPhase{
+						{
 							Func: function.KubeExecFuncName,
 							Name: "test-kube-exec",
 							Args: map[string]interface{}{
@@ -60,15 +60,15 @@ func (bs *BlueprintSuite) TestUpdateImageTags(c *C) {
 		},
 
 		// BP with multiple phases with image arg
-		&crv1alpha1.Blueprint{
+		{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "test-blueprint-",
 			},
 			Actions: map[string]*crv1alpha1.BlueprintAction{
-				"test": &crv1alpha1.BlueprintAction{
+				"test": {
 					Kind: "Deployment",
 					Phases: []crv1alpha1.BlueprintPhase{
-						crv1alpha1.BlueprintPhase{
+						{
 							Func: function.KubeTaskFuncName,
 							Name: "test-kube-task",
 							Args: map[string]interface{}{
@@ -77,7 +77,7 @@ func (bs *BlueprintSuite) TestUpdateImageTags(c *C) {
 								"command":   []string{"echo", "hello"},
 							},
 						},
-						crv1alpha1.BlueprintPhase{
+						{
 							Func: function.KubeTaskFuncName,
 							Name: "test-kube-task2",
 							Args: map[string]interface{}{
@@ -91,15 +91,15 @@ func (bs *BlueprintSuite) TestUpdateImageTags(c *C) {
 		},
 
 		// BP with multiple actions
-		&crv1alpha1.Blueprint{
+		{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "test-blueprint-",
 			},
 			Actions: map[string]*crv1alpha1.BlueprintAction{
-				"test": &crv1alpha1.BlueprintAction{
+				"test": {
 					Kind: "Deployment",
 					Phases: []crv1alpha1.BlueprintPhase{
-						crv1alpha1.BlueprintPhase{
+						{
 							Func: function.KubeTaskFuncName,
 							Name: "test-kube-task",
 							Args: map[string]interface{}{
@@ -108,7 +108,7 @@ func (bs *BlueprintSuite) TestUpdateImageTags(c *C) {
 								"command":   []string{"echo", "hello"},
 							},
 						},
-						crv1alpha1.BlueprintPhase{
+						{
 							Func: function.KubeTaskFuncName,
 							Name: "test-kube-task2",
 							Args: map[string]interface{}{
@@ -118,9 +118,9 @@ func (bs *BlueprintSuite) TestUpdateImageTags(c *C) {
 						},
 					},
 				},
-				"test2": &crv1alpha1.BlueprintAction{
+				"test2": {
 					Phases: []crv1alpha1.BlueprintPhase{
-						crv1alpha1.BlueprintPhase{
+						{
 							Func: function.PrepareDataFuncName,
 							Name: "test-prepare-data",
 							Args: map[string]interface{}{

--- a/pkg/app/elasticsearch.go
+++ b/pkg/app/elasticsearch.go
@@ -146,7 +146,7 @@ func (esi *ElasticsearchInstance) Uninstall(ctx context.Context) error {
 
 func (esi *ElasticsearchInstance) Secrets() map[string]crv1alpha1.ObjectReference {
 	return map[string]crv1alpha1.ObjectReference{
-		"elasticsearch": crv1alpha1.ObjectReference{
+		"elasticsearch": {
 			Kind:      "Secret",
 			Name:      esi.chart.Chart + "-master-credentials",
 			Namespace: esi.namespace,

--- a/pkg/app/mysql.go
+++ b/pkg/app/mysql.go
@@ -229,7 +229,7 @@ func (mdb *MysqlDB) ConfigMaps() map[string]crv1alpha1.ObjectReference {
 
 func (mdb *MysqlDB) Secrets() map[string]crv1alpha1.ObjectReference {
 	return map[string]crv1alpha1.ObjectReference{
-		"mysql": crv1alpha1.ObjectReference{
+		"mysql": {
 			Kind:      "Secret",
 			Name:      mdb.chart.Release,
 			Namespace: mdb.namespace,

--- a/pkg/app/postgresql.go
+++ b/pkg/app/postgresql.go
@@ -123,7 +123,7 @@ func (pdb PostgresDB) ConfigMaps() map[string]crv1alpha1.ObjectReference {
 
 func (pdb PostgresDB) Secrets() map[string]crv1alpha1.ObjectReference {
 	return map[string]crv1alpha1.ObjectReference{
-		"postgresql": crv1alpha1.ObjectReference{
+		"postgresql": {
 			Kind:      "secret",
 			Name:      pdb.getStatefulSetName(),
 			Namespace: pdb.namespace,

--- a/pkg/app/rds_postgres.go
+++ b/pkg/app/rds_postgres.go
@@ -318,7 +318,7 @@ func (pdb RDSPostgresDB) Initialize(ctx context.Context) error {
 
 func (pdb RDSPostgresDB) ConfigMaps() map[string]crv1alpha1.ObjectReference {
 	return map[string]crv1alpha1.ObjectReference{
-		"dbconfig": crv1alpha1.ObjectReference{
+		"dbconfig": {
 			Kind:      "configmap",
 			Name:      pdb.configMapName,
 			Namespace: pdb.namespace,
@@ -328,7 +328,7 @@ func (pdb RDSPostgresDB) ConfigMaps() map[string]crv1alpha1.ObjectReference {
 
 func (pdb RDSPostgresDB) Secrets() map[string]crv1alpha1.ObjectReference {
 	return map[string]crv1alpha1.ObjectReference{
-		"dbsecret": crv1alpha1.ObjectReference{
+		"dbsecret": {
 			Kind:      "secret",
 			Name:      pdb.secretName,
 			Namespace: pdb.namespace,

--- a/pkg/blockstorage/zone/zone_test.go
+++ b/pkg/blockstorage/zone/zone_test.go
@@ -45,7 +45,7 @@ func (s ZoneSuite) TestNodeZoneAndRegionGCP(c *C) {
 		},
 		Status: v1.NodeStatus{
 			Conditions: []v1.NodeCondition{
-				v1.NodeCondition{
+				{
 					Status: "True",
 					Type:   "Ready",
 				},
@@ -59,7 +59,7 @@ func (s ZoneSuite) TestNodeZoneAndRegionGCP(c *C) {
 		},
 		Status: v1.NodeStatus{
 			Conditions: []v1.NodeCondition{
-				v1.NodeCondition{
+				{
 					Status: "True",
 					Type:   "Ready",
 				},
@@ -73,7 +73,7 @@ func (s ZoneSuite) TestNodeZoneAndRegionGCP(c *C) {
 		},
 		Status: v1.NodeStatus{
 			Conditions: []v1.NodeCondition{
-				v1.NodeCondition{
+				{
 					Status: "True",
 					Type:   "Ready",
 				},
@@ -88,7 +88,7 @@ func (s ZoneSuite) TestNodeZoneAndRegionGCP(c *C) {
 		},
 		Status: v1.NodeStatus{
 			Conditions: []v1.NodeCondition{
-				v1.NodeCondition{
+				{
 					Status: "False",
 					Type:   "Ready",
 				},
@@ -105,7 +105,7 @@ func (s ZoneSuite) TestNodeZoneAndRegionGCP(c *C) {
 		},
 		Status: v1.NodeStatus{
 			Conditions: []v1.NodeCondition{
-				v1.NodeCondition{
+				{
 					Status: "True",
 					Type:   "Ready",
 				},
@@ -136,7 +136,7 @@ func (s ZoneSuite) TestNodeZoneAndRegionEBS(c *C) {
 		},
 		Status: v1.NodeStatus{
 			Conditions: []v1.NodeCondition{
-				v1.NodeCondition{
+				{
 					Status: "True",
 					Type:   "Ready",
 				},
@@ -150,7 +150,7 @@ func (s ZoneSuite) TestNodeZoneAndRegionEBS(c *C) {
 		},
 		Status: v1.NodeStatus{
 			Conditions: []v1.NodeCondition{
-				v1.NodeCondition{
+				{
 					Status: "True",
 					Type:   "Ready",
 				},
@@ -164,7 +164,7 @@ func (s ZoneSuite) TestNodeZoneAndRegionEBS(c *C) {
 		},
 		Status: v1.NodeStatus{
 			Conditions: []v1.NodeCondition{
-				v1.NodeCondition{
+				{
 					Status: "True",
 					Type:   "Ready",
 				},
@@ -179,7 +179,7 @@ func (s ZoneSuite) TestNodeZoneAndRegionEBS(c *C) {
 		},
 		Status: v1.NodeStatus{
 			Conditions: []v1.NodeCondition{
-				v1.NodeCondition{
+				{
 					Status: "False",
 					Type:   "Ready",
 				},
@@ -196,7 +196,7 @@ func (s ZoneSuite) TestNodeZoneAndRegionEBS(c *C) {
 		},
 		Status: v1.NodeStatus{
 			Conditions: []v1.NodeCondition{
-				v1.NodeCondition{
+				{
 					Status: "True",
 					Type:   "Ready",
 				},
@@ -227,7 +227,7 @@ func (s ZoneSuite) TestNodeZoneAndRegionAD(c *C) {
 		},
 		Status: v1.NodeStatus{
 			Conditions: []v1.NodeCondition{
-				v1.NodeCondition{
+				{
 					Status: "True",
 					Type:   "Ready",
 				},
@@ -241,7 +241,7 @@ func (s ZoneSuite) TestNodeZoneAndRegionAD(c *C) {
 		},
 		Status: v1.NodeStatus{
 			Conditions: []v1.NodeCondition{
-				v1.NodeCondition{
+				{
 					Status: "True",
 					Type:   "Ready",
 				},
@@ -255,7 +255,7 @@ func (s ZoneSuite) TestNodeZoneAndRegionAD(c *C) {
 		},
 		Status: v1.NodeStatus{
 			Conditions: []v1.NodeCondition{
-				v1.NodeCondition{
+				{
 					Status: "True",
 					Type:   "Ready",
 				},
@@ -270,7 +270,7 @@ func (s ZoneSuite) TestNodeZoneAndRegionAD(c *C) {
 		},
 		Status: v1.NodeStatus{
 			Conditions: []v1.NodeCondition{
-				v1.NodeCondition{
+				{
 					Status: "True",
 					Type:   "Ready",
 				},
@@ -285,7 +285,7 @@ func (s ZoneSuite) TestNodeZoneAndRegionAD(c *C) {
 		},
 		Status: v1.NodeStatus{
 			Conditions: []v1.NodeCondition{
-				v1.NodeCondition{
+				{
 					Status: "False",
 					Type:   "Ready",
 				},
@@ -302,7 +302,7 @@ func (s ZoneSuite) TestNodeZoneAndRegionAD(c *C) {
 		},
 		Status: v1.NodeStatus{
 			Conditions: []v1.NodeCondition{
-				v1.NodeCondition{
+				{
 					Status: "True",
 					Type:   "Ready",
 				},
@@ -435,7 +435,7 @@ func (s ZoneSuite) TestFromSourceRegionZone(c *C) {
 		},
 		Status: v1.NodeStatus{
 			Conditions: []v1.NodeCondition{
-				v1.NodeCondition{
+				{
 					Status: "True",
 					Type:   "Ready",
 				},
@@ -449,7 +449,7 @@ func (s ZoneSuite) TestFromSourceRegionZone(c *C) {
 		},
 		Status: v1.NodeStatus{
 			Conditions: []v1.NodeCondition{
-				v1.NodeCondition{
+				{
 					Status: "True",
 					Type:   "Ready",
 				},
@@ -463,7 +463,7 @@ func (s ZoneSuite) TestFromSourceRegionZone(c *C) {
 		},
 		Status: v1.NodeStatus{
 			Conditions: []v1.NodeCondition{
-				v1.NodeCondition{
+				{
 					Status: "True",
 					Type:   "Ready",
 				},
@@ -478,7 +478,7 @@ func (s ZoneSuite) TestFromSourceRegionZone(c *C) {
 		},
 		Status: v1.NodeStatus{
 			Conditions: []v1.NodeCondition{
-				v1.NodeCondition{
+				{
 					Status: "True",
 					Type:   "Ready",
 				},
@@ -493,7 +493,7 @@ func (s ZoneSuite) TestFromSourceRegionZone(c *C) {
 		},
 		Status: v1.NodeStatus{
 			Conditions: []v1.NodeCondition{
-				v1.NodeCondition{
+				{
 					Status: "True",
 					Type:   "Ready",
 				},
@@ -508,7 +508,7 @@ func (s ZoneSuite) TestFromSourceRegionZone(c *C) {
 		},
 		Status: v1.NodeStatus{
 			Conditions: []v1.NodeCondition{
-				v1.NodeCondition{
+				{
 					Status: "True",
 					Type:   "Ready",
 				},
@@ -523,7 +523,7 @@ func (s ZoneSuite) TestFromSourceRegionZone(c *C) {
 		},
 		Status: v1.NodeStatus{
 			Conditions: []v1.NodeCondition{
-				v1.NodeCondition{
+				{
 					Status: "True",
 					Type:   "Ready",
 				},
@@ -679,7 +679,7 @@ func (s ZoneSuite) TestGetReadySchedulableNodes(c *C) {
 		},
 		Status: v1.NodeStatus{
 			Conditions: []v1.NodeCondition{
-				v1.NodeCondition{
+				{
 					Status: "True",
 					Type:   "Ready",
 				},
@@ -696,7 +696,7 @@ func (s ZoneSuite) TestGetReadySchedulableNodes(c *C) {
 		},
 		Status: v1.NodeStatus{
 			Conditions: []v1.NodeCondition{
-				v1.NodeCondition{
+				{
 					Status: "True",
 					Type:   "Ready",
 				},
@@ -710,7 +710,7 @@ func (s ZoneSuite) TestGetReadySchedulableNodes(c *C) {
 		},
 		Status: v1.NodeStatus{
 			Conditions: []v1.NodeCondition{
-				v1.NodeCondition{
+				{
 					Status: "False",
 					Type:   "Ready",
 				},
@@ -737,15 +737,15 @@ func (s ZoneSuite) TestConsistentZones(c *C) {
 	c.Assert(z, Equals, "")
 
 	az1 := map[string]struct{}{
-		"a": struct{}{},
-		"b": struct{}{},
-		"c": struct{}{},
+		"a": {},
+		"b": {},
+		"c": {},
 	}
 
 	az2 := map[string]struct{}{
-		"c": struct{}{},
-		"a": struct{}{},
-		"b": struct{}{},
+		"c": {},
+		"a": {},
+		"b": {},
 	}
 
 	z1 := consistentZone("x", az1)

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -203,9 +203,9 @@ func newBPWithOutputArtifact() *crv1alpha1.Blueprint {
 			GenerateName: "test-blueprint-",
 		},
 		Actions: map[string]*crv1alpha1.BlueprintAction{
-			"myAction": &crv1alpha1.BlueprintAction{
+			"myAction": {
 				OutputArtifacts: map[string]crv1alpha1.Artifact{
-					"myArt": crv1alpha1.Artifact{
+					"myArt": {
 						KeyValue: map[string]string{
 							"key": "{{ .Phases.myPhase0.Output.key }}",
 						},
@@ -347,9 +347,9 @@ func newBPWithFakeOutputArtifact() *crv1alpha1.Blueprint {
 			GenerateName: "test-blueprint-",
 		},
 		Actions: map[string]*crv1alpha1.BlueprintAction{
-			"myAction": &crv1alpha1.BlueprintAction{
+			"myAction": {
 				OutputArtifacts: map[string]crv1alpha1.Artifact{
-					"myArt": crv1alpha1.Artifact{
+					"myArt": {
 						KeyValue: map[string]string{
 							"key": "{{ .Phases.myPhase0.Output.myKey }}",
 						},
@@ -375,7 +375,7 @@ func newBPWithKopiaSnapshotOutputArtifact() *crv1alpha1.Blueprint {
 		Actions: map[string]*crv1alpha1.BlueprintAction{
 			"myAction": {
 				OutputArtifacts: map[string]crv1alpha1.Artifact{
-					"myArt": crv1alpha1.Artifact{
+					"myArt": {
 						KopiaSnapshot: "{{ .Phases.myPhase0.Output.key }}",
 					},
 				},
@@ -418,7 +418,7 @@ func (s *ControllerSuite) TestSynchronousFailure(c *C) {
 		},
 		Spec: &crv1alpha1.ActionSetSpec{
 			Actions: []crv1alpha1.ActionSpec{
-				crv1alpha1.ActionSpec{
+				{
 					Object: crv1alpha1.ObjectReference{
 						Name: "foo",
 						Kind: param.NamespaceKind,
@@ -595,7 +595,7 @@ func (s *ControllerSuite) TestRuntimeObjEventLogs(c *C) {
 		},
 		Spec: &crv1alpha1.ActionSetSpec{
 			Actions: []crv1alpha1.ActionSpec{
-				crv1alpha1.ActionSpec{
+				{
 					Blueprint: "NONEXISTANT_BLUEPRINT",
 				},
 			},
@@ -846,7 +846,7 @@ func (s *ControllerSuite) TestActionSetExecWithoutProfile(c *C) {
 		},
 		Spec: &crv1alpha1.ActionSetSpec{
 			Actions: []crv1alpha1.ActionSpec{
-				crv1alpha1.ActionSpec{
+				{
 					Blueprint: bp.GetName(),
 					Name:      "myAction",
 					Object: crv1alpha1.ObjectReference{

--- a/pkg/function/kubeops_test.go
+++ b/pkg/function/kubeops_test.go
@@ -333,7 +333,7 @@ func getSampleCRD() *extensionsv1.CustomResourceDefinition {
 			},
 			Scope: extensionsv1.ResourceScope("Namespaced"),
 			Versions: []extensionsv1.CustomResourceDefinitionVersion{
-				extensionsv1.CustomResourceDefinitionVersion{
+				{
 					Name:    "v1alpha1",
 					Served:  true,
 					Storage: true,

--- a/pkg/kube/exec_test.go
+++ b/pkg/kube/exec_test.go
@@ -54,7 +54,7 @@ func (s *ExecSuite) SetUpSuite(c *C) {
 		ObjectMeta: metav1.ObjectMeta{Name: "testpod"},
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{
-				v1.Container{
+				{
 					Name:    "testcontainer",
 					Image:   "busybox",
 					Command: []string{"sh", "-c", "tail -f /dev/null"},
@@ -186,7 +186,7 @@ func (s *ExecSuite) TestKopiaCommand(c *C) {
 		},
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{
-				v1.Container{
+				{
 					Name:  "kanister-sidecar",
 					Image: "ghcr.io/kanisterio/kanister-tools:0.37.0",
 				},

--- a/pkg/kube/pod_writer_test.go
+++ b/pkg/kube/pod_writer_test.go
@@ -53,7 +53,7 @@ func (p *PodWriteSuite) SetUpSuite(c *C) {
 		ObjectMeta: metav1.ObjectMeta{Name: "testpod"},
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{
-				v1.Container{
+				{
 					Name:    "testcontainer",
 					Image:   "busybox",
 					Command: []string{"sh", "-c", "tail -f /dev/null"},

--- a/pkg/kube/workload_test.go
+++ b/pkg/kube/workload_test.go
@@ -74,7 +74,7 @@ func newDeploymentConfig() *osapps.DeploymentConfig {
 				},
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
-						v1.Container{
+						{
 							Image:   "alpine",
 							Name:    "container",
 							Command: []string{"tail", "-f", "/dev/null"},

--- a/pkg/param/param_test.go
+++ b/pkg/param/param_test.go
@@ -150,7 +150,7 @@ func (s *ParamsSuite) TestFetchStatefulSetParams(c *C) {
 		Pods:       []string{name + "-0"},
 		Containers: [][]string{{"test-container"}},
 		PersistentVolumeClaims: map[string]map[string]string{
-			name + "-0": map[string]string{
+			name + "-0": {
 				s.pvc + "-" + name + "-0": "/mnt/data/" + name,
 			},
 		},
@@ -202,7 +202,7 @@ func (s *ParamsSuite) TestFetchDeploymentParams(c *C) {
 	c.Assert(dp.Pods, HasLen, 1)
 	c.Assert(dp.Containers, DeepEquals, [][]string{{"test-container"}})
 	c.Assert(dp.PersistentVolumeClaims, DeepEquals, map[string]map[string]string{
-		dp.Pods[0]: map[string]string{
+		dp.Pods[0]: {
 			s.pvc: "/mnt/data/" + name,
 		},
 	})
@@ -407,7 +407,7 @@ func (s *ParamsSuite) testNewTemplateParams(ctx context.Context, c *C, dynCli dy
 	as := crv1alpha1.ActionSpec{
 		Object: object,
 		ConfigMaps: map[string]crv1alpha1.ObjectReference{
-			"myCM": crv1alpha1.ObjectReference{
+			"myCM": {
 				Name:      object.Name + "-cm",
 				Namespace: s.namespace,
 			},
@@ -436,13 +436,13 @@ func (s *ParamsSuite) testNewTemplateParams(ctx context.Context, c *C, dynCli dy
 	}
 
 	artsTpl := map[string]crv1alpha1.Artifact{
-		"my-art": crv1alpha1.Artifact{KeyValue: map[string]string{
+		"my-art": {KeyValue: map[string]string{
 			"my-key": "{{ .ConfigMaps.myCM.Data.someKey }}"},
 		},
-		"my-time": crv1alpha1.Artifact{KeyValue: map[string]string{
+		"my-time": {KeyValue: map[string]string{
 			"my-time": "{{ .Time }}"},
 		},
-		"kindArtifact": crv1alpha1.Artifact{KeyValue: map[string]string{"my-key": template}},
+		"kindArtifact": {KeyValue: map[string]string{"my-key": template}},
 	}
 	artsTpl["kindArtifact"] = crv1alpha1.Artifact{KeyValue: map[string]string{"my-key": template}}
 	artsTpl["objectNameArtifact"] = crv1alpha1.Artifact{KeyValue: map[string]string{"my-key": unstructuredTemplate}}
@@ -565,7 +565,7 @@ func (s *ParamsSuite) TestProfile(c *C) {
 		},
 		Spec: &crv1alpha1.ActionSetSpec{
 			Actions: []crv1alpha1.ActionSpec{
-				crv1alpha1.ActionSpec{
+				{
 					Object: crv1alpha1.ObjectReference{
 						Kind:      "StatefulSet",
 						Name:      "ssName",
@@ -640,7 +640,7 @@ func (s *ParamsSuite) TestParamsWithoutProfile(c *C) {
 			Kind:      PVCKind,
 		},
 		Secrets: map[string]crv1alpha1.ObjectReference{
-			"actionSetSecret": crv1alpha1.ObjectReference{
+			"actionSetSecret": {
 				Name:      secret.Name,
 				Namespace: secret.Namespace,
 			},
@@ -710,7 +710,7 @@ func (s *ParamsSuite) TestPhaseParams(c *C) {
 			Namespace: s.namespace,
 		},
 		Secrets: map[string]crv1alpha1.ObjectReference{
-			"actionSetSecret": crv1alpha1.ObjectReference{
+			"actionSetSecret": {
 				Name:      secret.Name,
 				Namespace: secret.Namespace,
 			},
@@ -745,7 +745,7 @@ func (s *ParamsSuite) TestRenderingPhaseParams(c *C) {
 	}
 	cli := fake.NewSimpleClientset(secret)
 	secretRef := map[string]crv1alpha1.ObjectReference{
-		"authSecret": crv1alpha1.ObjectReference{
+		"authSecret": {
 			Kind:      SecretKind,
 			Name:      secret.Name,
 			Namespace: secret.Namespace,
@@ -799,7 +799,7 @@ func newDeploymentConfig() *osapps.DeploymentConfig {
 				},
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
-						v1.Container{
+						{
 							Image:   "alpine",
 							Name:    "container",
 							Command: []string{"tail", "-f", "/dev/null"},

--- a/pkg/param/render_test.go
+++ b/pkg/param/render_test.go
@@ -144,7 +144,7 @@ func (s *RenderSuite) TestRenderObjects(c *C) {
 		},
 	}
 	in := map[string]crv1alpha1.ObjectReference{
-		"authSecret": crv1alpha1.ObjectReference{
+		"authSecret": {
 			Kind: SecretKind,
 			Name: "{{ .Object.spec.authSecret }}",
 		},
@@ -157,7 +157,7 @@ func (s *RenderSuite) TestRenderObjects(c *C) {
 func (s *RenderSuite) TestRenderArtifacts(c *C) {
 	tp := TemplateParams{
 		Phases: map[string]*Phase{
-			"myPhase": &Phase{
+			"myPhase": {
 				Output: map[string]interface{}{
 					"kopiaSnapshot": "a-snapshot-id",
 				},
@@ -173,13 +173,13 @@ func (s *RenderSuite) TestRenderArtifacts(c *C) {
 	}{
 		{
 			art: map[string]crv1alpha1.Artifact{
-				"myArt": crv1alpha1.Artifact{
+				"myArt": {
 					KopiaSnapshot: "{{ .Phases.myPhase.Output.kopiaSnapshot }}",
 				},
 			},
 			tp: tp,
 			out: map[string]crv1alpha1.Artifact{
-				"myArt": crv1alpha1.Artifact{
+				"myArt": {
 					KopiaSnapshot: "a-snapshot-id",
 				},
 			},
@@ -188,7 +188,7 @@ func (s *RenderSuite) TestRenderArtifacts(c *C) {
 
 		{
 			art: map[string]crv1alpha1.Artifact{
-				"myArt": crv1alpha1.Artifact{
+				"myArt": {
 					KeyValue: map[string]string{
 						"key": "{{ .Phases.myPhase.Output.kopiaSnapshot }}",
 					},
@@ -196,7 +196,7 @@ func (s *RenderSuite) TestRenderArtifacts(c *C) {
 			},
 			tp: tp,
 			out: map[string]crv1alpha1.Artifact{
-				"myArt": crv1alpha1.Artifact{
+				"myArt": {
 					KeyValue: map[string]string{
 						"key": "a-snapshot-id",
 					},

--- a/pkg/poll/poll_test.go
+++ b/pkg/poll/poll_test.go
@@ -65,7 +65,7 @@ func (s *PollSuite) TestWaitWithBackoff(c *C) {
 			f: mockPollFunc{
 				c: c,
 				res: []pollFuncResult{
-					pollFuncResult{ok: true, err: nil},
+					{ok: true, err: nil},
 				},
 			},
 			checker: IsNil,
@@ -74,7 +74,7 @@ func (s *PollSuite) TestWaitWithBackoff(c *C) {
 			f: mockPollFunc{
 				c: c,
 				res: []pollFuncResult{
-					pollFuncResult{ok: false, err: errFake},
+					{ok: false, err: errFake},
 				},
 			},
 			checker: NotNil,
@@ -83,7 +83,7 @@ func (s *PollSuite) TestWaitWithBackoff(c *C) {
 			f: mockPollFunc{
 				c: c,
 				res: []pollFuncResult{
-					pollFuncResult{ok: true, err: errFake},
+					{ok: true, err: errFake},
 				},
 			},
 			checker: NotNil,
@@ -92,8 +92,8 @@ func (s *PollSuite) TestWaitWithBackoff(c *C) {
 			f: mockPollFunc{
 				c: c,
 				res: []pollFuncResult{
-					pollFuncResult{ok: false, err: nil},
-					pollFuncResult{ok: true, err: nil},
+					{ok: false, err: nil},
+					{ok: true, err: nil},
 				},
 			},
 			checker: IsNil,
@@ -102,8 +102,8 @@ func (s *PollSuite) TestWaitWithBackoff(c *C) {
 			f: mockPollFunc{
 				c: c,
 				res: []pollFuncResult{
-					pollFuncResult{ok: false, err: nil},
-					pollFuncResult{ok: true, err: errFake},
+					{ok: false, err: nil},
+					{ok: true, err: errFake},
 				},
 			},
 			checker: NotNil,

--- a/pkg/reconcile/reconcile_test.go
+++ b/pkg/reconcile/reconcile_test.go
@@ -71,7 +71,7 @@ func (s *ReconcileSuite) SetUpSuite(c *C) {
 		},
 		Spec: &crv1alpha1.ActionSetSpec{
 			Actions: []crv1alpha1.ActionSpec{
-				crv1alpha1.ActionSpec{
+				{
 					Object: crv1alpha1.ObjectReference{
 						Name: "foo",
 						Kind: param.StatefulSetKind,
@@ -81,12 +81,12 @@ func (s *ReconcileSuite) SetUpSuite(c *C) {
 		},
 		Status: &crv1alpha1.ActionSetStatus{
 			Actions: []crv1alpha1.ActionStatus{
-				crv1alpha1.ActionStatus{
+				{
 					Phases: []crv1alpha1.Phase{
-						crv1alpha1.Phase{
+						{
 							State: crv1alpha1.StatePending,
 						},
-						crv1alpha1.Phase{
+						{
 							State: crv1alpha1.StatePending,
 						},
 					},

--- a/pkg/testing/e2e_test.go
+++ b/pkg/testing/e2e_test.go
@@ -109,10 +109,10 @@ func (s *E2ESuite) TestKubeExec(c *C) {
 			GenerateName: "test-blueprint-",
 		},
 		Actions: map[string]*crv1alpha1.BlueprintAction{
-			"test": &crv1alpha1.BlueprintAction{
+			"test": {
 				Kind: "Deployment",
 				Phases: []crv1alpha1.BlueprintPhase{
-					crv1alpha1.BlueprintPhase{
+					{
 						Func: function.KubeExecFuncName,
 						Name: "test-kube-exec",
 						Args: map[string]interface{}{
@@ -136,7 +136,7 @@ func (s *E2ESuite) TestKubeExec(c *C) {
 		},
 		Spec: &crv1alpha1.ActionSetSpec{
 			Actions: []crv1alpha1.ActionSpec{
-				crv1alpha1.ActionSpec{
+				{
 					Name: "test",
 					Object: crv1alpha1.ObjectReference{
 						Kind:      "Deployment",
@@ -221,10 +221,10 @@ func (s *E2ESuite) TestKubeTask(c *C) {
 			GenerateName: "test-blueprint-",
 		},
 		Actions: map[string]*crv1alpha1.BlueprintAction{
-			"test": &crv1alpha1.BlueprintAction{
+			"test": {
 				Kind: "Deployment",
 				Phases: []crv1alpha1.BlueprintPhase{
-					crv1alpha1.BlueprintPhase{
+					{
 						Func: function.KubeTaskFuncName,
 						Name: "test-kube-task",
 						Args: map[string]interface{}{
@@ -256,7 +256,7 @@ func (s *E2ESuite) TestKubeTask(c *C) {
 		},
 		Spec: &crv1alpha1.ActionSetSpec{
 			Actions: []crv1alpha1.ActionSpec{
-				crv1alpha1.ActionSpec{
+				{
 					Name: "test",
 					Object: crv1alpha1.ObjectReference{
 						Kind:      "Deployment",

--- a/pkg/testing/integration_test.go
+++ b/pkg/testing/integration_test.go
@@ -322,7 +322,7 @@ func newActionSet(bpName, profile, profileNs string, object crv1alpha1.ObjectRef
 		},
 		Spec: &crv1alpha1.ActionSetSpec{
 			Actions: []crv1alpha1.ActionSpec{
-				crv1alpha1.ActionSpec{
+				{
 					Name:      "backup",
 					Object:    object,
 					Blueprint: bpName,
@@ -358,7 +358,7 @@ func validateBlueprint(c *C, bp crv1alpha1.Blueprint, configMaps, secrets map[st
 		// Validate BP action ConfigMapNames with the app.ConfigMaps references
 		for _, bpc := range action.ConfigMapNames {
 			validConfig := false
-			for appc, _ := range configMaps {
+			for appc := range configMaps {
 				if appc == bpc {
 					validConfig = true
 				}
@@ -368,7 +368,7 @@ func validateBlueprint(c *C, bp crv1alpha1.Blueprint, configMaps, secrets map[st
 		// Validate BP action SecretNames with the app.Secrets reference
 		for _, bps := range action.SecretNames {
 			validSecret := false
-			for apps, _ := range secrets {
+			for apps := range secrets {
 				if apps == bps {
 					validSecret = true
 				}

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -100,7 +100,7 @@ func newTestPodTemplateSpec() v1.PodTemplateSpec {
 		},
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{
-				v1.Container{
+				{
 					Name:    "test-container",
 					Image:   consts.LatestKanisterToolsImage,
 					Command: []string{"tail"},
@@ -303,7 +303,7 @@ func NewTestBlueprint(poKind string, phaseFuncs ...string) *crv1alpha1.Blueprint
 			GenerateName: "test-blueprint-",
 		},
 		Actions: map[string]*crv1alpha1.BlueprintAction{
-			actionName: &crv1alpha1.BlueprintAction{
+			actionName: {
 				Kind:   "StatefulSet",
 				Phases: make([]crv1alpha1.BlueprintPhase, 0, len(phaseFuncs)),
 			},
@@ -323,7 +323,7 @@ func NewTestBlueprint(poKind string, phaseFuncs ...string) *crv1alpha1.Blueprint
 // ActionSetWithConfigMap function returns a pointer to a new ActionSet test object with CongigMap
 func ActionSetWithConfigMap(as *crv1alpha1.ActionSet, name string) *crv1alpha1.ActionSet {
 	as.Spec.Actions[0].ConfigMaps = map[string]crv1alpha1.ObjectReference{
-		"myCM": crv1alpha1.ObjectReference{
+		"myCM": {
 			Name:      name,
 			Namespace: as.GetNamespace(),
 		},

--- a/pkg/validate/validate_test.go
+++ b/pkg/validate/validate_test.go
@@ -64,13 +64,13 @@ func (s *ValidateSuite) TestActionSet(c *C) {
 				ObjectMeta: metav1.ObjectMeta{Namespace: "ns1"},
 				Spec: &crv1alpha1.ActionSetSpec{
 					Actions: []crv1alpha1.ActionSpec{
-						crv1alpha1.ActionSpec{
+						{
 							Object: crv1alpha1.ObjectReference{
 								Name: "ns1",
 								Kind: param.NamespaceKind,
 							},
 							ConfigMaps: map[string]crv1alpha1.ObjectReference{
-								"testCM": crv1alpha1.ObjectReference{
+								"testCM": {
 									Namespace: "ns2",
 								},
 							},
@@ -85,13 +85,13 @@ func (s *ValidateSuite) TestActionSet(c *C) {
 				ObjectMeta: metav1.ObjectMeta{Namespace: "ns1"},
 				Spec: &crv1alpha1.ActionSetSpec{
 					Actions: []crv1alpha1.ActionSpec{
-						crv1alpha1.ActionSpec{
+						{
 							Object: crv1alpha1.ObjectReference{
 								Name: "ns1",
 								Kind: param.NamespaceKind,
 							},
 							ConfigMaps: map[string]crv1alpha1.ObjectReference{
-								"testCM": crv1alpha1.ObjectReference{
+								"testCM": {
 									Namespace: "ns1",
 								},
 							},
@@ -106,13 +106,13 @@ func (s *ValidateSuite) TestActionSet(c *C) {
 				ObjectMeta: metav1.ObjectMeta{Namespace: "ns1"},
 				Spec: &crv1alpha1.ActionSetSpec{
 					Actions: []crv1alpha1.ActionSpec{
-						crv1alpha1.ActionSpec{
+						{
 							Object: crv1alpha1.ObjectReference{
 								Name: "ns1",
 								Kind: param.NamespaceKind,
 							},
 							Secrets: map[string]crv1alpha1.ObjectReference{
-								"testSecrets": crv1alpha1.ObjectReference{
+								"testSecrets": {
 									Namespace: "ns2",
 								},
 							},
@@ -127,13 +127,13 @@ func (s *ValidateSuite) TestActionSet(c *C) {
 				ObjectMeta: metav1.ObjectMeta{Namespace: "ns1"},
 				Spec: &crv1alpha1.ActionSetSpec{
 					Actions: []crv1alpha1.ActionSpec{
-						crv1alpha1.ActionSpec{
+						{
 							Object: crv1alpha1.ObjectReference{
 								Name: "ns1",
 								Kind: param.NamespaceKind,
 							},
 							Secrets: map[string]crv1alpha1.ObjectReference{
-								"testSecrets": crv1alpha1.ObjectReference{
+								"testSecrets": {
 									Namespace: "ns1",
 								},
 							},
@@ -163,7 +163,7 @@ func (s *ValidateSuite) TestActionSet(c *C) {
 			as: &crv1alpha1.ActionSet{
 				Spec: &crv1alpha1.ActionSetSpec{
 					Actions: []crv1alpha1.ActionSpec{
-						crv1alpha1.ActionSpec{
+						{
 							Object: crv1alpha1.ObjectReference{
 								Name: "ns1",
 								Kind: param.NamespaceKind,
@@ -181,7 +181,7 @@ func (s *ValidateSuite) TestActionSet(c *C) {
 			as: &crv1alpha1.ActionSet{
 				Spec: &crv1alpha1.ActionSetSpec{
 					Actions: []crv1alpha1.ActionSpec{
-						crv1alpha1.ActionSpec{
+						{
 							Object: crv1alpha1.ObjectReference{
 								Name: "ns1",
 								Kind: param.NamespaceKind,
@@ -192,7 +192,7 @@ func (s *ValidateSuite) TestActionSet(c *C) {
 				Status: &crv1alpha1.ActionSetStatus{
 					State: crv1alpha1.StatePending,
 					Actions: []crv1alpha1.ActionStatus{
-						crv1alpha1.ActionStatus{},
+						{},
 					},
 				},
 			},
@@ -202,7 +202,7 @@ func (s *ValidateSuite) TestActionSet(c *C) {
 			as: &crv1alpha1.ActionSet{
 				Spec: &crv1alpha1.ActionSetSpec{
 					Actions: []crv1alpha1.ActionSpec{
-						crv1alpha1.ActionSpec{
+						{
 							Object: crv1alpha1.ObjectReference{
 								Name: "ns1",
 								Kind: param.NamespaceKind,
@@ -213,7 +213,7 @@ func (s *ValidateSuite) TestActionSet(c *C) {
 				Status: &crv1alpha1.ActionSetStatus{
 					State: crv1alpha1.StatePending,
 					Actions: []crv1alpha1.ActionStatus{
-						crv1alpha1.ActionStatus{},
+						{},
 					},
 				},
 			},
@@ -225,7 +225,7 @@ func (s *ValidateSuite) TestActionSet(c *C) {
 				ObjectMeta: metav1.ObjectMeta{Namespace: "ns1"},
 				Spec: &crv1alpha1.ActionSetSpec{
 					Actions: []crv1alpha1.ActionSpec{
-						crv1alpha1.ActionSpec{
+						{
 							Object: crv1alpha1.ObjectReference{
 								Name: "foo",
 								Kind: param.NamespaceKind,
@@ -242,7 +242,7 @@ func (s *ValidateSuite) TestActionSet(c *C) {
 				ObjectMeta: metav1.ObjectMeta{Namespace: "ns1"},
 				Spec: &crv1alpha1.ActionSetSpec{
 					Actions: []crv1alpha1.ActionSpec{
-						crv1alpha1.ActionSpec{
+						{
 							Object: crv1alpha1.ObjectReference{
 								Name: "foo",
 								Kind: param.StatefulSetKind,
@@ -259,7 +259,7 @@ func (s *ValidateSuite) TestActionSet(c *C) {
 				ObjectMeta: metav1.ObjectMeta{Namespace: "ns1"},
 				Spec: &crv1alpha1.ActionSetSpec{
 					Actions: []crv1alpha1.ActionSpec{
-						crv1alpha1.ActionSpec{
+						{
 							Object: crv1alpha1.ObjectReference{
 								Name: "foo",
 								Kind: param.DeploymentKind,
@@ -276,7 +276,7 @@ func (s *ValidateSuite) TestActionSet(c *C) {
 				ObjectMeta: metav1.ObjectMeta{Namespace: "ns1"},
 				Spec: &crv1alpha1.ActionSetSpec{
 					Actions: []crv1alpha1.ActionSpec{
-						crv1alpha1.ActionSpec{
+						{
 							Object: crv1alpha1.ObjectReference{
 								Name: "foo",
 								Kind: param.PVCKind,
@@ -293,7 +293,7 @@ func (s *ValidateSuite) TestActionSet(c *C) {
 				ObjectMeta: metav1.ObjectMeta{Namespace: "ns1"},
 				Spec: &crv1alpha1.ActionSetSpec{
 					Actions: []crv1alpha1.ActionSpec{
-						crv1alpha1.ActionSpec{
+						{
 							Object: crv1alpha1.ObjectReference{
 								Name: "foo",
 								Kind: "unknown",
@@ -310,7 +310,7 @@ func (s *ValidateSuite) TestActionSet(c *C) {
 				ObjectMeta: metav1.ObjectMeta{Namespace: "ns1"},
 				Spec: &crv1alpha1.ActionSetSpec{
 					Actions: []crv1alpha1.ActionSpec{
-						crv1alpha1.ActionSpec{
+						{
 							Object: crv1alpha1.ObjectReference{
 								Name:       "foo",
 								APIVersion: "v1",
@@ -327,7 +327,7 @@ func (s *ValidateSuite) TestActionSet(c *C) {
 				ObjectMeta: metav1.ObjectMeta{Namespace: "ns1"},
 				Spec: &crv1alpha1.ActionSetSpec{
 					Actions: []crv1alpha1.ActionSpec{
-						crv1alpha1.ActionSpec{},
+						{},
 					},
 				},
 			},
@@ -362,7 +362,7 @@ func (s *ValidateSuite) TestActionSetStatus(c *C) {
 			as: &crv1alpha1.ActionSetStatus{
 				State: crv1alpha1.StatePending,
 				Actions: []crv1alpha1.ActionStatus{
-					crv1alpha1.ActionStatus{},
+					{},
 				},
 			},
 			checker: IsNil,
@@ -371,7 +371,7 @@ func (s *ValidateSuite) TestActionSetStatus(c *C) {
 			as: &crv1alpha1.ActionSetStatus{
 				State: crv1alpha1.StatePending,
 				Actions: []crv1alpha1.ActionStatus{
-					crv1alpha1.ActionStatus{},
+					{},
 				},
 			},
 			checker: IsNil,
@@ -380,7 +380,7 @@ func (s *ValidateSuite) TestActionSetStatus(c *C) {
 			as: &crv1alpha1.ActionSetStatus{
 				State: crv1alpha1.StatePending,
 				Actions: []crv1alpha1.ActionStatus{
-					crv1alpha1.ActionStatus{
+					{
 						Phases: []crv1alpha1.Phase{},
 					},
 				},
@@ -391,9 +391,9 @@ func (s *ValidateSuite) TestActionSetStatus(c *C) {
 			as: &crv1alpha1.ActionSetStatus{
 				State: crv1alpha1.StatePending,
 				Actions: []crv1alpha1.ActionStatus{
-					crv1alpha1.ActionStatus{
+					{
 						Phases: []crv1alpha1.Phase{
-							crv1alpha1.Phase{},
+							{},
 						},
 					},
 				},
@@ -404,9 +404,9 @@ func (s *ValidateSuite) TestActionSetStatus(c *C) {
 			as: &crv1alpha1.ActionSetStatus{
 				State: crv1alpha1.StatePending,
 				Actions: []crv1alpha1.ActionStatus{
-					crv1alpha1.ActionStatus{
+					{
 						Phases: []crv1alpha1.Phase{
-							crv1alpha1.Phase{},
+							{},
 						},
 					},
 				},
@@ -417,9 +417,9 @@ func (s *ValidateSuite) TestActionSetStatus(c *C) {
 			as: &crv1alpha1.ActionSetStatus{
 				State: crv1alpha1.StatePending,
 				Actions: []crv1alpha1.ActionStatus{
-					crv1alpha1.ActionStatus{
+					{
 						Phases: []crv1alpha1.Phase{
-							crv1alpha1.Phase{
+							{
 								State: crv1alpha1.StatePending,
 							},
 						},
@@ -432,9 +432,9 @@ func (s *ValidateSuite) TestActionSetStatus(c *C) {
 			as: &crv1alpha1.ActionSetStatus{
 				State: crv1alpha1.StateFailed,
 				Actions: []crv1alpha1.ActionStatus{
-					crv1alpha1.ActionStatus{
+					{
 						Phases: []crv1alpha1.Phase{
-							crv1alpha1.Phase{
+							{
 								State: crv1alpha1.StatePending,
 							},
 						},
@@ -447,9 +447,9 @@ func (s *ValidateSuite) TestActionSetStatus(c *C) {
 			as: &crv1alpha1.ActionSetStatus{
 				State: crv1alpha1.StateComplete,
 				Actions: []crv1alpha1.ActionStatus{
-					crv1alpha1.ActionStatus{
+					{
 						Phases: []crv1alpha1.Phase{
-							crv1alpha1.Phase{
+							{
 								State: crv1alpha1.StatePending,
 							},
 						},
@@ -462,12 +462,12 @@ func (s *ValidateSuite) TestActionSetStatus(c *C) {
 			as: &crv1alpha1.ActionSetStatus{
 				State: crv1alpha1.StateComplete,
 				Actions: []crv1alpha1.ActionStatus{
-					crv1alpha1.ActionStatus{
+					{
 						Phases: []crv1alpha1.Phase{
-							crv1alpha1.Phase{
+							{
 								State: crv1alpha1.StatePending,
 							},
-							crv1alpha1.Phase{
+							{
 								State: crv1alpha1.StateComplete,
 							},
 						},


### PR DESCRIPTION
Signed-off-by: Bhargav Ravuri <bhargav.ravuri@infracloud.io>

## Change Overview
- Fix the go formatting issues reported by [goreportcardare][1].
- Add `gofmt` in [golint.sh](golint.sh) to warn for future commits.
- No functional or test logic changes made. This is only for go formatting.

## Pull request type

Please check the type of change your PR introduces:
- [x] :rainbow: Refactoring (no functional changes, no api changes)

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #1274

## Test Plan
- [x] :muscle: Manual

1. Run `make golint`.
2. Install [goreportcard][1] and run `goreportcard-cli -v`. It should print stats similar to: 
```
Grade .......... A+ 100.0%
Files .............. 31757
Issues ................. 0
gofmt ............... 100%
go_vet .............. 100%
ineffassign ......... 100%
gocyclo ............. 100%
license ............. 100%
misspell ............ 100%
```
`Note:` % of `gofmt` should be higher than what it was before this commit.

## Message for maintainers
- [golint][2] is archived and so it was disabled from [goreportcard][1] in [commit][3].
- Also, [goreportcard][1] uses [gometalinter][4] which is archived. The replacement is [golangci-lint][5] which is being used by Kanister already. However, most of the common linter in it (like, gofmt, revive, etc.) are not enabled or skipped for packages. I'd recommend to have a `.golangci.yml` configured to make most out of it.

---

[1]: https://github.com/gojp/goreportcard
[2]: https://github.com/golang/lint
[3]: https://github.com/gojp/goreportcard/commit/5aeaec8b44c4446e92e66e23f0e04b24e95da4a5
[4]: https://github.com/alecthomas/gometalinter
[5]: https://github.com/golangci/golangci-lint