### PR TITLE
Use govet plugin instead of maligned

### DIFF
--- a/build/golint.sh
+++ b/build/golint.sh
@@ -22,7 +22,7 @@ TIMEOUT="10m"
 
 echo "Running golangci-lint..."
 
-golangci-lint run --timeout ${TIMEOUT} --skip-dirs ${SKIP_DIR_REGEX} -E maligned,whitespace,gocognit,unparam -e '`ctx` is unused'
+golangci-lint run --timeout ${TIMEOUT} --skip-dirs ${SKIP_DIR_REGEX} -E govet,whitespace,gocognit,unparam -e '`ctx` is unused'
 
 # gofmt should run everywhere, including
 #   1. Skipped directories in previous step


### PR DESCRIPTION
## Change Overview

https://github.com/mdempsky/maligned is deprecated.
maligned | The repository of the linter has been archived by the owner. Replaced by govet 'fieldalignment'.
Hence changed maligned plugin to govet.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
