### PR TITLE
Removed image values for MongoDB and PostgresDB charts in integration tests

### DIFF
--- a/pkg/app/postgresql-deploymentconfig.go
+++ b/pkg/app/postgresql-deploymentconfig.go
@@ -173,7 +173,7 @@ func (pgres *PostgreSQLDepConfig) Count(ctx context.Context) (int, error) {
 
 	out := strings.Fields(stdout)
 	if len(out) < 4 {
-		return 0, fmt.Errorf("Unknown response for count query")
+		return 0, fmt.Errorf("unknown response for count query")
 	}
 	count, err := strconv.Atoi(out[2])
 	if err != nil {

--- a/pkg/app/rds_postgres.go
+++ b/pkg/app/rds_postgres.go
@@ -95,7 +95,7 @@ func (pdb *RDSPostgresDB) Init(ctx context.Context) error {
 	if pdb.region == "" {
 		pdb.region, ok = os.LookupEnv(aws.Region)
 		if !ok {
-			return fmt.Errorf("Env var %s is not set", aws.Region)
+			return fmt.Errorf("env var %s is not set", aws.Region)
 		}
 	}
 
@@ -107,11 +107,11 @@ func (pdb *RDSPostgresDB) Init(ctx context.Context) error {
 
 	pdb.accessID, ok = os.LookupEnv(aws.AccessKeyID)
 	if !ok {
-		return fmt.Errorf("Env var %s is not set", aws.AccessKeyID)
+		return fmt.Errorf("env var %s is not set", aws.AccessKeyID)
 	}
 	pdb.secretKey, ok = os.LookupEnv(aws.SecretAccessKey)
 	if !ok {
-		return fmt.Errorf("Env var %s is not set", aws.SecretAccessKey)
+		return fmt.Errorf("env var %s is not set", aws.SecretAccessKey)
 	}
 	return nil
 }


### PR DESCRIPTION
## Change Overview

- removed usage of kanister images while installing MongoDB and PostgresDB helm charts
- fixed minor issues in formatting

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

## Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E

Ran integration tests for Mongodb and Postgresql using following commands
`./build/integration-test.sh ^PostgreSQL$` and `./build/integration-test.sh ^MongoDB$`