### PR TITLE
Added missing RestoreDataPodOverrideArg constant in restore_data function

### DIFF
--- a/pkg/function/restore_data.go
+++ b/pkg/function/restore_data.go
@@ -232,5 +232,6 @@ func (*restoreDataFunc) Arguments() []string {
 		RestoreDataVolsArg,
 		RestoreDataBackupTagArg,
 		RestoreDataBackupIdentifierArg,
+		RestoreDataPodOverrideArg,
 	}
 }


### PR DESCRIPTION
## Change Overview

Added missing RestoreDataPodOverrideArg constant in restore_data function

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #1909 

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E

Ran following commands to verify the change.
- make check
- make golint
- make test
- make build-controller 
- make release-controller IMAGE=docker.io/pratikrshah/controller VERSION=0.89.0
- helm install kanister ./helm/kanister-operator --create-namespace --namespace kanister --set image.repository=docker.io/pratikrshah/controller --set image.tag=0.89.0
- cd examples/mongodb-restic/
- kubectl apply -f ./mongodb-blueprint.yaml 

blueprint content for RestoreData function:
```yaml
    # Restore data to primary db
    - func: RestoreData
      name: restorePrimary
      args:
        namespace: "{{ .StatefulSet.Namespace }}"
        image: ghcr.io/kanisterio/kanister-tools:0.89.0
        backupArtifactPrefix: "{{ .Profile.Location.Bucket }}/mongodb-backups/{{ .StatefulSet.Name }}/rs_backup"
        podOverride:
          containers:
          - name: container
            imagePullPolicy: IfNotPresent
```
Result:
```bash
blueprint.cr.kanister.io/mongodb-blueprint created
```