### PR TITLE
Modify DeleteSecurityGroup function to use securityGroupId

### DIFF
--- a/pkg/app/rds_aurora_mysql.go
+++ b/pkg/app/rds_aurora_mysql.go
@@ -398,7 +398,7 @@ func (a *RDSAuroraMySQLDB) Uninstall(ctx context.Context) error {
 
 	// delete security group
 	log.Info().Print("Deleting security group.", field.M{"app": a.name})
-	_, err = ec2Cli.DeleteSecurityGroup(ctx, a.securityGroupName)
+	_, err = ec2Cli.DeleteSecurityGroup(ctx, a.securityGroupID)
 	if err != nil {
 		if err, ok := err.(awserr.Error); ok {
 			switch err.Code() {

--- a/pkg/app/rds_postgres.go
+++ b/pkg/app/rds_postgres.go
@@ -379,7 +379,7 @@ func (pdb RDSPostgresDB) Uninstall(ctx context.Context) error {
 
 	// Delete security group
 	log.Info().Print("Deleting security group.", field.M{"app": pdb.name})
-	_, err = ec2Cli.DeleteSecurityGroup(ctx, pdb.securityGroupName)
+	_, err = ec2Cli.DeleteSecurityGroup(ctx, pdb.securityGroupID)
 	if err != nil {
 		if err, ok := err.(awserr.Error); ok {
 			switch err.Code() {

--- a/pkg/aws/ec2/ec2.go
+++ b/pkg/aws/ec2/ec2.go
@@ -71,10 +71,10 @@ func (e EC2) AuthorizeSecurityGroupIngress(ctx context.Context, groupName, cidr,
 	return e.AuthorizeSecurityGroupIngressWithContext(ctx, sgi)
 }
 
-func (e EC2) DeleteSecurityGroup(ctx context.Context, groupName string) (*ec2.DeleteSecurityGroupOutput, error) {
+func (e EC2) DeleteSecurityGroup(ctx context.Context, groupId string) (*ec2.DeleteSecurityGroupOutput, error) {
 	sgi := &ec2.DeleteSecurityGroupInput{
-		DryRun:    &e.DryRun,
-		GroupName: &groupName,
+		DryRun:  &e.DryRun,
+		GroupId: aws.String(groupId),
 	}
 	return e.DeleteSecurityGroupWithContext(ctx, sgi)
 }


### PR DESCRIPTION
## Change Overview

This PR modifies DeleteSecurityGroup function to use SecurityGroupId instaed of securityGroupName. This is required for securityGroups resource present in different VPC other than `default`

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
