### PR TITLE
Run postgresql integration test on latest chart

### DIFF
--- a/pkg/app/postgresql.go
+++ b/pkg/app/postgresql.go
@@ -49,7 +49,6 @@ func NewPostgresDB(name string, subPath string) App {
 			RepoName: helm.BitnamiRepoName,
 			RepoURL:  helm.BitnamiRepoURL,
 			Chart:    "postgresql",
-			// Version:  "12.6.0", // use latest chart version
 			Values: map[string]string{
 				"image.pullPolicy":          "Always",
 				"auth.postgresPassword":     "test@54321",

--- a/pkg/app/postgresql.go
+++ b/pkg/app/postgresql.go
@@ -49,7 +49,7 @@ func NewPostgresDB(name string, subPath string) App {
 			RepoName: helm.BitnamiRepoName,
 			RepoURL:  helm.BitnamiRepoURL,
 			Chart:    "postgresql",
-			Version:  "12.6.0", // TODO: Revert once #2155 is addressed
+			// Version:  "12.6.0", // use latest chart version
 			Values: map[string]string{
 				"image.pullPolicy":          "Always",
 				"auth.postgresPassword":     "test@54321",


### PR DESCRIPTION
## Change Overview

Integration tests for postgres were failing for postgresql app with latest helm chart.
This PR reverts to the latest working version of postgres helm chart from earlier temporary fix version i.e 12.6.0 for the test app.

Generate random password as following were being ignored
- global.postgresql.auth.postgresPassword
- auth.postgresPassword 
Bug was reported for the same at bitnami/postgresql. New chart version fixed the issue.

Depends on: https://github.com/kanisterio/kanister/pull/2206
## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [x] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #2155

## Test Plan

Successfully ran integration tests for PostgreSQL application
```

./build/integration-test.sh ^PostgreSQL$
Running integration tests:
...
...
...
{"File":"pkg/app/postgresql.go","Function":"github.com/kanisterio/kanister/pkg/app.PostgresDB.Uninstall","Line":199,"app":"postgres","cluster_name":"4e3c7620-4569-4d87-8f7d-0f22884ca1ed","level":"info","msg":"Uninstalling helm chart.","namespace":"postgres-test","release":"postgres-cdqkp","time":"2023-07-19T10:24:25.000370184+05:30"}
OK: 1 passed
--- PASS: Test (68.09s)
PASS
ok      github.com/kanisterio/kanister/pkg/testing      68.132s
```
- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [x] :green_heart: E2E
