### PR TITLE
udpate mysql tools dockerfile

### DIFF
--- a/docker/kanister-mysql/image/Dockerfile
+++ b/docker/kanister-mysql/image/Dockerfile
@@ -1,5 +1,8 @@
 ARG TOOLS_IMAGE
 FROM registry.access.redhat.com/ubi8/ubi:8.1 as builder
+
+RUN dnf clean all && rm -rf /var/cache/dnf
+RUN dnf -y upgrade
 RUN dnf install -y https://dev.mysql.com/get/mysql80-community-release-el8-1.noarch.rpm
 
 # GPG keys for MySQL have expired. Importing the new key below.


### PR DESCRIPTION
## Change Overview

Docker build for mysql kansiter tools image is failing with the error
```
Updating Subscription Management repositories.
Unable to read consumer identity
This system is not registered to Red Hat Subscription Management. You can use subscription-manager to register.
Red Hat Universal Base Image 8 (RPMs) - BaseOS   62 kB/s | 827 kB     00:13    
Red Hat Universal Base Image 8 (RPMs) - AppStre 420 kB/s | 3.2 MB     00:07    
Red Hat Universal Base Image 8 (RPMs) - CodeRea  21 kB/s |  29 kB     00:01    
Last metadata expiration check: 0:00:01 ago on Tue Dec 13 10:49:40 2022.
[MIRROR] mysql80-community-release-el8-1.noarch.rpm: Status code: 403 for https://dev.mysql.com/get/mysql80-community-release-el8-1.noarch.rpm
[FAILED] mysql80-community-release-el8-1.noarch.rpm: Status code: 403 for https://dev.mysql.com/get/mysql80-community-release-el8-1.noarch.rpm
Status code: 403 for https://dev.mysql.com/get/mysql80-community-release-el8-1.noarch.rpm
The command '/bin/sh -c dnf install -y https://dev.mysql.com/get/mysql80-community-release-el8-1.noarch.rpm' returned a non-zero code: 1
```
This PR fixes the issue

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test



## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E

Integration test : https://gist.github.com/viveksinghggits/466b668847d30eba8292392e0dff8b36