### PR TITLE
Correct push_images.sh to not push removed images

### DIFF
--- a/build/push_images.sh
+++ b/build/push_images.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 
 IMAGE_REGISTRY="ghcr.io/kanisterio"
-IMAGES=("mysql-sidecar" "kafka-adobe-s3-sink-connector" "postgres-kanister-tools" "postgresql" "cassandra" "kanister-kubectl-1.18" "mongo-sidecar" "mongodb" "es-sidecar" "controller" "kanister-tools" "couchbase-tools" "kafka-adobe-s3-source-connector" "mssql-tools")
+IMAGES=("mysql-sidecar" "kafka-adobe-s3-sink-connector" "postgres-kanister-tools" "postgresql" "cassandra" "kanister-kubectl-1.18" "mongodb" "es-sidecar" "controller" "kanister-tools" "kafka-adobe-s3-source-connector" "mssql-tools")
 
 TAG=${1:-"v9.99.9-dev"}
 


### PR DESCRIPTION
## Change Overview

As part of PRs https://github.com/kanisterio/kanister/pull/2099 and https://github.com/kanisterio/kanister/pull/2096 we removed the `couchbase-tools` and `mongo-sidecar` images from goreleaser, this PR removes them from push_images.sh as well so that they are not tried to be pushed automatically.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

NA