### PR TITLE
Fix pkg/config to use standard kubeconfig machinery

### DIFF
--- a/pkg/config/helpers.go
+++ b/pkg/config/helpers.go
@@ -8,7 +8,7 @@ import (
 	"gopkg.in/check.v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 const (
@@ -47,7 +47,12 @@ func GetEnvOrSkip(c *check.C, varName string) string {
 
 // due to cycle imports issues pks/kube can not be used
 func newKubeClient() (kubernetes.Interface, error) {
-	c, err := rest.InClusterConfig()
+	cc := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		clientcmd.NewDefaultClientConfigLoadingRules(),
+		&clientcmd.ConfigOverrides{},
+	)
+
+	c, err := cc.ClientConfig()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Change Overview

The standard kubeconfig loading machinery provided by `k8s.io/client-go/tools/clientcmd` better handles what `./pkg/config.newKubeClient` was trying to do and better mimics what `./pkg/kube.LoadConfig` is doing in #2132.

## Pull request type

- [X] :hamster: Trivial/Minor

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- Related to #2132

## Test Plan

- [ ] :muscle: Manual
- [X] :zap: Unit test
- [X] :green_heart: E2E
