### PR TITLE
Refactoring push_images.sh to consume a single source of truth containing valid images

### DIFF
--- a/build/push_images.sh
+++ b/build/push_images.sh
@@ -18,7 +18,10 @@ set -o errexit
 set -o nounset
 
 IMAGE_REGISTRY="ghcr.io/kanisterio"
-IMAGES=("mysql-sidecar" "kafka-adobe-s3-sink-connector" "postgres-kanister-tools" "postgresql" "cassandra" "kanister-kubectl-1.18" "mongodb" "es-sidecar" "controller" "kanister-tools" "kafka-adobe-s3-source-connector" "mssql-tools")
+
+IMAGES_NAME_PATH="valid_images.json"
+
+IMAGES=(`cat $IMAGES_NAME_PATH | jq -r .images[]`)
 
 TAG=${1:-"v9.99.9-dev"}
 

--- a/build/valid_images.json
+++ b/build/valid_images.json
@@ -2,6 +2,7 @@
 	"image_registry": "ghcr.io/kanisterio",
 	"images": [ "mysql-sidecar", 
 	"kafka-adobe-s3-sink-connector", 
+	"postgres-kanister-tools",
 	"postgresql", 
 	"cassandra", 
 	"kanister-kubectl-1.18", 

--- a/build/valid_images.json
+++ b/build/valid_images.json
@@ -1,0 +1,15 @@
+{
+	"image_registry": "ghcr.io/kanisterio",
+	"images": [ "mysql-sidecar", 
+	"kafka-adobe-s3-sink-connector", 
+	"postgresql", 
+	"cassandra", 
+	"kanister-kubectl-1.18", 
+	"mongodb", 
+	"es-sidecar", 
+	"controller", 
+	"kanister-tools", 
+	"kafka-adobe-s3-source-connector", 
+	"mssql-tools"],
+	"tag": "v9.99.9-dev"
+}


### PR DESCRIPTION
## Change Overview

Introducing build/valid_images.json as a single source of truth for all valid images maintained by Kanister. This also includes a refactor to build/push_images.json to consume this single source of truth

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [x] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Test Plan
Pipelines should succeed as usual.
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [x] :green_heart: E2E
