### PR TITLE
Update postgres-ha-hook blueprint to be compatible with 15.3.0

### DIFF
--- a/examples/postgresql-ha/hook-blueprint/postgres-ha-hook.yaml
+++ b/examples/postgresql-ha/hook-blueprint/postgres-ha-hook.yaml
@@ -11,7 +11,7 @@ actions:
        timeout: 240s
        conditions:
           anyOf:
-          - condition: '{{ if { $.status.containerStatuses[].ready } }}true{{ else }}false{{ end }}'
+          - condition: '{{ if "$.status.containerStatuses[].ready"}}true{{ else }}false{{ end }}'
             objectReference:
               apiVersion: v1
               resource: pods
@@ -26,7 +26,7 @@ actions:
           namespace: '{{ .StatefulSet.Namespace }}'
       args:
         namespace: '{{ .StatefulSet.Namespace }}'
-        image: ghcr.io/kanisterio/postgres-kanister-tools:0.69.0
+        image: ghcr.io/kanisterio/postgres-kanister-tools:0.92.0
         command:
         - bash
         - -o
@@ -36,7 +36,7 @@ actions:
         - -c
         - |
           export PGHOST='{{ .StatefulSet.Name }}.{{ .StatefulSet.Namespace }}.svc.cluster.local'
-          export PGPASSWORD='{{ index .Phases.PgUpdate.Secrets.pgSecret.Data "postgresql-password" | toString }}'
+          export PGPASSWORD='{{ index .Phases.PgUpdate.Secrets.pgSecret.Data "password" | toString }}'
           export PGREPL='{{ index .Phases.PgUpdate.Secrets.pgSecret.Data "repmgr-password" | toString }}'
           postgresMaster=$(psql -U postgres -h $PGHOST -d repmgr  -t -c "select node_name from repmgr.nodes where type='primary'")
           postgresStandby=$(psql -U postgres -h $PGHOST -d repmgr  -t -c "select node_name from repmgr.nodes where type='standby'")


### PR DESCRIPTION
## Change Overview
This PR updates the `postgres-ha-hook` blueprint to be compatible with `postgres-ha` application version 15.3.0. Also updates the `kanister-tools` version 

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
