### PR TITLE
Add github workflow to build and push kanister image

### DIFF
--- a/.github/workflows/kanister-image-build.yaml
+++ b/.github/workflows/kanister-image-build.yaml
@@ -13,38 +13,38 @@ env:
   IMAGE_NAME: kanisterio/build
 
 jobs:
+  # TODO: Enable following when we want to automate this workflow on push to master branch
+  # check-files:
+  # runs-on: ubuntu-latest
+  #   outputs:
+  #     changed: ${{ steps.changed-files.outputs.any_changed }}
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #       with:
+  #         fetch-depth: 0
+  #     - uses: tj-actions/changed-files@v35
+  #       name: Get changed files
+  #       id: changed-files
+  #       with:
+  #         files: docker/build/Dockerfile
+
   build:
     runs-on: ubuntu-latest
+    # TODO: Uncomment following when we enable check-file job
+    # needs: check-files
+    # if: needs.check-files.outputs.changed == 'true'
     steps:
-    # TODO: Enable following when we want to automate this workflow on push to master branch
-    # - uses: actions/checkout@v3
-    #   with:
-    #     fetch-depth: 0
-    # - uses: tj-actions/changed-files@v35
-    #   name: Get changed files
-    #   id: changed-files
-    #   with:
-    #     files: docker/build/Dockerfile
-
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
-      # TODO: Uncomment following when we enable changed-files step
-      # if: steps.changed-files.outputs.any_changed == 'true'
-
-    - name: Login to Docker Hub
+    - name: Login to GHCR
       uses: docker/login-action@v2
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      # TODO: Uncomment following when we enable changed-files step
-      # if: steps.changed-files.outputs.any_changed == 'true'
-
     - name: Build and push
       uses: docker/build-push-action@v4
       with:
         context: "{{defaultContext}}:docker/build"
         push: true
         tags: ${{ env.IMAGE_NAME }}:${{ inputs.tag }}
-      # TODO: Uncomment following when we enable changed-files step
-      # if: steps.changed-files.outputs.any_changed == 'true'

--- a/.github/workflows/kanister-image-build.yaml
+++ b/.github/workflows/kanister-image-build.yaml
@@ -1,0 +1,39 @@
+name: build-kanister-image
+
+on:
+  pull_request:
+    branches:
+    - master
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: kanisterio/build
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: dorny/paths-filter@v2
+      id: filter
+      with:
+        filters: |
+          modified:
+            - 'docker/build/**'
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+      if: steps.filter.outputs.modified == 'true'
+    - name: Login to Docker Hub
+      uses: docker/login-action@v2
+      if: steps.filter.outputs.modified == 'true'
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Build and push
+      uses: docker/build-push-action@v4
+      if: steps.filter.outputs.modified == 'true'
+      with:
+        context: "{{defaultContext}}:docker/build"
+        push: true
+        tags: ${{ env.IMAGE_NAME }}:v0.0.23

--- a/.github/workflows/kanister-image-build.yaml
+++ b/.github/workflows/kanister-image-build.yaml
@@ -1,39 +1,50 @@
 name: build-kanister-image
 
 on:
-  pull_request:
-    branches:
-    - master
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Image tag in the format vx.x.x'
+        required: true
+        type: string
 
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: kanisterio/build
 
 jobs:
-  docker:
+  build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: dorny/paths-filter@v2
-      id: filter
-      with:
-        filters: |
-          modified:
-            - 'docker/build/**'
+    # TODO: Enable following when we want to automate this workflow on push to master branch
+    # - uses: actions/checkout@v3
+    #   with:
+    #     fetch-depth: 0
+    # - uses: tj-actions/changed-files@v35
+    #   name: Get changed files
+    #   id: changed-files
+    #   with:
+    #     files: docker/build/Dockerfile
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
-      if: steps.filter.outputs.modified == 'true'
+      # TODO: Uncomment following when we enable changed-files step
+      # if: steps.changed-files.outputs.any_changed == 'true'
+
     - name: Login to Docker Hub
       uses: docker/login-action@v2
-      if: steps.filter.outputs.modified == 'true'
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
+      # TODO: Uncomment following when we enable changed-files step
+      # if: steps.changed-files.outputs.any_changed == 'true'
+
     - name: Build and push
       uses: docker/build-push-action@v4
-      if: steps.filter.outputs.modified == 'true'
       with:
         context: "{{defaultContext}}:docker/build"
         push: true
-        tags: ${{ env.IMAGE_NAME }}:v0.0.23
+        tags: ${{ env.IMAGE_NAME }}:${{ inputs.tag }}
+      # TODO: Uncomment following when we enable changed-files step
+      # if: steps.changed-files.outputs.any_changed == 'true'

--- a/BUILD.md
+++ b/BUILD.md
@@ -135,9 +135,10 @@ configuration information and examples to show off your new function.
 
 ## Build Kanister image
 
-Kanister build image [workflow](.github/workflows/kanister-image-build.yaml) is
-used to build and push new Kanister build image. It is on-demand workflow and
-you need to run it manually.
-This workflow expects `image tag` value as an input which gets used while
-building and pushing the image.
-To make the new tag persistent, you need to set it [here](https://github.com/kanisterio/kanister/blob/bf570c75cfaa28a0c9038c8c2a611e4a8a2e517a/Makefile#L61) and raise a PR.
+The Kanister build image [workflow](.github/workflows/kanister-image-build.yaml)
+is used to build and push a new Kanister build image (`ghcr.io/kanisterio/build`).
+It is an on-demand workflow and needs to be run manually. This workflow expects
+`image tag` value as an input.
+
+The author updating the build image tag must raise a separate PR to update this
+value for it to be used in the build process. It should be set it [here](https://github.com/kanisterio/kanister/blob/master/Makefile#L61).

--- a/BUILD.md
+++ b/BUILD.md
@@ -32,7 +32,7 @@ The [Makefile](Makefile) provides a set of targets to help simplify the build
 tasks. To ensure cross-platform consistency, many of these targets use Docker
 to spawn build containers based on the `ghcr.io/kanisterio/build` public image.
 
-For `make test` to succeed, a valid `kubeconfig` file must be found at 
+For `make test` to succeed, a valid `kubeconfig` file must be found at
 `$HOME/.kube/config`. See the Docker command that runs `make test` [here](https://github.com/kanisterio/kanister/blob/fa04d77eb6f5c92521d1413ddded385168f39f42/Makefile#L219).
 
 Use the `check` target to ensure your development environment has the necessary
@@ -132,3 +132,12 @@ see how to write a new Kanister Function.
 
 Don't forget to update the documentation at `docs/functions.rst` with
 configuration information and examples to show off your new function.
+
+## Build Kanister image
+
+Kanister build image [workflow](.github/workflows/kanister-image-build.yaml) is
+used to build and push new Kanister build image. It is on-demand workflow and
+you need to run it manually.
+This workflow expects `image tag` value as an input which gets used while
+building and pushing the image.
+To make the new tag persistent, you need to set it [here](https://github.com/kanisterio/kanister/blob/bf570c75cfaa28a0c9038c8c2a611e4a8a2e517a/Makefile#L61) and raise a PR.


### PR DESCRIPTION
## Change Overview

This PR adds new GH workflow to build and push Kanister build image to ghcr.
To build an image with different tag, we need to modify workflow file.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [x] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #1685

## Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E

Manually verified the changes with personal GH repo and docker registry.