### PR TITLE
Add lifecycle param to PodOptions struct

### DIFF
--- a/pkg/kube/pod.go
+++ b/pkg/kube/pod.go
@@ -71,6 +71,7 @@ type PodOptions struct {
 	RestartPolicy            v1.RestartPolicy
 	OwnerReferences          []metav1.OwnerReference
 	EnvironmentVariables     []v1.EnvVar
+	Lifecycle                *v1.Lifecycle
 }
 
 func GetPodObjectFromPodOptions(cli kubernetes.Interface, opts *PodOptions) (*v1.Pod, error) {
@@ -176,6 +177,10 @@ func GetPodObjectFromPodOptions(cli kubernetes.Interface, opts *PodOptions) (*v1
 
 	if opts.ContainerSecurityContext != nil {
 		pod.Spec.Containers[0].SecurityContext = opts.ContainerSecurityContext
+	}
+
+	if opts.Lifecycle != nil {
+		pod.Spec.Containers[0].Lifecycle = opts.Lifecycle
 	}
 
 	for key, value := range opts.Labels {

--- a/pkg/kube/pod_test.go
+++ b/pkg/kube/pod_test.go
@@ -852,3 +852,26 @@ func (s *PodSuite) TestSetPodSecurityContextOverridesPodOverride(c *C) {
 	c.Assert(*pod.Spec.SecurityContext.RunAsUser, DeepEquals, uidAndGidExpected)
 	c.Assert(*pod.Spec.SecurityContext.RunAsGroup, DeepEquals, uidAndGidExpected)
 }
+
+func (s *PodSuite) TestSetLifecycleHook(c *C) {
+
+	lch := &v1.Lifecycle{
+		PostStart: &v1.LifecycleHandler{
+			Exec: &v1.ExecAction{
+				Command: []string{"/bin/bash", "-c", "echo 1"},
+			},
+		},
+	}
+
+	po := &PodOptions{
+		Namespace:    s.namespace,
+		GenerateName: "test-",
+		Image:        consts.LatestKanisterToolsImage,
+		Command:      []string{"sh", "-c", "tail -f /dev/null"},
+		Lifecycle:    lch,
+	}
+
+	pod, err := CreatePod(context.Background(), s.cli, po)
+	c.Assert(err, IsNil)
+	c.Assert(pod.Spec.Containers[0].Lifecycle, DeepEquals, lch)
+}

--- a/pkg/kube/pod_test.go
+++ b/pkg/kube/pod_test.go
@@ -854,7 +854,6 @@ func (s *PodSuite) TestSetPodSecurityContextOverridesPodOverride(c *C) {
 }
 
 func (s *PodSuite) TestSetLifecycleHook(c *C) {
-
 	lch := &v1.Lifecycle{
 		PostStart: &v1.LifecycleHandler{
 			Exec: &v1.ExecAction{


### PR DESCRIPTION
## Change Overview

Adding lifecycle param to PodOptions to allow set lifecycle hooks to pods

## Pull request type

Please check the type of change your PR introduces:
- [x] :sunflower: Feature
- [x] :robot: Test

## Test Plan

- [x] :zap: Unit test
