### PR TITLE
[Minor] Fix the broken link for Adopters

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ UTC, where we discuss ongoing interesting features, issues, and pull requests.
 Come join us! Everyone is welcome! 🙌 (Zoom link is pinned on Slack)
 
 If you are currently using Kanister, we would love to hear about it! Feel free
-to add your organization to the [`ADOPTERS.md`](adopters.md) by submitting a
+to add your organization to the [`ADOPTERS.md`](ADOPTERS.md) by submitting a
 pull request.
 
 ## Code of Conduct


### PR DESCRIPTION
## Change Overview

This PR fixes the broken link for adopters page in the repo

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
