### PR TITLE
Fixed issue-1176: Reduce resource requests while installing minio

### DIFF
--- a/build/minio.sh
+++ b/build/minio.sh
@@ -37,6 +37,7 @@ install_minio ()
     --set environment.MINIO_SSE_AUTO_ENCRYPTION=on \
     --set environment.MINIO_SSE_MASTER_KEY=my-minio-key:feb5bb6c5cf851e21dbc0376ca81012a9edc4ca0ceeb9df5064ccba2991ae9de \
     --set accessKey="AKIAIOSFODNN7EXAMPLE",secretKey="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" \
+    --set resources.requests.memory=200Mi \
     minio/minio --wait --timeout 3m
 
     # export default creds for minio


### PR DESCRIPTION
Signed-off-by: Pratik Shah <pratik@infracloud.io>

## Change Overview

- Set resources.requests.memory to 2Gi

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #1176 

## Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E

Ran integration tests locally `make install-minio; make integration-tests`