### PR TITLE
Remove Repository Server condition check from ServerReady to Ready

### DIFF
--- a/pkg/kanctl/actionset.go
+++ b/pkg/kanctl/actionset.go
@@ -764,7 +764,7 @@ func verifyRepositoryServerParams(repoServer *crv1alpha1.ObjectReference, crCli 
 			}
 			return errors.New("error while fetching repo server")
 		}
-		if rs.Status.Progress != "ServerReady" {
+		if rs.Status.Progress != crv1alpha1.Ready {
 			err = errors.New("Repository Server Not Ready")
 			return errors.Wrapf(err, "Please make sure that Repository Server CR '%s' is in Ready State", repoServer.Name)
 		}


### PR DESCRIPTION
## Change Overview

Due to Recent Changes in Repository Server Status Fields, While creating Actionsets with RepositoryServer reference, we were getting error even when RepositoryServer is in Ready state

```
$ ./kanctl create actionset --action backup --namespace kanister --blueprint backupdate-bp --deployment time-logger/time-logger --repository-server=kanister/kopia-repo-server-1

Please make sure that Repository Server CR 'kopia-repo-server-1' is in Ready State: Repository Server Not Ready
Error: resource verification failed
```

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #2185 

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
