### PR TITLE
Download the MySQL RPM file before install

### DIFF
--- a/docker/kanister-mysql/image/Dockerfile
+++ b/docker/kanister-mysql/image/Dockerfile
@@ -3,7 +3,10 @@ FROM registry.access.redhat.com/ubi8/ubi:8.1 as builder
 
 RUN dnf clean all && rm -rf /var/cache/dnf
 RUN dnf -y upgrade
-RUN dnf install -y https://dev.mysql.com/get/mysql80-community-release-el8-1.noarch.rpm
+# Download the RPM file to avoid timeouts during install
+RUN curl -LO https://dev.mysql.com/get/mysql80-community-release-el8-1.noarch.rpm
+# Install from the local file
+RUN dnf install -y mysql80-community-release-el8-1.noarch.rpm
 
 # GPG keys for MySQL have expired. Importing the new key below.
 # Please refer bug https://bugs.mysql.com/bug.php?id=106188 for more details


### PR DESCRIPTION
## Change Overview

- Updating the Dockerfile to fix timeout during docker build
```
Curl error (28): Timeout was reached for https://dev.mysql.com/get/mysql80-community-release-el8-1.noarch.rpm [Operation too slow. Less than 1000 bytes/sec transferred the last 30 seconds]
```

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
