### PR TITLE
fix deletion of the pod created by BP without NS

### DIFF
--- a/pkg/kube/pod_controller.go
+++ b/pkg/kube/pod_controller.go
@@ -177,7 +177,7 @@ func (p *podController) StopPod(ctx context.Context, stopTimeout time.Duration, 
 		defer cancel()
 	}
 
-	if err := p.pcp.deletePod(ctx, p.podOptions.Namespace, p.podName, metav1.DeleteOptions{GracePeriodSeconds: &gracePeriodSeconds}); err != nil {
+	if err := p.pcp.deletePod(ctx, p.pod.Namespace, p.podName, metav1.DeleteOptions{GracePeriodSeconds: &gracePeriodSeconds}); err != nil {
 		log.WithError(err).Print("Failed to delete pod", field.M{"PodName": p.podName, "Namespace": p.podOptions.Namespace})
 		return err
 	}

--- a/pkg/kube/pod_controller_test.go
+++ b/pkg/kube/pod_controller_test.go
@@ -231,7 +231,8 @@ func (s *PodControllerTestSuite) TestPodControllerStopPod(c *C) {
 		"Pod deletion error": func(pcp *fakePodControllerProcessor, pc PodController) {
 			pcp.createPodRet = &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: podControllerPodName,
+					Name:      podControllerPodName,
+					Namespace: podControllerNS,
 				},
 			}
 			err := pc.StartPod(ctx)
@@ -245,7 +246,8 @@ func (s *PodControllerTestSuite) TestPodControllerStopPod(c *C) {
 		"Pod successfully deleted": func(pcp *fakePodControllerProcessor, pc PodController) {
 			pcp.createPodRet = &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: podControllerPodName,
+					Name:      podControllerPodName,
+					Namespace: podControllerNS,
 				},
 			}
 			err := pc.StartPod(ctx)
@@ -270,8 +272,7 @@ func (s *PodControllerTestSuite) TestPodControllerStopPod(c *C) {
 		}
 
 		pc := NewPodController(cli, &PodOptions{
-			Namespace: podControllerNS,
-			Name:      podControllerPodName,
+			Name: podControllerPodName,
 		}, WithPodControllerProcessor(pcp))
 
 		tc(pcp, pc)


### PR DESCRIPTION
## Change Overview

This PR fixes pod which aren't deleted if create by blueprints without namespace

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->
 run blueprint without namespace:

`actions:
  post-export:
    name: ""
    kind: Namespace
    phases:
      - func: KubeTask
        name: hookPhase
        args:
          command:
            - /bin/sh
            - -c
            - |
              sleep 50
          image: bitnami/kubectl
          podOverride:`

ensure that kanister-job was deleted


- [x] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
