### PR TITLE
Bump helm version in kanister build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,8 @@ IMAGE_NAME := $(BIN)
 
 IMAGE := $(REGISTRY)/$(IMAGE_NAME)
 
-BUILD_IMAGE ?= ghcr.io/kanisterio/build:v0.0.23
+# BUILD_IMAGE ?= ghcr.io/kanisterio/build:v0.0.23
+BUILD_IMAGE ?= docker.io/mabhi2ic/kanister-home:v1.0.0
 
 # tag 0.1.0 is, 0.0.1 (latest) + gh + aws + helm binary
 DOCS_BUILD_IMAGE ?= ghcr.io/kanisterio/docker-sphinx:0.2.0

--- a/Makefile
+++ b/Makefile
@@ -62,8 +62,7 @@ IMAGE_NAME := $(BIN)
 
 IMAGE := $(REGISTRY)/$(IMAGE_NAME)
 
-# BUILD_IMAGE ?= ghcr.io/kanisterio/build:v0.0.23
-BUILD_IMAGE ?= docker.io/mabhi2ic/kanister-home:v1.0.0
+BUILD_IMAGE ?= ghcr.io/kanisterio/build:v0.0.24
 
 # tag 0.1.0 is, 0.0.1 (latest) + gh + aws + helm binary
 DOCS_BUILD_IMAGE ?= ghcr.io/kanisterio/docker-sphinx:0.2.0

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -15,7 +15,7 @@ COPY --from=bitnami/kubectl:1.26 /opt/bitnami/kubectl/bin/kubectl /usr/local/bin
 
 COPY --from=goreleaser/goreleaser:v1.12.3 /usr/bin/goreleaser /usr/local/bin/
 
-COPY --from=alpine/helm:3.2.0 /usr/bin/helm /usr/local/bin/
+COPY --from=alpine/helm:3.12.2 /usr/bin/helm /usr/local/bin/
 
 COPY --from=golangci/golangci-lint:v1.50 /usr/bin/golangci-lint /usr/local/bin/
 


### PR DESCRIPTION
## Change Overview

The previous version of helm used inside kanister binary is causing integration tests to fail. This happen for the latest PostgreSql helm charts.

<!-- Insert PR description-->
This PR is necessary as the bitnami helm chart for PostgreSql has undergone changes in their handling of secrets and setting passwords during helm install causing parsing errors during integration test. The bitnami fix is now available in the latest charts.
This bumps version from `3.2.0` -> `3.12.2`


## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [x] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
