### PR TITLE
Correct group name in fake clients generation

### DIFF
--- a/pkg/apis/cr/v1alpha1/doc.go
+++ b/pkg/apis/cr/v1alpha1/doc.go
@@ -1,7 +1,7 @@
 // +k8s:deepcopy-gen=package,register
 
 // Package v1alpha1 is the v1alpha1 version of the API.
-// +groupName=cr
+// +groupName=cr.kanister.io
 package v1alpha1
 
 // While generating client files, we need code-generator package to be installed

--- a/pkg/client/informers/externalversions/generic.go
+++ b/pkg/client/informers/externalversions/generic.go
@@ -52,7 +52,7 @@ func (f *genericInformer) Lister() cache.GenericLister {
 // TODO extend this to unknown resources with a client pool
 func (f *sharedInformerFactory) ForResource(resource schema.GroupVersionResource) (GenericInformer, error) {
 	switch resource {
-	// Group=cr, Version=v1alpha1
+	// Group=cr.kanister.io, Version=v1alpha1
 	case v1alpha1.SchemeGroupVersion.WithResource("actionsets"):
 		return &genericInformer{resource: resource.GroupResource(), informer: f.Cr().V1alpha1().ActionSets().Informer()}, nil
 	case v1alpha1.SchemeGroupVersion.WithResource("blueprints"):


### PR DESCRIPTION
## Change Overview

When we run `make codegen` command, group is considered as `cr` instead of `cr.kanister.io`. This PR fixes group string in APIs to `cr.kanister.io` during fake client code generation.


## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #2022 

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E

Manually ran `make codegen` and `make test` commands. Both gave successful response. 