### PR TITLE
chore(deps): only allow semver-patch dependabot updates for k8s deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,12 @@ updates:
     ignore:
       # Dependabot opens PRs for older versions of openshift that would downgrade the version in use.
       - dependency-name: "github.com/openshift/api"
+      - dependency-name: "k8s.io/*"
+        # only allow patch updates
+        update-types: ["version-update:semver-major","version-update:semver-minor"]
+      - dependency-name: "sigs/k8s.io/*"
+        # only allow patch updates
+        update-types: ["version-update:semver-major","version-update:semver-minor"]
     groups:
       # create large PR upgrading multiple infrastructure dependencies in one shot,
       # only include upstream dependencies that are stable and have somewhat


### PR DESCRIPTION
## Pull request type

- [x] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [x] :robot: @dependabot config


## Test Plan

- [x] :zap: CI. Github automatically validates the config when the PR is opened.
