### PR TITLE
Update kopia commit in kanister-tools image v0.13.0-rc2

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -50,8 +50,8 @@ dockers:
   dockerfile: 'docker/tools/Dockerfile'
   build_flag_templates:
   - "--build-arg=kan_tools_version={{ .Tag }}"
-# Refers to https://github.com/kopia/kopia/commit/5c901abc90857d4b85e6694ef4eeb86de7e5e89b
-  - "--build-arg=kopiaBuildCommit=5c901ab"
+# Refers to https://github.com/kopia/kopia/commit/a1eeeeadb3759fb94184f5c83d0f54e4cbc91f72
+  - "--build-arg=kopiaBuildCommit=a1eeeea"
   - "--build-arg=kopiaRepoOrg=kopia"
   extra_files:
   - 'LICENSE'


### PR DESCRIPTION
## Change Overview

This PR modifies kopia commit to https://github.com/kopia/kopia/commit/a1eeeeadb3759fb94184f5c83d0f54e4cbc91f72 (aka v0.13.0-rc2) in kanister-tools image after Kopia binary upgrade changes.

## Pull request type

Please check the type of change your PR introduces:
- [X] :rainbow: Refactoring (no functional changes, no api changes)
- [X] :hamster: Trivial/Minor

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [X] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
