### PR TITLE
Use specific version of k3s in k3d-action using argument

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -42,7 +42,7 @@ jobs:
         cluster-name: "kanister-run-${{ matrix.testSuite }}"
         args: >-
           --agents 3
-          --image docker.io/rancher/k3s:v1.24.7+k3s1
+          --image docker.io/rancher/k3s:v1.24.7-k3s1
           --no-lb
           --k3s-arg "--no-deploy=traefik,servicelb@server:*"
     - run: kubectl version

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -45,7 +45,6 @@ jobs:
           --image docker.io/rancher/k3s:v1.24.7-k3s1
           --no-lb
           --k3s-arg "--no-deploy=traefik,servicelb@server:*"
-    - run: kubectl version
     - run: tar -xvf ./src.tar.gz
     - run: |
         make install-csi-hostpath-driver

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -42,8 +42,10 @@ jobs:
         cluster-name: "kanister-run-${{ matrix.testSuite }}"
         args: >-
           --agents 3
+          --image docker.io/rancher/k3s:v1.24.7+k3s1
           --no-lb
           --k3s-arg "--no-deploy=traefik,servicelb@server:*"
+    - run: kubectl version
     - run: tar -xvf ./src.tar.gz
     - run: |
         make install-csi-hostpath-driver

--- a/pkg/kube/unstructured_test.go
+++ b/pkg/kube/unstructured_test.go
@@ -17,8 +17,9 @@ package kube
 import (
 	"bytes"
 	"context"
-	. "gopkg.in/check.v1"
 	"text/template"
+
+	. "gopkg.in/check.v1"
 
 	"github.com/Masterminds/sprig"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -37,9 +38,9 @@ func (s *UnstructuredSuite) TestFetch(c *C) {
 	gvr := schema.GroupVersionResource{
 		Group:    "",
 		Version:  "v1",
-		Resource: "serviceaccounts",
+		Resource: "service",
 	}
-	u, err := FetchUnstructuredObject(ctx, gvr, "default", "default")
+	u, err := FetchUnstructuredObject(ctx, gvr, "default", "kubernetes")
 	c.Assert(err, IsNil)
 
 	buf := bytes.NewBuffer(nil)
@@ -49,7 +50,7 @@ func (s *UnstructuredSuite) TestFetch(c *C) {
 		arg string
 	}{
 		{"{{ .Unstructured.metadata.name }}"},
-		{"{{ index .Unstructured.secrets 0 }}"},
+		{"{{ .Unstructured.spec.clusterIP }}"},
 	} {
 		t, err := template.New("config").Option("missingkey=error").Funcs(sprig.TxtFuncMap()).Parse(tc.arg)
 		c.Assert(err, IsNil)

--- a/pkg/kube/unstructured_test.go
+++ b/pkg/kube/unstructured_test.go
@@ -38,7 +38,7 @@ func (s *UnstructuredSuite) TestFetch(c *C) {
 	gvr := schema.GroupVersionResource{
 		Group:    "",
 		Version:  "v1",
-		Resource: "service",
+		Resource: "services",
 	}
 	u, err := FetchUnstructuredObject(ctx, gvr, "default", "kubernetes")
 	c.Assert(err, IsNil)


### PR DESCRIPTION
## Change Overview

The fix that is there in k3s for `error dialing backend` is not in the k3d version that we install by default. This commit tries to install the k3s version that has the fix using the argument `image docker.io/rancher/k3s:v1.24.7+k3s1`.


## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
