### PR TITLE
Add `--egress-selector-mode` flag while starting k3d

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -43,7 +43,7 @@ jobs:
         args: >-
           --agents 3
           --no-lb
-          --k3s-arg "--no-deploy=traefik,--egress-selector-mode=agent,servicelb@server:*"
+          --k3s-arg "--no-deploy=traefik,--egress-selector-mode=disabled,servicelb@server:*"
     - run: tar -xvf ./src.tar.gz
     - run: |
         make install-csi-hostpath-driver

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -43,7 +43,7 @@ jobs:
         args: >-
           --agents 3
           --no-lb
-          --k3s-arg "--no-deploy=traefik,servicelb@server:*"
+          --k3s-arg "--no-deploy=traefik,--egress-selector-mode=agent,servicelb@server:*"
     - run: tar -xvf ./src.tar.gz
     - run: |
         make install-csi-hostpath-driver


### PR DESCRIPTION
## Change Overview

Kanister CI tests were failing very frequently with below error while execing a command into a pod

```
error dialing backend: EOF
```

We are not able to reproduce this, and did look like a networking issue to me, because this was failing even before initiating the pod deletion. Which means, it's not like the pod is not in the correct state and that is the reason we see this failure.

By looking further I got to this issue https://github.com/k3s-io/k3s/issues/5633 which seems to be very closely related to our failure. This commit incorporates the suggested change in our code.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
