### PR TITLE
Do not ignore permission errors in kopia restore command

### DIFF
--- a/pkg/kopia/command/const.go
+++ b/pkg/kopia/command/const.go
@@ -52,6 +52,7 @@ const (
 	unsafeIgnoreSourceFlag     = "--unsafe-ignore-source"
 	ownerFlag                  = "--owner"
 	sparseFlag                 = "--write-sparse-files"
+	ignorePermissionsError     = "--ignore-permission-errors"
 
 	// Server specific
 	addSubCommand             = "add"

--- a/pkg/kopia/command/restore.go
+++ b/pkg/kopia/command/restore.go
@@ -14,17 +14,20 @@
 
 package command
 
+import "strconv"
+
 type RestoreCommandArgs struct {
 	*CommandArgs
-	RootID     string
-	TargetPath string
+	RootID                 string
+	TargetPath             string
+	IgnorePermissionErrors bool
 }
 
 // Restore returns the kopia command for restoring root of a snapshot with given root ID
 func Restore(cmdArgs RestoreCommandArgs) []string {
 	args := commonArgs(cmdArgs.CommandArgs, false)
 	args = args.AppendLoggable(restoreSubCommand, cmdArgs.RootID, cmdArgs.TargetPath)
-	args = args.AppendLoggableKV(ignorePermissionsError, "false")
+	args = args.AppendLoggableKV(ignorePermissionsError, strconv.FormatBool(cmdArgs.IgnorePermissionErrors))
 
 	return stringSliceCommand(args)
 }

--- a/pkg/kopia/command/restore.go
+++ b/pkg/kopia/command/restore.go
@@ -24,6 +24,7 @@ type RestoreCommandArgs struct {
 func Restore(cmdArgs RestoreCommandArgs) []string {
 	args := commonArgs(cmdArgs.CommandArgs, false)
 	args = args.AppendLoggable(restoreSubCommand, cmdArgs.RootID, cmdArgs.TargetPath)
+	args = args.AppendLoggableKV(ignorePermissionsError, "false")
 
 	return stringSliceCommand(args)
 }

--- a/pkg/kopia/command/restore_test.go
+++ b/pkg/kopia/command/restore_test.go
@@ -44,6 +44,22 @@ func (kRestore *KopiaRestoreTestSuite) TestRestoreCommands(c *C) {
 			},
 			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log --password=encr-key restore snapshot-id target/path --ignore-permission-errors=false",
 		},
+		{
+			f: func() []string {
+				args := RestoreCommandArgs{
+					CommandArgs: &CommandArgs{
+						RepoPassword:   "encr-key",
+						ConfigFilePath: "path/kopia.config",
+						LogDirectory:   "cache/log",
+					},
+					RootID:                 "snapshot-id",
+					TargetPath:             "target/path",
+					IgnorePermissionErrors: true,
+				}
+				return Restore(args)
+			},
+			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log --password=encr-key restore snapshot-id target/path --ignore-permission-errors=true",
+		},
 	} {
 		cmd := strings.Join(tc.f(), " ")
 		c.Check(cmd, Equals, tc.expectedLog)

--- a/pkg/kopia/command/restore_test.go
+++ b/pkg/kopia/command/restore_test.go
@@ -42,7 +42,7 @@ func (kRestore *KopiaRestoreTestSuite) TestRestoreCommands(c *C) {
 				}
 				return Restore(args)
 			},
