### PR TITLE
Update mysql to el9 version

### DIFF
--- a/docker/kanister-mysql/image/Dockerfile
+++ b/docker/kanister-mysql/image/Dockerfile
@@ -4,13 +4,9 @@ FROM registry.access.redhat.com/ubi9/ubi:9.1.0-1646.1669627755 as builder
 RUN dnf clean all && rm -rf /var/cache/dnf
 RUN dnf -y upgrade
 # Download the RPM file to avoid timeouts during install
-RUN curl -LO https://dev.mysql.com/get/mysql80-community-release-el8-1.noarch.rpm
+RUN curl -LO https://dev.mysql.com/get/mysql80-community-release-el9-1.noarch.rpm
 # Install from the local file
-RUN dnf install -y mysql80-community-release-el8-1.noarch.rpm
-
-# GPG keys for MySQL have expired. Importing the new key below.
-# Please refer bug https://bugs.mysql.com/bug.php?id=106188 for more details
-RUN rpm --import https://repo.mysql.com/RPM-GPG-KEY-mysql-2022
+RUN dnf install -y mysql80-community-release-el9-1.noarch.rpm
 
 RUN dnf install -y mysql-community-client
 


### PR DESCRIPTION
## Change Overview

We updated `mysql-sidecar` to ubi9 base image but not the MySQL version. This PR fixes that by updating the MySQL version
Before:
```
[root@ccc4b4dbe66c /]# mysqldump --version
mysqldump: error while loading shared libraries: libssl.so.1.1: cannot open shared object file: No such file or directory
```

After:
```
[root@81ce7d45cff1 /]# mysqldump --version
mysqldump  Ver 8.0.31 for Linux on x86_64 (MySQL Community Server - GPL)
```

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
