### PR TITLE
Increase goreleaser release timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -259,7 +259,7 @@ gorelease:
 	@$(MAKE) run CMD='-c "./build/gorelease.sh"'
 
 release-snapshot:
-	@$(MAKE) run CMD='-c "GORELEASER_CURRENT_TAG=v9.99.9-dev goreleaser --debug release --rm-dist --snapshot"'
+	@$(MAKE) run CMD='-c "GORELEASER_CURRENT_TAG=v9.99.9-dev goreleaser --debug release --rm-dist --snapshot --timeout=60m0s"'
 
 go-mod-download:
 	@$(MAKE) run CMD='-c "go mod download"'


### PR DESCRIPTION
## Change Overview

The CI has been timing out while building docker images ever since we moved to `ubi9` base image. Increasing the timeout to 60 mins

Part of the failure error:
```
  ⨯ release failed after 30m0s               error=context deadline exceeded
make[1]: *** [Makefile:214: run] Error 1
make[1]: Leaving directory '/home/runner/work/kanister/kanister'
make: *** [Makefile:262: release-snapshot] Error 2
Error: Process completed with exit code 2.
```

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
