### PR TITLE
Fixed source location in copy command for build-controller target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ build: bin/$(ARCH)/$(BIN)
 build-controller:
 	@$(MAKE) run CMD='-c " \
 	goreleaser build --id $(BIN) --rm-dist --debug --snapshot \
-	&& cp dist/$(BIN)_linux_$(ARCH)/$(BIN) bin/$(ARCH)/$(BIN) \
+	&& cp dist/$(BIN)_linux_$(ARCH)_*/$(BIN) bin/$(ARCH)/$(BIN) \
 	"'
 
 bin/$(ARCH)/$(BIN):


### PR DESCRIPTION
## Change Overview

With goreleaser v1.8.0, ARCH targets are appended with `_v1` to `_v4` suffixes. Made changes in build-controller target to handle this. 

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #1738 

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E

Ran `make build-controller` with the changes. target was completed successfully