### PR TITLE
deps(go): fix dependency name for sigs.k8s.io in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
       - dependency-name: "k8s.io/*"
         # only allow patch updates
         update-types: ["version-update:semver-major","version-update:semver-minor"]
-      - dependency-name: "sigs/k8s.io/*"
+      - dependency-name: "sigs.k8s.io/*"
         # only allow patch updates
         update-types: ["version-update:semver-major","version-update:semver-minor"]
     groups:


### PR DESCRIPTION
## Change Overview

Fix dependency name for sigs.k8s.io in @dependabot config

## Pull request type

- [x] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [x] :robot: @dependabot


## Test Plan

- [x] :zap: CI

