### PR TITLE
Prevent dependabot from upgrading github.com/openshift/api

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,5 @@ updates:
       # starting with kanister and go through additional validation.
       - dependency-name: "k8s.io/*"
       - dependency-name: "sigs.k8s.io/*"
+      # Dependabot opens PRs for older versions of openshift that would downgrade the version in use.
+      - dependency-name: "github.com/openshift/api"


### PR DESCRIPTION
## Change Overview

@dependabot attempts to downgrade the version, instead of using the most recent one.


## Pull request type

- [x] :hamster: Trivial/Minor

