### PR TITLE
Fix crash in copyVolumeDataPodFunc when location type is not GCS

### DIFF
--- a/pkg/function/copy_volume_data.go
+++ b/pkg/function/copy_volume_data.go
@@ -99,7 +99,9 @@ func copyVolumeDataPodFunc(cli kubernetes.Interface, tp param.TemplateParams, na
 			return nil, errors.Wrapf(err, "Failed to write credentials to Pod %s", pc.PodName())
 		}
 
-		defer remover.Remove(context.Background()) //nolint:errcheck
+		if remover != nil { // WriteCredsToPod might return nil when nothing was written
+			defer remover.Remove(context.Background()) //nolint:errcheck
+		}
 
 		pod := pc.Pod()
 		// Get restic repository

--- a/pkg/function/copy_volume_data.go
+++ b/pkg/function/copy_volume_data.go
@@ -99,9 +99,8 @@ func copyVolumeDataPodFunc(cli kubernetes.Interface, tp param.TemplateParams, na
 			return nil, errors.Wrapf(err, "Failed to write credentials to Pod %s", pc.PodName())
 		}
 
-		if remover != nil { // WriteCredsToPod might return nil when nothing was written
-			defer remover.Remove(context.Background()) //nolint:errcheck
-		}
+		// Parent context could already be dead, so removing file within new context
+		defer remover.Remove(context.Background()) //nolint:errcheck
 
 		pod := pc.Pod()
 		// Get restic repository

--- a/pkg/function/utils.go
+++ b/pkg/function/utils.go
@@ -99,6 +99,19 @@ func ValidateProfile(profile *param.Profile) error {
 	return nil
 }
 
+type nopRemover struct {
+}
+
+var _ kube.PodFileRemover = (*nopRemover)(nil)
+
+func (nr *nopRemover) Remove(ctx context.Context) error {
+	return nil
+}
+
+func (nr *nopRemover) Path() string {
+	return ""
+}
+
 // WriteCredsToPod creates a file with Google credentials if the given profile points to a GCS location
 func WriteCredsToPod(ctx context.Context, writer kube.PodFileWriter, profile *param.Profile) (kube.PodFileRemover, error) {
 	if profile.Location.Type == crv1alpha1.LocationTypeGCS {
@@ -109,7 +122,7 @@ func WriteCredsToPod(ctx context.Context, writer kube.PodFileWriter, profile *pa
 
 		return remover, nil
 	}
-	return nil, nil
+	return &nopRemover{}, nil
 }
 
 // GetPodWriter creates a file with Google credentials if the given profile points to a GCS location

--- a/pkg/function/utils.go
+++ b/pkg/function/utils.go
@@ -102,13 +102,13 @@ func ValidateProfile(profile *param.Profile) error {
 type nopRemover struct {
 }
 
-var _ kube.PodFileRemover = (*nopRemover)(nil)
+var _ kube.PodFileRemover = nopRemover{}
 
-func (nr *nopRemover) Remove(ctx context.Context) error {
+func (nr nopRemover) Remove(ctx context.Context) error {
 	return nil
 }
 
-func (nr *nopRemover) Path() string {
+func (nr nopRemover) Path() string {
 	return ""
 }
 
@@ -122,7 +122,7 @@ func WriteCredsToPod(ctx context.Context, writer kube.PodFileWriter, profile *pa
 
 		return remover, nil
 	}
-	return &nopRemover{}, nil
+	return nopRemover{}, nil
 }
 
 // GetPodWriter creates a file with Google credentials if the given profile points to a GCS location


### PR DESCRIPTION
## Change Overview

copyVolumeDataPodFunc is crashing when location type is not GCS

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
