### PR TITLE
Add setfcap capability to setcap tool

### DIFF
--- a/docker/tools/Dockerfile
+++ b/docker/tools/Dockerfile
@@ -52,6 +52,7 @@ LABEL name="kanister-tools" \
 COPY --from=restic/restic:0.11.0 /usr/bin/restic /usr/local/bin/restic
 COPY --from=builder /kopia/kopia /usr/local/bin/kopia
 COPY LICENSE /licenses/LICENSE
+RUN setcap cap_setfcap+i /usr/sbin/setcap
 
 ADD kando /usr/local/bin/
 RUN microdnf -y update && microdnf -y install shadow-utils gzip && \


### PR DESCRIPTION
## Change Overview

Adding setfcap capability to setcap tool will allow to change capabilities at the "runtime"(or startup time). Mainly needed for kopia to give it all needed capabilities to work in the non-privileged environments. I'm not adding those capabilities to kopia directly to not to brake any possible backward compatibility and to keep the possibility to work without any capabilities in case of privileged environment 

## Pull request type

Please check the type of change your PR introduces:
- [x] :sunflower: Feature

## Test Plan

- [x] :muscle: Manual
- [x] :green_heart: E2E
