### PR TITLE
Pass Context to `kube.execute()` in `pkg/kube/exec.go`

### DIFF
--- a/pkg/app/cassandra.go
+++ b/pkg/app/cassandra.go
@@ -222,5 +222,5 @@ func (cas *CassandraInstance) execCommand(ctx context.Context, command []string)
 	if err != nil || podname == "" {
 		return "", "", errors.Wrapf(err, "Error getting the pod and container name %s.", cas.name)
 	}
-	return kube.Exec(cas.cli, cas.namespace, podname, containername, command, nil)
+	return kube.Exec(ctx, cas.cli, cas.namespace, podname, containername, command, nil)
 }

--- a/pkg/app/cockroachdb.go
+++ b/pkg/app/cockroachdb.go
@@ -295,7 +295,7 @@ func (c *CockroachDB) execCommand(ctx context.Context, command []string) (string
 	if err != nil || podName == "" {
 		return "", "", errors.Wrapf(err, "Error  getting pod and container name %s.", c.name)
 	}
-	return kube.Exec(c.cli, c.namespace, podName, containerName, command, nil)
+	return kube.Exec(ctx, c.cli, c.namespace, podName, containerName, command, nil)
 }
 
 func (c *CockroachDB) waitForGC(ctx context.Context) error {

--- a/pkg/app/couchbase.go
+++ b/pkg/app/couchbase.go
@@ -262,7 +262,7 @@ func (cb CouchbaseDB) execCommand(ctx context.Context, command []string) (string
 	if err != nil || len(container) == 0 {
 		return "", "", err
 	}
-	return kube.Exec(cb.cli, cb.namespace, podName, container[0].Name, command, nil)
+	return kube.Exec(ctx, cb.cli, cb.namespace, podName, container[0].Name, command, nil)
 }
 
 // getRunningCBPod name of running couchbase cluster pod if its in ready state

--- a/pkg/app/csi-snapshot.go
+++ b/pkg/app/csi-snapshot.go
@@ -169,7 +169,7 @@ func (tlc *TimeLogCSI) execCommand(ctx context.Context, command []string) (strin
 	if err != nil || podname == "" {
 		return "", errors.Wrapf(err, "Error getting pod and containername %s.", tlc.name)
 	}
-	_, stderr, err := kube.Exec(tlc.cli, tlc.namespace, podname, containername, command, nil)
+	_, stderr, err := kube.Exec(ctx, tlc.cli, tlc.namespace, podname, containername, command, nil)
 	return stderr, err
 }
 

--- a/pkg/app/elasticsearch.go
+++ b/pkg/app/elasticsearch.go
@@ -230,7 +230,7 @@ func (esi *ElasticsearchInstance) execCommand(ctx context.Context, command []str
 	if err != nil || podname == "" {
 		return "", "", errors.Wrapf(err, "Error getting the pod and container name %s.", esi.name)
 	}
-	return kube.Exec(esi.cli, esi.namespace, podname, containername, command, nil)
+	return kube.Exec(ctx, esi.cli, esi.namespace, podname, containername, command, nil)
 }
 
 func (esi *ElasticsearchInstance) curlCommand(method, path string) string {

--- a/pkg/app/foundationdb.go
+++ b/pkg/app/foundationdb.go
@@ -245,5 +245,5 @@ func (fdb *FoundationDB) execCommand(ctx context.Context, command []string) (str
 		return "", "", err
 	}
 
-	return kube.Exec(fdb.cli, fdb.namespace, podName, containers[0].Name, command, nil)
+	return kube.Exec(ctx, fdb.cli, fdb.namespace, podName, containers[0].Name, command, nil)
 }

--- a/pkg/app/mariadb.go
+++ b/pkg/app/mariadb.go
@@ -217,7 +217,7 @@ func (m *MariaDB) execCommand(ctx context.Context, command []string) (string, st
 	if err != nil || podname == "" {
 		return "", "", errors.Wrapf(err, "Error  getting pod and containername %s.", m.name)
 	}
-	return kube.Exec(m.cli, m.namespace, podname, containername, command, nil)
+	return kube.Exec(ctx, m.cli, m.namespace, podname, containername, command, nil)
 }
 
 func mariaDBSTSName(release string) string {

--- a/pkg/app/mongodb-deploymentconfig.go
+++ b/pkg/app/mongodb-deploymentconfig.go
@@ -181,7 +181,7 @@ func (mongo *MongoDBDepConfig) execCommand(ctx context.Context, command []string
 	if err != nil {
 		return "", "", err
 	}
-	stdout, stderr, err := kube.Exec(mongo.cli, mongo.namespace, podName, containerName, command, nil)
+	stdout, stderr, err := kube.Exec(ctx, mongo.cli, mongo.namespace, podName, containerName, command, nil)
 	log.Print("Executing the command in pod and contianer", field.M{"pod": podName, "container": containerName, "cmd": command})
 
 	return stdout, stderr, errors.Wrapf(err, "Error executing command in the pod")

--- a/pkg/app/mongodb.go
+++ b/pkg/app/mongodb.go
@@ -226,5 +226,5 @@ func (mongo *MongoDB) execCommand(ctx context.Context, command []string) (string
 	if err != nil || podName == "" {
 		return "", "", err
 	}
-	return kube.Exec(mongo.cli, mongo.namespace, podName, containerName, command, nil)
+	return kube.Exec(ctx, mongo.cli, mongo.namespace, podName, containerName, command, nil)
 }

--- a/pkg/app/mssql.go
+++ b/pkg/app/mssql.go
@@ -245,7 +245,7 @@ func (m MssqlDB) execCommand(ctx context.Context, command []string) (string, str
 	if err != nil || podName == "" {
 		return "", "", errors.Wrapf(err, "Error getting pod and container name for app %s.", m.name)
 	}
-	return kube.Exec(m.cli, m.namespace, podName, containerName, command, nil)
+	return kube.Exec(ctx, m.cli, m.namespace, podName, containerName, command, nil)
 }
 
 func (m *MssqlDB) getDeploymentObj() (*appsv1.Deployment, error) {

--- a/pkg/app/mysql-deploymentconfig.go
+++ b/pkg/app/mysql-deploymentconfig.go
@@ -194,7 +194,7 @@ func (mdep *MysqlDepConfig) execCommand(ctx context.Context, command []string) (
 	if err != nil {
 		return "", "", err
 	}
-	stdout, stderr, err := kube.Exec(mdep.cli, mdep.namespace, podName, containerName, command, nil)
+	stdout, stderr, err := kube.Exec(ctx, mdep.cli, mdep.namespace, podName, containerName, command, nil)
 	if err != nil {
 		return stdout, stderr, errors.Wrapf(err, "Error executing command in the pod.")
 	}

--- a/pkg/app/mysql.go
+++ b/pkg/app/mysql.go
@@ -242,5 +242,5 @@ func (mdb *MysqlDB) execCommand(ctx context.Context, command []string) (string, 
 	if err != nil || podname == "" {
 		return "", "", errors.Wrapf(err, "Error  getting pod and containername %s.", mdb.name)
 	}
-	return kube.Exec(mdb.cli, mdb.namespace, podname, containername, command, nil)
+	return kube.Exec(ctx, mdb.cli, mdb.namespace, podname, containername, command, nil)
 }

--- a/pkg/app/postgresql-deploymentconfig.go
+++ b/pkg/app/postgresql-deploymentconfig.go
@@ -223,5 +223,5 @@ func (pgres *PostgreSQLDepConfig) execCommand(ctx context.Context, command []str
 	if err != nil {
 		return "", "", err
 	}
-	return kube.Exec(pgres.cli, pgres.namespace, pod, container, command, nil)
+	return kube.Exec(ctx, pgres.cli, pgres.namespace, pod, container, command, nil)
 }

--- a/pkg/app/postgresql.go
+++ b/pkg/app/postgresql.go
@@ -217,5 +217,5 @@ func (pdb PostgresDB) execCommand(ctx context.Context, command []string) (string
 	if err != nil {
 		return "", "", err
 	}
-	return kube.Exec(pdb.cli, pdb.namespace, pod, container, command, nil)
+	return kube.Exec(ctx, pdb.cli, pdb.namespace, pod, container, command, nil)
 }

--- a/pkg/app/rds_aurora_mysql.go
+++ b/pkg/app/rds_aurora_mysql.go
@@ -396,5 +396,5 @@ func (a RDSAuroraMySQLDB) execCommand(ctx context.Context, command []string) (st
 	if err != nil || podName == "" {
 		return "", "", err
 	}
-	return kube.Exec(a.cli, a.namespace, podName, containerName, command, nil)
+	return kube.Exec(ctx, a.cli, a.namespace, podName, containerName, command, nil)
 }

--- a/pkg/app/rds_postgres.go
+++ b/pkg/app/rds_postgres.go
@@ -477,5 +477,5 @@ func (pdb RDSPostgresDB) execCommand(ctx context.Context, command []string) (str
 	if err != nil || podName == "" {
 		return "", "", err
 	}
-	return kube.Exec(pdb.cli, pdb.namespace, podName, containerName, command, nil)
+	return kube.Exec(ctx, pdb.cli, pdb.namespace, podName, containerName, command, nil)
 }

--- a/pkg/controllers/repositoryserver/handler.go
+++ b/pkg/controllers/repositoryserver/handler.go
@@ -71,7 +71,7 @@ func (h *RepoServerHandler) CreateOrUpdateOwnedResources(ctx context.Context) er
 		}
 	}
 
-	if err := h.connectToKopiaRepository(); err != nil {
+	if err := h.connectToKopiaRepository(ctx); err != nil {
 		return errors.Wrap(err, "Failed to connect to Kopia repository")
 	}
 

--- a/pkg/controllers/repositoryserver/repository.go
+++ b/pkg/controllers/repositoryserver/repository.go
@@ -15,6 +15,7 @@
 package repositoryserver
 
 import (
+	"context"
 	"strconv"
 
 	"github.com/kanisterio/kanister/pkg/kopia/command"
@@ -25,7 +26,7 @@ const (
 	repoPasswordKey = "repo-password"
 )
 
-func (h *RepoServerHandler) connectToKopiaRepository() error {
+func (h *RepoServerHandler) connectToKopiaRepository(ctx context.Context) error {
 	contentCacheMB, metadataCacheMB, err := h.getRepositoryCacheSettings()
 	if err != nil {
 		return err
@@ -47,6 +48,7 @@ func (h *RepoServerHandler) connectToKopiaRepository() error {
 	}
 
 	return repository.ConnectToKopiaRepository(
+		ctx,
 		h.KubeCli,
 		h.RepositoryServer.Namespace,
 		h.RepositoryServer.Status.ServerInfo.PodName,

--- a/pkg/controllers/repositoryserver/server.go
+++ b/pkg/controllers/repositoryserver/server.go
@@ -65,7 +65,7 @@ func (h *RepoServerHandler) startRepoProxyServer(ctx context.Context) (err error
 			Background:       true,
 		},
 	)
-	stdout, stderr, err := kube.Exec(h.KubeCli, h.RepositoryServer.Namespace, h.RepositoryServer.Status.ServerInfo.PodName, repoServerPodContainerName, cmd, nil)
+	stdout, stderr, err := kube.Exec(ctx, h.KubeCli, h.RepositoryServer.Namespace, h.RepositoryServer.Status.ServerInfo.PodName, repoServerPodContainerName, cmd, nil)
 	format.Log(h.RepositoryServer.Status.ServerInfo.PodName, repoServerPodContainerName, stdout)
 	format.Log(h.RepositoryServer.Status.ServerInfo.PodName, repoServerPodContainerName, stderr)
 	if err != nil {
@@ -101,7 +101,7 @@ func (h *RepoServerHandler) checkServerStatus(ctx context.Context, serverAddress
 	if err != nil {
 		return errors.Wrap(err, "Failed to extract fingerprint from Kopia API server certificate secret data")
 	}
-	stdout, stderr, exErr := kube.Exec(h.KubeCli, h.RepositoryServer.Namespace, h.RepositoryServer.Status.ServerInfo.PodName, repoServerPodContainerName, cmd, nil)
+	stdout, stderr, exErr := kube.Exec(ctx, h.KubeCli, h.RepositoryServer.Namespace, h.RepositoryServer.Status.ServerInfo.PodName, repoServerPodContainerName, cmd, nil)
 	format.Log(h.RepositoryServer.Status.ServerInfo.PodName, repoServerPodContainerName, stdout)
 	format.Log(h.RepositoryServer.Status.ServerInfo.PodName, repoServerPodContainerName, stderr)
 	return exErr
@@ -129,7 +129,7 @@ func (h *RepoServerHandler) createOrUpdateClientUsers(ctx context.Context) error
 				LogDirectory:   command.DefaultLogDirectory,
 			},
 		})
-	stdout, stderr, err := kube.Exec(h.KubeCli, h.RepositoryServer.Namespace, h.RepositoryServer.Status.ServerInfo.PodName, repoServerPodContainerName, cmd, nil)
+	stdout, stderr, err := kube.Exec(ctx, h.KubeCli, h.RepositoryServer.Namespace, h.RepositoryServer.Status.ServerInfo.PodName, repoServerPodContainerName, cmd, nil)
 	format.Log(h.RepositoryServer.Status.ServerInfo.PodName, repoServerPodContainerName, stdout)
 	format.Log(h.RepositoryServer.Status.ServerInfo.PodName, repoServerPodContainerName, stderr)
 	if err != nil {
@@ -166,7 +166,7 @@ func (h *RepoServerHandler) createOrUpdateClientUsers(ctx context.Context) error
 					NewUsername:  serverUsername,
 					UserPassword: string(password),
 				})
-			stdout, stderr, err := kube.Exec(h.KubeCli, h.RepositoryServer.Namespace, h.RepositoryServer.Status.ServerInfo.PodName, repoServerPodContainerName, cmd, nil)
+			stdout, stderr, err := kube.Exec(ctx, h.KubeCli, h.RepositoryServer.Namespace, h.RepositoryServer.Status.ServerInfo.PodName, repoServerPodContainerName, cmd, nil)
 			format.Log(h.RepositoryServer.Status.ServerInfo.PodName, repoServerPodContainerName, stdout)
 			format.Log(h.RepositoryServer.Status.ServerInfo.PodName, repoServerPodContainerName, stderr)
 			if err != nil {
@@ -184,7 +184,7 @@ func (h *RepoServerHandler) createOrUpdateClientUsers(ctx context.Context) error
 				NewUsername:  serverUsername,
 				UserPassword: string(password),
 			})
-		stdout, stderr, err := kube.Exec(h.KubeCli, h.RepositoryServer.Namespace, h.RepositoryServer.Status.ServerInfo.PodName, repoServerPodContainerName, cmd, nil)
+		stdout, stderr, err := kube.Exec(ctx, h.KubeCli, h.RepositoryServer.Namespace, h.RepositoryServer.Status.ServerInfo.PodName, repoServerPodContainerName, cmd, nil)
 		format.Log(h.RepositoryServer.Status.ServerInfo.PodName, repoServerPodContainerName, stdout)
 		format.Log(h.RepositoryServer.Status.ServerInfo.PodName, repoServerPodContainerName, stderr)
 		if err != nil {
@@ -222,7 +222,7 @@ func (h *RepoServerHandler) refreshServer(ctx context.Context, serverAddress, us
 			ServerPassword: password,
 			Fingerprint:    fingerprint,
 		})
-	stdout, stderr, err := kube.Exec(h.KubeCli, h.RepositoryServer.Namespace, h.RepositoryServer.Status.ServerInfo.PodName, repoServerPodContainerName, cmd, nil)
+	stdout, stderr, err := kube.Exec(ctx, h.KubeCli, h.RepositoryServer.Namespace, h.RepositoryServer.Status.ServerInfo.PodName, repoServerPodContainerName, cmd, nil)
 	format.Log(h.RepositoryServer.Status.ServerInfo.PodName, repoServerPodContainerName, stdout)
 	format.Log(h.RepositoryServer.Status.ServerInfo.PodName, repoServerPodContainerName, stderr)
 	if err != nil {

--- a/pkg/controllers/repositoryserver/utils.go
+++ b/pkg/controllers/repositoryserver/utils.go
@@ -215,7 +215,7 @@ func WaitTillCommandSucceed(ctx context.Context, cli kubernetes.Interface, cmd [
 		Min:    100 * time.Millisecond,
 		Max:    180 * time.Second,
 	}, func(context.Context) (bool, error) {
-		stdout, stderr, exErr := kube.Exec(cli, namespace, podName, container, cmd, nil)
+		stdout, stderr, exErr := kube.Exec(ctx, cli, namespace, podName, container, cmd, nil)
 		format.Log(podName, container, stdout)
 		format.Log(podName, container, stderr)
 		if exErr != nil {

--- a/pkg/function/backup_data.go
+++ b/pkg/function/backup_data.go
@@ -154,7 +154,7 @@ func backupData(ctx context.Context, cli kubernetes.Interface, namespace, pod, c
 		return backupDataParsedOutput{}, err
 	}
 	defer CleanUpCredsFile(ctx, pw, namespace, pod, container)
-	if err = restic.GetOrCreateRepository(cli, namespace, pod, container, backupArtifactPrefix, encryptionKey, tp.Profile); err != nil {
+	if err = restic.GetOrCreateRepository(ctx, cli, namespace, pod, container, backupArtifactPrefix, encryptionKey, tp.Profile); err != nil {
 		return backupDataParsedOutput{}, err
 	}
 
@@ -164,7 +164,7 @@ func backupData(ctx context.Context, cli kubernetes.Interface, namespace, pod, c
 	if err != nil {
 		return backupDataParsedOutput{}, err
 	}
-	stdout, stderr, err := kube.Exec(cli, namespace, pod, container, cmd, nil)
+	stdout, stderr, err := kube.Exec(ctx, cli, namespace, pod, container, cmd, nil)
 	format.LogWithCtx(ctx, pod, container, stdout)
 	format.LogWithCtx(ctx, pod, container, stderr)
 	if err != nil {

--- a/pkg/function/backup_data_stats.go
+++ b/pkg/function/backup_data_stats.go
@@ -89,7 +89,7 @@ func backupDataStatsPodFunc(cli kubernetes.Interface, tp param.TemplateParams, n
 		if err != nil {
 			return nil, err
 		}
-		stdout, stderr, err := kube.Exec(cli, namespace, pod.Name, pod.Spec.Containers[0].Name, cmd, nil)
+		stdout, stderr, err := kube.Exec(ctx, cli, namespace, pod.Name, pod.Spec.Containers[0].Name, cmd, nil)
 		format.LogWithCtx(ctx, pod.Name, pod.Spec.Containers[0].Name, stdout)
 		format.LogWithCtx(ctx, pod.Name, pod.Spec.Containers[0].Name, stderr)
 		if err != nil {

--- a/pkg/function/backup_data_using_kopia_server.go
+++ b/pkg/function/backup_data_using_kopia_server.go
@@ -126,6 +126,7 @@ func (*backupDataUsingKopiaServerFunc) Exec(ctx context.Context, tp param.Templa
 	}
 
 	snapInfo, err := backupDataUsingKopiaServer(
+		ctx,
 		cli,
 		container,
 		hostname,
@@ -158,6 +159,7 @@ func (*backupDataUsingKopiaServerFunc) Exec(ctx context.Context, tp param.Templa
 }
 
 func backupDataUsingKopiaServer(
+	ctx context.Context,
 	cli kubernetes.Interface,
 	container,
 	hostname,
@@ -186,7 +188,7 @@ func backupDataUsingKopiaServer(
 		MetadataCacheMB: metadataCacheMB,
 	})
 
-	stdout, stderr, err := kube.Exec(cli, namespace, pod, container, cmd, nil)
+	stdout, stderr, err := kube.Exec(ctx, cli, namespace, pod, container, cmd, nil)
 	format.Log(pod, container, stdout)
 	format.Log(pod, container, stderr)
 	if err != nil {
@@ -208,7 +210,7 @@ func backupDataUsingKopiaServer(
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to construct snapshot create command")
 	}
-	stdout, stderr, err = kube.Exec(cli, namespace, pod, container, cmd, nil)
+	stdout, stderr, err = kube.Exec(ctx, cli, namespace, pod, container, cmd, nil)
 	format.Log(pod, container, stdout)
 	format.Log(pod, container, stderr)
 

--- a/pkg/function/checkRepository.go
+++ b/pkg/function/checkRepository.go
@@ -69,7 +69,7 @@ func CheckRepositoryPodFunc(cli kubernetes.Interface, tp param.TemplateParams, n
 			return nil, err
 		}
 		defer CleanUpCredsFile(ctx, pw, pod.Namespace, pod.Name, pod.Spec.Containers[0].Name)
-		err = restic.CheckIfRepoIsReachable(tp.Profile, targetPath, encryptionKey, cli, namespace, pod.Name, pod.Spec.Containers[0].Name)
+		err = restic.CheckIfRepoIsReachable(ctx, tp.Profile, targetPath, encryptionKey, cli, namespace, pod.Name, pod.Spec.Containers[0].Name)
 		switch {
 		case err == nil:
 			break

--- a/pkg/function/copy_volume_data.go
+++ b/pkg/function/copy_volume_data.go
@@ -104,7 +104,7 @@ func copyVolumeDataPodFunc(cli kubernetes.Interface, tp param.TemplateParams, na
 
 		pod := pc.Pod()
 		// Get restic repository
-		if err := restic.GetOrCreateRepository(cli, namespace, pod.Name, pod.Spec.Containers[0].Name, targetPath, encryptionKey, tp.Profile); err != nil {
+		if err := restic.GetOrCreateRepository(ctx, cli, namespace, pod.Name, pod.Spec.Containers[0].Name, targetPath, encryptionKey, tp.Profile); err != nil {
 			return nil, err
 		}
 		// Copy data to object store

--- a/pkg/function/delete_data.go
+++ b/pkg/function/delete_data.go
@@ -98,7 +98,7 @@ func deleteDataPodFunc(cli kubernetes.Interface, tp param.TemplateParams, reclai
 			if err != nil {
 				return nil, err
 			}
-			stdout, stderr, err := kube.Exec(cli, namespace, pod.Name, pod.Spec.Containers[0].Name, cmd, nil)
+			stdout, stderr, err := kube.Exec(ctx, cli, namespace, pod.Name, pod.Spec.Containers[0].Name, cmd, nil)
 			format.LogWithCtx(ctx, pod.Name, pod.Spec.Containers[0].Name, stdout)
 			format.LogWithCtx(ctx, pod.Name, pod.Spec.Containers[0].Name, stderr)
 			if err != nil {
@@ -116,14 +116,14 @@ func deleteDataPodFunc(cli kubernetes.Interface, tp param.TemplateParams, reclai
 			if err != nil {
 				return nil, err
 			}
-			stdout, stderr, err := kube.Exec(cli, namespace, pod.Name, pod.Spec.Containers[0].Name, cmd, nil)
+			stdout, stderr, err := kube.Exec(ctx, cli, namespace, pod.Name, pod.Spec.Containers[0].Name, cmd, nil)
 			format.LogWithCtx(ctx, pod.Name, pod.Spec.Containers[0].Name, stdout)
 			format.LogWithCtx(ctx, pod.Name, pod.Spec.Containers[0].Name, stderr)
 			if err != nil {
 				return nil, errors.Wrapf(err, "Failed to forget data")
 			}
 			if reclaimSpace {
-				spaceFreedStr, err := pruneData(cli, tp, pod, namespace, encryptionKey, targetPaths[i])
+				spaceFreedStr, err := pruneData(ctx, cli, tp, pod, namespace, encryptionKey, targetPaths[i])
 				if err != nil {
 					return nil, errors.Wrapf(err, "Error executing prune command")
 				}
@@ -137,12 +137,12 @@ func deleteDataPodFunc(cli kubernetes.Interface, tp param.TemplateParams, reclai
 	}
 }
 
-func pruneData(cli kubernetes.Interface, tp param.TemplateParams, pod *v1.Pod, namespace, encryptionKey, targetPath string) (string, error) {
+func pruneData(ctx context.Context, cli kubernetes.Interface, tp param.TemplateParams, pod *v1.Pod, namespace, encryptionKey, targetPath string) (string, error) {
 	cmd, err := restic.PruneCommand(tp.Profile, targetPath, encryptionKey)
 	if err != nil {
 		return "", err
 	}
-	stdout, stderr, err := kube.Exec(cli, namespace, pod.Name, pod.Spec.Containers[0].Name, cmd, nil)
+	stdout, stderr, err := kube.Exec(ctx, cli, namespace, pod.Name, pod.Spec.Containers[0].Name, cmd, nil)
 	format.Log(pod.Name, pod.Spec.Containers[0].Name, stdout)
 	format.Log(pod.Name, pod.Spec.Containers[0].Name, stderr)
 	spaceFreed := restic.SpaceFreedFromPruneLog(stdout)

--- a/pkg/function/delete_data_using_kopia_server.go
+++ b/pkg/function/delete_data_using_kopia_server.go
@@ -180,7 +180,7 @@ func deleteDataFromServerPodFunc(
 				ContentCacheMB:  contentCacheMB,
 				MetadataCacheMB: metadataCacheMB,
 			})
-		stdout, stderr, err := kube.Exec(cli, namespace, pod.Name, pod.Spec.Containers[0].Name, cmd, nil)
+		stdout, stderr, err := kube.Exec(ctx, cli, namespace, pod.Name, pod.Spec.Containers[0].Name, cmd, nil)
 		format.Log(pod.Name, pod.Spec.Containers[0].Name, stdout)
 		format.Log(pod.Name, pod.Spec.Containers[0].Name, stderr)
 		if err != nil {
@@ -196,7 +196,7 @@ func deleteDataFromServerPodFunc(
 				},
 				SnapID: snapID,
 			})
-		stdout, stderr, err = kube.Exec(cli, namespace, pod.Name, pod.Spec.Containers[0].Name, cmd, nil)
+		stdout, stderr, err = kube.Exec(ctx, cli, namespace, pod.Name, pod.Spec.Containers[0].Name, cmd, nil)
 		format.Log(pod.Name, pod.Spec.Containers[0].Name, stdout)
 		format.Log(pod.Name, pod.Spec.Containers[0].Name, stderr)
 		return nil, errors.Wrap(err, "Failed to delete backup from Kopia API server")

--- a/pkg/function/describe_backups.go
+++ b/pkg/function/describe_backups.go
@@ -87,7 +87,7 @@ func describeBackupsPodFunc(cli kubernetes.Interface, tp param.TemplateParams, n
 			return nil, err
 		}
 		defer CleanUpCredsFile(ctx, pw, pod.Namespace, pod.Name, pod.Spec.Containers[0].Name)
-		err = restic.CheckIfRepoIsReachable(tp.Profile, targetPath, encryptionKey, cli, namespace, pod.Name, pod.Spec.Containers[0].Name)
+		err = restic.CheckIfRepoIsReachable(ctx, tp.Profile, targetPath, encryptionKey, cli, namespace, pod.Name, pod.Spec.Containers[0].Name)
 		switch {
 		case err == nil:
 			break
@@ -117,7 +117,7 @@ func describeBackupsPodFunc(cli kubernetes.Interface, tp param.TemplateParams, n
 		if err != nil {
 			return nil, err
 		}
-		stdout, stderr, err := kube.Exec(cli, namespace, pod.Name, pod.Spec.Containers[0].Name, cmd, nil)
+		stdout, stderr, err := kube.Exec(ctx, cli, namespace, pod.Name, pod.Spec.Containers[0].Name, cmd, nil)
 		format.LogWithCtx(ctx, pod.Name, pod.Spec.Containers[0].Name, stdout)
 		format.LogWithCtx(ctx, pod.Name, pod.Spec.Containers[0].Name, stderr)
 		if err != nil {

--- a/pkg/function/kube_exec.go
+++ b/pkg/function/kube_exec.go
@@ -96,7 +96,7 @@ func (kef *kubeExecFunc) Exec(ctx context.Context, tp param.TemplateParams, args
 		bufStdout  = &bytes.Buffer{}
 		outWriters = io.MultiWriter(os.Stdout, bufStdout)
 	)
-	if err := kube.ExecOutput(cli, namespace, pod, container, cmd, nil, outWriters, os.Stderr); err != nil {
+	if err := kube.ExecOutput(ctx, cli, namespace, pod, container, cmd, nil, outWriters, os.Stderr); err != nil {
 		return nil, err
 	}
 

--- a/pkg/function/kube_exec_all.go
+++ b/pkg/function/kube_exec_all.go
@@ -100,7 +100,7 @@ func execAll(ctx context.Context, cli kubernetes.Interface, namespace string, ps
 	for _, p := range ps {
 		for _, c := range cs {
 			go func(p string, c string) {
-				stdout, stderr, err := kube.Exec(cli, namespace, p, c, cmd, nil)
+				stdout, stderr, err := kube.Exec(ctx, cli, namespace, p, c, cmd, nil)
 				format.LogWithCtx(ctx, p, c, stdout)
 				format.LogWithCtx(ctx, p, c, stderr)
 				errChan <- err

--- a/pkg/function/restore_data.go
+++ b/pkg/function/restore_data.go
@@ -150,7 +150,7 @@ func restoreDataPodFunc(cli kubernetes.Interface, tp param.TemplateParams, names
 		if err != nil {
 			return nil, err
 		}
-		stdout, stderr, err := kube.Exec(cli, namespace, pod.Name, pod.Spec.Containers[0].Name, cmd, nil)
+		stdout, stderr, err := kube.Exec(ctx, cli, namespace, pod.Name, pod.Spec.Containers[0].Name, cmd, nil)
 		format.LogWithCtx(ctx, pod.Name, pod.Spec.Containers[0].Name, stdout)
 		format.LogWithCtx(ctx, pod.Name, pod.Spec.Containers[0].Name, stderr)
 		if err != nil {

--- a/pkg/function/restore_data_using_kopia_server.go
+++ b/pkg/function/restore_data_using_kopia_server.go
@@ -228,7 +228,7 @@ func restoreDataFromServerPodFunc(
 				ContentCacheMB:  contentCacheMB,
 				MetadataCacheMB: metadataCacheMB,
 			})
-		stdout, stderr, err := kube.Exec(cli, namespace, pod.Name, pod.Spec.Containers[0].Name, cmd, nil)
+		stdout, stderr, err := kube.Exec(ctx, cli, namespace, pod.Name, pod.Spec.Containers[0].Name, cmd, nil)
 		format.Log(pod.Name, pod.Spec.Containers[0].Name, stdout)
 		format.Log(pod.Name, pod.Spec.Containers[0].Name, stderr)
 		if err != nil {
@@ -247,7 +247,7 @@ func restoreDataFromServerPodFunc(
 				SparseRestore:          sparseRestore,
 				IgnorePermissionErrors: true,
 			})
-		stdout, stderr, err = kube.Exec(cli, namespace, pod.Name, pod.Spec.Containers[0].Name, cmd, nil)
+		stdout, stderr, err = kube.Exec(ctx, cli, namespace, pod.Name, pod.Spec.Containers[0].Name, cmd, nil)
 		format.Log(pod.Name, pod.Spec.Containers[0].Name, stdout)
 		format.Log(pod.Name, pod.Spec.Containers[0].Name, stderr)
 		return nil, errors.Wrap(err, "Failed to restore backup from Kopia API server")

--- a/pkg/kopia/maintenance/get_maintenance_owner.go
+++ b/pkg/kopia/maintenance/get_maintenance_owner.go
@@ -15,6 +15,7 @@
 package maintenance
 
 import (
+	"context"
 	"strings"
 
 	"github.com/kopia/kopia/repo/manifest"
@@ -38,6 +39,7 @@ type KopiaUserProfile struct {
 // GetMaintenanceOwnerForConnectedRepository executes maintenance info command, parses output
 // and returns maintenance owner
 func GetMaintenanceOwnerForConnectedRepository(
+	ctx context.Context,
 	cli kubernetes.Interface,
 	namespace,
 	pod,
@@ -55,7 +57,7 @@ func GetMaintenanceOwnerForConnectedRepository(
 		GetJsonOutput: false,
 	}
 	cmd := command.MaintenanceInfo(args)
-	stdout, stderr, err := kube.Exec(cli, namespace, pod, container, cmd, nil)
+	stdout, stderr, err := kube.Exec(ctx, cli, namespace, pod, container, cmd, nil)
 	format.Log(pod, container, stdout)
 	format.Log(pod, container, stderr)
 	if err != nil {

--- a/pkg/kopia/repository/connect.go
+++ b/pkg/kopia/repository/connect.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"context"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -14,6 +15,7 @@ import (
 
 // ConnectToKopiaRepository connects to an already existing kopia repository
 func ConnectToKopiaRepository(
+	ctx context.Context,
 	cli kubernetes.Interface,
 	namespace,
 	pod,
@@ -25,7 +27,7 @@ func ConnectToKopiaRepository(
 		return errors.Wrap(err, "Failed to generate repository connect command")
 	}
 
-	stdout, stderr, err := kube.Exec(cli, namespace, pod, container, cmd, nil)
+	stdout, stderr, err := kube.Exec(ctx, cli, namespace, pod, container, cmd, nil)
 	format.Log(pod, container, stdout)
 	format.Log(pod, container, stderr)
 	if err == nil {

--- a/pkg/kopia/repository/connect_or_create.go
+++ b/pkg/kopia/repository/connect_or_create.go
@@ -15,6 +15,8 @@
 package repository
 
 import (
+	"context"
+
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/kanisterio/kanister/pkg/kopia/command"
@@ -23,6 +25,7 @@ import (
 
 // ConnectToOrCreateKopiaRepository connects to a kopia repository if present or creates if not already present
 func ConnectToOrCreateKopiaRepository(
+	ctx context.Context,
 	cli kubernetes.Interface,
 	namespace,
 	pod,
@@ -30,6 +33,7 @@ func ConnectToOrCreateKopiaRepository(
 	cmdArgs command.RepositoryCommandArgs,
 ) error {
 	err := ConnectToKopiaRepository(
+		ctx,
 		cli,
 		namespace,
 		pod,
@@ -47,6 +51,7 @@ func ConnectToOrCreateKopiaRepository(
 
 	// Create a new repository
 	err = CreateKopiaRepository(
+		ctx,
 		cli,
 		namespace,
 		pod,
@@ -62,6 +67,7 @@ func ConnectToOrCreateKopiaRepository(
 	// Creation failed. Repository may already exist or may have been
 	// created by some parallel operation. Attempt connecting again.
 	connectErr := ConnectToKopiaRepository(
+		ctx,
 		cli,
 		namespace,
 		pod,

--- a/pkg/kube/fips_test.go
+++ b/pkg/kube/fips_test.go
@@ -72,7 +72,7 @@ func (s *FIPSSuite) SetUpSuite(c *C) {
 	// install go in kanister-tools pod
 	cmd := []string{"microdnf", "install", "-y", "go"}
 	for _, cs := range s.pod.Status.ContainerStatuses {
-		stdout, stderr, err := Exec(s.cli, s.pod.Namespace, s.pod.Name, cs.Name, cmd, nil)
+		stdout, stderr, err := Exec(ctx, s.cli, s.pod.Namespace, s.pod.Name, cs.Name, cmd, nil)
 		c.Assert(err, IsNil)
 		c.Log(stderr)
 		c.Log(stdout)
@@ -87,6 +87,8 @@ func (s *FIPSSuite) TearDownSuite(c *C) {
 }
 
 func (s *FIPSSuite) TestFIPSBoringEnabled(c *C) {
+	ctx := context.Background()
+
 	for _, tool := range []string{
 		"/usr/local/bin/kopia",
 		"/usr/local/bin/kando",
@@ -94,7 +96,7 @@ func (s *FIPSSuite) TestFIPSBoringEnabled(c *C) {
 		c.Logf("Testing %s", tool)
 		cmd := []string{"go", "tool", "nm", tool}
 		for _, cs := range s.pod.Status.ContainerStatuses {
-			stdout, stderr, err := Exec(s.cli, s.pod.Namespace, s.pod.Name, cs.Name, cmd, nil)
+			stdout, stderr, err := Exec(ctx, s.cli, s.pod.Namespace, s.pod.Name, cs.Name, cmd, nil)
 			c.Assert(err, IsNil)
 			c.Assert(stderr, Equals, "")
 			scanner := bufio.NewScanner(strings.NewReader(stdout))

--- a/pkg/kube/pod_command_executor.go
+++ b/pkg/kube/pod_command_executor.go
@@ -46,7 +46,7 @@ type PodCommandExecutor interface {
 
 // podCommandExecutorProcessor aids in unit testing
 type podCommandExecutorProcessor interface {
-	execWithOptions(cli kubernetes.Interface, opts ExecOptions) (string, string, error)
+	execWithOptions(ctx context.Context, cli kubernetes.Interface, opts ExecOptions) (string, string, error)
 }
 
 // podCommandExecutor keeps everything required to execute command within a pod
@@ -86,7 +86,7 @@ func (p *podCommandExecutor) Exec(ctx context.Context, command []string, stdin i
 	}
 
 	go func() {
-		_, _, err = p.pcep.execWithOptions(p.cli, opts)
+		_, _, err = p.pcep.execWithOptions(ctx, p.cli, opts)
 		close(cmdDone)
 	}()
 
@@ -106,6 +106,6 @@ func (p *podCommandExecutor) Exec(ctx context.Context, command []string, stdin i
 	return err
 }
 
-func (p *podCommandExecutor) execWithOptions(cli kubernetes.Interface, opts ExecOptions) (string, string, error) {
-	return ExecWithOptions(p.cli, opts)
+func (p *podCommandExecutor) execWithOptions(ctx context.Context, cli kubernetes.Interface, opts ExecOptions) (string, string, error) {
+	return ExecWithOptions(ctx, p.cli, opts)
 }

--- a/pkg/kube/pod_command_executor_test.go
+++ b/pkg/kube/pod_command_executor_test.go
@@ -83,7 +83,7 @@ type fakePodCommandExecutorProcessor struct {
 	execWithOptionsSyncEnd   testBarrier
 }
 
-func (fprp *fakePodCommandExecutorProcessor) execWithOptions(cli kubernetes.Interface, opts ExecOptions) (string, string, error) {
+func (fprp *fakePodCommandExecutorProcessor) execWithOptions(ctx context.Context, cli kubernetes.Interface, opts ExecOptions) (string, string, error) {
 	fprp.inExecWithOptionsCli = cli
 	fprp.inExecWithOptionsOpts = &opts
 	fprp.execWithOptionsSyncStart.SyncWithController()

--- a/pkg/kube/pod_writer.go
+++ b/pkg/kube/pod_writer.go
@@ -54,7 +54,7 @@ func NewPodWriter(cli kubernetes.Interface, path string, content io.Reader) PodW
 // Write will create a new file(if not present) and write the provided content to the file
 func (p *podWriter) Write(ctx context.Context, namespace, podName, containerName string) error {
 	cmd := []string{"sh", "-c", "cat - > " + p.path}
-	stdout, stderr, err := Exec(p.cli, namespace, podName, containerName, cmd, p.content)
+	stdout, stderr, err := Exec(ctx, p.cli, namespace, podName, containerName, cmd, p.content)
 	format.LogWithCtx(ctx, podName, containerName, stdout)
 	format.LogWithCtx(ctx, podName, containerName, stderr)
 	return errors.Wrap(err, "Failed to write contents to file")
@@ -63,7 +63,7 @@ func (p *podWriter) Write(ctx context.Context, namespace, podName, containerName
 // Remove will delete the file created by Write() func
 func (p *podWriter) Remove(ctx context.Context, namespace, podName, containerName string) error {
 	cmd := []string{"sh", "-c", "rm " + p.path}
-	stdout, stderr, err := Exec(p.cli, namespace, podName, containerName, cmd, nil)
+	stdout, stderr, err := Exec(ctx, p.cli, namespace, podName, containerName, cmd, nil)
 	format.LogWithCtx(ctx, podName, containerName, stdout)
 	format.LogWithCtx(ctx, podName, containerName, stderr)
 	return errors.Wrap(err, "Failed to delete file")

--- a/pkg/kube/pod_writer_test.go
+++ b/pkg/kube/pod_writer_test.go
@@ -79,6 +79,8 @@ func (p *PodWriteSuite) TearDownSuite(c *C) {
 	}
 }
 func (p *PodWriteSuite) TestPodWriter(c *C) {
+	ctx := context.Background()
+
 	path := "/tmp/test.txt"
 	c.Assert(p.pod.Status.Phase, Equals, v1.PodRunning)
 	c.Assert(len(p.pod.Status.ContainerStatuses) > 0, Equals, true)
@@ -87,7 +89,7 @@ func (p *PodWriteSuite) TestPodWriter(c *C) {
 		err := pw.Write(context.Background(), p.pod.Namespace, p.pod.Name, cs.Name)
 		c.Assert(err, IsNil)
 		cmd := []string{"sh", "-c", "cat " + filepath.Clean(path)}
-		stdout, stderr, err := Exec(p.cli, p.pod.Namespace, p.pod.Name, cs.Name, cmd, nil)
+		stdout, stderr, err := Exec(ctx, p.cli, p.pod.Namespace, p.pod.Name, cs.Name, cmd, nil)
 		c.Assert(err, IsNil)
 		c.Assert(stdout, Equals, "badabing")
 		c.Assert(stderr, Equals, "")


### PR DESCRIPTION
## Change Overview

Pass context from parent levels to `kube.execute()` in `pkg/kube/exec.go` for further propagation in future changes on package kube.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- fixes #1930

## Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [x] :green_heart: E2E

> _No new tests are required. This change just propagates ctx from the upper layers to `pkg/kube/`._
