### PR TITLE
Wait for ready

### DIFF
--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -103,11 +103,15 @@ func (s *ControllerSuite) SetUpSuite(c *C) {
 	ss, err = s.cli.AppsV1().StatefulSets(s.namespace).Create(ctx, ss, metav1.CreateOptions{})
 	c.Assert(err, IsNil)
 	s.ss = ss
+	err = kube.WaitOnStatefulSetReady(ctx, s.cli, s.namespace, s.ss.Name)
+	c.Assert(err, IsNil)
 
 	d := testutil.NewTestDeployment(1)
 	d, err = s.cli.AppsV1().Deployments(s.namespace).Create(ctx, d, metav1.CreateOptions{})
 	c.Assert(err, IsNil)
 	s.deployment = d
+	err = kube.WaitOnDeploymentReady(ctx, s.cli, s.namespace, s.deployment.Name)
+	c.Assert(err, IsNil)
 
 	cm := testutil.NewTestConfigMap()
 	cm, err = s.cli.CoreV1().ConfigMaps(s.namespace).Create(ctx, cm, metav1.CreateOptions{})


### PR DESCRIPTION
## Change Overview

This PR waits for the deployment and statefulset to be ready before running tests. This will fix the flaky behavior of the tests

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