-			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log --password=encr-key restore snapshot-id target/path",
+			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log --password=encr-key restore snapshot-id target/path --ignore-permission-errors=false",
 		},
 	} {
 		cmd := strings.Join(tc.f(), " ")

--- a/pkg/kopia/command/snapshot.go
+++ b/pkg/kopia/command/snapshot.go
@@ -54,19 +54,20 @@ func SnapshotCreate(cmdArgs SnapshotCreateCommandArgs) []string {
 
 type SnapshotRestoreCommandArgs struct {
 	*CommandArgs
-	SnapID        string
-	TargetPath    string
-	SparseRestore bool
+	SnapID                 string
+	TargetPath             string
+	SparseRestore          bool
+	IgnorePermissionErrors bool
 }
 
 // SnapshotRestore returns kopia command restoring snapshots with given snap ID
 func SnapshotRestore(cmdArgs SnapshotRestoreCommandArgs) []string {
 	args := commonArgs(cmdArgs.CommandArgs, false)
 	args = args.AppendLoggable(snapshotSubCommand, restoreSubCommand, cmdArgs.SnapID, cmdArgs.TargetPath)
+	args = args.AppendLoggableKV(ignorePermissionsError, strconv.FormatBool(cmdArgs.IgnorePermissionErrors))
 	if cmdArgs.SparseRestore {
 		args = args.AppendLoggable(sparseFlag)
 	}
-	args = args.AppendLoggableKV(ignorePermissionsError, "false")
 
 	return stringSliceCommand(args)
 }

--- a/pkg/kopia/command/snapshot.go
+++ b/pkg/kopia/command/snapshot.go
@@ -66,7 +66,7 @@ func SnapshotRestore(cmdArgs SnapshotRestoreCommandArgs) []string {
 	if cmdArgs.SparseRestore {
 		args = args.AppendLoggable(sparseFlag)
 	}
-	args.AppendLoggableKV(ignorePermissionsError, "false")
+	args = args.AppendLoggableKV(ignorePermissionsError, "false")
 
 	return stringSliceCommand(args)
 }

--- a/pkg/kopia/command/snapshot.go
+++ b/pkg/kopia/command/snapshot.go
@@ -66,6 +66,7 @@ func SnapshotRestore(cmdArgs SnapshotRestoreCommandArgs) []string {
 	if cmdArgs.SparseRestore {
 		args = args.AppendLoggable(sparseFlag)
 	}
+	args.AppendLoggableKV(ignorePermissionsError, "false")
 
 	return stringSliceCommand(args)
 }

--- a/pkg/kopia/command/snapshot_test.go
+++ b/pkg/kopia/command/snapshot_test.go
@@ -93,7 +93,7 @@ func (kSnapshot *KopiaSnapshotTestSuite) TestSnapshotCommands(c *C) {
 				}
 				return SnapshotRestore(args)
 			},
-			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log --password=encr-key snapshot restore snapshot-id target/path --write-sparse-files --ignore-permission-errors=true",
+			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log --password=encr-key snapshot restore snapshot-id target/path --ignore-permission-errors=true --write-sparse-files",
 		},
 		{
 			f: func() []string {

--- a/pkg/kopia/command/snapshot_test.go
+++ b/pkg/kopia/command/snapshot_test.go
@@ -85,6 +85,17 @@ func (kSnapshot *KopiaSnapshotTestSuite) TestSnapshotCommands(c *C) {
 		{
 			f: func() []string {
 				args := SnapshotRestoreCommandArgs{
+					CommandArgs: commandArgs,
+					SnapID:      "snapshot-id",
+					TargetPath:  "target/path",
+				}
+				return SnapshotRestore(args)
+			},
+			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log --password=encr-key snapshot restore snapshot-id target/path --ignore-permission-errors=false",
+		},
+		{
+			f: func() []string {
+				args := SnapshotRestoreCommandArgs{
 					CommandArgs:            commandArgs,
 					SnapID:                 "snapshot-id",
 					TargetPath:             "target/path",

--- a/pkg/kopia/command/snapshot_test.go
+++ b/pkg/kopia/command/snapshot_test.go
@@ -72,10 +72,11 @@ func (kSnapshot *KopiaSnapshotTestSuite) TestSnapshotCommands(c *C) {
 		{
 			f: func() []string {
 				args := SnapshotRestoreCommandArgs{
-					CommandArgs:   commandArgs,
-					SnapID:        "snapshot-id",
-					TargetPath:    "target/path",
-					SparseRestore: false,
+					CommandArgs:            commandArgs,
+					SnapID:                 "snapshot-id",
+					TargetPath:             "target/path",
+					SparseRestore:          false,
+					IgnorePermissionErrors: false,
 				}
 				return SnapshotRestore(args)
 			},
@@ -84,14 +85,15 @@ func (kSnapshot *KopiaSnapshotTestSuite) TestSnapshotCommands(c *C) {
 		{
 			f: func() []string {
 				args := SnapshotRestoreCommandArgs{
-					CommandArgs:   commandArgs,
-					SnapID:        "snapshot-id",
-					TargetPath:    "target/path",
-					SparseRestore: true,
+					CommandArgs:            commandArgs,
+					SnapID:                 "snapshot-id",
+					TargetPath:             "target/path",
+					SparseRestore:          true,
+					IgnorePermissionErrors: true,
 				}
 				return SnapshotRestore(args)
 			},
-			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log --password=encr-key snapshot restore snapshot-id target/path --write-sparse-files --ignore-permission-errors=false",
+			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log --password=encr-key snapshot restore snapshot-id target/path --write-sparse-files --ignore-permission-errors=true",
 		},
 		{
 			f: func() []string {

--- a/pkg/kopia/command/snapshot_test.go
+++ b/pkg/kopia/command/snapshot_test.go
@@ -79,7 +79,7 @@ func (kSnapshot *KopiaSnapshotTestSuite) TestSnapshotCommands(c *C) {
 				}
 				return SnapshotRestore(args)
 			},
-			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log --password=encr-key snapshot restore snapshot-id target/path",
+			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log --password=encr-key snapshot restore snapshot-id target/path --ignore-permission-errors=false",
 		},
 		{
 			f: func() []string {
@@ -91,7 +91,7 @@ func (kSnapshot *KopiaSnapshotTestSuite) TestSnapshotCommands(c *C) {
 				}
 				return SnapshotRestore(args)
 			},
-			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log --password=encr-key snapshot restore snapshot-id target/path --write-sparse-files",
+			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log --password=encr-key snapshot restore snapshot-id target/path --write-sparse-files --ignore-permission-errors=false",
 		},
 		{
 			f: func() []string {


### PR DESCRIPTION
## Change Overview

By default kopia ignores all the errors about permissions (see https://github.com/kopia/kopia/blob/master/cli/command_restore.go#L144) 
It leads to hiding such errors and incorrectly restored apps without any notifications.

## Pull request type

Please check the type of change your PR introduces:
- [x] :sunflower: Feature

## Test Plan
- [x] :zap: Unit test
