### PR TITLE
Format bool arguments in a way it expected by kopia's cmd lib.

### DIFF
--- a/pkg/kopia/command/const.go
+++ b/pkg/kopia/command/const.go
@@ -53,6 +53,7 @@ const (
 	ownerFlag                  = "--owner"
 	sparseFlag                 = "--write-sparse-files"
 	ignorePermissionsError     = "--ignore-permission-errors"
+	noIgnorePermissionsError   = "--no-ignore-permission-errors"
 
 	// Server specific
 	addSubCommand             = "add"

--- a/pkg/kopia/command/restore.go
+++ b/pkg/kopia/command/restore.go
@@ -14,8 +14,6 @@
 
 package command
 
-import "strconv"
-
 type RestoreCommandArgs struct {
 	*CommandArgs
 	RootID                 string
@@ -27,7 +25,7 @@ type RestoreCommandArgs struct {
 func Restore(cmdArgs RestoreCommandArgs) []string {
 	args := commonArgs(cmdArgs.CommandArgs, false)
 	args = args.AppendLoggable(restoreSubCommand, cmdArgs.RootID, cmdArgs.TargetPath)
-	args = args.AppendLoggableKV(ignorePermissionsError, strconv.FormatBool(cmdArgs.IgnorePermissionErrors))
+	args = args.AppendLoggableBool(ignorePermissionsError, cmdArgs.IgnorePermissionErrors)
 
 	return stringSliceCommand(args)
 }

--- a/pkg/kopia/command/restore.go
+++ b/pkg/kopia/command/restore.go
@@ -25,7 +25,11 @@ type RestoreCommandArgs struct {
 func Restore(cmdArgs RestoreCommandArgs) []string {
 	args := commonArgs(cmdArgs.CommandArgs, false)
 	args = args.AppendLoggable(restoreSubCommand, cmdArgs.RootID, cmdArgs.TargetPath)
-	args = args.AppendLoggableBool(ignorePermissionsError, cmdArgs.IgnorePermissionErrors)
+	if cmdArgs.IgnorePermissionErrors {
+		args = args.AppendLoggable(ignorePermissionsError)
+	} else {
+		args = args.AppendLoggable(noIgnorePermissionsError)
+	}
 
 	return stringSliceCommand(args)
 }

--- a/pkg/kopia/command/restore_test.go
+++ b/pkg/kopia/command/restore_test.go
@@ -42,7 +42,7 @@ func (kRestore *KopiaRestoreTestSuite) TestRestoreCommands(c *C) {
 				}
 				return Restore(args)
 			},
-			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log --password=encr-key restore snapshot-id target/path --ignore-permission-errors=false",
+			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log --password=encr-key restore snapshot-id target/path --no-ignore-permission-errors",
 		},
 		{
 			f: func() []string {
@@ -58,7 +58,7 @@ func (kRestore *KopiaRestoreTestSuite) TestRestoreCommands(c *C) {
 				}
 				return Restore(args)
 			},
-			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log --password=encr-key restore snapshot-id target/path --ignore-permission-errors=true",
+			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log --password=encr-key restore snapshot-id target/path --ignore-permission-errors",
 		},
 	} {
 		cmd := strings.Join(tc.f(), " ")

--- a/pkg/kopia/command/snapshot.go
+++ b/pkg/kopia/command/snapshot.go
@@ -64,7 +64,7 @@ type SnapshotRestoreCommandArgs struct {
 func SnapshotRestore(cmdArgs SnapshotRestoreCommandArgs) []string {
 	args := commonArgs(cmdArgs.CommandArgs, false)
 	args = args.AppendLoggable(snapshotSubCommand, restoreSubCommand, cmdArgs.SnapID, cmdArgs.TargetPath)
-	args = args.AppendLoggableKV(ignorePermissionsError, strconv.FormatBool(cmdArgs.IgnorePermissionErrors))
+	args = args.AppendLoggableBool(ignorePermissionsError, cmdArgs.IgnorePermissionErrors)
 	if cmdArgs.SparseRestore {
 		args = args.AppendLoggable(sparseFlag)
 	}

--- a/pkg/kopia/command/snapshot.go
+++ b/pkg/kopia/command/snapshot.go
@@ -64,7 +64,11 @@ type SnapshotRestoreCommandArgs struct {
 func SnapshotRestore(cmdArgs SnapshotRestoreCommandArgs) []string {
 	args := commonArgs(cmdArgs.CommandArgs, false)
 	args = args.AppendLoggable(snapshotSubCommand, restoreSubCommand, cmdArgs.SnapID, cmdArgs.TargetPath)
-	args = args.AppendLoggableBool(ignorePermissionsError, cmdArgs.IgnorePermissionErrors)
+	if cmdArgs.IgnorePermissionErrors {
+		args = args.AppendLoggable(ignorePermissionsError)
+	} else {
+		args = args.AppendLoggable(noIgnorePermissionsError)
+	}
 	if cmdArgs.SparseRestore {
 		args = args.AppendLoggable(sparseFlag)
 	}

--- a/pkg/kopia/command/snapshot_test.go
+++ b/pkg/kopia/command/snapshot_test.go
@@ -80,7 +80,7 @@ func (kSnapshot *KopiaSnapshotTestSuite) TestSnapshotCommands(c *C) {
 				}
 				return SnapshotRestore(args)
 			},
-			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log --password=encr-key snapshot restore snapshot-id target/path --ignore-permission-errors=false",
+			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log --password=encr-key snapshot restore snapshot-id target/path --no-ignore-permission-errors",
 		},
 		{
 			f: func() []string {
@@ -91,7 +91,7 @@ func (kSnapshot *KopiaSnapshotTestSuite) TestSnapshotCommands(c *C) {
 				}
 				return SnapshotRestore(args)
 			},
-			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log --password=encr-key snapshot restore snapshot-id target/path --ignore-permission-errors=false",
+			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log --password=encr-key snapshot restore snapshot-id target/path --no-ignore-permission-errors",
 		},
 		{
 			f: func() []string {
@@ -104,7 +104,7 @@ func (kSnapshot *KopiaSnapshotTestSuite) TestSnapshotCommands(c *C) {
 				}
 				return SnapshotRestore(args)
 			},
-			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log --password=encr-key snapshot restore snapshot-id target/path --ignore-permission-errors=true --write-sparse-files",
+			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log --password=encr-key snapshot restore snapshot-id target/path --ignore-permission-errors --write-sparse-files",
 		},
 		{
 			f: func() []string {

--- a/pkg/logsafe/logsafe.go
+++ b/pkg/logsafe/logsafe.go
@@ -18,7 +18,6 @@
 package logsafe
 
 import (
-	"fmt"
 	"strings"
 )
 
@@ -70,18 +69,6 @@ func (c Cmd) AppendLoggable(vl ...string) Cmd {
 		c = append(c, arg{value: v, plainText: true})
 	}
 
-	return c
-}
-
-// AppendLoggableBool appends a boolean value in a "--value\--no-value" format.
-// In case of "true" value it will append "--key".
-// In case of "false" value it will append "--no-key"
-func (c Cmd) AppendLoggableBool(k string, v bool) Cmd {
-	if v {
-		c = append(c, arg{key: k})
-	} else {
-		c = append(c, arg{key: fmt.Sprintf("%s%s", noboolpref, k[2:])})
-	}
 	return c
 }
 

--- a/pkg/logsafe/logsafe.go
+++ b/pkg/logsafe/logsafe.go
@@ -73,9 +73,9 @@ func (c Cmd) AppendLoggable(vl ...string) Cmd {
 	return c
 }
 
-// AppendLoggableBool appends a boolean value in a "value\no-value" format.
-// In case of "true" value it will append "key".
-// In case of "false" value it will append "no-key"
+// AppendLoggableBool appends a boolean value in a "--value\--no-value" format.
+// In case of "true" value it will append "--key".
+// In case of "false" value it will append "--no-key"
 func (c Cmd) AppendLoggableBool(k string, v bool) Cmd {
 	if v {
 		c = append(c, arg{key: k})

--- a/pkg/logsafe/logsafe.go
+++ b/pkg/logsafe/logsafe.go
@@ -21,10 +21,7 @@ import (
 	"strings"
 )
 
-const (
-	argRedacted = "<****>"
-	noboolpref  = "--no-"
-)
+const argRedacted = "<****>"
 
 // Cmd is a way of building a command, token by token, such that
 // it can be safely logged with redacted fields. The methods provided
@@ -152,8 +149,6 @@ func (a arg) String() string {
 func combineKeyValue(k, v string) string {
 	if k == "" {
 		return v
-	} else if k != "" && v == "" {
-		return k
 	}
 	return k + "=" + v
 }

--- a/pkg/logsafe/logsafe.go
+++ b/pkg/logsafe/logsafe.go
@@ -18,10 +18,14 @@
 package logsafe
 
 import (
+	"fmt"
 	"strings"
 )
 
-const argRedacted = "<****>"
+const (
+	argRedacted = "<****>"
+	noboolpref  = "--no-"
+)
 
 // Cmd is a way of building a command, token by token, such that
 // it can be safely logged with redacted fields. The methods provided
@@ -66,6 +70,18 @@ func (c Cmd) AppendLoggable(vl ...string) Cmd {
 		c = append(c, arg{value: v, plainText: true})
 	}
 
+	return c
+}
+
+// AppendLoggableBool appends a boolean value in a "value\no-value" format.
+// In case of "true" value it will append "key".
+// In case of "false" value it will append "no-key"
+func (c Cmd) AppendLoggableBool(k string, v bool) Cmd {
+	if v {
+		c = append(c, arg{key: k})
+	} else {
+		c = append(c, arg{key: fmt.Sprintf("%s%s", noboolpref, k[2:])})
+	}
 	return c
 }
 
@@ -149,6 +165,8 @@ func (a arg) String() string {
 func combineKeyValue(k, v string) string {
 	if k == "" {
 		return v
+	} else if k != "" && v == "" {
+		return k
 	}
 	return k + "=" + v
 }


### PR DESCRIPTION
## Change Overview

Kopia uses Kingpin(https://github.com/alecthomas/kingpin) lib for handling cmd args. 
This lib does not allow to set bool var in k=v way. Instead it uses k\no-k format. 
It means that instead of --ingore-permission-errors=false we should use --no-ignore-permission-errors argument. 

From https://github.com/alecthomas/kingpin/blob/master/README.md#boolean-values 
> Boolean values are uniquely managed by Kingpin. Each boolean flag will have a negative complement: --\<name\> and --no-\<name\>.

## Pull request type

Please check the type of change your PR introduces:
- [x] :bug: Bugfix

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :zap: Unit test
