### PR TITLE
Add Type S3Compliant to Kopia Repository Storage Args

### DIFF
--- a/pkg/kopia/command/storage/storage_args.go
+++ b/pkg/kopia/command/storage/storage_args.go
@@ -40,6 +40,8 @@ func KopiaStorageArgs(params *StorageCommandParams) (logsafe.Cmd, error) {
 		return filesystemArgs(params.Location, params.RepoPathPrefix), nil
 	case repositoryserver.LocTypeS3:
 		return s3Args(params.Location, params.RepoPathPrefix), nil
+	case repositoryserver.LocTypes3Compliant:
+		return s3Args(params.Location, params.RepoPathPrefix), nil
 	case repositoryserver.LocTypeGCS:
 		return gcsArgs(params.Location, params.RepoPathPrefix), nil
 	case repositoryserver.LocTypeAzure:

--- a/pkg/kopia/command/storage/storage_args_test.go
+++ b/pkg/kopia/command/storage/storage_args_test.go
@@ -50,6 +50,27 @@ func (s *StorageUtilsSuite) TestStorageArgsUtil(c *check.C) {
 		{
 			params: &StorageCommandParams{
 				Location: map[string][]byte{
+					repositoryserver.BucketKey:        []byte("test-bucket"),
+					repositoryserver.EndpointKey:      []byte("test-endpoint"),
+					repositoryserver.PrefixKey:        []byte("test-prefix"),
+					repositoryserver.RegionKey:        []byte("test-region"),
+					repositoryserver.SkipSSLVerifyKey: []byte("true"),
+					repositoryserver.TypeKey:          []byte("s3Compliant"),
+				},
+				RepoPathPrefix: "dir/subdir/",
+			},
+			Checker: check.IsNil,
+			expectedCmd: fmt.Sprint(
+				s3SubCommand,
+				fmt.Sprintf(" %s=test-bucket", bucketFlag),
+				fmt.Sprintf(" %s=test-endpoint", s3EndpointFlag),
+				fmt.Sprintf(" %s=test-prefix/dir/subdir/ %s", prefixFlag, s3DisableTLSVerifyFlag),
+				fmt.Sprintf(" %s=test-region", s3RegionFlag),
+			),
+		},
+		{
+			params: &StorageCommandParams{
+				Location: map[string][]byte{
 					repositoryserver.PrefixKey: []byte("test-prefix"),
 					repositoryserver.TypeKey:   []byte("filestore"),
 				},

--- a/pkg/secrets/repositoryserver/const.go
+++ b/pkg/secrets/repositoryserver/const.go
@@ -21,10 +21,11 @@ import (
 type LocType string
 
 const (
-	LocTypeS3        LocType = "s3"
-	LocTypeGCS       LocType = "gcs"
-	LocTypeAzure     LocType = "azure"
-	LocTypeFilestore LocType = "filestore"
+	LocTypeS3          LocType = "s3"
+	LocTypes3Compliant LocType = "s3Compliant"
+	LocTypeGCS         LocType = "gcs"
+	LocTypeAzure       LocType = "azure"
+	LocTypeFilestore   LocType = "filestore"
 
 	// Location represents the storage location secret type for kopia repository server
 	Location corev1.SecretType = "secrets.kanister.io/storage-location"

--- a/pkg/secrets/repositoryserver/s3compliant_secrets.go
+++ b/pkg/secrets/repositoryserver/s3compliant_secrets.go
@@ -15,9 +15,10 @@
 package repositoryserver
 
 import (
-	secerrors "github.com/kanisterio/kanister/pkg/secrets/errors"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+
+	secerrors "github.com/kanisterio/kanister/pkg/secrets/errors"
 )
 
 type s3Compliant struct {

--- a/pkg/secrets/repositoryserver/s3compliant_secrets.go
+++ b/pkg/secrets/repositoryserver/s3compliant_secrets.go
@@ -1,0 +1,49 @@
+// Copyright 2023 The Kanister Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package repositoryserver
+
+import (
+	secerrors "github.com/kanisterio/kanister/pkg/secrets/errors"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type s3Compliant struct {
+	storageLocation *corev1.Secret
+}
+
+func NewS3CompliantLocation(secret *corev1.Secret) *s3Compliant {
+	return &s3Compliant{
+		storageLocation: secret,
+	}
+}
+
+var _ Secret = &s3Compliant{}
+
+func (s s3Compliant) Validate() error {
+	if s.storageLocation == nil {
+		return errors.Wrapf(secerrors.ErrValidate, secerrors.NilSecretErrorMessage)
+	}
+	if len(s.storageLocation.Data) == 0 {
+		return errors.Wrapf(secerrors.ErrValidate, secerrors.EmptySecretErrorMessage, s.storageLocation.Namespace, s.storageLocation.Name)
+	}
+	if _, ok := s.storageLocation.Data[EndpointKey]; !ok {
+		return errors.Wrapf(secerrors.ErrValidate, secerrors.MissingRequiredFieldErrorMsg, EndpointKey, s.storageLocation.Namespace, s.storageLocation.Name)
+	}
+	if _, ok := s.storageLocation.Data[RegionKey]; !ok {
+		return errors.Wrapf(secerrors.ErrValidate, secerrors.MissingRequiredFieldErrorMsg, RegionKey, s.storageLocation.Namespace, s.storageLocation.Name)
+	}
+	return nil
+}

--- a/pkg/secrets/repositoryserver/s3compliant_secrets.go
+++ b/pkg/secrets/repositoryserver/s3compliant_secrets.go
@@ -40,6 +40,9 @@ func (s s3Compliant) Validate() error {
 	if len(s.storageLocation.Data) == 0 {
 		return errors.Wrapf(secerrors.ErrValidate, secerrors.EmptySecretErrorMessage, s.storageLocation.Namespace, s.storageLocation.Name)
 	}
+	if _, ok := s.storageLocation.Data[BucketKey]; !ok {
+		return errors.Wrapf(secerrors.ErrValidate, secerrors.MissingRequiredFieldErrorMsg, BucketKey, s.storageLocation.Namespace, s.storageLocation.Name)
+	}
 	if _, ok := s.storageLocation.Data[EndpointKey]; !ok {
 		return errors.Wrapf(secerrors.ErrValidate, secerrors.MissingRequiredFieldErrorMsg, EndpointKey, s.storageLocation.Namespace, s.storageLocation.Name)
 	}

--- a/pkg/secrets/repositoryserver/s3compliant_secrets_test.go
+++ b/pkg/secrets/repositoryserver/s3compliant_secrets_test.go
@@ -1,0 +1,119 @@
+// Copyright 2023 The Kanister Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package repositoryserver
+
+import (
+	"github.com/pkg/errors"
+	. "gopkg.in/check.v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	secerrors "github.com/kanisterio/kanister/pkg/secrets/errors"
+)
+
+type S3CompliantSecretTestSuite struct{}
+
+var _ = Suite(&S3CompliantSecretTestSuite{})
+
+func (s *S3CompliantSecretTestSuite) TestValidateRepoServerS3CompliantCredentials(c *C) {
+	for i, tc := range []struct {
+		secret        Secret
+		errChecker    Checker
+		expectedError error
+	}{
+		{ // Valid S3 Compatible Secret
+			secret: NewS3CompliantLocation(&v1.Secret{
+				Type: v1.SecretType(LocTypes3Compliant),
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "sec",
+					Namespace: "ns",
+				},
+				Data: map[string][]byte{
+					BucketKey:   []byte("bucket"),
+					RegionKey:   []byte("region"),
+					EndpointKey: []byte("endpoint"),
+				},
+			}),
+			errChecker: IsNil,
+		},
+		{ // Missing required field - Bucket Key
+			secret: NewS3CompliantLocation(&v1.Secret{
+				Type: v1.SecretType(LocTypes3Compliant),
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "sec",
+					Namespace: "ns",
+				},
+				Data: map[string][]byte{
+					RegionKey:   []byte("region"),
+					EndpointKey: []byte("endpoint"),
+				},
+			}),
+			errChecker:    NotNil,
+			expectedError: errors.Wrapf(secerrors.ErrValidate, secerrors.MissingRequiredFieldErrorMsg, BucketKey, "ns", "sec"),
+		},
+		{ // Missing required field - Region Key
+			secret: NewS3CompliantLocation(&v1.Secret{
+				Type: v1.SecretType(LocTypes3Compliant),
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "sec",
+					Namespace: "ns",
+				},
+				Data: map[string][]byte{
+					BucketKey:   []byte("bucket"),
+					EndpointKey: []byte("endpoint"),
+				},
+			}),
+			errChecker:    NotNil,
+			expectedError: errors.Wrapf(secerrors.ErrValidate, secerrors.MissingRequiredFieldErrorMsg, RegionKey, "ns", "sec"),
+		},
+		{ // Missing required field - Endpoint Key
+			secret: NewS3CompliantLocation(&v1.Secret{
+				Type: v1.SecretType(LocTypes3Compliant),
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "sec",
+					Namespace: "ns",
+				},
+				Data: map[string][]byte{
+					RegionKey: []byte("region"),
+					BucketKey: []byte("bucket"),
+				},
+			}),
+			errChecker:    NotNil,
+			expectedError: errors.Wrapf(secerrors.ErrValidate, secerrors.MissingRequiredFieldErrorMsg, EndpointKey, "ns", "sec"),
+		},
+		{ // Empty Secret
+			secret: NewS3CompliantLocation(&v1.Secret{
+				Type: v1.SecretType(LocTypes3Compliant),
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "sec",
+					Namespace: "ns",
+				},
+			}),
+			errChecker:    NotNil,
+			expectedError: errors.Wrapf(secerrors.ErrValidate, secerrors.EmptySecretErrorMessage, "ns", "sec"),
+		},
+		{ // Nil Secret
+			secret:        NewS3CompliantLocation(nil),
+			errChecker:    NotNil,
+			expectedError: errors.Wrapf(secerrors.ErrValidate, secerrors.NilSecretErrorMessage),
+		},
+	} {
+		err := tc.secret.Validate()
+		c.Check(err, tc.errChecker)
+		if err != nil {
+			c.Check(err.Error(), Equals, tc.expectedError.Error(), Commentf("test number: %d", i))
+		}
+	}
+}

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -61,7 +61,7 @@ func getLocationSecret(secret *corev1.Secret) (reposerver.Secret, error) {
 	case reposerver.LocTypeS3:
 		return reposerver.NewAWSLocation(secret), nil
 	case reposerver.LocTypes3Compliant:
-		return reposerver.NewAWSLocation(secret), nil
+		return reposerver.NewS3CompliantLocation(secret), nil
 	case reposerver.LocTypeAzure:
 		return reposerver.NewAzureLocation(secret), nil
 	case reposerver.LocTypeGCS:

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -60,6 +60,8 @@ func getLocationSecret(secret *corev1.Secret) (reposerver.Secret, error) {
 	switch reposerver.LocType(string(locationType)) {
 	case reposerver.LocTypeS3:
 		return reposerver.NewAWSLocation(secret), nil
+	case reposerver.LocTypes3Compliant:
+		return reposerver.NewAWSLocation(secret), nil
 	case reposerver.LocTypeAzure:
 		return reposerver.NewAzureLocation(secret), nil
 	case reposerver.LocTypeGCS:


### PR DESCRIPTION
## Change Overview

Add Type S3Compliant to Kopia Repository Storage Args

- In order to use `s3compliant` as Type for Storage Arguments while testing Repository Server Workflows in
- - [Integration Tests](https://github.com/kanisterio/kanister/pull/2026)
- - [Tests for Updated `kando` command line](https://github.com/kanisterio/kanister/pull/2145/)

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E


### Manual Testing Steps

#### 1) Create Images for Kanister and Repo Server controller

```
git tag -fa v21-repo-server-rajat -m "Testing"

bash build/gorelease.sh

docker tag ghcr.io/kanisterio/controller:v21-repo-server-rajat r4rajat/controller:v21-repo-server-rajat

docker tag ghcr.io/kanisterio/repo-server-controller:v21-repo-server-rajat r4rajat/repo-server-controller:v21-repo-server-rajat

docker push r4rajat/controller:v21-repo-server-rajat && docker push r4rajat/repo-server-controller:v21-repo-server-rajat
``` 

#### 2) Install Kanister 

```
helm install kanister ./helm/kanister-operator \
--namespace kanister \
--set image.repository=r4rajat/controller \
--set image.tag=v21-repo-server-rajat \
--set repositoryServerImage.repository=r4rajat/repo-server-controller \
--set repositoryServerImage.tag=v21-repo-server-rajat \
--set controller.parallelism=10 \
--create-namespace
```

#### 3) Apply Repo Server CRD

```
kubectl apply -f pkg/customresource/repositoryserver.yaml -n kanister
```

#### 4) Create Test Application [Time Logger]

```
kubectl create namespace time-logger

kubectl create -f ./examples/time-log/time-logger-deployment.yaml -n time-logger
```

#### 5) Create OpenSSL Certificate

```
openssl req -newkey rsa:2048 -nodes -keyout key.pem -x509 -days 365 -out certificate.pem
```

#### 6) Create S3 Location and Location Secret Config Files

- S3 Location Secret [ Created for minio as s3Compliant Storage from `make install-minio` target]
```
vi s3_location_creds.yaml
```
```
apiVersion: v1
kind: Secret
metadata:
   name: s3-creds
   namespace: kanister
   labels:
      repo.kanister.io/target-namespace: monitoring
type: secrets.kanister.io/aws
data:
   # required: base64 encoded value for key with proper permissions for the bucket
   aws_access_key_id: QUtJQUlPU0ZPRE5ON0VYQU1QTEU=
   # required: base64 encoded value for the secret corresponding to the key above
   aws_secret_access_key: d0phbHJYVXRuRkVNSS9LN01ERU5HL2JQeFJmaUNZRVhBTVBMRUtFWQ==
```
- S3 Location
```
vi s3_location.yaml
```
```
apiVersion: v1
kind: Secret
metadata:
   name: s3-location
   namespace: kanister
   labels:
      repo.kanister.io/target-namespace: monitoring
type: Opaque
data:
   type: czNjb21wbGFudA==
   bucket: dGVzdHMua2FuaXN0ZXIuaW8=
   path: cmVwb3NpdG9yeS1zZXJ2ZXItdGVzdA==
   region: dXMtd2VzdC0y
   endpoint: aHR0cDovL21pbmlvLm1pbmlvLnN2Yy5jbHVzdGVyLmxvY2FsOjkwMDA=
   
```

#### 7) Apply Secrets

```
kubectl create secret tls repository-server-tls-cert --cert=certificate.pem --key=key.pem -n kanister

kubectl create secret generic repository-server-user-access -n kanister --from-literal=localhost=test1234

kubectl create secret generic repository-admin-user -n kanister --from-literal=username=admin@testpod1 --from-literal=password=test1234

kubectl create secret generic repo-pass -n kanister --from-literal=repo-password=test1234

kubectl apply -f s3_location_creds.yaml -n kanister

kubectl apply -f s3_location.yaml -n kanister
```

#### 8) Create Repository

```
kopia --log-level=error --config-file=/tmp/kopia-repository.config --log-dir=/tmp/kopia-cache repository create --no-check-for-updates --cache-directory=/tmp/cache.dir --content-cache-size-mb=0 --metadata-cache-size-mb=500 --override-hostname=mysql.app --override-username=kanisterAdmin s3 --bucket=tests.kanister.io --prefix=repository-server-test --region=us-west-2 --access-key=AKIAIOSFODNN7EXAMPLE --secret-access-key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY --endpoint=http://minio.minio.svc.cluster.local:9000
```

#### 9) Create Repository Server CR

```
vi repo-server-cr.yaml
```

```
apiVersion: cr.kanister.io/v1alpha1
kind: RepositoryServer
metadata:
  labels:
    app.kubernetes.io/name: repositoryserver
    app.kubernetes.io/instance: repositoryserver-sample
    app.kubernetes.io/part-of: kanister
    app.kuberentes.io/managed-by: kustomize
    app.kubernetes.io/created-by: kanister
  name: kopia-repo-server-1
  namespace: kanister
spec:
  storage:
    secretRef:
      name: s3-location
      namespace: kanister
    credentialSecretRef:
      name: s3-creds
      namespace: kanister
  repository:
    rootPath: /repo-controller/
    passwordSecretRef:
      name: repo-pass
      namespace: kanister
    username: kanisterAdmin
    hostname: mysql.app
  server:
    adminSecretRef:
      name: repository-admin-user
      namespace: kanister
    tlsSecretRef:
      name: repository-server-tls-cert
      namespace: kanister
    userAccess:
      userAccessSecretRef:
        name: repository-server-user-access
        namespace: kanister
      username: kanisteruser
```

```bash
kubectl apply -f repo-server-cr.yaml -n kanister
```

Wait till the status of Repository Server CR gets to ```ServerReady``` , You could check it by running following command
```
kubectl describe -n kanister repositoryserver.cr.kanister.io/kopia-repo-server-1
```

#### 10) Create Blueprint
````
vi test-blueprint.yaml
````
```
apiVersion: cr.kanister.io/v1alpha1
kind: Blueprint
metadata:
  name: backupdate-bp
  namespace: kanister
actions:
  backup:
    outputArtifacts:
      timeLog:
        keyValue:
          path: '/repo-controller/time-logger/'
      backupIdentifier:
        keyValue:
          id: "{{ .Phases.backupToS3.Output.backupID }}"
    phases:
    - func: BackupDataUsingKopiaServer
      name: backupToS3
      args:
        namespace: "{{ .Deployment.Namespace }}"
        pod: "{{ index .Deployment.Pods 0 }}"
        container: test-container
        includePath: /var/log

  restore:
    inputArtifactNames:
    - timeLog
    - backupIdentifier
    phases:
    - func: ScaleWorkload
      name: shutdownPod
      args:
        namespace: "{{ .Deployment.Namespace }}"
        name: "{{ .Deployment.Name }}"
        kind: Deployment
        replicas: 0
    - func: RestoreDataUsingKopiaServer
      name: restoreFromS3
      args:
        namespace: "{{ .Deployment.Namespace }}"
        pod: "{{ index .Deployment.Pods 0 }}"
        image: ghcr.io/kanisterio/kanister-tools:0.89.0
        backupIdentifier: "{{ .ArtifactsIn.backupIdentifier.KeyValue.id }}"
        restorePath: /var/log
    - func: ScaleWorkload
      name: bringupPod
      args:
        namespace: "{{ .Deployment.Namespace }}"
        name: "{{ .Deployment.Name }}"
        kind: Deployment
        replicas: 1
```
```
kubectl create -f test-blueprint.yaml -n kanister
```

#### 11) Build kanctl with latest changes
```
go build -o kanctl cmd/kanctl/main.go 
```

#### 12) Take Backup of the Application
```
./kanctl create actionset --action backup --namespace kanister --blueprint backupdate-bp --deployment time-logger/time-logger --repository-server=kopia-repo-server-1

actionset backup-7m5lh created
```

Check Status of the actionset
```
kubectl describe actionsets -n kanister backup-7m5lh

Events:
  Type    Reason           Age   From                 Message
  ----    ------           ----  ----                 -------
  Normal  Started Action   9s    Kanister Controller  Executing action backup
  Normal  Started Phase    9s    Kanister Controller  Executing phase backupToS3
  Normal  Ended Phase      3s    Kanister Controller  Completed phase backupToS3
  Normal  Update Complete  3s    Kanister Controller  Updated ActionSet 'backup-7m5lh' Status->complete
```

#### 13) Restore the Application

- Delete the files in /var/log folder in time-logger pod

```
kubectl exec -n time-logger time-logger-6c95887764-lrzjg -it sh

sh-5.1# cd /var/log/

sh-5.1# rm -rf time.log
```

- Run Restore Action
```
./kanctl --namespace kanister create actionset --action restore --from  "backup-7m5lh"
```

Check status
```
kubectl describe actionsets -n kanister restore-backup-7m5lh-crwlw

Events:
  Type    Reason           Age   From                 Message
  ----    ------           ----  ----                 -------
  Normal  Started Action   43s   Kanister Controller  Executing action restore
  Normal  Started Phase    43s   Kanister Controller  Executing phase shutdownPod
  Normal  Ended Phase      11s   Kanister Controller  Completed phase shutdownPod
  Normal  Started Phase    11s   Kanister Controller  Executing phase restoreFromS3
  Normal  Ended Phase      5s    Kanister Controller  Completed phase restoreFromS3
  Normal  Started Phase    5s    Kanister Controller  Executing phase bringupPod
  Normal  Ended Phase      1s    Kanister Controller  Completed phase bringupPod
  Normal  Update Complete  1s    Kanister Controller  Updated ActionSet 'restore-backup-7m5lh-crwlw' Status->complete
```

- Verify the restore
```
kubectl exec -n time-logger time-logger-7z87759646-mvtkb -it sh

sh-5.1# cd /var/log/

sh-5.1# ls
time.log
```