### PR TITLE
fix connecting to kopia repository using GCP credentials in repository server controller

### DIFF
--- a/pkg/controllers/repositoryserver/repository.go
+++ b/pkg/controllers/repositoryserver/repository.go
@@ -27,6 +27,7 @@ const (
 )
 
 func (h *RepoServerHandler) connectToKopiaRepository() error {
+
 	contentCacheMB, metadataCacheMB := command.GetGeneralCacheSizeSettings()
 	args := command.RepositoryCommandArgs{
 		CommandArgs: &command.CommandArgs{

--- a/pkg/controllers/repositoryserver/repository.go
+++ b/pkg/controllers/repositoryserver/repository.go
@@ -27,7 +27,6 @@ const (
 )
 
 func (h *RepoServerHandler) connectToKopiaRepository() error {
-
 	contentCacheMB, metadataCacheMB := command.GetGeneralCacheSizeSettings()
 	args := command.RepositoryCommandArgs{
 		CommandArgs: &command.CommandArgs{


### PR DESCRIPTION
## Change Overview

Connecting to kopia repository using GCP location credentials was not working correctly. The creds file for GCP was being written to a repo server pod before the pod was created. This PR moves the code to write the gcp location credentials to file after the repo server pod is created
## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
