### PR TITLE
Return empty snapshot ID if any fatal error happened during the snapshot creation

### DIFF
--- a/pkg/kopia/command/parse_command_output.go
+++ b/pkg/kopia/command/parse_command_output.go
@@ -106,7 +106,7 @@ func SnapshotInfoFromSnapshotCreateOutput(output string) (string, string, error)
 		if snapManifest.RootEntry != nil {
 			rootID = snapManifest.RootEntry.ObjectID.String()
 			if snapManifest.RootEntry.DirSummary != nil && snapManifest.RootEntry.DirSummary.FatalErrorCount > 0 {
-				return "", "", errors.New(fmt.Sprintf("Error occurred while snapshot creation. Output %s", output))
+				return "", "", errors.New(fmt.Sprintf("Error occurred during snapshot creation. Output %s", output))
 			}
 		}
 	}

--- a/pkg/kopia/command/parse_command_output.go
+++ b/pkg/kopia/command/parse_command_output.go
@@ -95,6 +95,7 @@ func LatestSnapshotInfoFromManifestList(output string) (string, string, error) {
 func SnapshotInfoFromSnapshotCreateOutput(output string) (string, string, error) {
 	snapID := ""
 	rootID := ""
+	var snapErr error
 	scanner := bufio.NewScanner(strings.NewReader(output))
 	for scanner.Scan() {
 		snapManifest := &snapshot.Manifest{}
@@ -106,7 +107,7 @@ func SnapshotInfoFromSnapshotCreateOutput(output string) (string, string, error)
 		if snapManifest.RootEntry != nil {
 			rootID = snapManifest.RootEntry.ObjectID.String()
 			if snapManifest.RootEntry.DirSummary != nil && snapManifest.RootEntry.DirSummary.FatalErrorCount > 0 {
-				return "", "", errors.New(fmt.Sprintf("Error occurred while snapshot creation"))
+				snapErr = errors.New(fmt.Sprintf("Error occurred while snapshot creation. Output %s", output))
 			}
 		}
 	}
@@ -116,7 +117,7 @@ func SnapshotInfoFromSnapshotCreateOutput(output string) (string, string, error)
 	if rootID == "" {
 		return "", "", errors.New(fmt.Sprintf("Failed to get root ID from create snapshot output %s", output))
 	}
-	return snapID, rootID, nil
+	return snapID, rootID, snapErr
 }
 
 // SnapSizeStatsFromSnapListAll returns a list of snapshot logical sizes assuming the input string

--- a/pkg/kopia/command/parse_command_output.go
+++ b/pkg/kopia/command/parse_command_output.go
@@ -95,7 +95,6 @@ func LatestSnapshotInfoFromManifestList(output string) (string, string, error) {
 func SnapshotInfoFromSnapshotCreateOutput(output string) (string, string, error) {
 	snapID := ""
 	rootID := ""
-	var snapErr error
 	scanner := bufio.NewScanner(strings.NewReader(output))
 	for scanner.Scan() {
 		snapManifest := &snapshot.Manifest{}
@@ -107,7 +106,7 @@ func SnapshotInfoFromSnapshotCreateOutput(output string) (string, string, error)
 		if snapManifest.RootEntry != nil {
 			rootID = snapManifest.RootEntry.ObjectID.String()
 			if snapManifest.RootEntry.DirSummary != nil && snapManifest.RootEntry.DirSummary.FatalErrorCount > 0 {
-				snapErr = errors.New(fmt.Sprintf("Error occurred while snapshot creation. Output %s", output))
+				return "", "", errors.New(fmt.Sprintf("Error occurred while snapshot creation. Output %s", output))
 			}
 		}
 	}
@@ -117,7 +116,7 @@ func SnapshotInfoFromSnapshotCreateOutput(output string) (string, string, error)
 	if rootID == "" {
 		return "", "", errors.New(fmt.Sprintf("Failed to get root ID from create snapshot output %s", output))
 	}
-	return snapID, rootID, snapErr
+	return snapID, rootID, nil
 }
 
 // SnapSizeStatsFromSnapListAll returns a list of snapshot logical sizes assuming the input string

--- a/pkg/kopia/command/parse_command_output.go
+++ b/pkg/kopia/command/parse_command_output.go
@@ -105,6 +105,9 @@ func SnapshotInfoFromSnapshotCreateOutput(output string) (string, string, error)
 		snapID = string(snapManifest.ID)
 		if snapManifest.RootEntry != nil {
 			rootID = snapManifest.RootEntry.ObjectID.String()
+			if snapManifest.RootEntry.DirSummary != nil && snapManifest.RootEntry.DirSummary.FatalErrorCount > 0 {
+				return "", "", errors.New(fmt.Sprintf("Error occurred while snapshot creation"))
+			}
 		}
 	}
 	if snapID == "" {

--- a/pkg/kopia/command/parse_command_output_test.go
+++ b/pkg/kopia/command/parse_command_output_test.go
@@ -16,6 +16,7 @@ package command
 
 import (
 	"encoding/json"
+
 	"github.com/kopia/kopia/fs"
 	"github.com/kopia/kopia/snapshot"
 	. "gopkg.in/check.v1"
@@ -136,6 +137,12 @@ func (kParse *KopiaParseUtilsTestSuite) TestSnapshotInfoFromSnapshotCreateOutput
 		{
 			output: `ERROR: unable to get local filesystem entry: resolveSymlink: stat: lstat /tmp/aaa2: no such file or directory
 			`,
+			checker:        NotNil,
+			expectedSnapID: "",
+			expectedRootID: "",
+		},
+		{
+			output:         `{"id":"1b6639b9797dc77dd4ddf57723918187","source":{"host":"da","userName":"kk","path":"/mnt/nfspvc"},"description":"","startTime":"2023-07-13T00:08:08.049239555Z","endTime":"2023-07-13T00:08:08.054904252Z","incomplete":"canceled","rootEntry":{"name":"nfspvc","type":"d","mode":"0755","mtime":"2023-07-11T20:33:41.386653643Z","obj":"k453085aaf775ecb9018a3fa8e276ca5d","summ":{"size":0,"files":0,"symlinks":0,"dirs":2,"maxTime":"2023-07-11T20:33:27.628326361Z","incomplete":"canceled","numFailed":1,"errors":[{"path":"for1001","error":"permission denied"}]}}}`,
 			checker:        NotNil,
 			expectedSnapID: "",
 			expectedRootID: "",


### PR DESCRIPTION
## Change Overview
Small update to not to return partially created snapshots in case if any fatal error happened during the snapshot creation.
We cannot rely on a partial created snapshot. 

## Pull request type

Please check the type of change your PR introduces:
- [x] :sunflower: Feature

## Test Plan

- [x] :zap: Unit test
