### PR TITLE
Make RepositoryServer struct consistent with RepositoryServer CRD

### DIFF
--- a/pkg/apis/cr/v1alpha1/repositoryserver_types.go
+++ b/pkg/apis/cr/v1alpha1/repositoryserver_types.go
@@ -33,7 +33,7 @@ type RepositoryServer struct {
 	// It has all the details required to start the kopia repository server
 	Spec RepositoryServerSpec `json:"spec"`
 	// Status refers to the current status of the repository server.
-	Status RepositoryServerStatus `json:"status"`
+	Status RepositoryServerStatus `json:"status,omitempty"`
 }
 
 // RepositoryServerSpec is the specification for the RepositoryServer
@@ -55,7 +55,6 @@ type RepositoryServerSpec struct {
 type Storage struct {
 	// SecretRef has the details of the object storage (location)
 	// where the kopia would backup the data
-	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	SecretRef corev1.SecretReference `json:"secretRef"`
 	// CredentialSecretRef stores the credentials required
@@ -69,17 +68,16 @@ type Repository struct {
 	// Path for the repository, it will be a relative sub path
 	// within the path prefix specified in the location
 	// More info: https://kopia.io/docs/reference/command-line/common/#commands-to-manipulate-repository
-	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	RootPath string `json:"rootPath"`
 	// If specified, these values will be used by the controller to
 	// override default username when connecting to the
 	// repository from the server.
-	Username string `json:"username"`
+	Username string `json:"username,omitempty"`
 	// If specified, these values will be used by the controller to
 	// override default hostname when connecting to the
 	// repository from the server.
-	Hostname string `json:"hostname"`
+	Hostname string `json:"hostname,omitempty"`
 	// PasswordSecretRef has the password required to connect to kopia repository
 	PasswordSecretRef corev1.SecretReference `json:"passwordSecretRef"`
 	CacheSizeSettings CacheSizeSettings      `json:"cacheSizeSettings,omitempty"`
@@ -99,12 +97,10 @@ type Server struct {
 	UserAccess UserAccess `json:"userAccess"`
 	// AdminSecretRef has the username and password required to start the
 	// kopia repository server
-	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	AdminSecretRef corev1.SecretReference `json:"adminSecretRef"`
 	// TLSSecretRef has the certificates required for kopia repository
 	// client server connection
-	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	TLSSecretRef corev1.SecretReference `json:"tlsSecretRef"`
 }
@@ -123,7 +119,7 @@ type UserAccess struct {
 type RepositoryServerStatus struct {
 	Conditions []Condition              `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 	ServerInfo ServerInfo               `json:"serverInfo,omitempty"`
-	Progress   RepositoryServerProgress `json:"progress"`
+	Progress   RepositoryServerProgress `json:"progress,omitempty"`
 }
 
 // Condition contains details of the current state of the RepositoryServer resource

--- a/pkg/customresource/repositoryserver.yaml
+++ b/pkg/customresource/repositoryserver.yaml
@@ -11,220 +11,220 @@ spec:
     singular: repositoryserver
   scope: Namespaced
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: RepositoryServer manages the lifecycle of Kopia Repository Server
-            within a Pod
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: RepositoryServer manages the lifecycle of Kopia Repository Server
+          within a Pod
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: Spec defines the spec of repository server. It has all the
-                details required to start the kopia repository server
-              properties:
-                repository:
-                  description: Repository has the details required by the repository
-                    server to connect to kopia repository
-                  properties:
-                    cacheSizeSettings:
-                      description: CacheSizeSettings are the metadata/content cache
-                        size details that can be used while establishing connection
-                        to the kopia repository
-                      properties:
-                        content:
-                          type: string
-                        metadata:
-                          type: string
-                      required:
-                        - content
-                        - metadata
-                      type: object
-                    hostname:
-                      description: If specified, these values will be used by the controller
-                        to override default hostname when connecting to the repository
-                        from the server.
-                      type: string
-                    passwordSecretRef:
-                      description: PasswordSecretRef has the password required to connect
-                        to kopia repository
-                      properties:
-                        name:
-                          description: name is unique within a namespace to reference
-                            a secret resource.
-                          type: string
-                        namespace:
-                          description: namespace defines the space within which the
-                            secret name must be unique.
-                          type: string
-                      type: object
-                      x-kubernetes-map-type: atomic
-                    rootPath:
-                      description: 'Path for the repository, it will be a relative sub
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the spec of repository server. It has all the
+              details required to start the kopia repository server
+            properties:
+              repository:
+                description: Repository has the details required by the repository
+                  server to connect to kopia repository
+                properties:
+                  cacheSizeSettings:
+                    description: CacheSizeSettings are the metadata/content cache
+                      size details that can be used while establishing connection
+                      to the kopia repository
+                    properties:
+                      content:
+                        type: string
+                      metadata:
+                        type: string
+                    required:
+                    - content
+                    - metadata
+                    type: object
+                  hostname:
+                    description: If specified, these values will be used by the controller
+                      to override default hostname when connecting to the repository
+                      from the server.
+                    type: string
+                  passwordSecretRef:
+                    description: PasswordSecretRef has the password required to connect
+                      to kopia repository
+                    properties:
+                      name:
+                        description: name is unique within a namespace to reference
+                          a secret resource.
+                        type: string
+                      namespace:
+                        description: namespace defines the space within which the
+                          secret name must be unique.
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  rootPath:
+                    description: 'Path for the repository, it will be a relative sub
                       path within the path prefix specified in the location More info:
                       https://kopia.io/docs/reference/command-line/common/#commands-to-manipulate-repository'
-                      type: string
-                      x-kubernetes-validations:
-                        - message: Value is immutable
-                          rule: self == oldSelf
-                    username:
-                      description: If specified, these values will be used by the controller
-                        to override default username when connecting to the repository
-                        from the server.
-                      type: string
-                  required:
-                    - passwordSecretRef
-                    - rootPath
-                  type: object
-                  x-kubernetes-validations:
-                    - message: rootPath field must not be allowed to be removed
-                      rule: '!has(oldSelf.rootPath) || has(self.rootPath)'
-                server:
-                  description: Server has the details of all the secrets required to
-                    start the kopia repository server
-                  properties:
-                    adminSecretRef:
-                      description: AdminSecretRef has the username and password required
-                        to start the kopia repository server
-                      properties:
-                        name:
-                          description: name is unique within a namespace to reference
-                            a secret resource.
-                          type: string
-                        namespace:
-                          description: namespace defines the space within which the
-                            secret name must be unique.
-                          type: string
-                      type: object
-                      x-kubernetes-map-type: atomic
-                      x-kubernetes-validations:
-                        - message: Value is immutable
-                          rule: self == oldSelf
-                    tlsSecretRef:
-                      description: TLSSecretRef has the certificates required for kopia
-                        repository client server connection
-                      properties:
-                        name:
-                          description: name is unique within a namespace to reference
-                            a secret resource.
-                          type: string
-                        namespace:
-                          description: namespace defines the space within which the
-                            secret name must be unique.
-                          type: string
-                      type: object
-                      x-kubernetes-map-type: atomic
-                      x-kubernetes-validations:
-                        - message: Value is immutable
-                          rule: self == oldSelf
-                    userAccess:
-                      description: UserAccess has the details of the user credentials
-                        required by client to connect to kopia repository server
-                      properties:
-                        userAccessSecretRef:
-                          description: UserAccessSecretRef stores the list of hostname
-                            and passwords used by kopia clients to connect to kopia
-                            repository server
-                          properties:
-                            name:
-                              description: name is unique within a namespace to reference
-                                a secret resource.
-                              type: string
-                            namespace:
-                              description: namespace defines the space within which
-                                the secret name must be unique.
-                              type: string
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        username:
-                          description: Username is the user required by client to connect
-                            to kopia repository server
-                          type: string
-                      required:
-                        - userAccessSecretRef
-                        - username
-                      type: object
-                  required:
-                    - adminSecretRef
-                    - tlsSecretRef
-                    - userAccess
-                  type: object
-                  x-kubernetes-validations:
-                    - message: adminSecretRef field must not be allowed to be removed
-                      rule: '!has(oldSelf.adminSecretRef) || has(self.adminSecretRef)'
-                    - message: tlsSecretRef field must not be allowed to be removed
-                      rule: '!has(oldSelf.tlsSecretRef) || has(self.tlsSecretRef)'
-                storage:
-                  description: Storage references the backend store where a repository
-                    already exists and the credential necessary to connect to the backend
-                    store
-                  properties:
-                    credentialSecretRef:
-                      description: CredentialSecretRef stores the credentials required
-                        to connect to the object storage specified in `SecretRef` field
-                      properties:
-                        name:
-                          description: name is unique within a namespace to reference
-                            a secret resource.
-                          type: string
-                        namespace:
-                          description: namespace defines the space within which the
-                            secret name must be unique.
-                          type: string
-                      type: object
-                      x-kubernetes-map-type: atomic
-                    secretRef:
-                      description: SecretRef has the details of the object storage (location)
-                        where the kopia would backup the data
-                      properties:
-                        name:
-                          description: name is unique within a namespace to reference
-                            a secret resource.
-                          type: string
-                        namespace:
-                          description: namespace defines the space within which the
-                            secret name must be unique.
-                          type: string
-                      type: object
-                      x-kubernetes-map-type: atomic
-                      x-kubernetes-validations:
-                        - message: Value is immutable
-                          rule: self == oldSelf
-                  required:
-                    - credentialSecretRef
-                    - secretRef
-                  type: object
-                  x-kubernetes-validations:
-                    - message: secretRef field must not be allowed to be removed
-                      rule: '!has(oldSelf.secretRef) || has(self.secretRef)'
-              required:
-                - repository
-                - server
-                - storage
-              type: object
-            status:
-              description: Status refers to the current status of the repository server.
-              properties:
-                conditions:
-                  items:
-                    description: Condition contains details of the current state of
-                      the RepositoryServer resource
+                    type: string
+                    x-kubernetes-validations:
+                    - message: Value is immutable
+                      rule: self == oldSelf
+                  username:
+                    description: If specified, these values will be used by the controller
+                      to override default username when connecting to the repository
+                      from the server.
+                    type: string
+                required:
+                - passwordSecretRef
+                - rootPath
+                type: object
+                x-kubernetes-validations:
+                - message: rootPath field must not be allowed to be removed
+                  rule: '!has(oldSelf.rootPath) || has(self.rootPath)'
+              server:
+                description: Server has the details of all the secrets required to
+                  start the kopia repository server
+                properties:
+                  adminSecretRef:
+                    description: AdminSecretRef has the username and password required
+                      to start the kopia repository server
                     properties:
-                      lastTransitionTime:
-                        format: date-time
+                      name:
+                        description: name is unique within a namespace to reference
+                          a secret resource.
                         type: string
-                      lastUpdateTime:
-                        description: "Condition contains details for one aspect of the
+                      namespace:
+                        description: namespace defines the space within which the
+                          secret name must be unique.
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                    x-kubernetes-validations:
+                    - message: Value is immutable
+                      rule: self == oldSelf
+                  tlsSecretRef:
+                    description: TLSSecretRef has the certificates required for kopia
+                      repository client server connection
+                    properties:
+                      name:
+                        description: name is unique within a namespace to reference
+                          a secret resource.
+                        type: string
+                      namespace:
+                        description: namespace defines the space within which the
+                          secret name must be unique.
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                    x-kubernetes-validations:
+                    - message: Value is immutable
+                      rule: self == oldSelf
+                  userAccess:
+                    description: UserAccess has the details of the user credentials
+                      required by client to connect to kopia repository server
+                    properties:
+                      userAccessSecretRef:
+                        description: UserAccessSecretRef stores the list of hostname
+                          and passwords used by kopia clients to connect to kopia
+                          repository server
+                        properties:
+                          name:
+                            description: name is unique within a namespace to reference
+                              a secret resource.
+                            type: string
+                          namespace:
+                            description: namespace defines the space within which
+                              the secret name must be unique.
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      username:
+                        description: Username is the user required by client to connect
+                          to kopia repository server
+                        type: string
+                    required:
+                    - userAccessSecretRef
+                    - username
+                    type: object
+                required:
+                - adminSecretRef
+                - tlsSecretRef
+                - userAccess
+                type: object
+                x-kubernetes-validations:
+                - message: adminSecretRef field must not be allowed to be removed
+                  rule: '!has(oldSelf.adminSecretRef) || has(self.adminSecretRef)'
+                - message: tlsSecretRef field must not be allowed to be removed
+                  rule: '!has(oldSelf.tlsSecretRef) || has(self.tlsSecretRef)'
+              storage:
+                description: Storage references the backend store where a repository
+                  already exists and the credential necessary to connect to the backend
+                  store
+                properties:
+                  credentialSecretRef:
+                    description: CredentialSecretRef stores the credentials required
+                      to connect to the object storage specified in `SecretRef` field
+                    properties:
+                      name:
+                        description: name is unique within a namespace to reference
+                          a secret resource.
+                        type: string
+                      namespace:
+                        description: namespace defines the space within which the
+                          secret name must be unique.
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  secretRef:
+                    description: SecretRef has the details of the object storage (location)
+                      where the kopia would backup the data
+                    properties:
+                      name:
+                        description: name is unique within a namespace to reference
+                          a secret resource.
+                        type: string
+                      namespace:
+                        description: namespace defines the space within which the
+                          secret name must be unique.
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                    x-kubernetes-validations:
+                    - message: Value is immutable
+                      rule: self == oldSelf
+                required:
+                - credentialSecretRef
+                - secretRef
+                type: object
+                x-kubernetes-validations:
+                - message: secretRef field must not be allowed to be removed
+                  rule: '!has(oldSelf.secretRef) || has(self.secretRef)'
+            required:
+            - repository
+            - server
+            - storage
+            type: object
+          status:
+            description: Status refers to the current status of the repository server.
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details of the current state of
+                    the RepositoryServer resource
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    lastUpdateTime:
+                      description: "Condition contains details for one aspect of the
                         current state of this API Resource. --- This struct is intended
                         for direct use as an array at the field path .status.conditions.
                         \ For example, \n type FooStatus struct{ // Represents the
@@ -234,99 +234,93 @@ spec:
                         Conditions []metav1.Condition `json:\"conditions,omitempty\"
                         patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
                         \n // other fields }"
-                        properties:
-                          lastTransitionTime:
-                            description: lastTransitionTime is the last time the condition
-                              transitioned from one status to another. This should be
-                              when the underlying condition changed.  If that is not
-                              known, then using the time when the API field changed
-                              is acceptable.
-                            format: date-time
-                            type: string
-                          message:
-                            description: message is a human readable message indicating
-                              details about the transition. This may be an empty string.
-                            maxLength: 32768
-                            type: string
-                          observedGeneration:
-                            description: observedGeneration represents the .metadata.generation
-                              that the condition was set based upon. For instance, if
-                              .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
-                              is 9, the condition is out of date with respect to the
-                              current state of the instance.
-                            format: int64
-                            minimum: 0
-                            type: integer
-                          reason:
-                            description: reason contains a programmatic identifier indicating
-                              the reason for the condition's last transition. Producers
-                              of specific condition types may define expected values
-                              and meanings for this field, and whether the values are
-                              considered a guaranteed API. The value should be a CamelCase
-                              string. This field may not be empty.
-                            maxLength: 1024
-                            minLength: 1
-                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                            type: string
-                          status:
-                            description: status of the condition, one of True, False,
-                              Unknown.
-                            enum:
-                              - "True"
-                              - "False"
-                              - Unknown
-                            type: string
-                          type:
-                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                              --- Many .condition.type values are consistent across
-                              resources like Available, but because arbitrary conditions
-                              can be useful (see .node.status.conditions), the ability
-                              to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                            maxLength: 316
-                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                            type: string
-                        required:
-                          - lastTransitionTime
-                          - message
-                          - reason
-                          - status
-                          - type
-                        type: object
-                      status:
-                        type: string
-                      type:
-                        description: RepositoryServerConditionType defines all the various
-                          condition types of the RepositoryServer resource
-                        type: string
-                    required:
+                      properties:
+                        lastTransitionTime:
+                          description: lastTransitionTime is the last time the condition
+                            transitioned from one status to another. This should be
+                            when the underlying condition changed.  If that is not
+                            known, then using the time when the API field changed
+                            is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: message is a human readable message indicating
+                            details about the transition. This may be an empty string.
+                          maxLength: 32768
+                          type: string
+                        observedGeneration:
+                          description: observedGeneration represents the .metadata.generation
+                            that the condition was set based upon. For instance, if
+                            .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                            is 9, the condition is out of date with respect to the
+                            current state of the instance.
+                          format: int64
+                          minimum: 0
+                          type: integer
+                        reason:
+                          description: reason contains a programmatic identifier indicating
+                            the reason for the condition's last transition. Producers
+                            of specific condition types may define expected values
+                            and meanings for this field, and whether the values are
+                            considered a guaranteed API. The value should be a CamelCase
+                            string. This field may not be empty.
+                          maxLength: 1024
+                          minLength: 1
+                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                          type: string
+                        status:
+                          description: status of the condition, one of True, False,
+                            Unknown.
+                          enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                          type: string
+                        type:
+                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            --- Many .condition.type values are consistent across
+                            resources like Available, but because arbitrary conditions
+                            can be useful (see .node.status.conditions), the ability
+                            to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                          maxLength: 316
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          type: string
+                      required:
+                      - lastTransitionTime
+                      - message
+                      - reason
                       - status
                       - type
-                    type: object
-                  type: array
-                progress:
-                  description: RepositoryServerProgress is the field users would check
-                    to know the state of RepositoryServer
-                  type: string
-                serverInfo:
-                  description: ServerInfo describes all the information required by
-                    the client users to connect to the repository server
-                  properties:
-                    podName:
+                      type: object
+                    status:
                       type: string
-                    serviceName:
+                    type:
+                      description: RepositoryServerConditionType defines all the various
+                        condition types of the RepositoryServer resource
                       type: string
+                  required:
+                  - status
+                  - type
                   type: object
-              type: object
-          required:
-            - spec
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
+                type: array
+              progress:
+                description: RepositoryServerProgress is the field users would check
+                  to know the state of RepositoryServer
+                type: string
+              serverInfo:
+                description: ServerInfo describes all the information required by
+                  the client users to connect to the repository server
+                properties:
+                  podName:
+                    type: string
+                  serviceName:
+                    type: string
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}


### PR DESCRIPTION
## Change Overview
Here in this PR, we are modifying markers in RepositoryServer CR field, so that the controller-gen generates same CRD as we are maintaining in [https://github.com/kanisterio/kanister/blob/master/pkg/customresource/repositoryserver.yaml](https://github.com/kanisterio/kanister/blob/master/pkg/customresource/repositoryserver.yaml)

* Also we have fix the indention for the CRD file.


## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [x] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #2119 

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E

`make manifest`

this generates CRD 
[https://gist.github.com/akankshakumari393/13e3086c03ca4bec7805c5b776a19cfa](https://gist.github.com/akankshakumari393/13e3086c03ca4bec7805c5b776a19cfa) similar to what we have in [https://github.com/kanisterio/kanister/blob/master/pkg/customresource/repositoryserver.yaml](https://github.com/kanisterio/kanister/blob/master/pkg/customresource/repositoryserver.yaml)