### PR TITLE
Update condition for statefulset ready in Wait tests

### DIFF
--- a/pkg/function/wait_test.go
+++ b/pkg/function/wait_test.go
@@ -161,11 +161,11 @@ func waitStatefulSetPhase(namespace, sts string) crv1alpha1.BlueprintPhase {
 		Name: "waitStsReady",
 		Func: WaitFuncName,
 		Args: map[string]interface{}{
-			WaitTimeoutArg: "1m",
+			WaitTimeoutArg: "5m",
 			WaitConditionsArg: map[string]interface{}{
 				"allOf": []interface{}{
 					map[string]interface{}{
-						"condition": `{{ if (eq "{$.spec.replicas}" "{$.status.availableReplicas}" )}}
+						"condition": `{{ if (eq "{$.spec.replicas}" "{$.status.currentReplicas}" )}}
 									true
 								{{ else }}
 									false

--- a/pkg/function/waitv2_test.go
+++ b/pkg/function/waitv2_test.go
@@ -155,11 +155,11 @@ func waitV2StatefulSetPhase(namespace, sts string) crv1alpha1.BlueprintPhase {
 		Name: "waitV2StsReady",
 		Func: WaitV2FuncName,
 		Args: map[string]interface{}{
-			WaitV2TimeoutArg: "1m",
+			WaitV2TimeoutArg: "5m",
 			WaitV2ConditionsArg: map[string]interface{}{
 				"allOf": []interface{}{
 					map[string]interface{}{
-						"condition": `{{ if (eq .spec.replicas .status.availableReplicas )}}true{{ else }}false{{ end }}`,
+						"condition": `{{ if (eq .spec.replicas .status.currentReplicas )}}true{{ else }}false{{ end }}`,
 						"objectReference": map[string]interface{}{
 							"apiVersion": "v1",
 							"group":      "apps",


### PR DESCRIPTION
## Change Overview

This PR
- Updates wait for ready conditions for statefulset in Wait func unit tests
- Fixes UT failures on GKE 1.21 clusters 

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Test Plan


- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E

Validated unit tests against gke cluster

```
$ go test -v -check.f="Wait*" .
=== RUN   Test
OK: 4 passed
--- PASS: Test (42.33s)
PASS
ok      github.com/kanisterio/kanister/pkg/function     43.352s

```
