### PR TITLE
PodOptions should take ImagePullSecrets

### DIFF
--- a/pkg/kube/pod.go
+++ b/pkg/kube/pod.go
@@ -72,6 +72,7 @@ type PodOptions struct {
 	OwnerReferences          []metav1.OwnerReference
 	EnvironmentVariables     []v1.EnvVar
 	Lifecycle                *v1.Lifecycle
+	ImagePullSecrets         []v1.LocalObjectReference
 }
 
 func GetPodObjectFromPodOptions(cli kubernetes.Interface, opts *PodOptions) (*v1.Pod, error) {
@@ -127,6 +128,7 @@ func GetPodObjectFromPodOptions(cli kubernetes.Interface, opts *PodOptions) (*v1
 		RestartPolicy:      opts.RestartPolicy,
 		Volumes:            podVolumes,
 		ServiceAccountName: sa,
+		ImagePullSecrets:   opts.ImagePullSecrets,
 	}
 
 	if opts.EnvironmentVariables != nil && len(opts.EnvironmentVariables) > 0 {

--- a/pkg/kube/pod_test.go
+++ b/pkg/kube/pod_test.go
@@ -80,6 +80,7 @@ func (s *PodSuite) TearDownSuite(c *C) {
 	}
 }
 
+//nolint:gocognit
 func (s *PodSuite) TestPod(c *C) {
 	// get controllers's namespace
 	cns, err := GetControllerNamespace()

--- a/pkg/kube/pod_test.go
+++ b/pkg/kube/pod_test.go
@@ -192,6 +192,15 @@ func (s *PodSuite) TestPod(c *C) {
 				},
 			},
 		},
+		{
+			Namespace:    s.namespace,
+			GenerateName: "test-",
+			Image:        consts.LatestKanisterToolsImage,
+			Command:      []string{"sh", "-c", "tail -f /dev/null"},
+			ImagePullSecrets: []v1.LocalObjectReference{
+				{Name: "test-secret"},
+			},
+		},
 	}
 
 	for _, po := range podOptions {
@@ -233,6 +242,9 @@ func (s *PodSuite) TestPod(c *C) {
 		if po.Resources.Requests != nil {
 			c.Assert(pod.Spec.Containers[0].Resources.Requests, NotNil)
 			c.Assert(pod.Spec.Containers[0].Resources.Requests, DeepEquals, po.Resources.Requests)
+		}
+		if po.ImagePullSecrets != nil {
+			c.Assert(pod.Spec.ImagePullSecrets, DeepEquals, po.ImagePullSecrets)
 		}
 
 		switch {


### PR DESCRIPTION
## Change Overview

This modification will enable PodOptions to take ImagePullSecrets as an input when creating a Pod.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [x] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
