### PR TITLE
Update stale workflow to 90 days

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -8,10 +8,10 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-    - uses: actions/stale@v5
+    - uses: actions/stale@v7
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        days-before-stale: 60
+        days-before-stale: 90
         days-before-close: 30
         close-issue-label: rotten
         close-pr-label: rotten
@@ -23,3 +23,5 @@ jobs:
         close-pr-message: This PR is closed due to inactivity. Feel free to reopen it, if it's still relevant.
         stale-issue-message: This issue is marked as stale due to inactivity. Add a new comment to reactivate it.
         stale-pr-message: This PR is marked as stale due to inactivity. Add a new comment to reactivate it.
+        remove-issue-stale-when-updated: true
+        remove-pr-stale-when-updated: true


### PR DESCRIPTION
## Change Overview

- Noticed that a lot of issues were closed in the last few weeks. Even though 60 days is long enough, it is hard to keep long-term issues active before the work is planned.
- Making the default time 90 days to allow an extra time buffer to triage issues.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
