### PR TITLE
Remove setting unnecessary password flag to all commands

### DIFF
--- a/pkg/kopia/command/blob_test.go
+++ b/pkg/kopia/command/blob_test.go
@@ -30,7 +30,6 @@ var _ = Suite(&KopiaBlobTestSuite{})
 
 func (kBlob *KopiaBlobTestSuite) TestBlobCommands(c *C) {
 	commandArgs := &CommandArgs{
-		RepoPassword:   "encr-key",
 		ConfigFilePath: "path/kopia.config",
 		LogDirectory:   "cache/log",
 	}
@@ -46,7 +45,7 @@ func (kBlob *KopiaBlobTestSuite) TestBlobCommands(c *C) {
 				}
 				return BlobList(args)
 			},
-			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log --password=encr-key blob list",
+			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log blob list",
 		},
 		{
 			f: func() []string {
@@ -55,7 +54,7 @@ func (kBlob *KopiaBlobTestSuite) TestBlobCommands(c *C) {
 				}
 				return BlobStats(args)
 			},
-			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log --password=encr-key blob stats --raw",
+			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log blob stats --raw",
 		},
 	} {
 		cmd := strings.Join(tc.f(), " ")

--- a/pkg/kopia/command/common.go
+++ b/pkg/kopia/command/common.go
@@ -23,7 +23,6 @@ import (
 )
 
 type CommandArgs struct {
-	RepoPassword   string
 	ConfigFilePath string
 	LogDirectory   string
 }
@@ -50,9 +49,6 @@ func commonArgs(cmdArgs *CommandArgs, requireInfoLevel bool) logsafe.Cmd {
 	}
 	if cmdArgs.LogDirectory != "" {
 		c = c.AppendLoggableKV(logDirectoryFlag, cmdArgs.LogDirectory)
-	}
-	if cmdArgs.RepoPassword != "" {
-		c = c.AppendRedactedKV(passwordFlag, cmdArgs.RepoPassword)
 	}
 	return c
 }

--- a/pkg/kopia/command/maintenance_test.go
+++ b/pkg/kopia/command/maintenance_test.go
@@ -26,7 +26,6 @@ var _ = Suite(&KopiaMaintenanceTestSuite{})
 
 func (kMaintenance *KopiaMaintenanceTestSuite) TestMaintenanceCommands(c *C) {
 	commandArgs := &CommandArgs{
-		RepoPassword:   "encr-key",
 		ConfigFilePath: "path/kopia.config",
 		LogDirectory:   "cache/log",
 	}
@@ -43,7 +42,7 @@ func (kMaintenance *KopiaMaintenanceTestSuite) TestMaintenanceCommands(c *C) {
 				}
 				return MaintenanceInfo(args)
 			},
