### PR TITLE
Improve ActionSet Progress RunningPhase unit test

### DIFF
--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -436,10 +436,10 @@ func newBPForProgressRunningPhase() *crv1alpha1.Blueprint {
 				// set output artifacts from main phases as well as deferPhase
 				OutputArtifacts: map[string]crv1alpha1.Artifact{},
 				Phases: []crv1alpha1.BlueprintPhase{
-					*phaseWithNameAndCMD("backupPhaseOne", []string{"sleep", "8"}),
-					*phaseWithNameAndCMD("backupPhaseTwo", []string{"sleep", "5"}),
+					*phaseWithNameAndCMD("backupPhaseOne", []string{"sleep", "10"}),
+					*phaseWithNameAndCMD("backupPhaseTwo", []string{"sleep", "8"}),
 				},
-				DeferPhase: phaseWithNameAndCMD("deferPhase", []string{"sleep", "5"}),
+				DeferPhase: phaseWithNameAndCMD("deferPhase", []string{"sleep", "8"}),
 			},
 		},
 	}

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -198,6 +198,40 @@ func (s *ControllerSuite) waitOnDeferPhaseState(c *C, as *crv1alpha1.ActionSet, 
 	return errors.Wrapf(err, "State '%s' never reached", state)
 }
 
+//nolint:unparam
+func (s *ControllerSuite) waitOnActionSetCompleteWithRunningPhases(as *crv1alpha1.ActionSet, rp *sets.String) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+	err := poll.Wait(ctx, func(context.Context) (bool, error) {
+		as, err := s.crCli.ActionSets(as.GetNamespace()).Get(ctx, as.GetName(), metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		if as.Status == nil {
+			return false, nil
+		}
+		if as.Status.State == crv1alpha1.StateComplete {
+			return true, nil
+		}
+		// These are non-terminal states.
+		if as.Status.State == crv1alpha1.StatePending {
+			return false, nil
+		}
+		if as.Status.State == crv1alpha1.StateRunning {
+			// Delete running phases
+			if rp.Has(as.Status.Progress.RunningPhase) {
+				rp.Delete(as.Status.Progress.RunningPhase)
+			}
+			return false, nil
+		}
+		return false, errors.New(fmt.Sprintf("Unexpected state: %s", as.Status.State))
+	})
+	if err == nil {
+		return nil
+	}
+	return errors.Wrapf(err, "ActionSet did not reach '%s' state", crv1alpha1.StateComplete)
+}
+
 func newBPWithOutputArtifact() *crv1alpha1.Blueprint {
 	return &crv1alpha1.Blueprint{
 		ObjectMeta: metav1.ObjectMeta{
@@ -387,6 +421,25 @@ func newBPWithKopiaSnapshotOutputArtifact() *crv1alpha1.Blueprint {
 						Func: testutil.OutputFuncName,
 					},
 				},
+			},
+		},
+	}
+}
+
+func newBPForProgressRunningPhase() *crv1alpha1.Blueprint {
+	return &crv1alpha1.Blueprint{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "test-bp-running-phase-",
+		},
+		Actions: map[string]*crv1alpha1.BlueprintAction{
+			"backup": {
+				// set output artifacts from main phases as well as deferPhase
+				OutputArtifacts: map[string]crv1alpha1.Artifact{},
+				Phases: []crv1alpha1.BlueprintPhase{
+					*phaseWithNameAndCMD("backupPhaseOne", []string{"sleep", "8"}),
+					*phaseWithNameAndCMD("backupPhaseTwo", []string{"sleep", "5"}),
+				},
+				DeferPhase: phaseWithNameAndCMD("deferPhase", []string{"sleep", "5"}),
 			},
 		},
 	}
