### PR TITLE
chore(infra): cleanup triage workflows

### DIFF
--- a/.github/workflows/triage-issues.yaml
+++ b/.github/workflows/triage-issues.yaml
@@ -1,0 +1,33 @@
+on:
+  issues:
+    types:
+    - opened
+    - reopened
+
+jobs:
+  triage:
+    if: github.repository == 'kanisterio/kanister'
+    name: Triage New Issue
+    permissions:
+      issues: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions-ecosystem/action-add-labels@v1.1.3
+      with:
+        labels: "triage"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: actions-ecosystem/action-create-comment@v1.0.2
+      if: github.event.action == 'opened'
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        body: |
+          Thanks for opening this issue :+1:. The team will review it shortly.
+
+          If this is a bug report, make sure to include clear instructions how on to reproduce the problem with [minimal reproducible examples](https://stackoverflow.com/help/minimal-reproducible-example), where possible. If this is a security report, please review our security policy as outlined in [SECURITY.md](https://github.com/kanisterio/kanister/blob/master/SECURITY.md).
+
+          If you haven't already, please take a moment to review our project's [Code of Conduct](https://github.com/kanisterio/kanister/blob/master/CODE_OF_CONDUCT.md) document.
+    - uses: alex-page/github-project-automation-plus@v0.8.3
+      with:
+        repo-token: ${{ secrets.GH_TOKEN }} # must use a PAT here
+        project: Kanister
+        column: To Be Triaged

--- a/.github/workflows/triage-issues.yaml
+++ b/.github/workflows/triage-issues.yaml
@@ -1,3 +1,5 @@
+name: Triage Issues
+
 on:
   issues:
     types:
@@ -7,16 +9,20 @@ on:
 jobs:
   triage:
     if: github.repository == 'kanisterio/kanister'
-    name: Triage New Issue
+    name: Triage
     permissions:
       issues: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions-ecosystem/action-add-labels@v1.1.3
+    -
+      name: Add label
+      uses: actions-ecosystem/action-add-labels@v1.1.3
       with:
         labels: "triage"
         github_token: ${{ secrets.GITHUB_TOKEN }}
-    - uses: actions-ecosystem/action-create-comment@v1.0.2
+    -
+      name: Add comment
+      uses: actions-ecosystem/action-create-comment@v1.0.2
       if: github.event.action == 'opened'
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -26,7 +32,9 @@ jobs:
           If this is a bug report, make sure to include clear instructions how on to reproduce the problem with [minimal reproducible examples](https://stackoverflow.com/help/minimal-reproducible-example), where possible. If this is a security report, please review our security policy as outlined in [SECURITY.md](https://github.com/kanisterio/kanister/blob/master/SECURITY.md).
 
           If you haven't already, please take a moment to review our project's [Code of Conduct](https://github.com/kanisterio/kanister/blob/master/CODE_OF_CONDUCT.md) document.
-    - uses: alex-page/github-project-automation-plus@v0.8.3
+    -
+      name: Update project
+      uses: alex-page/github-project-automation-plus@v0.8.3
       with:
         repo-token: ${{ secrets.GH_TOKEN }} # must use a PAT here
         project: Kanister

--- a/.github/workflows/triage-prs.yaml
+++ b/.github/workflows/triage-prs.yaml
@@ -4,6 +4,9 @@ on:
     - opened
     - reopened
 
+permissions:
+  contents: read
+
 jobs:
   pull-requests-comment:
     name: Triage Pull Request

--- a/.github/workflows/triage-prs.yaml
+++ b/.github/workflows/triage-prs.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   pull-requests-comment:
     name: Triage Pull Request
-    if: github.repository == 'kanisterio/kanister' && github.event_name == 'pull_request' &&  github.actor != 'dependabot'
+    if: github.repository == 'kanisterio/kanister' && github.actor != 'dependabot'
     permissions:
       pull-requests: write
     runs-on: ubuntu-latest

--- a/.github/workflows/triage-prs.yaml
+++ b/.github/workflows/triage-prs.yaml
@@ -1,39 +1,10 @@
 on:
-  issues:
-    types:
-    - opened
-    - reopened
   pull_request:
     types:
     - opened
     - reopened
+
 jobs:
-  issues:
-    if: github.repository == 'kanisterio/kanister' && github.event_name == 'issues'
-    name: Triage New Issue
-    permissions:
-      issues: write
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions-ecosystem/action-add-labels@v1.1.3
-      with:
-        labels: "triage"
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-    - uses: actions-ecosystem/action-create-comment@v1.0.2
-      if: github.event.action == 'opened'
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        body: |
-          Thanks for opening this issue :+1:. The team will review it shortly.
-
-          If this is a bug report, make sure to include clear instructions how on to reproduce the problem with [minimal reproducible examples](https://stackoverflow.com/help/minimal-reproducible-example), where possible. If this is a security report, please review our security policy as outlined in [SECURITY.md](https://github.com/kanisterio/kanister/blob/master/SECURITY.md).
-
-          If you haven't already, please take a moment to review our project's [Code of Conduct](https://github.com/kanisterio/kanister/blob/master/CODE_OF_CONDUCT.md) document.
-    - uses: alex-page/github-project-automation-plus@v0.8.3
-      with:
-        repo-token: ${{ secrets.GH_TOKEN }} # must use a PAT here
-        project: Kanister
-        column: To Be Triaged
   pull-requests-comment:
     name: Triage Pull Request
     if: github.repository == 'kanisterio/kanister' && github.event_name == 'pull_request' &&  github.actor != 'dependabot'

--- a/.github/workflows/triage-prs.yaml
+++ b/.github/workflows/triage-prs.yaml
@@ -1,3 +1,5 @@
+name: Triage
+
 on:
   pull_request:
     types:
@@ -9,13 +11,15 @@ permissions:
 
 jobs:
   pull-requests-comment:
-    name: Triage Pull Request
+    name: Comment and Triage
     if: github.repository == 'kanisterio/kanister' && github.actor != 'dependabot'
     permissions:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions-ecosystem/action-create-comment@v1.0.2
+    -
+      name: Comment
+      uses: actions-ecosystem/action-create-comment@v1.0.2
       # Avoid adding a comment when the PR is on the same repo.
       if: github.event.action == 'opened' && github.event.pull_request.head.repo.fork
       with:
@@ -24,7 +28,9 @@ jobs:
           Thanks for submitting this pull request :tada:. The team will review it soon and get back to you.
 
           If you haven't already, please take a moment to review our project [contributing guideline](https://github.com/kanisterio/kanister/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kanisterio/kanister/blob/master/CODE_OF_CONDUCT.md) document.
-    - uses: alex-page/github-project-automation-plus@v0.8.3
+    -
+      name: Update status in project
+      uses: alex-page/github-project-automation-plus@v0.8.3
       # This only works for PRs opened in the same repo and not by dependabot.
       # Other PRs don't get the necessary credentials.
       if: github.repository == 'kanisterio/kanister' && !github.event.pull_request.head.repo.fork && github.actor != 'dependabot'

--- a/.github/workflows/triage.yaml
+++ b/.github/workflows/triage.yaml
@@ -10,6 +10,7 @@ on:
 jobs:
   issues:
     if: github.repository == 'kanisterio/kanister' && github.event_name == 'issues'
+    name: Triage New Issue
     permissions:
       issues: write
     runs-on: ubuntu-latest
@@ -33,13 +34,15 @@ jobs:
         repo-token: ${{ secrets.GH_TOKEN }} # must use a PAT here
         project: Kanister
         column: To Be Triaged
-  pull-requests:
-    if: github.repository == 'kanisterio/kanister' && github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
+  pull-requests-comment:
+    name: Triage Pull Request
+    if: github.repository == 'kanisterio/kanister' && github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && github.actor != 'dependabot'
     permissions:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
     - uses: actions-ecosystem/action-create-comment@v1.0.2
+      # Avoid adding a comment when the PR is on the same repo.
       if: github.event.action == 'opened'
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -48,6 +51,9 @@ jobs:
 
           If you haven't already, please take a moment to review our project [contributing guideline](https://github.com/kanisterio/kanister/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kanisterio/kanister/blob/master/CODE_OF_CONDUCT.md) document.
     - uses: alex-page/github-project-automation-plus@v0.8.3
+      # This only works for PRs opened in the same repo and not by dependabot.
+      # Other PRs don't get the necessary credentials.
+      if: github.repository == 'kanisterio/kanister' && !github.event.pull_request.head.repo.fork && github.actor != 'dependabot'
       with:
         repo-token: ${{ secrets.GH_TOKEN }}
         project: Kanister

--- a/.github/workflows/triage.yaml
+++ b/.github/workflows/triage.yaml
@@ -36,14 +36,14 @@ jobs:
         column: To Be Triaged
   pull-requests-comment:
     name: Triage Pull Request
-    if: github.repository == 'kanisterio/kanister' && github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && github.actor != 'dependabot'
+    if: github.repository == 'kanisterio/kanister' && github.event_name == 'pull_request' &&  github.actor != 'dependabot'
     permissions:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
     - uses: actions-ecosystem/action-create-comment@v1.0.2
       # Avoid adding a comment when the PR is on the same repo.
-      if: github.event.action == 'opened'
+      if: github.event.action == 'opened' && github.event.pull_request.head.repo.fork
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         body: |


### PR DESCRIPTION
## Change Overview

Split the `triage.yml` workflow into 2 separate ones, one for PRs and another one for issues, since these jobs execute on different triggered events (`pull_request` & `issues`). This also simplifies the conditions in the jobs and the steps, since it is no longer necessary to check for the type of event that triggered the workflow.

It also prevents running the triage PR workflow for PRs submitted by `dependabot`.
This is failing because the required credential is not available for PRs submitted by `dependabot`.

Allow running the "comment" step on PRs submitted from forks, and avoid adding a rather useless comment on PRs opened from the same repo.

Other minor cleanups.

## Pull request type

- [x] :construction: Work in Progress
- [x] :hamster: Trivial/Minor
- [x] :bug: Minor bug fix


## Test Plan

- [x] :zap: CI: GHA run

- No automatically added comment should be added in this PR. In order to re-run the workflow it is necessary to close and re-open the PR :( 
- The PR should be triaged nonetheless and added to the appropriate column in the project.
- The triage issues workflow can only be tested after merging this PR into the main branch (AFAICT).

See sample run of the `triage-pr.yaml` workflow at https://github.com/kanisterio/kanister/pull/2336 (https://github.com/kanisterio/kanister/actions/runs/6192490531/job/16812642576)
