### PR TITLE
Add -y option to microdnf commands in ubi9 based Dockerfiles

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -10,9 +10,8 @@ LABEL name=ARG_BIN \
       maintainer="Tom Manville<tom@kasten.io>" \
       description="Frameworks and utilities for application-specific data management, has updated openssl-libs."
 
-RUN microdnf update openssl-libs && \
-    microdnf update cyrus-sasl-lib && \
-    microdnf install git && \
+RUN microdnf -y update openssl-libs cyrus-sasl-lib && \
+    microdnf -y install git && \
     microdnf clean all
 
 COPY licenses /licenses/licenses

--- a/docker/controller/Dockerfile
+++ b/docker/controller/Dockerfile
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:9.1.0-1656.1669627757
 
 LABEL maintainer="Tom Manville<tom@kasten.io>"
 
-RUN microdnf update openssl-libs
+RUN microdnf -y update openssl-libs
 
 ADD controller /controller
 ENTRYPOINT ["/controller"]

--- a/docker/tools/Dockerfile
+++ b/docker/tools/Dockerfile
@@ -54,9 +54,9 @@ COPY --from=builder /kopia/kopia /usr/local/bin/kopia
 COPY LICENSE /licenses/LICENSE
 
 ADD kando /usr/local/bin/
-RUN microdnf update && microdnf install shadow-utils gzip && \
+RUN microdnf -y update && microdnf -y install shadow-utils gzip && \
   adduser -U kanister -u 1000 && \
-  microdnf remove shadow-utils && \
+  microdnf -y remove shadow-utils && \
   microdnf clean all
 
 CMD [ "/usr/bin/tail", "-f", "/dev/null" ]


### PR DESCRIPTION
## Change Overview

- Add `-y` to pass automated image builds

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
