### PR TITLE
Set ImagePullPolicy to Always in test_util templateParams

### DIFF
--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -101,10 +101,11 @@ func newTestPodTemplateSpec() v1.PodTemplateSpec {
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{
 				{
-					Name:    "test-container",
-					Image:   consts.LatestKanisterToolsImage,
-					Command: []string{"tail"},
-					Args:    []string{"-f", "/dev/null"},
+					Name:            "test-container",
+					Image:           consts.LatestKanisterToolsImage,
+					Command:         []string{"tail"},
+					Args:            []string{"-f", "/dev/null"},
+					ImagePullPolicy: v1.PullAlways,
 				},
 			},
 		},


### PR DESCRIPTION
## Change Overview

Due to ImagePullPolicy not being set, it was defaulting to IfNotPresent. Due to this, there were some test failures where `LatestKanisterToolsImage` which is `ghcr.io/kanisterio/kanister-tools:v9.99.9-dev` was not getting updated properly.
This PR fixes the same

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [x] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
