### PR TITLE
Import the general client/auth package

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -20,11 +20,8 @@ import (
 	"github.com/pkg/errors"
 	crdclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/kubernetes" // Load the GCP plugin - required to authenticate against
-
-	// GKE clusters
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
-	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
+	"k8s.io/client-go/kubernetes"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )


### PR DESCRIPTION
## Change Overview

Rather than manually importing each auth sub-package, the `…/client/auth` package is imported instead. This package imports the default set of built-in client auth methods (which is a superset of the ones previously imported).

## Pull request type

- [X] :hamster: Trivial/Minor

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- N/A

## Test Plan

- [ ] :muscle: Manual
- [X] :zap: Unit test
- [X] :green_heart: E2E
