### PR TITLE
Add JSON output flag to kopia repo status command

### DIFF
--- a/pkg/kopia/command/repository.go
+++ b/pkg/kopia/command/repository.go
@@ -137,6 +137,7 @@ func RepositoryConnectServerCommand(cmdArgs RepositoryServerCommandArgs) []strin
 
 type RepositoryStatusCommandArgs struct {
 	*CommandArgs
+	GetJsonOutput bool
 }
 
 // RepositoryStatusCommand returns the kopia command for checking status of the Kopia repository
@@ -151,5 +152,9 @@ func RepositoryStatusCommand(cmdArgs RepositoryStatusCommandArgs) []string {
 
 	args := commonArgs(cmdArgs.CommandArgs)
 	args = args.AppendLoggable(repositorySubCommand, statusSubCommand)
+	if cmdArgs.GetJsonOutput {
+		args = args.AppendLoggable(jsonFlag)
+	}
+
 	return stringSliceCommand(args)
 }

--- a/pkg/kopia/command/repository_test.go
+++ b/pkg/kopia/command/repository_test.go
@@ -222,6 +222,19 @@ func (kRepoStatus *RepositoryUtilsSuite) TestRepositoryStatusCommand(c *check.C)
 			},
 			expectedLog: "kopia --log-level=info --config-file=path/kopia.config --log-dir=cache/log repository status",
 		},
+		{
+			f: func() []string {
+				args := RepositoryStatusCommandArgs{
+					CommandArgs: &CommandArgs{
+						ConfigFilePath: "path/kopia.config",
+						LogDirectory:   "cache/log",
+					},
+					GetJsonOutput: true,
+				}
+				return RepositoryStatusCommand(args)
+			},
+			expectedLog: "kopia --log-level=info --config-file=path/kopia.config --log-dir=cache/log repository status --json",
+		},
 	} {
 		cmd := strings.Join(tc.f(), " ")
 		c.Check(cmd, check.Equals, tc.expectedLog)


### PR DESCRIPTION

## Change Overview

Add the option to generate the kopia repo status command with JSON output.

I agree to the DCO for all the commits in this PR.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [x] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Test Plan

```
# cd pkg/kopia/command
# go test
OK: 18 passed
PASS
ok      github.com/kanisterio/kanister/pkg/kopia/command        0.040s
```

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
