### PR TITLE
chore(deps): add dependabot group for common Go dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,11 +9,6 @@ updates:
     commit-message:
       prefix: "deps(go):"
     ignore:
-      # Avoids unnecessarily auto-creating PRs for k8s dependencies, as these
-      # will be closed since k8s dependencies need to be updated all at once
-      # starting with kanister and go through additional validation.
-      - dependency-name: "k8s.io/*"
-      - dependency-name: "sigs.k8s.io/*"
       # Dependabot opens PRs for older versions of openshift that would downgrade the version in use.
       - dependency-name: "github.com/openshift/api"
     groups:
@@ -28,3 +23,9 @@ updates:
         - "github.com/minio/minio-go/*"
         - "golang.org/x/*"
         - "google.golang.org/*"
+      # create a single PR for k8s dependencies, so they can be updated all at
+      # once and go through additional validation.
+      k8s:
+        patterns:
+        - "k8s.io/*"
+        - "sigs.k8s.io/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,9 +2,10 @@ version: 2
 updates:
   - package-ecosystem: gomod
     directory: "/"
-    open-pull-requests-limit: 2
+    open-pull-requests-limit: 4
     schedule:
-      interval: daily
+      interval: weekly
+      day: tuesday
     commit-message:
       prefix: "deps(go):"
     ignore:
@@ -15,3 +16,15 @@ updates:
       - dependency-name: "sigs.k8s.io/*"
       # Dependabot opens PRs for older versions of openshift that would downgrade the version in use.
       - dependency-name: "github.com/openshift/api"
+    groups:
+      # create large PR upgrading multiple infrastructure dependencies in one shot,
+      # only include upstream dependencies that are stable and have somewhat
+      # regular releases which would be otherwise hard to manually manage.
+      common-golang:
+        patterns:
+        - "cloud.google.com/*"
+        - "github.com/aws/aws-sdk-go/*"
+        - "github.com/Azure/azure-sdk-for-go/sdk/*"
+        - "github.com/minio/minio-go/*"
+        - "golang.org/x/*"
+        - "google.golang.org/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,6 @@ updates:
     open-pull-requests-limit: 4
     schedule:
       interval: weekly
-      day: tuesday
     commit-message:
       prefix: "deps(go):"
     ignore:


### PR DESCRIPTION
## Change Overview

This produces a single @dependabot PR once a week that contains all the updates from commonly used and relatively stable. Updates to the dependencies in this group will not be included in other more frequent updates.
Other dependencies could be added to this group if needed in the future.

Additional info: [dependabot grouping feature](https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/)

## Pull request type

- [x] infra chore
- [x] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor

## Test Plan

- [x] :muscle: Manual. This approach has been tried out in the kopia/kopia project as well. It will need iteration though.