### PR TITLE
Configuration File `.golangci.yml` for `golangci-lint` Runs

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,7 +9,6 @@ linters:
                                         #   7. unused
   enable:
     - gofmt
-    - maligned
     - whitespace
     - gocognit
     - unparam

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,9 @@
+linters:
+  disable-all: false                    # This enabled 7 default linters as of golangci-lint@v1.50.0:
+                                        # 1. errcheck
+                                        # 2. gosimple
+                                        # 3. govet
+                                        # 4. ineffassign
+                                        # 5. staticcheck
+                                        # 6. typecheck
+                                        # 7. unused

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,3 +7,17 @@ linters:
                                         # 5. staticcheck
                                         # 6. typecheck
                                         # 7. unused
+  enable:
+    - gofmt
+
+run:
+  timeout: 10m                          # golangci-lint run's timeout.
+
+  build-tags:                           # All linters will run with below mentioned build tags.
+    - "integration"
+
+issues:
+  exclude-rules:
+    - path: '_test.go'
+      linters:
+        - errcheck                      # Errors may be ignored in tests

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,14 +1,18 @@
 linters:
   disable-all: false                    # This enabled 7 default linters as of golangci-lint@v1.50.0:
-                                        # 1. errcheck
-                                        # 2. gosimple
-                                        # 3. govet
-                                        # 4. ineffassign
-                                        # 5. staticcheck
-                                        # 6. typecheck
-                                        # 7. unused
+                                        #   1. errcheck
+                                        #   2. gosimple
+                                        #   3. govet
+                                        #   4. ineffassign
+                                        #   5. staticcheck
+                                        #   6. typecheck
+                                        #   7. unused
   enable:
     - gofmt
+    - maligned
+    - whitespace
+    - gocognit
+    - unparam
 
 run:
   timeout: 10m                          # golangci-lint run's timeout.
@@ -20,4 +24,9 @@ issues:
   exclude-rules:
     - path: '_test.go'
       linters:
-        - errcheck                      # Errors may be ignored in tests
+        - errcheck                      # Errors may be ignored in tests.
+        - unparam                       # Tests might have unused function parameters.
+
+    - text: "`ctx` is unused"           # Context might not be in use in places, but for consistency, we pass it.
+      linters:
+        - unparam

--- a/build/golint.sh
+++ b/build/golint.sh
@@ -23,17 +23,10 @@ CONFIG_FILE=".golangci.yml"
 
 echo "Running golangci-lint..."
 
-golangci-lint run --timeout ${TIMEOUT} --disable-all --skip-dirs ${SKIP_DIR_REGEX} -E maligned,whitespace,gocognit,unparam -e '`ctx` is unused'
-
-# gofmt should run everywhere, including
-#   1. Skipped directories in previous step
-#   2. Build exempted files using build tags
-#      Note: Future build tags should be included.
-echo "Running gofmt..."
-golangci-lint run --timeout ${TIMEOUT} --disable-all --enable gofmt --build-tags integration
+golangci-lint run --timeout ${TIMEOUT} --no-config --disable-all --skip-dirs ${SKIP_DIR_REGEX} -E maligned,whitespace,gocognit,unparam -e '`ctx` is unused'
 
 echo "Running golangci-lint from config file: ${CONFIG_FILE}"
-golangci-lint run --timeout ${TIMEOUT} --config=${CONFIG_FILE}
+golangci-lint run --config=${CONFIG_FILE}
 
 echo "PASS"
 echo

--- a/build/golint.sh
+++ b/build/golint.sh
@@ -19,10 +19,11 @@ set -o nounset
 
 SKIP_DIR_REGEX="pkg/client"
 TIMEOUT="10m"
+CONFIG_FILE=".golangci.yml"
 
 echo "Running golangci-lint..."
 
