### PR TITLE
Update kopia commit in kanister-tools image

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -50,8 +50,8 @@ dockers:
   dockerfile: 'docker/tools/Dockerfile'
   build_flag_templates:
   - "--build-arg=kan_tools_version={{ .Tag }}"
-# Refers to https://github.com/kopia/kopia/commit/f8be8f6a5698edba055291b138c117ec6eaae125
-  - "--build-arg=kopiaBuildCommit=f8be8f6"
+# Refers to https://github.com/kopia/kopia/commit/5c901abc90857d4b85e6694ef4eeb86de7e5e89b
+  - "--build-arg=kopiaBuildCommit=5c901ab"
   - "--build-arg=kopiaRepoOrg=kopia"
   extra_files:
   - 'LICENSE'


### PR DESCRIPTION
## Change Overview

This PR modifies kopia commit to 5c901abc90857d4b85e6694ef4eeb86de7e5e89b in kanister-tools image after k8s lib upgrade changes.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
