### PR TITLE
Fix the delete action in etcd-incluster-ocp-blueprint 

### DIFF
--- a/examples/etcd/etcd-in-cluster/ocp/blueprint-v2/etcd-incluster-ocp-blueprint.yaml
+++ b/examples/etcd/etcd-in-cluster/ocp/blueprint-v2/etcd-incluster-ocp-blueprint.yaml
@@ -107,7 +107,7 @@ actions:
     - func: KubeTask
       name: deleteFromObjectStore
       args:
-        namespace: "{{ .Object.metadata.namespace }}"
+        namespace: "{{ .Namespace.Name }}"
         image: "ghcr.io/kanisterio/kanister-tools:0.92.0"
         command:
         - bash


### PR DESCRIPTION
## Change Overview

The [etcd-blueprint-v2](https://raw.githubusercontent.com/kanisterio/kanister/0.82.0/examples/etcd/etcd-in-cluster/ocp/blueprint-v2/etcd-incluster-ocp-blueprint.yaml) for OCP clusters was failing on delete action with the following error:
`Failed to execute phase: v1alpha1.Phase{Name:"deleteFromObjectStore", State:"pending", Output:map[string]interface {}(nil)}: Failed to render template: "namespace" not found`

This PR fixes this issue

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
