### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -41,7 +41,7 @@ jobs:
       with:
         cluster-name: "kanister-run-${{ matrix.testSuite }}"
         args: >-
-          --agents 3
+          --agents 4
           --no-lb
           --k3s-arg "--no-deploy=traefik,servicelb,metrics-server@server:*"
     - run: tar -xvf ./src.tar.gz

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -43,7 +43,7 @@ jobs:
         args: >-
           --agents 3
           --no-lb
-          --k3s-arg "--no-deploy=traefik,servicelb@server:*"
+          --k3s-arg "--no-deploy=traefik,servicelb,metrics-server@server:*"
     - run: tar -xvf ./src.tar.gz
     - run: |
         make install-csi-hostpath-driver

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -81,7 +81,7 @@ jobs:
     - uses: actions/download-artifact@v3
       with:
         name: src
-    - uses: docker/login-action@v1
+    - uses: docker/login-action@v2
       with:
         registry: ghcr.io
         username: ${{ github.actor }}

--- a/build/integration-test.sh
+++ b/build/integration-test.sh
@@ -20,7 +20,7 @@ set -o nounset
 # Default bucket name
 INTEGRATION_TEST_DIR=pkg/testing
 # Degree of parallelism for integration tests
-DOP="4"
+DOP="2"
 TEST_TIMEOUT="30m"
 # Set default options
 TEST_OPTIONS="-tags=integration -timeout ${TEST_TIMEOUT} -check.suitep ${DOP}"


### PR DESCRIPTION
## Change Overview

Fixes:
1. GHA errors
```
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: docker/login-action@v1
```
Missed this one when updating the action/checkout

2. Remove metrics server from k3d deployment in CI
3. Reduce integration test parallelism to 2 to avoid hitting resource constraints

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
