### PR TITLE
Comment in `start_localkube` that its not used to create CI cluster

### DIFF
--- a/build/local_kubernetes.sh
+++ b/build/local_kubernetes.sh
@@ -48,6 +48,9 @@ check_or_get_dependencies() {
     done
 }
 
+# This function is not used to create Kubernetes cluster in CI anymore. We are
+# using `helm/kind-action@v1.4.0` instead in our github actions source file
+# `.github/workflows/main.yaml` to create the cluster
 start_localkube() {
     if ! command -v kind
     then


### PR DESCRIPTION
## Change Overview

`start_localkube` is not actually used to create cluster in our CI. This makes that explicit so that people don't get confused.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
