### PR TITLE
Convert auto-generated repo-controller test to use gocheck

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,8 +36,6 @@ require (
 	github.com/lib/pq v1.10.7
 	github.com/luci/go-render v0.0.0-20160219211803-9a04cc21af0f
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/onsi/ginkgo/v2 v2.6.0
-	github.com/onsi/gomega v1.24.1
 
 	//pinned openshift to release-4.5 branch
 	github.com/openshift/api v0.0.0-20200526144822-34f54f12813a

--- a/go.sum
+++ b/go.sum
@@ -419,11 +419,9 @@ github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/ginkgo v1.11.0 h1:JAKSXpt1YjtLA7YpPiqO9ss6sNXEsPfSGdwN0UHqzrw=
 github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo/v2 v2.6.0 h1:9t9b9vRUbFq3C4qKFCGkVuq/fIHji802N1nrtkh1mNc=
-github.com/onsi/ginkgo/v2 v2.6.0/go.mod h1:63DOGlLAH8+REH8jUGdL3YpCpu7JODesutUjdENfUAc=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.24.1 h1:KORJXNNTzJXzu4ScJWssJfJMnJ+2QJqhoQSRwNlze9E=
-github.com/onsi/gomega v1.24.1/go.mod h1:3AOiACssS3/MajrniINInwbfOOtfZvplPzuRSmvt1jM=
 github.com/openshift/api v0.0.0-20200521101457-60c476765272/go.mod h1:TkhafijfTiRi1Q3120/ZSE4oIWKQ4DGRh3byPywv4Mw=
 github.com/openshift/api v0.0.0-20200526144822-34f54f12813a h1:riE/kCXnb051RWT/z+DytxKEZ3+JromVDl79rXAKyFY=
 github.com/openshift/api v0.0.0-20200526144822-34f54f12813a/go.mod h1:l6TGeqJ92DrZBuWMNKcot1iZUHfbYSJyBWHGgg6Dn6s=


### PR DESCRIPTION
## Change Overview

- The auto-generated tests used `BDD-style Go testing framework`. This also led to some third-party modules being direct dependencies and causing issues in compilation of the tests.
- Converted the test to use `gocheck` like the rest of Kanister and added support for running it in our environment.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [x] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
Test compile before fix:
```
# github.com/onsi/gomega/internal
/cachevol/mod/github.com/onsi/gomega@v1.27.6/internal/polling_signal_error.go:19:33: predeclared any requires go1.18 or later (-lang was set to go1.16; check go.mod)
/cachevol/mod/github.com/onsi/gomega@v1.27.6/internal/polling_signal_error.go:40:14: predeclared any requires go1.18 or later (-lang was set to go1.16; check go.mod)
/cachevol/mod/github.com/onsi/gomega@v1.27.6/internal/polling_signal_error.go:56:65: predeclared any requires go1.18 or later (-lang was set to go1.16; check go.mod)
# github.com/onsi/ginkgo/v2/internal/testingtproxy
/cachevol/mod/github.com/onsi/ginkgo/v2@v2.9.2/internal/testingtproxy/testing_t_proxy.go:15:31: predeclared any requires go1.18 or later (-lang was set to go1.16; check go.mod)
/cachevol/mod/github.com/onsi/ginkgo/v2@v2.9.2/internal/testingtproxy/testing_t_proxy.go:17:52: predeclared any requires go1.18 or later (-lang was set to go1.16; check go.mod)
/cachevol/mod/github.com/onsi/ginkgo/v2@v2.9.2/internal/testingtproxy/testing_t_proxy.go:158:83: predeclared any requires go1.18 or later (-lang was set to go1.16; check go.mod)
/cachevol/mod/github.com/onsi/ginkgo/v2@v2.9.2/internal/testingtproxy/testing_t_proxy.go:162:93: predeclared any requires go1.18 or later (-lang was set to go1.16; check go.mod)
/cachevol/mod/github.com/onsi/ginkgo/v2@v2.9.2/internal/testingtproxy/testing_t_proxy.go:166:82: predeclared any requires go1.18 or later (-lang was set to go1.16; check go.mod)
/cachevol/mod/github.com/onsi/ginkgo/v2@v2.9.2/internal/testingtproxy/testing_t_proxy.go:170:42: predeclared any requires go1.18 or later (-lang was set to go1.16; check go.mod)
/cachevol/mod/github.com/onsi/ginkgo/v2@v2.9.2/internal/testingtproxy/testing_t_proxy.go:173:58: predeclared any requires go1.18 or later (-lang was set to go1.16; check go.mod)
/cachevol/mod/github.com/onsi/ginkgo/v2@v2.9.2/internal/testingtproxy/testing_t_proxy.go:176:44: predeclared any requires go1.18 or later (-lang was set to go1.16; check go.mod)
/cachevol/mod/github.com/onsi/ginkgo/v2@v2.9.2/internal/testingtproxy/testing_t_proxy.go:179:56: predeclared any requires go1.18 or later (-lang was set to go1.16; check go.mod)
/cachevol/mod/github.com/onsi/ginkgo/v2@v2.9.2/internal/testingtproxy/testing_t_proxy.go:182:75: predeclared any requires go1.18 or later (-lang was set to go1.16; check go.mod)
/cachevol/mod/github.com/onsi/ginkgo/v2@v2.9.2/internal/testingtproxy/testing_t_proxy.go:182:75: too many errors
FAIL	./pkg/controllers/repositoryserver [build failed]
```
Test compile after fix:
```
ok  	./pkg/controllers/repositoryserver	0.001s
```