### PR TITLE
fix GOMODCACHE path in codegen script

### DIFF
--- a/build/codegen.sh
+++ b/build/codegen.sh
@@ -22,7 +22,7 @@ set -o xtrace
 
 export GO111MODULE=on
 go mod download
-execDir="/root/go/pkg/mod/k8s.io/code-generator@$(go list -f '{{.Version}}' -m k8s.io/code-generator)"
+execDir="/go/pkg/mod/k8s.io/code-generator@$(go list -f '{{.Version}}' -m k8s.io/code-generator)"
 chmod +x "${execDir}"/generate-groups.sh
 "${execDir}"/generate-groups.sh                         \
   all                                        \


### PR DESCRIPTION
## Change Overview

With recent changes to build image, `make codegen` was failing with this error since the path `GOMODCACHE=` in the build container has changed
```
+ chmod +x /root/go/pkg/mod/k8s.io/code-generator@v0.24.4/generate-groups.sh
chmod: cannot access '/root/go/pkg/mod/k8s.io/code-generator@v0.24.4/generate-groups.sh': No such file or directory
make[1]: *** [Makefile:214: run] Error 1
```
This PR is to modify the path in the script according to build container

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E

Output of codegen after updating the script:

```
make[1]: Entering directory '/home/infracloud/go/src/github.com/kanisterio/kanister'
running CMD in the containerized build environment
+ export GO111MODULE=on
+ GO111MODULE=on
+ go mod download
++ go list -f '{{.Version}}' -m k8s.io/code-generator
+ execDir=/go/pkg/mod/k8s.io/code-generator@v0.24.4
+ chmod +x /go/pkg/mod/k8s.io/code-generator@v0.24.4/generate-groups.sh
+ /go/pkg/mod/k8s.io/code-generator@v0.24.4/generate-groups.sh all github.com/kanisterio/kanister/pkg/client github.com/kanisterio/kanister/pkg/apis cr:v1alpha1 --go-header-file /go/pkg/mod/k8s.io/code-generator@v0.24.4/hack/boilerplate.go.txt -o /go/src/
Generating deepcopy funcs
Generating clientset for cr:v1alpha1 at github.com/kanisterio/kanister/pkg/client/clientset
Generating listers for cr:v1alpha1 at github.com/kanisterio/kanister/pkg/client/listers
Generating informers for cr:v1alpha1 at github.com/kanisterio/kanister/pkg/client/informers
make[1]: Leaving directory '/home/infracloud/go/src/github.com/kanisterio/kanister'
```