-			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log --password=encr-key maintenance info",
+			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log maintenance info",
 		},
 		{
 			f: func() []string {
@@ -53,7 +52,7 @@ func (kMaintenance *KopiaMaintenanceTestSuite) TestMaintenanceCommands(c *C) {
 				}
 				return MaintenanceInfo(args)
 			},
-			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log --password=encr-key maintenance info --json",
+			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log maintenance info --json",
 		},
 		{
 			f: func() []string {
@@ -63,7 +62,7 @@ func (kMaintenance *KopiaMaintenanceTestSuite) TestMaintenanceCommands(c *C) {
 				}
 				return MaintenanceSetOwner(args)
 			},
-			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log --password=encr-key maintenance set --owner=username@hostname",
+			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log maintenance set --owner=username@hostname",
 		},
 		{
 			f: func() []string {
@@ -72,7 +71,7 @@ func (kMaintenance *KopiaMaintenanceTestSuite) TestMaintenanceCommands(c *C) {
 				}
 				return MaintenanceRunCommand(args)
 			},
-			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log --password=encr-key maintenance run",
+			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log maintenance run",
 		},
 	} {
 		cmd := strings.Join(tc.f(), " ")

--- a/pkg/kopia/command/policy_set_global_test.go
+++ b/pkg/kopia/command/policy_set_global_test.go
@@ -33,7 +33,6 @@ func (kPolicy *KopiaPolicyTestSuite) TestPolicyCommands(c *C) {
 			f: func() []string {
 				args := PolicySetGlobalCommandArgs{
 					CommandArgs: &CommandArgs{
-						RepoPassword:   "encr-key",
 						ConfigFilePath: "path/kopia.config",
 						LogDirectory:   "cache/log",
 					},
@@ -41,7 +40,7 @@ func (kPolicy *KopiaPolicyTestSuite) TestPolicyCommands(c *C) {
 				}
 				return PolicySetGlobal(args)
 			},
-			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log --password=encr-key policy set --global asdf=bsdf",
+			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log policy set --global asdf=bsdf",
 		},
 	} {
 		cmd := strings.Join(tc.f(), " ")

--- a/pkg/kopia/command/repository.go
+++ b/pkg/kopia/command/repository.go
@@ -27,6 +27,7 @@ import (
 // creating or connecting to a Kopia repository
 type RepositoryCommandArgs struct {
 	*CommandArgs
+	RepoPassword    string
 	CacheDirectory  string
 	Hostname        string
 	ContentCacheMB  int
@@ -41,6 +42,7 @@ type RepositoryCommandArgs struct {
 // RepositoryConnectCommand returns the kopia command for connecting to an existing repo
 func RepositoryConnectCommand(cmdArgs RepositoryCommandArgs) ([]string, error) {
 	args := commonArgs(cmdArgs.CommandArgs, false)
+	args = args.AppendRedactedKV(passwordFlag, cmdArgs.RepoPassword)
 	args = args.AppendLoggable(repositorySubCommand, connectSubCommand, noCheckForUpdatesFlag)
 
 	args = kopiaCacheArgs(args, cmdArgs.CacheDirectory, cmdArgs.ContentCacheMB, cmdArgs.MetadataCacheMB)
@@ -71,6 +73,7 @@ func RepositoryConnectCommand(cmdArgs RepositoryCommandArgs) ([]string, error) {
 // RepositoryCreateCommand returns the kopia command for creation of a repo
 func RepositoryCreateCommand(cmdArgs RepositoryCommandArgs) ([]string, error) {
 	args := commonArgs(cmdArgs.CommandArgs, false)
+	args = args.AppendRedactedKV(passwordFlag, cmdArgs.RepoPassword)
 	args = args.AppendLoggable(repositorySubCommand, createSubCommand, noCheckForUpdatesFlag)
 
 	args = kopiaCacheArgs(args, cmdArgs.CacheDirectory, cmdArgs.ContentCacheMB, cmdArgs.MetadataCacheMB)
@@ -97,9 +100,8 @@ func RepositoryCreateCommand(cmdArgs RepositoryCommandArgs) ([]string, error) {
 // RepositoryServerCommandArgs contains fields required for connecting
 // to Kopia Repository API server
 type RepositoryServerCommandArgs struct {
+	*CommandArgs
 	UserPassword    string
-	ConfigFilePath  string
-	LogDirectory    string
 	CacheDirectory  string
 	Hostname        string
 	ServerURL       string
@@ -113,10 +115,10 @@ type RepositoryServerCommandArgs struct {
 // repository on Kopia Repository API server
 func RepositoryConnectServerCommand(cmdArgs RepositoryServerCommandArgs) []string {
 	args := commonArgs(&CommandArgs{
-		RepoPassword:   cmdArgs.UserPassword,
 		ConfigFilePath: cmdArgs.ConfigFilePath,
 		LogDirectory:   cmdArgs.LogDirectory,
 	}, false)
+	args = args.AppendRedactedKV(passwordFlag, cmdArgs.UserPassword)
 	args = args.AppendLoggable(repositorySubCommand, connectSubCommand, serverSubCommand, noCheckForUpdatesFlag, noGrpcFlag)
 
 	args = kopiaCacheArgs(args, cmdArgs.CacheDirectory, cmdArgs.ContentCacheMB, cmdArgs.MetadataCacheMB)

--- a/pkg/kopia/command/repository_test.go
+++ b/pkg/kopia/command/repository_test.go
@@ -39,10 +39,10 @@ func (s *RepositoryUtilsSuite) TestRepositoryCreateUtil(c *check.C) {
 		{
 			cmdArg: RepositoryCommandArgs{
 				CommandArgs: &CommandArgs{
-					RepoPassword:   "pass123",
 					ConfigFilePath: "/tmp/config.file",
 					LogDirectory:   "/tmp/log.dir",
 				},
+				RepoPassword:    "pass123",
 				CacheDirectory:  "/tmp/cache.dir",
 				Hostname:        "test-hostname",
 				ContentCacheMB:  0,
@@ -57,10 +57,10 @@ func (s *RepositoryUtilsSuite) TestRepositoryCreateUtil(c *check.C) {
 		{
 			cmdArg: RepositoryCommandArgs{
 				CommandArgs: &CommandArgs{
-					RepoPassword:   "pass123",
 					ConfigFilePath: "/tmp/config.file",
 					LogDirectory:   "/tmp/log.dir",
 				},
+				RepoPassword:    "pass123",
 				CacheDirectory:  "/tmp/cache.dir",
 				Hostname:        "test-hostname",
 				ContentCacheMB:  0,
@@ -112,10 +112,10 @@ func (s *RepositoryUtilsSuite) TestRepositoryConnectUtil(c *check.C) {
 		{
 			cmdArg: RepositoryCommandArgs{
 				CommandArgs: &CommandArgs{
-					RepoPassword:   "pass123",
 					ConfigFilePath: "/tmp/config.file",
 					LogDirectory:   "/tmp/log.dir",
 				},
+				RepoPassword:    "pass123",
 				CacheDirectory:  "/tmp/cache.dir",
 				Hostname:        "test-hostname",
 				ContentCacheMB:  0,
@@ -130,10 +130,10 @@ func (s *RepositoryUtilsSuite) TestRepositoryConnectUtil(c *check.C) {
 		{
 			cmdArg: RepositoryCommandArgs{
 				CommandArgs: &CommandArgs{
-					RepoPassword:   "pass123",
 					ConfigFilePath: "/tmp/config.file",
 					LogDirectory:   "/tmp/log.dir",
 				},
+				RepoPassword:    "pass123",
 				CacheDirectory:  "/tmp/cache.dir",
 				ContentCacheMB:  0,
 				MetadataCacheMB: 0,
@@ -174,9 +174,11 @@ func (s *RepositoryUtilsSuite) TestRepositoryConnectUtil(c *check.C) {
 
 func (s *RepositoryUtilsSuite) TestRepositoryConnectServerUtil(c *check.C) {
 	cmd := RepositoryConnectServerCommand(RepositoryServerCommandArgs{
+		CommandArgs: &CommandArgs{
+			ConfigFilePath: "/tmp/config.file",
+			LogDirectory:   "/tmp/log.dir",
+		},
 		UserPassword:    "testpass123",
-		ConfigFilePath:  "/tmp/config.file",
-		LogDirectory:    "/tmp/log.dir",
 		CacheDirectory:  "/tmp/cache.dir",
 		Hostname:        "test-hostname",
 		Username:        "test-username",

--- a/pkg/kopia/command/restore_test.go
+++ b/pkg/kopia/command/restore_test.go
@@ -33,7 +33,6 @@ func (kRestore *KopiaRestoreTestSuite) TestRestoreCommands(c *C) {
 			f: func() []string {
 				args := RestoreCommandArgs{
 					CommandArgs: &CommandArgs{
-						RepoPassword:   "encr-key",
 						ConfigFilePath: "path/kopia.config",
 						LogDirectory:   "cache/log",
 					},
@@ -42,13 +41,12 @@ func (kRestore *KopiaRestoreTestSuite) TestRestoreCommands(c *C) {
 				}
 				return Restore(args)
 			},
-			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log --password=encr-key restore snapshot-id target/path --no-ignore-permission-errors",
+			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log restore snapshot-id target/path --no-ignore-permission-errors",
 		},
 		{
 			f: func() []string {
 				args := RestoreCommandArgs{
 					CommandArgs: &CommandArgs{
-						RepoPassword:   "encr-key",
 						ConfigFilePath: "path/kopia.config",
 						LogDirectory:   "cache/log",
 					},
@@ -58,7 +56,7 @@ func (kRestore *KopiaRestoreTestSuite) TestRestoreCommands(c *C) {
 				}
 				return Restore(args)
 			},
-			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log --password=encr-key restore snapshot-id target/path --ignore-permission-errors",
+			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log restore snapshot-id target/path --ignore-permission-errors",
 		},
 	} {
 		cmd := strings.Join(tc.f(), " ")

--- a/pkg/kopia/command/server_test.go
+++ b/pkg/kopia/command/server_test.go
@@ -26,7 +26,6 @@ var _ = Suite(&KopiaServerTestSuite{})
 
 func (kServer *KopiaServerTestSuite) TestServerCommands(c *C) {
 	commandArgs := &CommandArgs{
-		RepoPassword:   "encr-key",
 		ConfigFilePath: "path/kopia.config",
 		LogDirectory:   "cache/log",
 	}
@@ -105,7 +104,7 @@ func (kServer *KopiaServerTestSuite) TestServerCommands(c *C) {
 				}
 				return ServerAddUser(args)
 			},
-			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log --password=encr-key server user add a-username@a-hostname --user-password=a-user-password",
+			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log server user add a-username@a-hostname --user-password=a-user-password",
 		},
 		{
 			f: func() []string {
@@ -116,7 +115,7 @@ func (kServer *KopiaServerTestSuite) TestServerCommands(c *C) {
 				}
 				return ServerSetUser(args)
 			},
-			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log --password=encr-key server user set a-username@a-hostname --user-password=a-user-password",
+			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log server user set a-username@a-hostname --user-password=a-user-password",
 		},
 		{
 			f: func() []string {
@@ -125,7 +124,7 @@ func (kServer *KopiaServerTestSuite) TestServerCommands(c *C) {
 				}
 				return ServerListUser(args)
 			},
-			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log --password=encr-key server user list --json",
+			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log server user list --json",
 		},
 		{
 			f: func() []string {
@@ -138,7 +137,7 @@ func (kServer *KopiaServerTestSuite) TestServerCommands(c *C) {
 				}
 				return ServerRefresh(args)
 			},
-			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log --password=encr-key server refresh --server-cert-fingerprint=a-fingerprint --address=a-server-address --server-username=a-username@a-hostname --server-password=a-user-password",
+			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log server refresh --server-cert-fingerprint=a-fingerprint --address=a-server-address --server-username=a-username@a-hostname --server-password=a-user-password",
 		},
 	} {
 		cmd := strings.Join(tc.f(), " ")

--- a/pkg/kopia/command/snapshot_test.go
+++ b/pkg/kopia/command/snapshot_test.go
@@ -27,7 +27,6 @@ var _ = Suite(&KopiaSnapshotTestSuite{})
 
 func (kSnapshot *KopiaSnapshotTestSuite) TestSnapshotCommands(c *C) {
 	commandArgs := &CommandArgs{
-		RepoPassword:   "encr-key",
 		ConfigFilePath: "path/kopia.config",
 		LogDirectory:   "cache/log",
 	}
@@ -46,7 +45,7 @@ func (kSnapshot *KopiaSnapshotTestSuite) TestSnapshotCommands(c *C) {
 				}
 				return SnapshotCreate(args)
 			},
-			expectedLog: "kopia --log-level=info --config-file=path/kopia.config --log-dir=cache/log --password=encr-key snapshot create path/to/backup --json --parallel=8 --progress-update-interval=1h",
+			expectedLog: "kopia --log-level=info --config-file=path/kopia.config --log-dir=cache/log snapshot create path/to/backup --json --parallel=8 --progress-update-interval=1h",
 		},
 		{
 			f: func() []string {
@@ -58,7 +57,7 @@ func (kSnapshot *KopiaSnapshotTestSuite) TestSnapshotCommands(c *C) {
 				}
 				return SnapshotCreate(args)
 			},
-			expectedLog: "kopia --log-level=info --config-file=path/kopia.config --log-dir=cache/log --password=encr-key snapshot create path/to/backup --json --parallel=8 --progress-update-interval=2m",
+			expectedLog: "kopia --log-level=info --config-file=path/kopia.config --log-dir=cache/log snapshot create path/to/backup --json --parallel=8 --progress-update-interval=2m",
 		},
 		{
 			f: func() []string {
@@ -69,7 +68,7 @@ func (kSnapshot *KopiaSnapshotTestSuite) TestSnapshotCommands(c *C) {
 				}
 				return SnapshotExpire(args)
 			},
-			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log --password=encr-key snapshot expire root-id --delete",
+			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log snapshot expire root-id --delete",
 		},
 		{
 			f: func() []string {
@@ -82,7 +81,7 @@ func (kSnapshot *KopiaSnapshotTestSuite) TestSnapshotCommands(c *C) {
 				}
 				return SnapshotRestore(args)
 			},
-			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log --password=encr-key snapshot restore snapshot-id target/path --no-ignore-permission-errors",
+			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log snapshot restore snapshot-id target/path --no-ignore-permission-errors",
 		},
 		{
 			f: func() []string {
@@ -93,7 +92,7 @@ func (kSnapshot *KopiaSnapshotTestSuite) TestSnapshotCommands(c *C) {
 				}
 				return SnapshotRestore(args)
 			},
-			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log --password=encr-key snapshot restore snapshot-id target/path --no-ignore-permission-errors",
+			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log snapshot restore snapshot-id target/path --no-ignore-permission-errors",
 		},
 		{
 			f: func() []string {
@@ -106,13 +105,12 @@ func (kSnapshot *KopiaSnapshotTestSuite) TestSnapshotCommands(c *C) {
 				}
 				return SnapshotRestore(args)
 			},
-			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log --password=encr-key snapshot restore snapshot-id target/path --ignore-permission-errors --write-sparse-files",
+			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log snapshot restore snapshot-id target/path --ignore-permission-errors --write-sparse-files",
 		},
 		{
 			f: func() []string {
 				args := SnapshotDeleteCommandArgs{
 					CommandArgs: &CommandArgs{
-						RepoPassword:   "encr-key",
 						ConfigFilePath: "path/kopia.config",
 						LogDirectory:   "cache/log",
 					},
@@ -120,20 +118,19 @@ func (kSnapshot *KopiaSnapshotTestSuite) TestSnapshotCommands(c *C) {
 				}
 				return SnapshotDelete(args)
 			},
-			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log --password=encr-key snapshot delete snapshot-id --unsafe-ignore-source",
+			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log snapshot delete snapshot-id --unsafe-ignore-source",
 		},
 		{
 			f: func() []string {
 				args := SnapListAllWithSnapIDsCommandArgs{
 					CommandArgs: &CommandArgs{
-						RepoPassword:   "encr-key",
 						ConfigFilePath: "path/kopia.config",
 						LogDirectory:   "cache/log",
 					},
 				}
 				return SnapListAllWithSnapIDs(args)
 			},
-			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log --password=encr-key manifest list --json --filter=type:snapshot",
+			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log manifest list --json --filter=type:snapshot",
 		},
 		{
 			f: func() []string {
@@ -143,7 +140,7 @@ func (kSnapshot *KopiaSnapshotTestSuite) TestSnapshotCommands(c *C) {
 				}
 				return SnapListByTags(args)
 			},
-			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log --password=encr-key snapshot list --all --delta --show-identical --json --tags tag1:val1 --tags tag2:val2",
+			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log snapshot list --all --delta --show-identical --json --tags tag1:val1 --tags tag2:val2",
 		},
 	} {
 		cmd := strings.Join(tc.f(), " ")

--- a/pkg/kopia/maintenance/get_maintenance_owner.go
+++ b/pkg/kopia/maintenance/get_maintenance_owner.go
@@ -48,7 +48,6 @@ func GetMaintenanceOwnerForConnectedRepository(
 ) (string, error) {
 	args := command.MaintenanceInfoCommandArgs{
 		CommandArgs: &command.CommandArgs{
-			RepoPassword:   repoPassword,
 			ConfigFilePath: configFilePath,
 			LogDirectory:   logDirectory,
 		},


### PR DESCRIPTION
## Change Overview

This PR removes RepoPassword from common args, as it's only required for establishing connection to the repository.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
