### PR TITLE
Support OCP 4.12 in templates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ DOCKER_CONFIG ?= "$(HOME)/.docker"
 vm-driver ?= "kvm"
 
 # Default OCP version in which the OpenShift apps are going to run
-ocp_version ?= "4.11"
+ocp_version ?= "4.12"
 ###
 ### These variables should not need tweaking.
 ###

--- a/build/integration-test.sh
+++ b/build/integration-test.sh
@@ -35,6 +35,7 @@ OC_APPS4_5="MysqlDBDepConfig4_5|MongoDBDepConfig4_5|PostgreSQLDepConfig4_5"
 # https://github.com/openshift/origin/commit/4ea9e6c5961eb815c200df933eee30c48a5c9166
 OC_APPS4_10="MysqlDBDepConfig4_10|PostgreSQLDepConfig4_10"
 OC_APPS4_11="MysqlDBDepConfig4_11|PostgreSQLDepConfig4_11"
+OC_APPS4_12="MysqlDBDepConfig4_12|PostgreSQLDepConfig4_12"
 
 check_dependencies() {
     # Check if minio is already deployed
@@ -58,7 +59,7 @@ Where app-type is one of [short|all]:
   all: Runs e2e integration tests for all apps
   OR
   You can also provide regex to match apps you want to run.
-  openshift ocp_version=<ocp_version>: Runs e2e integration tests for specific version of OpenShift apps, OCP version can be provided using ocp_version argument. Currently supported versions are 3.11, 4.4, 4.5, 4.10, 4.11.
+  openshift ocp_version=<ocp_version>: Runs e2e integration tests for specific version of OpenShift apps, OCP version can be provided using ocp_version argument. Currently supported versions are 3.11, 4.4, 4.5, 4.10, 4.11, 4.12.
 
 EOM
     exit 1
@@ -94,6 +95,9 @@ case "${1}" in
                 ;;
             "4.11")
                 TEST_APPS=${OC_APPS4_11}
+                ;;
+            "4.12")
+                TEST_APPS=${OC_APPS4_12}
                 ;;
             *)
                 usage

--- a/pkg/app/utils.go
+++ b/pkg/app/utils.go
@@ -45,6 +45,8 @@ const (
 	TemplateVersionOCP4_10 DBTemplate = "release-4.10"
 	// TemplateVersionOCP4_11 stores version of db template 4.11
 	TemplateVersionOCP4_11 DBTemplate = "release-4.11"
+	// TemplateVersionOCP4_12 stores version of db template 4.12
+	TemplateVersionOCP4_12 DBTemplate = "release-4.12"
 )
 
 type storage string

--- a/pkg/testing/integration_register.go
+++ b/pkg/testing/integration_register.go
@@ -490,3 +490,33 @@ var _ = Suite(&PostgreSQLDepConfig4_11{
 		profile:   newSecretProfile(),
 	},
 })
+
+// MysqlDBDepConfig4_12 for Mysql Instance that is deployed through DeploymentConfig on OpenShift cluster
+type MysqlDBDepConfig4_12 struct {
+	IntegrationSuite
+}
+
+var _ = Suite(&MysqlDBDepConfig4_12{
+	IntegrationSuite{
+		name:      "mysqldc",
+		namespace: "mysqldc4-12-test",
+		app:       app.NewMysqlDepConfig("mysqldeploymentconfig", app.TemplateVersionOCP4_12, app.EphemeralStorage, "8.0"),
+		bp:        app.NewBlueprint("mysql-dep-config", "", true),
+		profile:   newSecretProfile(),
+	},
+})
+
+// PostgreSQLDepConfig4_12 for PostgreSQL deployed on openshift cluster
+type PostgreSQLDepConfig4_12 struct {
+	IntegrationSuite
+}
+
+var _ = Suite(&PostgreSQLDepConfig4_12{
+	IntegrationSuite{
+		name:      "postgresdepconf",
+		namespace: "postgresdepconf4-12-test",
+		app:       app.NewPostgreSQLDepConfig("postgresdepconf", app.TemplateVersionOCP4_12, app.EphemeralStorage),
+		bp:        app.NewBlueprint("postgres-dep-config", "", true),
+		profile:   newSecretProfile(),
+	},
+})


### PR DESCRIPTION
## Change Overview

Add templates for ocp apps for 4.12 version. Similar to this PR
https://github.com/kanisterio/kanister/pull/1681

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
