### PR TITLE
Use kind to create cluster in CI, instead of k3d

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -43,6 +43,12 @@ jobs:
         make install-csi-hostpath-driver
         make install-minio
       if: matrix.testSuite == 'integration-test' || matrix.testSuite == 'helm-test'
+    # A test (CRDSuite) that runs as part of `make test` requies atleast one CRD to
+    # be present on the cluster. That's why we are only installing csi-hostpath-driver
+    # before running `make test` to make sure some CRDs are installed in the cluster.
+    - run: |
+        make install-csi-hostpath-driver
+      if: matrix.testSuite == 'test'
     - run: make ${{ matrix.testSuite }}
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -37,13 +37,8 @@ jobs:
     - uses: actions/download-artifact@v3
       with:
         name: src
-    - uses: AbsaOSS/k3d-action@v2
-      with:
-        cluster-name: "kanister-run-${{ matrix.testSuite }}"
-        args: >-
-          --agents 3
-          --no-lb
-          --k3s-arg "--no-deploy=traefik,servicelb@server:*"
+    - uses: helm/kind-action@v1.4.0
+    - run: kubectl version
     - run: tar -xvf ./src.tar.gz
     - run: |
         make install-csi-hostpath-driver

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -38,7 +38,6 @@ jobs:
       with:
         name: src
     - uses: helm/kind-action@v1.4.0
-    - run: kubectl version
     - run: tar -xvf ./src.tar.gz
     - run: |
         make install-csi-hostpath-driver

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -43,7 +43,7 @@ jobs:
     - run: |
         make install-csi-hostpath-driver
         make install-minio
-      if: matrix.testSuite == 'integration-test' || matrix.testSuite == 'helm-test'
+      if: matrix.testSuite == 'integration-test' || matrix.testSuite == 'helm-test' || matrix.testSuite == 'test'
     - run: make ${{ matrix.testSuite }}
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -42,7 +42,7 @@ jobs:
     - run: |
         make install-csi-hostpath-driver
         make install-minio
-      if: matrix.testSuite == 'integration-test' || matrix.testSuite == 'helm-test' || matrix.testSuite == 'test'
+      if: matrix.testSuite == 'integration-test' || matrix.testSuite == 'helm-test'
     - run: make ${{ matrix.testSuite }}
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -45,7 +45,7 @@ jobs:
       if: matrix.testSuite == 'integration-test' || matrix.testSuite == 'helm-test'
     # A test (CRDSuite) that runs as part of `make test` requies atleast one CRD to
     # be present on the cluster. That's why we are only installing csi-hostpath-driver
-    # before running `make test` to make sure some CRDs are installed in the cluster.
+    # before running `make test`, to create some CRDs on the cluster.
     - run: |
         make install-csi-hostpath-driver
       if: matrix.testSuite == 'test'

--- a/pkg/kube/unstructured_test.go
+++ b/pkg/kube/unstructured_test.go
@@ -17,8 +17,9 @@ package kube
 import (
 	"bytes"
 	"context"
-	. "gopkg.in/check.v1"
 	"text/template"
+
+	. "gopkg.in/check.v1"
 
 	"github.com/Masterminds/sprig"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -37,9 +38,9 @@ func (s *UnstructuredSuite) TestFetch(c *C) {
 	gvr := schema.GroupVersionResource{
 		Group:    "",
 		Version:  "v1",
-		Resource: "serviceaccounts",
+		Resource: "service",
 	}
-	u, err := FetchUnstructuredObject(ctx, gvr, "default", "default")
+	u, err := FetchUnstructuredObject(ctx, gvr, "default", "kubernetes")
 	c.Assert(err, IsNil)
 
 	buf := bytes.NewBuffer(nil)
@@ -49,7 +50,7 @@ func (s *UnstructuredSuite) TestFetch(c *C) {
 		arg string
 	}{
 		{"{{ .Unstructured.metadata.name }}"},
-		{"{{ index .Unstructured.secrets 0 }}"},
+		{"{{ .Unstructured.spec.clusterIP }}"},
 	} {
 		t, err := template.New("config").Option("missingkey=error").Funcs(sprig.TxtFuncMap()).Parse(tc.arg)
 		c.Assert(err, IsNil)

--- a/pkg/kube/unstructured_test.go
+++ b/pkg/kube/unstructured_test.go
@@ -38,7 +38,7 @@ func (s *UnstructuredSuite) TestFetch(c *C) {
 	gvr := schema.GroupVersionResource{
 		Group:    "",
 		Version:  "v1",
-		Resource: "service",
+		Resource: "services",
 	}
 	u, err := FetchUnstructuredObject(ctx, gvr, "default", "kubernetes")
 	c.Assert(err, IsNil)


### PR DESCRIPTION
## Change Overview

This PR removes `k3d-action` from Kanister CI and  and uses `helm/kind-action@v1.4.0` action instead to create a Kubernetes cluster.
Using kind in CI for Kanister should be preferred because 
- It is easy to decide which Kubernetes version we want to run our tests against
- In case of k3d-action, since it depends on k3d and then k3d actually depends on k3s, it's a bit tedious to figure the dependency out. 

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [x] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