-golangci-lint run --timeout ${TIMEOUT} --skip-dirs ${SKIP_DIR_REGEX} -E maligned,whitespace,gocognit,unparam -e '`ctx` is unused'
+golangci-lint run --timeout ${TIMEOUT} --disable-all --skip-dirs ${SKIP_DIR_REGEX} -E maligned,whitespace,gocognit,unparam -e '`ctx` is unused'
 
 # gofmt should run everywhere, including
 #   1. Skipped directories in previous step
@@ -30,6 +31,9 @@ golangci-lint run --timeout ${TIMEOUT} --skip-dirs ${SKIP_DIR_REGEX} -E maligned
 #      Note: Future build tags should be included.
 echo "Running gofmt..."
 golangci-lint run --timeout ${TIMEOUT} --disable-all --enable gofmt --build-tags integration
+
+echo "Running golangci-lint from config file: ${CONFIG_FILE}"
+golangci-lint run --timeout ${TIMEOUT} --config=${CONFIG_FILE}
 
 echo "PASS"
 echo

--- a/build/golint.sh
+++ b/build/golint.sh
@@ -17,13 +17,7 @@
 set -o errexit
 set -o nounset
 
-SKIP_DIR_REGEX="pkg/client"
-TIMEOUT="10m"
 CONFIG_FILE=".golangci.yml"
-
-echo "Running golangci-lint..."
-
-golangci-lint run --timeout ${TIMEOUT} --no-config --disable-all --skip-dirs ${SKIP_DIR_REGEX} -E maligned,whitespace,gocognit,unparam -e '`ctx` is unused'
 
 echo "Running golangci-lint from config file: ${CONFIG_FILE}"
 golangci-lint run --config=${CONFIG_FILE}

--- a/pkg/testing/integration_test.go
+++ b/pkg/testing/integration_test.go
@@ -169,7 +169,7 @@ func newSecretProfile() *secretProfile {
 
 func (s *IntegrationSuite) SetUpSuite(c *C) {
 	ctx := context.Background()
-	ctx, s.cancel = context.WithCancel(ctx)
+	_, s.cancel = context.WithCancel(ctx)
 
 	// Instantiate Client SDKs
 	cfg, err := kube.LoadConfig()


### PR DESCRIPTION
## Change Overview

Configuration file `.golangci.yml` for `golangci-lint` runs as explained in #1761.

#### Changes
1. Linter: Run 7 default linters (`errcheck`, `gosimple`, `govet`, `ineffassign`, `staticcheck`, `typecheck` & `unused`) from `.golangci.yaml`.
2. Linter: Run linter `gofmt` from `.golangci.yaml`.
3. Linter: Run custom linters (`maligned`, `whitespace`, `gocognit` & `unparam`) from `.golangci.yaml`.
4. Linter: Remove linter `maligned` due to following reasons:
    - Linter `maligned` is archived by owner and deprecated from `golangci-lint`.
    - `maligned` (or it's replacement: govet's fieldalignment) recommends >50 struct's field alignment. Too many changes for much less value.
    - Struct fields might be ordered per their similarities. Rearranging for saving few bytes is not reasonable.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [x] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [x] :robot: Test

## Issues

- fixes #1761 

## Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E

Run the command:
```
make golint
```

It should pass as it was before. Output similar to:
```
make[1]: Entering directory '/home/bhargav-infracloud/Workspace/go/src/github.com/Bhargav-InfraCloud/kanister'
running CMD in the containerized build environment
Running golangci-lint from config file: .golangci.yml
PASS

PASS

make[1]: Leaving directory '/home/bhargav-infracloud/Workspace/go/src/github.com/Bhargav-InfraCloud/kanister'
```
## To Maintainers
~The `gofmt` and `govet` are ran in `make golint` as well as the following scripts:~
~1. build/test.sh~
~2. examples/aws-rds/postgresql/pgtest/build/test.sh~

~Is there any particular reason for this or can these be eliminated from (or) replaced in scripts?~ This is discussed in the comments.
