### PR TITLE
Fix pkg/kube to use standard kubeconfig machinery

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -15,8 +15,6 @@
 package kube
 
 import (
-	"os"
-
 	"github.com/pkg/errors"
 	crdclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/client-go/dynamic"
@@ -48,19 +46,6 @@ func ConfigNamespace() (string, error) {
 
 // LoadConfig returns a kubernetes client config based on global settings.
 func LoadConfig() (*rest.Config, error) {
-	kubeConfigEnv := os.Getenv(clientcmd.RecommendedConfigPathEnvVar)
-	if len(kubeConfigEnv) != 0 {
-		return clientcmd.BuildConfigFromFlags("", kubeConfigEnv)
-	}
-
-	if c, err := clientcmd.BuildConfigFromFlags("", clientcmd.RecommendedHomeFile); err == nil {
-		return c, nil
-	}
-
-	if c, err := rest.InClusterConfig(); err == nil {
-		return c, nil
-	}
-
 	return newClientConfig().ClientConfig()
 }
 


### PR DESCRIPTION
## Change Overview

The standard kubeconfig loading machinery provided by `k8s.io/client-go/tools/clientcmd` handles all of the same variants that `./pkg/kube.LoadConfig` was trying to handle. It also better handles certain cases, such as the `KUBECONFIG` environment variable referencing multiple kubeconfig files.

Since the `newClientConfig` function was already using the standard machinery (`clientcmd.NewNonInteractiveDeferredLoadingClientConfig` and `clientcmd.NewDefaultClientConfigLoadingRules`), simply removing the other special cases and letting it fall through was all that was necessary.

## Pull request type

- [X] :bug: Bugfix

## Issues

- N/A

## Test Plan

- [ ] :muscle: Manual
- [X] :zap: Unit test
- [X] :green_heart: E2E
