### PR TITLE
Implement ExecutionProgress method on Kanister functions

### DIFF
--- a/pkg/function/backup_data.go
+++ b/pkg/function/backup_data.go
@@ -205,5 +205,4 @@ func (b *backupDataFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {
 		ProgressPercent:    b.progressPercent,
 		LastTransitionTime: &metav1Time,
 	}, nil
-
 }

--- a/pkg/function/backup_data.go
+++ b/pkg/function/backup_data.go
@@ -202,7 +202,7 @@ func backupData(ctx context.Context, cli kubernetes.Interface, namespace, pod, c
 func (b *backupDataFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {
 	metav1Time := metav1.NewTime(time.Now())
 	return crv1alpha1.PhaseProgress{
-		ProgressPercent:    string(string(b.progressPercent)),
+		ProgressPercent:    b.progressPercent,
 		LastTransitionTime: &metav1Time,
 	}, nil
 

--- a/pkg/function/backup_data_all.go
+++ b/pkg/function/backup_data_all.go
@@ -19,15 +19,19 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
 	kanister "github.com/kanisterio/kanister/pkg"
+	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	"github.com/kanisterio/kanister/pkg/consts"
 	"github.com/kanisterio/kanister/pkg/field"
 	"github.com/kanisterio/kanister/pkg/kube"
 	"github.com/kanisterio/kanister/pkg/param"
+	"github.com/kanisterio/kanister/pkg/progress"
 	"github.com/kanisterio/kanister/pkg/restic"
 )
 
@@ -62,13 +66,19 @@ func init() {
 
 var _ kanister.Func = (*backupDataAllFunc)(nil)
 
-type backupDataAllFunc struct{}
+type backupDataAllFunc struct {
+	progressPercent string
+}
 
 func (*backupDataAllFunc) Name() string {
 	return BackupDataAllFuncName
 }
 
-func (*backupDataAllFunc) Exec(ctx context.Context, tp param.TemplateParams, args map[string]interface{}) (map[string]interface{}, error) {
+func (b *backupDataAllFunc) Exec(ctx context.Context, tp param.TemplateParams, args map[string]interface{}) (map[string]interface{}, error) {
+	// Set progress percent
+	b.progressPercent = progress.StartedPercent
+	defer func() { b.progressPercent = progress.CompletedPercent }()
+
 	var namespace, pods, container, includePath, backupArtifactPrefix, encryptionKey string
 	var err error
 	if err = Arg(args, BackupDataAllNamespaceArg, &namespace); err != nil {
@@ -170,5 +180,13 @@ func backupDataAll(ctx context.Context, cli kubernetes.Interface, namespace stri
 	return map[string]interface{}{
 		BackupDataAllOutput:   string(manifestData),
 		FunctionOutputVersion: kanister.DefaultVersion,
+	}, nil
+}
+
+func (b *backupDataAllFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {
+	metav1Time := metav1.NewTime(time.Now())
+	return crv1alpha1.PhaseProgress{
+		ProgressPercent:    string(b.progressPercent),
+		LastTransitionTime: &metav1Time,
 	}, nil
 }

--- a/pkg/function/backup_data_all.go
+++ b/pkg/function/backup_data_all.go
@@ -186,7 +186,7 @@ func backupDataAll(ctx context.Context, cli kubernetes.Interface, namespace stri
 func (b *backupDataAllFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {
 	metav1Time := metav1.NewTime(time.Now())
 	return crv1alpha1.PhaseProgress{
-		ProgressPercent:    string(b.progressPercent),
+		ProgressPercent:    b.progressPercent,
 		LastTransitionTime: &metav1Time,
 	}, nil
 }

--- a/pkg/function/backup_data_stats.go
+++ b/pkg/function/backup_data_stats.go
@@ -17,8 +17,10 @@ package function
 import (
 	"bytes"
 	"context"
+	"time"
 
 	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
 	kanister "github.com/kanisterio/kanister/pkg"
@@ -27,6 +29,7 @@ import (
 	"github.com/kanisterio/kanister/pkg/format"
 	"github.com/kanisterio/kanister/pkg/kube"
 	"github.com/kanisterio/kanister/pkg/param"
+	"github.com/kanisterio/kanister/pkg/progress"
 	"github.com/kanisterio/kanister/pkg/restic"
 )
 
@@ -56,7 +59,9 @@ func init() {
 
 var _ kanister.Func = (*BackupDataStatsFunc)(nil)
 
-type BackupDataStatsFunc struct{}
+type BackupDataStatsFunc struct {
+	progressPercent string
+}
 
 func (*BackupDataStatsFunc) Name() string {
 	return BackupDataStatsFuncName
@@ -130,7 +135,11 @@ func backupDataStatsPodFunc(
 	}
 }
 
-func (*BackupDataStatsFunc) Exec(ctx context.Context, tp param.TemplateParams, args map[string]interface{}) (map[string]interface{}, error) {
+func (b *BackupDataStatsFunc) Exec(ctx context.Context, tp param.TemplateParams, args map[string]interface{}) (map[string]interface{}, error) {
+	// Set progress percent
+	b.progressPercent = progress.StartedPercent
+	defer func() { b.progressPercent = progress.CompletedPercent }()
+
 	var namespace, backupArtifactPrefix, backupID, mode, encryptionKey string
 	var err error
 	if err = Arg(args, BackupDataStatsNamespaceArg, &namespace); err != nil {
@@ -182,4 +191,12 @@ func (*BackupDataStatsFunc) Arguments() []string {
 		BackupDataStatsMode,
 		BackupDataStatsEncryptionKeyArg,
 	}
+}
+
+func (b *BackupDataStatsFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {
+	metav1Time := metav1.NewTime(time.Now())
+	return crv1alpha1.PhaseProgress{
+		ProgressPercent:    string(b.progressPercent),
+		LastTransitionTime: &metav1Time,
+	}, nil
 }

--- a/pkg/function/backup_data_stats.go
+++ b/pkg/function/backup_data_stats.go
@@ -196,7 +196,7 @@ func (*BackupDataStatsFunc) Arguments() []string {
 func (b *BackupDataStatsFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {
 	metav1Time := metav1.NewTime(time.Now())
 	return crv1alpha1.PhaseProgress{
-		ProgressPercent:    string(b.progressPercent),
+		ProgressPercent:    b.progressPercent,
 		LastTransitionTime: &metav1Time,
 	}, nil
 }

--- a/pkg/function/backup_data_using_kopia_server.go
+++ b/pkg/function/backup_data_using_kopia_server.go
@@ -19,18 +19,22 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"strings"
+	"time"
 
 	"github.com/dustin/go-humanize"
 	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
 	kanister "github.com/kanisterio/kanister/pkg"
+	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	"github.com/kanisterio/kanister/pkg/format"
 	kankopia "github.com/kanisterio/kanister/pkg/kopia"
 	kopiacmd "github.com/kanisterio/kanister/pkg/kopia/command"
 	kerrors "github.com/kanisterio/kanister/pkg/kopia/errors"
 	"github.com/kanisterio/kanister/pkg/kube"
 	"github.com/kanisterio/kanister/pkg/param"
+	"github.com/kanisterio/kanister/pkg/progress"
 	"github.com/kanisterio/kanister/pkg/utils"
 )
 
@@ -42,7 +46,9 @@ const (
 	KopiaRepositoryServerUserHostname = "repositoryServerUserHostname"
 )
 
-type backupDataUsingKopiaServerFunc struct{}
+type backupDataUsingKopiaServerFunc struct {
+	progressPercent string
+}
 
 func init() {
 	err := kanister.Register(&backupDataUsingKopiaServerFunc{})
@@ -77,7 +83,11 @@ func (*backupDataUsingKopiaServerFunc) Arguments() []string {
 	}
 }
 
-func (*backupDataUsingKopiaServerFunc) Exec(ctx context.Context, tp param.TemplateParams, args map[string]any) (map[string]any, error) {
+func (b *backupDataUsingKopiaServerFunc) Exec(ctx context.Context, tp param.TemplateParams, args map[string]any) (map[string]any, error) {
+	// Set progress percent
+	b.progressPercent = progress.StartedPercent
+	defer func() { b.progressPercent = progress.CompletedPercent }()
+
 	var (
 		container    string
 		err          error
@@ -161,6 +171,14 @@ func (*backupDataUsingKopiaServerFunc) Exec(ctx context.Context, tp param.Templa
 		BackupDataOutputBackupPhysicalSize: humanize.Bytes(uint64(phySize)),
 	}
 	return output, nil
+}
+
+func (b *backupDataUsingKopiaServerFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {
+	metav1Time := metav1.NewTime(time.Now())
+	return crv1alpha1.PhaseProgress{
+		ProgressPercent:    string(b.progressPercent),
+		LastTransitionTime: &metav1Time,
+	}, nil
 }
 
 func backupDataUsingKopiaServer(

--- a/pkg/function/backup_data_using_kopia_server.go
+++ b/pkg/function/backup_data_using_kopia_server.go
@@ -176,7 +176,7 @@ func (b *backupDataUsingKopiaServerFunc) Exec(ctx context.Context, tp param.Temp
 func (b *backupDataUsingKopiaServerFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {
 	metav1Time := metav1.NewTime(time.Now())
 	return crv1alpha1.PhaseProgress{
-		ProgressPercent:    string(b.progressPercent),
+		ProgressPercent:    b.progressPercent,
 		LastTransitionTime: &metav1Time,
 	}, nil
 }

--- a/pkg/function/checkRepository.go
+++ b/pkg/function/checkRepository.go
@@ -163,7 +163,7 @@ func (*CheckRepositoryFunc) Arguments() []string {
 func (c *CheckRepositoryFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {
 	metav1Time := metav1.NewTime(time.Now())
 	return crv1alpha1.PhaseProgress{
-		ProgressPercent:    string(c.progressPercent),
+		ProgressPercent:    c.progressPercent,
 		LastTransitionTime: &metav1Time,
 	}, nil
 }

--- a/pkg/function/copy_volume_data.go
+++ b/pkg/function/copy_volume_data.go
@@ -220,7 +220,7 @@ func (*copyVolumeDataFunc) Arguments() []string {
 func (c *copyVolumeDataFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {
 	metav1Time := metav1.NewTime(time.Now())
 	return crv1alpha1.PhaseProgress{
-		ProgressPercent:    string(c.progressPercent),
+		ProgressPercent:    c.progressPercent,
 		LastTransitionTime: &metav1Time,
 	}, nil
 }

--- a/pkg/function/create_csi_snapshot.go
+++ b/pkg/function/create_csi_snapshot.go
@@ -161,7 +161,7 @@ func defaultSnapshotName(pvcName string, len int) string {
 func (c *createCSISnapshotFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {
 	metav1Time := metav1.NewTime(time.Now())
 	return crv1alpha1.PhaseProgress{
-		ProgressPercent:    string(c.progressPercent),
+		ProgressPercent:    c.progressPercent,
 		LastTransitionTime: &metav1Time,
 	}, nil
 }

--- a/pkg/function/create_csi_snapshot.go
+++ b/pkg/function/create_csi_snapshot.go
@@ -17,15 +17,19 @@ package function
 import (
 	"context"
 	"fmt"
+	"time"
 
 	v1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
 	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 
 	kanister "github.com/kanisterio/kanister/pkg"
+	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	"github.com/kanisterio/kanister/pkg/kube"
 	"github.com/kanisterio/kanister/pkg/kube/snapshot"
 	"github.com/kanisterio/kanister/pkg/param"
+	"github.com/kanisterio/kanister/pkg/progress"
 )
 
 func init() {
@@ -55,13 +59,19 @@ const (
 	CreateCSISnapshotSnapshotContentNameArg = "snapshotContent"
 )
 
-type createCSISnapshotFunc struct{}
+type createCSISnapshotFunc struct {
+	progressPercent string
+}
 
 func (*createCSISnapshotFunc) Name() string {
 	return CreateCSISnapshotFuncName
 }
 
-func (*createCSISnapshotFunc) Exec(ctx context.Context, tp param.TemplateParams, args map[string]interface{}) (map[string]interface{}, error) {
+func (c *createCSISnapshotFunc) Exec(ctx context.Context, tp param.TemplateParams, args map[string]interface{}) (map[string]interface{}, error) {
+	// Set progress percent
+	c.progressPercent = progress.StartedPercent
+	defer func() { c.progressPercent = progress.CompletedPercent }()
+
 	var snapshotClass string
 	var labels map[string]string
 	var name, pvc, namespace string
@@ -146,4 +156,12 @@ func createCSISnapshot(ctx context.Context, snapshotter snapshot.Snapshotter, na
 // defaultSnapshotName generates snapshot name using <pvcName>-snapshot-<randomValue>
 func defaultSnapshotName(pvcName string, len int) string {
 	return fmt.Sprintf("%s-snapshot-%s", pvcName, rand.String(len))
+}
+
+func (c *createCSISnapshotFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {
+	metav1Time := metav1.NewTime(time.Now())
+	return crv1alpha1.PhaseProgress{
+		ProgressPercent:    string(c.progressPercent),
+		LastTransitionTime: &metav1Time,
+	}, nil
 }

--- a/pkg/function/create_csi_snapshot_static.go
+++ b/pkg/function/create_csi_snapshot_static.go
@@ -172,7 +172,7 @@ func createCSISnapshotStatic(
 func (c *createCSISnapshotStaticFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {
 	metav1Time := metav1.NewTime(time.Now())
 	return crv1alpha1.PhaseProgress{
-		ProgressPercent:    string(c.progressPercent),
+		ProgressPercent:    c.progressPercent,
 		LastTransitionTime: &metav1Time,
 	}, nil
 }

--- a/pkg/function/create_csi_snapshot_static.go
+++ b/pkg/function/create_csi_snapshot_static.go
@@ -16,13 +16,17 @@ package function
 
 import (
 	"context"
+	"time"
 
 	v1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	kanister "github.com/kanisterio/kanister/pkg"
+	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	"github.com/kanisterio/kanister/pkg/kube"
 	"github.com/kanisterio/kanister/pkg/kube/snapshot"
 	"github.com/kanisterio/kanister/pkg/param"
+	"github.com/kanisterio/kanister/pkg/progress"
 )
 
 func init() {
@@ -59,13 +63,19 @@ const (
 	CreateCSISnapshotStaticOutputSnapshotContentName = "snapshotContent"
 )
 
-type createCSISnapshotStaticFunc struct{}
+type createCSISnapshotStaticFunc struct {
+	progressPercent string
+}
 
 func (*createCSISnapshotStaticFunc) Name() string {
 	return CreateCSISnapshotStaticFuncName
 }
 
-func (*createCSISnapshotStaticFunc) Exec(ctx context.Context, tp param.TemplateParams, args map[string]interface{}) (map[string]interface{}, error) {
+func (c *createCSISnapshotStaticFunc) Exec(ctx context.Context, tp param.TemplateParams, args map[string]interface{}) (map[string]interface{}, error) {
+	// Set progress percent
+	c.progressPercent = progress.StartedPercent
+	defer func() { c.progressPercent = progress.CompletedPercent }()
+
 	var (
 		name, namespace                       string
 		driver, snapshotHandle, snapshotClass string
@@ -157,4 +167,12 @@ func createCSISnapshotStatic(
 	}
 
 	return snapshotter.Get(ctx, name, namespace)
+}
+
+func (c *createCSISnapshotStaticFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {
+	metav1Time := metav1.NewTime(time.Now())
+	return crv1alpha1.PhaseProgress{
+		ProgressPercent:    string(c.progressPercent),
+		LastTransitionTime: &metav1Time,
+	}, nil
 }

--- a/pkg/function/create_rds_snapshot.go
+++ b/pkg/function/create_rds_snapshot.go
@@ -194,7 +194,7 @@ func (crs *createRDSSnapshotFunc) Arguments() []string {
 func (crs *createRDSSnapshotFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {
 	metav1Time := metav1.NewTime(time.Now())
 	return crv1alpha1.PhaseProgress{
-		ProgressPercent:    string(crs.progressPercent),
+		ProgressPercent:    crs.progressPercent,
 		LastTransitionTime: &metav1Time,
 	}, nil
 }

--- a/pkg/function/create_rds_snapshot.go
+++ b/pkg/function/create_rds_snapshot.go
@@ -18,16 +18,20 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"sigs.k8s.io/yaml"
 
 	kanister "github.com/kanisterio/kanister/pkg"
+	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	"github.com/kanisterio/kanister/pkg/aws/rds"
 	"github.com/kanisterio/kanister/pkg/field"
 	"github.com/kanisterio/kanister/pkg/log"
 	"github.com/kanisterio/kanister/pkg/param"
+	"github.com/kanisterio/kanister/pkg/progress"
 )
 
 func init() {
@@ -61,7 +65,9 @@ const (
 	DBEngineAuroraPostgreSQL RDSDBEngine = "aurora-postgresql"
 )
 
-type createRDSSnapshotFunc struct{}
+type createRDSSnapshotFunc struct {
+	progressPercent string
+}
 
 func (*createRDSSnapshotFunc) Name() string {
 	return CreateRDSSnapshotFuncName
@@ -155,6 +161,10 @@ func createRDSSnapshot(ctx context.Context, instanceID string, dbEngine RDSDBEng
 }
 
 func (crs *createRDSSnapshotFunc) Exec(ctx context.Context, tp param.TemplateParams, args map[string]interface{}) (map[string]interface{}, error) {
+	// Set progress percent
+	crs.progressPercent = progress.StartedPercent
+	defer func() { crs.progressPercent = progress.CompletedPercent }()
+
 	var instanceID string
 	var dbEngine RDSDBEngine
 	if err := Arg(args, CreateRDSSnapshotInstanceIDArg, &instanceID); err != nil {
@@ -179,4 +189,12 @@ func (crs *createRDSSnapshotFunc) Arguments() []string {
 		CreateRDSSnapshotInstanceIDArg,
 		CreateRDSSnapshotDBEngine,
 	}
+}
+
+func (crs *createRDSSnapshotFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {
+	metav1Time := metav1.NewTime(time.Now())
+	return crv1alpha1.PhaseProgress{
+		ProgressPercent:    string(crs.progressPercent),
+		LastTransitionTime: &metav1Time,
+	}, nil
 }

--- a/pkg/function/create_volume_from_snapshot.go
+++ b/pkg/function/create_volume_from_snapshot.go
@@ -167,7 +167,7 @@ func (*createVolumeFromSnapshotFunc) Arguments() []string {
 func (crs *createVolumeFromSnapshotFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {
 	metav1Time := metav1.NewTime(time.Now())
 	return crv1alpha1.PhaseProgress{
-		ProgressPercent:    string(crs.progressPercent),
+		ProgressPercent:    crs.progressPercent,
 		LastTransitionTime: &metav1Time,
 	}, nil
 }

--- a/pkg/function/create_volume_from_snapshot.go
+++ b/pkg/function/create_volume_from_snapshot.go
@@ -17,12 +17,14 @@ package function
 import (
 	"context"
 	"encoding/json"
+	"time"
 
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
 	kanister "github.com/kanisterio/kanister/pkg"
+	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	awsconfig "github.com/kanisterio/kanister/pkg/aws"
 	"github.com/kanisterio/kanister/pkg/blockstorage"
 	"github.com/kanisterio/kanister/pkg/blockstorage/getter"
@@ -31,6 +33,7 @@ import (
 	kubevolume "github.com/kanisterio/kanister/pkg/kube/volume"
 	"github.com/kanisterio/kanister/pkg/log"
 	"github.com/kanisterio/kanister/pkg/param"
+	"github.com/kanisterio/kanister/pkg/progress"
 )
 
 func init() {
@@ -49,7 +52,9 @@ const (
 	CreateVolumeFromSnapshotPVCNamesArg  = "pvcNames"
 )
 
-type createVolumeFromSnapshotFunc struct{}
+type createVolumeFromSnapshotFunc struct {
+	progressPercent string
+}
 
 func (*createVolumeFromSnapshotFunc) Name() string {
 	return CreateVolumeFromSnapshotFuncName
@@ -120,7 +125,11 @@ func createVolumeFromSnapshot(ctx context.Context, cli kubernetes.Interface, nam
 	return providerList, nil
 }
 
-func (kef *createVolumeFromSnapshotFunc) Exec(ctx context.Context, tp param.TemplateParams, args map[string]interface{}) (map[string]interface{}, error) {
+func (c *createVolumeFromSnapshotFunc) Exec(ctx context.Context, tp param.TemplateParams, args map[string]interface{}) (map[string]interface{}, error) {
+	// Set progress percent
+	c.progressPercent = progress.StartedPercent
+	defer func() { c.progressPercent = progress.CompletedPercent }()
+
 	cli, err := kube.NewClient()
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed to create Kubernetes client")
@@ -153,4 +162,12 @@ func (*createVolumeFromSnapshotFunc) Arguments() []string {
 		CreateVolumeFromSnapshotManifestArg,
 		CreateVolumeFromSnapshotPVCNamesArg,
 	}
+}
+
+func (crs *createVolumeFromSnapshotFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {
+	metav1Time := metav1.NewTime(time.Now())
+	return crv1alpha1.PhaseProgress{
+		ProgressPercent:    string(crs.progressPercent),
+		LastTransitionTime: &metav1Time,
+	}, nil
 }

--- a/pkg/function/create_volume_snapshot.go
+++ b/pkg/function/create_volume_snapshot.go
@@ -329,7 +329,7 @@ func (*createVolumeSnapshotFunc) Arguments() []string {
 func (c *createVolumeSnapshotFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {
 	metav1Time := metav1.NewTime(time.Now())
 	return crv1alpha1.PhaseProgress{
-		ProgressPercent:    string(c.progressPercent),
+		ProgressPercent:    c.progressPercent,
 		LastTransitionTime: &metav1Time,
 	}, nil
 }

--- a/pkg/function/create_volume_snapshot.go
+++ b/pkg/function/create_volume_snapshot.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
@@ -35,6 +36,7 @@ import (
 	"github.com/kanisterio/kanister/pkg/blockstorage/getter"
 	"github.com/kanisterio/kanister/pkg/kube"
 	"github.com/kanisterio/kanister/pkg/param"
+	"github.com/kanisterio/kanister/pkg/progress"
 	"github.com/kanisterio/kanister/pkg/secrets"
 )
 
@@ -54,7 +56,9 @@ const (
 	CreateVolumeSnapshotSkipWaitArg  = "skipWait"
 )
 
-type createVolumeSnapshotFunc struct{}
+type createVolumeSnapshotFunc struct {
+	progressPercent string
+}
 
 func (*createVolumeSnapshotFunc) Name() string {
 	return CreateVolumeSnapshotFuncName
@@ -261,7 +265,11 @@ func getPVCList(tp param.TemplateParams) ([]string, error) {
 	return pvcList, nil
 }
 
-func (kef *createVolumeSnapshotFunc) Exec(ctx context.Context, tp param.TemplateParams, args map[string]interface{}) (map[string]interface{}, error) {
+func (c *createVolumeSnapshotFunc) Exec(ctx context.Context, tp param.TemplateParams, args map[string]interface{}) (map[string]interface{}, error) {
+	// Set progress percent
+	c.progressPercent = progress.StartedPercent
+	defer func() { c.progressPercent = progress.CompletedPercent }()
+
 	cli, err := kube.NewClient()
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed to create Kubernetes client")
@@ -316,4 +324,12 @@ func (*createVolumeSnapshotFunc) Arguments() []string {
 		CreateVolumeSnapshotPVCsArg,
 		CreateVolumeSnapshotSkipWaitArg,
 	}
+}
+
+func (c *createVolumeSnapshotFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {
+	metav1Time := metav1.NewTime(time.Now())
+	return crv1alpha1.PhaseProgress{
+		ProgressPercent:    string(c.progressPercent),
+		LastTransitionTime: &metav1Time,
+	}, nil
 }

--- a/pkg/function/delete_csi_snapshot.go
+++ b/pkg/function/delete_csi_snapshot.go
@@ -16,15 +16,19 @@ package function
 
 import (
 	"context"
+	"time"
 
 	v1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	kanister "github.com/kanisterio/kanister/pkg"
+	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	"github.com/kanisterio/kanister/pkg/kube"
 	"github.com/kanisterio/kanister/pkg/kube/snapshot"
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/poll"
+	"github.com/kanisterio/kanister/pkg/progress"
 )
 
 func init() {
@@ -44,13 +48,19 @@ const (
 	DeleteCSISnapshotNamespaceArg = "namespace"
 )
 
-type deleteCSISnapshotFunc struct{}
+type deleteCSISnapshotFunc struct {
+	progressPercent string
+}
 
 func (*deleteCSISnapshotFunc) Name() string {
 	return DeleteCSISnapshotFuncName
 }
 
-func (*deleteCSISnapshotFunc) Exec(ctx context.Context, tp param.TemplateParams, args map[string]interface{}) (map[string]interface{}, error) {
+func (d *deleteCSISnapshotFunc) Exec(ctx context.Context, tp param.TemplateParams, args map[string]interface{}) (map[string]interface{}, error) {
+	// Set progress percent
+	d.progressPercent = progress.StartedPercent
+	defer func() { d.progressPercent = progress.CompletedPercent }()
+
 	var name, namespace string
 	if err := Arg(args, DeleteCSISnapshotNameArg, &name); err != nil {
 		return nil, err
@@ -91,6 +101,14 @@ func (*deleteCSISnapshotFunc) Arguments() []string {
 		DeleteCSISnapshotNameArg,
 		DeleteCSISnapshotNamespaceArg,
 	}
+}
+
+func (c *deleteCSISnapshotFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {
+	metav1Time := metav1.NewTime(time.Now())
+	return crv1alpha1.PhaseProgress{
+		ProgressPercent:    string(c.progressPercent),
+		LastTransitionTime: &metav1Time,
+	}, nil
 }
 
 func deleteCSISnapshot(ctx context.Context, snapshotter snapshot.Snapshotter, name, namespace string) (*v1.VolumeSnapshot, error) {

--- a/pkg/function/delete_csi_snapshot.go
+++ b/pkg/function/delete_csi_snapshot.go
@@ -106,7 +106,7 @@ func (*deleteCSISnapshotFunc) Arguments() []string {
 func (c *deleteCSISnapshotFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {
 	metav1Time := metav1.NewTime(time.Now())
 	return crv1alpha1.PhaseProgress{
-		ProgressPercent:    string(c.progressPercent),
+		ProgressPercent:    c.progressPercent,
 		LastTransitionTime: &metav1Time,
 	}, nil
 }

--- a/pkg/function/delete_csi_snapshot_content.go
+++ b/pkg/function/delete_csi_snapshot_content.go
@@ -16,6 +16,7 @@ package function
 
 import (
 	"context"
+	"time"
 
 	kanister "github.com/kanisterio/kanister/pkg"
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
@@ -23,6 +24,7 @@ import (
 	"github.com/kanisterio/kanister/pkg/kube/snapshot"
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/progress"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func init() {
@@ -90,7 +92,11 @@ func (*deleteCSISnapshotContentFunc) Arguments() []string {
 }
 
 func (c *deleteCSISnapshotContentFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {
-	return crv1alpha1.PhaseProgress{ProgressPercent: string(c.progressPercent)}, nil
+	metav1Time := metav1.NewTime(time.Now())
+	return crv1alpha1.PhaseProgress{
+		ProgressPercent:    c.progressPercent,
+		LastTransitionTime: &metav1Time,
+	}, nil
 }
 
 func deleteCSISnapshotContent(ctx context.Context, snapshotter snapshot.Snapshotter, name string) error {

--- a/pkg/function/delete_data.go
+++ b/pkg/function/delete_data.go
@@ -19,9 +19,11 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
 	kanister "github.com/kanisterio/kanister/pkg"
@@ -262,5 +264,9 @@ func (*deleteDataFunc) Arguments() []string {
 }
 
 func (d *deleteDataFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {
-	return crv1alpha1.PhaseProgress{ProgressPercent: string(d.progressPercent)}, nil
+	metav1Time := metav1.NewTime(time.Now())
+	return crv1alpha1.PhaseProgress{
+		ProgressPercent:    d.progressPercent,
+		LastTransitionTime: &metav1Time,
+	}, nil
 }

--- a/pkg/function/delete_data_all.go
+++ b/pkg/function/delete_data_all.go
@@ -134,7 +134,7 @@ func (*deleteDataAllFunc) Arguments() []string {
 func (d *deleteDataAllFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {
 	metav1Time := metav1.NewTime(time.Now())
 	return crv1alpha1.PhaseProgress{
-		ProgressPercent:    string(d.progressPercent),
+		ProgressPercent:    d.progressPercent,
 		LastTransitionTime: &metav1Time,
 	}, nil
 }

--- a/pkg/function/delete_data_all.go
+++ b/pkg/function/delete_data_all.go
@@ -18,12 +18,16 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	kanister "github.com/kanisterio/kanister/pkg"
+	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	"github.com/kanisterio/kanister/pkg/kube"
 	"github.com/kanisterio/kanister/pkg/param"
+	"github.com/kanisterio/kanister/pkg/progress"
 	"github.com/kanisterio/kanister/pkg/restic"
 )
 
@@ -51,13 +55,19 @@ func init() {
 
 var _ kanister.Func = (*deleteDataAllFunc)(nil)
 
-type deleteDataAllFunc struct{}
+type deleteDataAllFunc struct {
+	progressPercent string
+}
 
 func (*deleteDataAllFunc) Name() string {
 	return DeleteDataAllFuncName
 }
 
-func (*deleteDataAllFunc) Exec(ctx context.Context, tp param.TemplateParams, args map[string]interface{}) (map[string]interface{}, error) {
+func (d *deleteDataAllFunc) Exec(ctx context.Context, tp param.TemplateParams, args map[string]interface{}) (map[string]interface{}, error) {
+	// Set progress percent
+	d.progressPercent = progress.StartedPercent
+	defer func() { d.progressPercent = progress.CompletedPercent }()
+
 	var namespace, deleteArtifactPrefix, backupInfo, encryptionKey string
 	var reclaimSpace bool
 	var err error
@@ -119,4 +129,12 @@ func (*deleteDataAllFunc) Arguments() []string {
 		DeleteDataAllEncryptionKeyArg,
 		DeleteDataAllReclaimSpace,
 	}
+}
+
+func (d *deleteDataAllFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {
+	metav1Time := metav1.NewTime(time.Now())
+	return crv1alpha1.PhaseProgress{
+		ProgressPercent:    string(d.progressPercent),
+		LastTransitionTime: &metav1Time,
+	}, nil
 }

--- a/pkg/function/delete_data_using_kopia_server.go
+++ b/pkg/function/delete_data_using_kopia_server.go
@@ -134,7 +134,7 @@ func (d *deleteDataUsingKopiaServerFunc) Exec(ctx context.Context, tp param.Temp
 func (d *deleteDataUsingKopiaServerFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {
 	metav1Time := metav1.NewTime(time.Now())
 	return crv1alpha1.PhaseProgress{
-		ProgressPercent:    string(d.progressPercent),
+		ProgressPercent:    d.progressPercent,
 		LastTransitionTime: &metav1Time,
 	}, nil
 }

--- a/pkg/function/delete_rds_snapshot.go
+++ b/pkg/function/delete_rds_snapshot.go
@@ -146,7 +146,7 @@ func (*deleteRDSSnapshotFunc) Arguments() []string {
 func (d *deleteRDSSnapshotFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {
 	metav1Time := metav1.NewTime(time.Now())
 	return crv1alpha1.PhaseProgress{
-		ProgressPercent:    string(d.progressPercent),
+		ProgressPercent:    d.progressPercent,
 		LastTransitionTime: &metav1Time,
 	}, nil
 }

--- a/pkg/function/delete_volume_snapshot.go
+++ b/pkg/function/delete_volume_snapshot.go
@@ -136,7 +136,7 @@ func (*deleteVolumeSnapshotFunc) Arguments() []string {
 func (d *deleteVolumeSnapshotFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {
 	metav1Time := metav1.NewTime(time.Now())
 	return crv1alpha1.PhaseProgress{
-		ProgressPercent:    string(d.progressPercent),
+		ProgressPercent:    d.progressPercent,
 		LastTransitionTime: &metav1Time,
 	}, nil
 }

--- a/pkg/function/describe_backups.go
+++ b/pkg/function/describe_backups.go
@@ -18,8 +18,10 @@ import (
 	"bytes"
 	"context"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
 	kanister "github.com/kanisterio/kanister/pkg"
@@ -28,6 +30,7 @@ import (
 	"github.com/kanisterio/kanister/pkg/format"
 	"github.com/kanisterio/kanister/pkg/kube"
 	"github.com/kanisterio/kanister/pkg/param"
+	"github.com/kanisterio/kanister/pkg/progress"
 	"github.com/kanisterio/kanister/pkg/restic"
 )
 
@@ -54,7 +57,9 @@ func init() {
 
 var _ kanister.Func = (*DescribeBackupsFunc)(nil)
 
-type DescribeBackupsFunc struct{}
+type DescribeBackupsFunc struct {
+	progressPercent string
+}
 
 func (*DescribeBackupsFunc) Name() string {
 	return DescribeBackupsFuncName
@@ -167,7 +172,11 @@ func describeBackupsPodFunc(
 	}
 }
 
-func (*DescribeBackupsFunc) Exec(ctx context.Context, tp param.TemplateParams, args map[string]interface{}) (map[string]interface{}, error) {
+func (d *DescribeBackupsFunc) Exec(ctx context.Context, tp param.TemplateParams, args map[string]interface{}) (map[string]interface{}, error) {
+	// Set progress percent
+	d.progressPercent = progress.StartedPercent
+	defer func() { d.progressPercent = progress.CompletedPercent }()
+
 	var describeBackupsArtifactPrefix, encryptionKey string
 	var err error
 	if err = Arg(args, DescribeBackupsArtifactPrefixArg, &describeBackupsArtifactPrefix); err != nil {
@@ -203,4 +212,12 @@ func (*DescribeBackupsFunc) Arguments() []string {
 		DescribeBackupsArtifactPrefixArg,
 		DescribeBackupsEncryptionKeyArg,
 	}
+}
+
+func (d *DescribeBackupsFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {
+	metav1Time := metav1.NewTime(time.Now())
+	return crv1alpha1.PhaseProgress{
+		ProgressPercent:    string(d.progressPercent),
+		LastTransitionTime: &metav1Time,
+	}, nil
 }

--- a/pkg/function/describe_backups.go
+++ b/pkg/function/describe_backups.go
@@ -217,7 +217,7 @@ func (*DescribeBackupsFunc) Arguments() []string {
 func (d *DescribeBackupsFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {
 	metav1Time := metav1.NewTime(time.Now())
 	return crv1alpha1.PhaseProgress{
-		ProgressPercent:    string(d.progressPercent),
+		ProgressPercent:    d.progressPercent,
 		LastTransitionTime: &metav1Time,
 	}, nil
 }

--- a/pkg/function/export_rds_snapshot_location.go
+++ b/pkg/function/export_rds_snapshot_location.go
@@ -19,8 +19,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"sigs.k8s.io/yaml"
 
@@ -32,6 +34,7 @@ import (
 	"github.com/kanisterio/kanister/pkg/log"
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/postgres"
+	"github.com/kanisterio/kanister/pkg/progress"
 )
 
 func init() {
@@ -64,7 +67,9 @@ const (
 	postgresToolsImage = "ghcr.io/kanisterio/postgres-kanister-tools:0.96.0"
 )
 
-type exportRDSSnapshotToLocationFunc struct{}
+type exportRDSSnapshotToLocationFunc struct {
+	progressPercent string
+}
 
 // RDSDBEngine for RDS Engine types
 type RDSDBEngine string
@@ -151,6 +156,10 @@ func exportRDSSnapshotToLoc(ctx context.Context, namespace, instanceID, snapshot
 }
 
 func (crs *exportRDSSnapshotToLocationFunc) Exec(ctx context.Context, tp param.TemplateParams, args map[string]interface{}) (map[string]interface{}, error) {
+	// Set progress percent
+	crs.progressPercent = progress.StartedPercent
+	defer func() { crs.progressPercent = progress.CompletedPercent }()
+
 	var namespace, instanceID, snapshotID, username, password, dbSubnetGroup, backupArtifact string
 	var dbEngine RDSDBEngine
 
@@ -215,6 +224,14 @@ func (*exportRDSSnapshotToLocationFunc) Arguments() []string {
 		ExportRDSSnapshotToLocSecGrpIDArg,
 		ExportRDSSnapshotToLocDBSubnetGroupArg,
 	}
+}
+
+func (d *exportRDSSnapshotToLocationFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {
+	metav1Time := metav1.NewTime(time.Now())
+	return crv1alpha1.PhaseProgress{
+		ProgressPercent:    string(d.progressPercent),
+		LastTransitionTime: &metav1Time,
+	}, nil
 }
 
 func execDumpCommand(ctx context.Context, dbEngine RDSDBEngine, action RDSAction, namespace, dbEndpoint, username, password string, databases []string, backupPrefix, backupID string, profile *param.Profile, dbEngineVersion string) (map[string]interface{}, error) {

--- a/pkg/function/export_rds_snapshot_location.go
+++ b/pkg/function/export_rds_snapshot_location.go
@@ -229,7 +229,7 @@ func (*exportRDSSnapshotToLocationFunc) Arguments() []string {
 func (d *exportRDSSnapshotToLocationFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {
 	metav1Time := metav1.NewTime(time.Now())
 	return crv1alpha1.PhaseProgress{
-		ProgressPercent:    string(d.progressPercent),
+		ProgressPercent:    d.progressPercent,
 		LastTransitionTime: &metav1Time,
 	}, nil
 }

--- a/pkg/function/kube_exec.go
+++ b/pkg/function/kube_exec.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"os"
 	"regexp"
+	"time"
 
 	kanister "github.com/kanisterio/kanister/pkg"
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
@@ -27,6 +28,7 @@ import (
 	"github.com/kanisterio/kanister/pkg/output"
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/progress"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func init() {
@@ -129,5 +131,9 @@ func (*kubeExecFunc) Arguments() []string {
 }
 
 func (kef *kubeExecFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {
-	return crv1alpha1.PhaseProgress{ProgressPercent: string(kef.progressPercent)}, nil
+	metav1Time := metav1.NewTime(time.Now())
+	return crv1alpha1.PhaseProgress{
+		ProgressPercent:    kef.progressPercent,
+		LastTransitionTime: &metav1Time,
+	}, nil
 }

--- a/pkg/function/kube_exec_all.go
+++ b/pkg/function/kube_exec_all.go
@@ -17,14 +17,18 @@ package function
 import (
 	"context"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
 	kanister "github.com/kanisterio/kanister/pkg"
+	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	"github.com/kanisterio/kanister/pkg/format"
 	"github.com/kanisterio/kanister/pkg/kube"
 	"github.com/kanisterio/kanister/pkg/param"
+	"github.com/kanisterio/kanister/pkg/progress"
 )
 
 func init() {
@@ -44,13 +48,19 @@ const (
 	KubeExecAllCommandArg        = "command"
 )
 
-type kubeExecAllFunc struct{}
+type kubeExecAllFunc struct {
+	progressPercent string
+}
 
 func (*kubeExecAllFunc) Name() string {
 	return KubeExecAllFuncName
 }
 
-func (*kubeExecAllFunc) Exec(ctx context.Context, tp param.TemplateParams, args map[string]interface{}) (map[string]interface{}, error) {
+func (kef *kubeExecAllFunc) Exec(ctx context.Context, tp param.TemplateParams, args map[string]interface{}) (map[string]interface{}, error) {
+	// Set progress percent
+	kef.progressPercent = progress.StartedPercent
+	defer func() { kef.progressPercent = progress.CompletedPercent }()
+
 	cli, err := kube.NewClient()
 	if err != nil {
 		return nil, err
@@ -90,6 +100,14 @@ func (*kubeExecAllFunc) Arguments() []string {
 		KubeExecAllContainersNameArg,
 		KubeExecAllCommandArg,
 	}
+}
+
+func (k *kubeExecAllFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {
+	metav1Time := metav1.NewTime(time.Now())
+	return crv1alpha1.PhaseProgress{
+		ProgressPercent:    string(k.progressPercent),
+		LastTransitionTime: &metav1Time,
+	}, nil
 }
 
 func execAll(ctx context.Context, cli kubernetes.Interface, namespace string, ps []string, cs []string, cmd []string) (map[string]interface{}, error) {

--- a/pkg/function/kube_exec_all.go
+++ b/pkg/function/kube_exec_all.go
@@ -105,7 +105,7 @@ func (*kubeExecAllFunc) Arguments() []string {
 func (k *kubeExecAllFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {
 	metav1Time := metav1.NewTime(time.Now())
 	return crv1alpha1.PhaseProgress{
-		ProgressPercent:    string(k.progressPercent),
+		ProgressPercent:    k.progressPercent,
 		LastTransitionTime: &metav1Time,
 	}, nil
 }

--- a/pkg/function/restore_data.go
+++ b/pkg/function/restore_data.go
@@ -17,6 +17,7 @@ package function
 import (
 	"bytes"
 	"context"
+	"time"
 
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,6 +28,7 @@ import (
 	"github.com/kanisterio/kanister/pkg/format"
 	"github.com/kanisterio/kanister/pkg/kube"
 	"github.com/kanisterio/kanister/pkg/param"
+	"github.com/kanisterio/kanister/pkg/progress"
 	"github.com/kanisterio/kanister/pkg/restic"
 )
 
@@ -62,7 +64,9 @@ func init() {
 
 var _ kanister.Func = (*restoreDataFunc)(nil)
 
-type restoreDataFunc struct{}
+type restoreDataFunc struct {
+	progressPercent string
+}
 
 func (*restoreDataFunc) Name() string {
 	return RestoreDataFuncName
@@ -180,7 +184,11 @@ func restoreDataPodFunc(
 	}
 }
 
-func (*restoreDataFunc) Exec(ctx context.Context, tp param.TemplateParams, args map[string]interface{}) (map[string]interface{}, error) {
+func (r *restoreDataFunc) Exec(ctx context.Context, tp param.TemplateParams, args map[string]interface{}) (map[string]interface{}, error) {
+	// Set progress percent
+	r.progressPercent = progress.StartedPercent
+	defer func() { r.progressPercent = progress.CompletedPercent }()
+
 	var namespace, image, backupArtifactPrefix, backupTag, backupID string
 	var podOverride crv1alpha1.JSONMap
 	var err error
@@ -253,4 +261,12 @@ func (*restoreDataFunc) Arguments() []string {
 		RestoreDataBackupIdentifierArg,
 		RestoreDataPodOverrideArg,
 	}
+}
+
+func (d *restoreDataFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {
+	metav1Time := metav1.NewTime(time.Now())
+	return crv1alpha1.PhaseProgress{
+		ProgressPercent:    d.progressPercent,
+		LastTransitionTime: &metav1Time,
+	}, nil
 }

--- a/pkg/function/restore_data_using_kopia_server.go
+++ b/pkg/function/restore_data_using_kopia_server.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,6 +31,7 @@ import (
 	kopiacmd "github.com/kanisterio/kanister/pkg/kopia/command"
 	"github.com/kanisterio/kanister/pkg/kube"
 	"github.com/kanisterio/kanister/pkg/param"
+	"github.com/kanisterio/kanister/pkg/progress"
 )
 
 const (
@@ -38,7 +40,9 @@ const (
 	SparseRestoreOption = "sparseRestore"
 )
 
-type restoreDataUsingKopiaServerFunc struct{}
+type restoreDataUsingKopiaServerFunc struct {
+	progressPercent string
+}
 
 func init() {
 	_ = kanister.Register(&restoreDataUsingKopiaServerFunc{})
@@ -72,7 +76,11 @@ func (*restoreDataUsingKopiaServerFunc) Arguments() []string {
 	}
 }
 
-func (*restoreDataUsingKopiaServerFunc) Exec(ctx context.Context, tp param.TemplateParams, args map[string]any) (map[string]any, error) {
+func (r *restoreDataUsingKopiaServerFunc) Exec(ctx context.Context, tp param.TemplateParams, args map[string]any) (map[string]any, error) {
+	// Set progress percent
+	r.progressPercent = progress.StartedPercent
+	defer func() { r.progressPercent = progress.CompletedPercent }()
+
 	var (
 		err          error
 		image        string
@@ -149,6 +157,14 @@ func (*restoreDataUsingKopiaServerFunc) Exec(ctx context.Context, tp param.Templ
 		vols,
 		podOverride,
 	)
+}
+
+func (r *restoreDataUsingKopiaServerFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {
+	metav1Time := metav1.NewTime(time.Now())
+	return crv1alpha1.PhaseProgress{
+		ProgressPercent:    r.progressPercent,
+		LastTransitionTime: &metav1Time,
+	}, nil
 }
 
 func restoreDataFromServer(


### PR DESCRIPTION
## Change Overview

This PR implements `ExecutionProgress()` on Kanister functions to address the interface changes introduced in https://github.com/kanisterio/kanister/pull/2023 to report progress tracking by each function

This PR is part of https://github.com/kanisterio/kanister/pull/2023, split to make it easier for review

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test


## Test Plan

Added in https://github.com/kanisterio/kanister/pull/2023