### PR TITLE
Fix Source Location in `cp` command for `repo-server-build` target

### DIFF
--- a/Makefile.kubebuilder
+++ b/Makefile.kubebuilder
@@ -43,5 +43,5 @@ repo-server-help: ## Display the help regarding building and deloying kopia repo
 repo-server-build:  ## Build repository server binary.
 	@$(MAKE) run CMD='-c " \
 	goreleaser build --id $(REPOSERVER_BIN) --rm-dist --debug --snapshot \
-	&& cp dist/$(REPOSERVER_BIN)_linux_$(ARCH)/$(REPOSERVER_BIN) bin/$(ARCH)/$(REPOSERVER_BIN) \
+	&& cp dist/$(REPOSERVER_BIN)_linux_$(ARCH)_*/$(REPOSERVER_BIN) bin/$(ARCH)/$(REPOSERVER_BIN) \
 	"'


### PR DESCRIPTION
## Change Overview

With goreleaser v1.8.0, ARCH targets are appended with _v1 to _v4 suffixes. Made changes in `repo-server-build` target to handle this.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
```
make repo-server-build
```
```                                                           
make[1]: Entering directory 'kanister'
  • build succeeded after 4s
make[1]: Leaving directory 'kanister'
```