### PR TITLE
Updated kubernetes cluster version to 1.26

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ IMAGE_NAME := $(BIN)
 
 IMAGE := $(REGISTRY)/$(IMAGE_NAME)
 
-BUILD_IMAGE ?= ghcr.io/kanisterio/build:v0.0.22
+BUILD_IMAGE ?= ghcr.io/kanisterio/build:v0.0.23
 
 # tag 0.1.0 is, 0.0.1 (latest) + gh + aws + helm binary
 DOCS_BUILD_IMAGE ?= ghcr.io/kanisterio/docker-sphinx:0.2.0

--- a/build/local_kubernetes.sh
+++ b/build/local_kubernetes.sh
@@ -15,11 +15,11 @@ export MINIKUBE_WANTREPORTERRORPROMPT=false
 export MINIKUBE_HOME=$HOME
 export CHANGE_MINIKUBE_NONE_USER=true
 export KUBECONFIG=$HOME/.kube/config
-export KUBE_VERSION=${KUBE_VERSION:-"v1.21.1"}
-export KIND_VERSION=${KIND_VERSION:-"v0.11.1"}
+export KUBE_VERSION=${KUBE_VERSION:-"v1.26.0"}
+export KIND_VERSION=${KIND_VERSION:-"v0.18.0"}
 export LOCAL_CLUSTER_NAME=${LOCAL_CLUSTER_NAME:-"kanister"}
 export LOCAL_PATH_PROV_VERSION="v0.0.11"
-export SNAPSHOTTER_VERSION="v5.0.0"
+export SNAPSHOTTER_VERSION="v6.2.1"
 declare -a REQUIRED_BINS=( docker jq go )
 
 if command -v apt-get

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -22,6 +22,8 @@ COPY --from=golangci/golangci-lint:v1.50 /usr/bin/golangci-lint /usr/local/bin/
 RUN wget -O /usr/local/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/v0.18.0/kind-linux-amd64 \
     && chmod +x /usr/local/bin/kind
 
+RUN git config --global --add safe.directory /go/src/github.com/kanisterio/kanister
+
 # Adding CRD documentation generation tool.
 RUN GOBIN=/usr/local/bin go install github.com/ahmetb/gen-crd-api-reference-docs@v0.3.0
 

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -3,15 +3,15 @@ FROM golang:1.19-bullseye
 LABEL maintainer="Tom Manville<tom@kasten.io>"
 
 RUN apt-get update && apt-get -y install apt-transport-https ca-certificates bash git gnupg2 software-properties-common curl jq wget \
-    && update-ca-certificates 
+    && update-ca-certificates
 
 RUN curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg \
     && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list
-    
+
 RUN apt update && apt install -y docker-ce docker-ce-cli containerd.io \
     && apt-get clean
 
-COPY --from=bitnami/kubectl:1.17 /opt/bitnami/kubectl/bin/kubectl /usr/local/bin/
+COPY --from=bitnami/kubectl:1.26 /opt/bitnami/kubectl/bin/kubectl /usr/local/bin/
 
 COPY --from=goreleaser/goreleaser:v1.12.3 /usr/bin/goreleaser /usr/local/bin/
 
@@ -19,7 +19,7 @@ COPY --from=alpine/helm:3.2.0 /usr/bin/helm /usr/local/bin/
 
 COPY --from=golangci/golangci-lint:v1.50 /usr/bin/golangci-lint /usr/local/bin/
 
-RUN wget -O /usr/local/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/v0.11.1/kind-linux-amd64 \
+RUN wget -O /usr/local/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/v0.18.0/kind-linux-amd64 \
     && chmod +x /usr/local/bin/kind
 
 # Adding CRD documentation generation tool.


### PR DESCRIPTION
## Change Overview

This PR upgrades kubectl, kind, snapshotter to their latest versions. 

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #1983 

## Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E

- Manually built and push image to private repo using `docker build` and `docker push` commands inside `docker/build` directory.
- ran `make start-kind` and `make stop-kind` to verify kind cluster is deployed with v1.26.0 image. (since we are supporting v1.26.1, I have used v1.26.0 as KUBE_VERSION even though v1.26.3 is the latest supported version by kind)