### PR TITLE
Update MongoDB base image

### DIFF
--- a/docker/mongodb/Dockerfile
+++ b/docker/mongodb/Dockerfile
@@ -1,6 +1,6 @@
-FROM bitnami/mongodb:4.4.13-debian-10-r52
+FROM bitnami/mongodb:5.0.14-debian-11-r0
 
-MAINTAINER "Tom Manville <tom@kasten.io>"
+LABEL maintainer="Tom Manville <tom@kasten.io>"
 
 # Install kando
 ADD kando /usr/local/bin/


### PR DESCRIPTION
## Change Overview

The minimum image version for the latest MongoDB helm chart is 5.0. Updating the base image to make it compatible and fix CI failures.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #1753

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