@@ -665,35 +718,12 @@ func (s *ControllerSuite) TestDeferPhase(c *C) {
 	err = s.waitOnActionSetState(c, as, crv1alpha1.StateRunning)
 	c.Assert(err, IsNil)
 
-	// we need a set to avoid duplicate values of `runningPhase`
-	// as we are continuously fetching the value from the ActionSet
-	runningPhases := sets.NewString()
-	go func() {
-		// get actionset and store the runningPhase fields to a set
-		for {
-			a, err := s.crCli.ActionSets(s.namespace).Get(ctx, as.Name, metav1.GetOptions{})
-			c.Assert(err, IsNil)
-			if a.Status.Progress.RunningPhase != "" {
-				runningPhases.Insert(a.Status.Progress.RunningPhase)
-			}
-		}
-	}()
-
 	// make sure deferPhase is also run successfully
 	err = s.waitOnDeferPhaseState(c, as, crv1alpha1.StateComplete)
 	c.Assert(err, IsNil)
 
 	err = s.waitOnActionSetState(c, as, crv1alpha1.StateComplete)
 	c.Assert(err, IsNil)
-
-	// once actionset is completed make sure all the phases are in runningPhases
-	// that would confirm that the actionset's status.progress.runningPhase was set
-	// to those phases
-	op := sets.NewString()
-	// these phases are from blueprint that we create above
-	// and after actionset completion the runningPhase becomes ""
-	op.Insert("backupPhaseOne").Insert("backupPhaseTwo").Insert("deferPhase")
-	c.Assert(runningPhases.Equal(op), Equals, true)
 
 	as, err = s.crCli.ActionSets(s.namespace).Get(ctx, as.Name, metav1.GetOptions{})
 	c.Assert(err, IsNil)
@@ -925,4 +955,27 @@ func (s *ControllerSuite) TestRenderArtifactsFailure(c *C) {
 
 	err = s.waitOnActionSetState(c, as, crv1alpha1.StateFailed)
 	c.Assert(err, IsNil)
+}
+
+func (s *ControllerSuite) TestProgressRunningPhase(c *C) {
+	os.Setenv(kube.PodNSEnvVar, "test")
+	ctx := context.Background()
+
+	bp := newBPForProgressRunningPhase()
+	bp, err := s.crCli.Blueprints(s.namespace).Create(ctx, bp, metav1.CreateOptions{})
+	c.Assert(err, IsNil)
+
+	// create actionset and wait for it to reach Running state
+	as := testutil.NewTestActionSet(s.namespace, bp.GetName(), "Deployment", s.deployment.GetName(), s.namespace, kanister.DefaultVersion, "backup")
+	as, err = s.crCli.ActionSets(s.namespace).Create(ctx, as, metav1.CreateOptions{})
+	c.Assert(err, IsNil)
+	err = s.waitOnActionSetState(c, as, crv1alpha1.StateRunning)
+	c.Assert(err, IsNil)
+
+	runningPhases := sets.NewString()
+	runningPhases.Insert("backupPhaseOne").Insert("backupPhaseTwo").Insert("deferPhase")
+
+	err = s.waitOnActionSetCompleteWithRunningPhases(as, &runningPhases)
+	c.Assert(err, IsNil)
+	c.Assert(runningPhases, HasLen, 0)
 }


### PR DESCRIPTION
## Change Overview

- Adding a separate test
- Blueprint phases used have `sleep` command to ensure we get the `RunningPhase` value at least once

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [x] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [x] :zap: Unit test
```=== RUN   Test
START: controller_test.go:68: ControllerSuite.SetUpSuite
W0106 17:33:36.345532   17143 gcp.go:120] WARNING: the gcp auth plugin is deprecated in v1.22+, unavailable in v1.25+; use gcloud instead.
To learn more, consult https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke
PASS: controller_test.go:68: ControllerSuite.SetUpSuite	2.833s

START: controller_test.go:960: ControllerSuite.TestProgressRunningPhase
START: controller_test.go:126: ControllerSuite.SetUpTest
PASS: controller_test.go:126: ControllerSuite.SetUpTest	0.178s

{"File":"pkg/controller/controller.go","Function":"github.com/kanisterio/kanister/pkg/controller.(*Controller).logAndSuccessEvent","Line":687,"level":"info","msg":"Added blueprint test-bp-running-phase-nxt8p","time":"2023-01-06T17:33:39.456117-08:00"}
{"ActionSet":"test-actionset-b298b","File":"pkg/controller/controller.go","Function":"github.com/kanisterio/kanister/pkg/controller.(*Controller).onUpdateActionSet","Line":240,"Status":"pending","level":"info","msg":"Updated ActionSet","time":"2023-01-06T17:33:39.599369-08:00"}
{"ActionSet":"test-actionset-b298b","File":"pkg/controller/controller.go","Function":"github.com/kanisterio/kanister/pkg/controller.(*Controller).onUpdateActionSet","Line":247,"Phase":"backupPhaseOne-\u003epending","Status":"running","level":"info","msg":"Updated ActionSet","time":"2023-01-06T17:33:39.674578-08:00"}
{"ActionSet":"test-actionset-b298b","File":"pkg/controller/controller.go","Function":"github.com/kanisterio/kanister/pkg/controller.(*Controller).logAndSuccessEvent","Line":687,"level":"info","msg":"Executing action backup","time":"2023-01-06T17:33:39.72064-08:00"}
{"ActionSet":"test-actionset-b298b","File":"pkg/controller/controller.go","Function":"github.com/kanisterio/kanister/pkg/controller.(*Controller).handleActionSet","Line":416,"NewActionSetName":"test-actionset-b298b","level":"info","msg":"Created actionset and started executing actions","time":"2023-01-06T17:33:40.066567-08:00"}
{"ActionSet":"test-actionset-b298b","File":"pkg/controller/controller.go","Function":"github.com/kanisterio/kanister/pkg/controller.(*Controller).logAndSuccessEvent","Line":687,"Phase":"backupPhaseOne","level":"info","msg":"Executing phase backupPhaseOne","time":"2023-01-06T17:33:40.06665-08:00"}
{"ActionSet":"test-actionset-b298b","File":"pkg/controller/controller.go","Function":"github.com/kanisterio/kanister/pkg/controller.(*Controller).onUpdateActionSet","Line":247,"Phase":"backupPhaseOne-\u003epending","Status":"running","level":"info","msg":"Updated ActionSet","time":"2023-01-06T17:33:40.230606-08:00"}
{"ActionSet":"test-actionset-b298b","File":"pkg/controller/controller.go","Function":"github.com/kanisterio/kanister/pkg/controller.(*Controller).onUpdateActionSet","Line":247,"Phase":"backupPhaseOne-\u003epending","Status":"running","level":"info","msg":"Updated ActionSet","time":"2023-01-06T17:33:41.802171-08:00"}
{"ActionSet":"test-actionset-b298b","File":"pkg/controller/controller.go","Function":"github.com/kanisterio/kanister/pkg/controller.(*Controller).onUpdateActionSet","Line":247,"Phase":"backupPhaseOne-\u003epending","Status":"running","level":"info","msg":"Updated ActionSet","time":"2023-01-06T17:33:43.791495-08:00"}
{"ActionSet":"test-actionset-b298b","File":"pkg/controller/controller.go","Function":"github.com/kanisterio/kanister/pkg/controller.(*Controller).onUpdateActionSet","Line":247,"Phase":"backupPhaseOne-\u003epending","Status":"running","level":"info","msg":"Updated ActionSet","time":"2023-01-06T17:33:45.790681-08:00"}
{"ActionSet":"test-actionset-b298b","File":"pkg/controller/controller.go","Function":"github.com/kanisterio/kanister/pkg/controller.(*Controller).onUpdateActionSet","Line":247,"Phase":"backupPhaseOne-\u003epending","Status":"running","level":"info","msg":"Updated ActionSet","time":"2023-01-06T17:33:47.782919-08:00"}
{"ActionSet":"test-actionset-b298b","File":"pkg/controller/controller.go","Function":"github.com/kanisterio/kanister/pkg/controller.(*Controller).onUpdateActionSet","Line":247,"Phase":"backupPhaseOne-\u003epending","Status":"running","level":"info","msg":"Updated ActionSet","time":"2023-01-06T17:33:49.787333-08:00"}
{"ActionSet":"test-actionset-b298b","File":"pkg/controller/controller.go","Function":"github.com/kanisterio/kanister/pkg/controller.(*Controller).onUpdateActionSet","Line":247,"Phase":"backupPhaseTwo-\u003epending","Status":"running","level":"info","msg":"Updated ActionSet","time":"2023-01-06T17:33:49.859978-08:00"}
{"ActionSet":"test-actionset-b298b","File":"pkg/controller/controller.go","Function":"github.com/kanisterio/kanister/pkg/controller.(*Controller).logAndSuccessEvent","Line":687,"Phase":"backupPhaseOne","level":"info","msg":"Completed phase backupPhaseOne","time":"2023-01-06T17:33:49.860408-08:00"}
{"ActionSet":"test-actionset-b298b","File":"pkg/controller/controller.go","Function":"github.com/kanisterio/kanister/pkg/controller.(*Controller).logAndSuccessEvent","Line":687,"Phase":"backupPhaseTwo","level":"info","msg":"Executing phase backupPhaseTwo","time":"2023-01-06T17:33:49.860456-08:00"}
{"ActionSet":"test-actionset-b298b","File":"pkg/controller/controller.go","Function":"github.com/kanisterio/kanister/pkg/controller.(*Controller).onUpdateActionSet","Line":247,"Phase":"backupPhaseTwo-\u003epending","Status":"running","level":"info","msg":"Updated ActionSet","time":"2023-01-06T17:33:49.953327-08:00"}
{"ActionSet":"test-actionset-b298b","File":"pkg/controller/controller.go","Function":"github.com/kanisterio/kanister/pkg/controller.(*Controller).onUpdateActionSet","Line":247,"Phase":"backupPhaseTwo-\u003epending","Status":"running","level":"info","msg":"Updated ActionSet","time":"2023-01-06T17:33:51.791472-08:00"}
{"ActionSet":"test-actionset-b298b","File":"pkg/controller/controller.go","Function":"github.com/kanisterio/kanister/pkg/controller.(*Controller).onUpdateActionSet","Line":247,"Phase":"backupPhaseTwo-\u003epending","Status":"running","level":"info","msg":"Updated ActionSet","time":"2023-01-06T17:33:53.800753-08:00"}
{"ActionSet":"test-actionset-b298b","File":"pkg/controller/controller.go","Function":"github.com/kanisterio/kanister/pkg/controller.(*Controller).onUpdateActionSet","Line":247,"Phase":"backupPhaseTwo-\u003epending","Status":"running","level":"info","msg":"Updated ActionSet","time":"2023-01-06T17:33:55.827616-08:00"}
{"ActionSet":"test-actionset-b298b","File":"pkg/controller/controller.go","Function":"github.com/kanisterio/kanister/pkg/controller.(*Controller).onUpdateActionSet","Line":247,"Phase":"backupPhaseTwo-\u003epending","Status":"running","level":"info","msg":"Updated ActionSet","time":"2023-01-06T17:33:57.78712-08:00"}
{"ActionSet":"test-actionset-b298b","File":"pkg/controller/controller.go","Function":"github.com/kanisterio/kanister/pkg/controller.(*Controller).logAndSuccessEvent","Line":687,"Phase":"backupPhaseTwo","level":"info","msg":"Completed phase backupPhaseTwo","time":"2023-01-06T17:33:58.518883-08:00"}
{"ActionSet":"test-actionset-b298b","File":"pkg/controller/controller.go","Function":"github.com/kanisterio/kanister/pkg/controller.(*Controller).logAndSuccessEvent","Line":687,"Phase":"deferPhase","level":"info","msg":"Executing deferPhase deferPhase","time":"2023-01-06T17:33:58.593962-08:00"}
{"ActionSet":"test-actionset-b298b","File":"pkg/controller/controller.go","Function":"github.com/kanisterio/kanister/pkg/controller.(*Controller).logAndSuccessEvent","Line":687,"Phase":"deferPhase","level":"info","msg":"Completed deferPhase deferPhase","time":"2023-01-06T17:34:08.181316-08:00"}
{"ActionSet":"test-actionset-b298b","File":"pkg/controller/controller.go","Function":"github.com/kanisterio/kanister/pkg/controller.(*Controller).logAndSuccessEvent","Line":687,"level":"info","msg":"Updated ActionSet 'test-actionset-b298b' Status-\u003ecomplete","time":"2023-01-06T17:34:08.261152-08:00"}
START: controller_test.go:138: ControllerSuite.TearDownTest
PASS: controller_test.go:138: ControllerSuite.TearDownTest	0.000s

PASS: controller_test.go:960: ControllerSuite.TestProgressRunningPhase	33.516s

START: controller_test.go:118: ControllerSuite.TearDownSuite
PASS: controller_test.go:118: ControllerSuite.TearDownSuite	0.062s

OK: 1 passed
--- PASS: Test (36.59s)
PASS
ok  	github.com/kanisterio/kanister/pkg/controller	37.166s
```
- [ ] :green_heart: E2E
