### PR TITLE
Run PostgreSQL integration tests on 12.6.0 chart

### DIFF
--- a/pkg/app/postgresql.go
+++ b/pkg/app/postgresql.go
@@ -49,6 +49,7 @@ func NewPostgresDB(name string, subPath string) App {
 			RepoName: helm.BitnamiRepoName,
 			RepoURL:  helm.BitnamiRepoURL,
 			Chart:    "postgresql",
+			Version:  "12.6.0", // TODO: Revert once #2155 is addressed
 			Values: map[string]string{
 				"image.pullPolicy":          "Always",
 				"auth.postgresPassword":     "test@54321",


### PR DESCRIPTION
## Change Overview

Integration tests for postgres are failing for postgresql app with latest helm chart.
Thi PR sets latest working version of postgres helm chart i.e  `12.6.0` for the test app.
This is a temporary fix till https://github.com/kanisterio/kanister/issues/2155 gets addressed 

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [x] :robot: Test

## Test Plan

Successfully ran integration tests for PostgreSQL application
```
./build/integration-test.sh ^PostgreSQL$
.
.
.
{"File":"pkg/app/postgresql.go","Function":"github.com/kanisterio/kanister/pkg/app.PostgresDB.Uninstall","Line":199,"app":"postgres","cluster_name":"c55343ff-f132-4395-88d9-e3a4f2757e68","level":"info","msg":"Uninstalling helm chart.","namespace":"postgres-test","release":"postgres-lsrfp","time":"2023-07-05T18:19:41.703384+05:30"}
OK: 1 passed
--- PASS: Test (74.69s)
PASS
ok      github.com/kanisterio/kanister/pkg/testing      75.856s
```