### PR TITLE
Refactoring push_images.sh to consume a single source of truth containing valid images 

### DIFF
--- a/.github/workflows/grype-vulnerability-scanner.yaml
+++ b/.github/workflows/grype-vulnerability-scanner.yaml
@@ -9,7 +9,7 @@ jobs:
       - name: Checkout the latest code
         uses: actions/checkout@v2
         with:
-          ref: vulnerability-scanning-github-action
+          ref: grype-vulnerability-scanner-single-source-of-truth-refactor
           path: repo
       - name: Read JSON file
         id: valid-image-json
@@ -53,7 +53,7 @@ jobs:
       - name: Checkout the latest code
         uses: actions/checkout@v2
         with:
-          ref: vulnerability-scanning-github-action
+          ref: grype-vulnerability-scanner-single-source-of-truth-refactor
           path: repo
       - name: Parsing vulnerability scanner report 
         run: go run repo/scripts/grype_report_parser.go -sl "High,Critical" -p results.json

--- a/build/push_images.sh
+++ b/build/push_images.sh
@@ -18,7 +18,8 @@ set -o errexit
 set -o nounset
 
 IMAGE_REGISTRY="ghcr.io/kanisterio"
-IMAGES=("mysql-sidecar" "kafka-adobe-s3-sink-connector" "postgres-kanister-tools" "postgresql" "cassandra" "kanister-kubectl-1.18" "mongodb" "es-sidecar" "controller" "kanister-tools" "kafka-adobe-s3-source-connector" "mssql-tools")
+IMAGES_NAME_PATH="../scripts/valid_images.json"
+IMAGES=(`cat $IMAGES_NAME_PATH | jq -r .images[]`)
 
 TAG=${1:-"v9.99.9-dev"}
 


### PR DESCRIPTION
## Change Overview
Since we introduced scripts/valid_images.json as a single source of truth for the grype vulnerability scanning GitHub action tool, this PR refactors the existing build/push_images.sh to consume the same single source of truth

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [x] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test



<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [x] :green_heart: E2E
