### PR TITLE
Fix flaky respository server controller unit test

### DIFF
--- a/pkg/controllers/repositoryserver/repositoryserver_controller_test.go
+++ b/pkg/controllers/repositoryserver/repositoryserver_controller_test.go
@@ -256,7 +256,7 @@ func (s *RepoServerControllerSuite) TestRepositoryServerStatusIsServerReady(c *C
 	err = testutil.CreateTestKopiaRepository(s.kubeCli, repoServerCRCreated, testutil.GetDefaultS3CompliantStorageLocation())
 	c.Assert(err, IsNil)
 
-	err = s.waitOnRepositoryServerState(c, repoServerCRCreated.Name)
+	_, err = s.waitOnRepositoryServerState(c, repoServerCRCreated.Name)
 	c.Assert(err, IsNil)
 
 	err = s.crCli.RepositoryServers(s.repoServerControllerNamespace).Delete(context.Background(), repoServerCRCreated.Name, metav1.DeleteOptions{})
@@ -271,14 +271,9 @@ func (s *RepoServerControllerSuite) TestRepositoryServerCRStateWithoutSecrets(c 
 	repoServerCRCreated, err := s.crCli.RepositoryServers(s.repoServerControllerNamespace).Create(ctx, repoServerCR, metav1.CreateOptions{})
 	c.Assert(err, IsNil)
 
-	err = s.waitOnRepositoryServerState(c, repoServerCRCreated.Name)
+	state, err := s.waitOnRepositoryServerState(c, repoServerCRCreated.Name)
 	c.Assert(err, NotNil)
-
-	// Get repository server CR with the updated server information
-	repoServerCRCreated, err = s.crCli.RepositoryServers(s.repoServerControllerNamespace).Get(ctx, repoServerCRCreated.Name, metav1.GetOptions{})
-	c.Assert(err, IsNil)
-
-	c.Assert(repoServerCRCreated.Status.Progress, Equals, v1alpha1.Failed)
+	c.Assert(state, Equals, v1alpha1.Failed)
 
 	err = s.crCli.RepositoryServers(s.repoServerControllerNamespace).Delete(context.Background(), repoServerCRCreated.Name, metav1.DeleteOptions{})
 	c.Assert(err, IsNil)
@@ -367,14 +362,9 @@ func (s *RepoServerControllerSuite) TestInvalidRepositoryPassword(c *C) {
 		repoServerCRCreated, err := s.crCli.RepositoryServers(s.repoServerControllerNamespace).Create(ctx, &invalidCR, metav1.CreateOptions{})
 		c.Assert(err, IsNil)
 
-		err = s.waitOnRepositoryServerState(c, repoServerCRCreated.Name)
+		state, err := s.waitOnRepositoryServerState(c, repoServerCRCreated.Name)
 		c.Assert(err, NotNil)
-
-		//Get repository server CR with the updated server information
-		repoServerCRCreated, err = s.crCli.RepositoryServers(s.repoServerControllerNamespace).Get(ctx, repoServerCRCreated.Name, metav1.GetOptions{})
-		c.Assert(err, IsNil)
-
-		c.Assert(repoServerCRCreated.Status.Progress, Equals, v1alpha1.Failed)
+		c.Assert(state, Equals, v1alpha1.Failed)
 	}
 }
 
@@ -405,15 +395,18 @@ func (s *RepoServerControllerSuite) waitForRepoServerInfoUpdateInCR(repoServerNa
 	return err
 }
 
-func (s *RepoServerControllerSuite) waitOnRepositoryServerState(c *C, reposerverName string) error {
+func (s *RepoServerControllerSuite) waitOnRepositoryServerState(c *C, reposerverName string) (v1alpha1.RepositoryServerProgress, error) {
 	ctxTimeout := 15 * time.Minute
 	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
 	defer cancel()
+	var repoServerState v1alpha1.RepositoryServerProgress
 	err := poll.Wait(ctx, func(ctx context.Context) (bool, error) {
 		repoServerCR, err := s.crCli.RepositoryServers(s.repoServerControllerNamespace).Get(ctx, reposerverName, metav1.GetOptions{})
 		if err != nil {
+			repoServerState = ""
 			return false, err
 		}
+		repoServerState = repoServerCR.Status.Progress
 		if repoServerCR.Status.Progress == "" || repoServerCR.Status.Progress == v1alpha1.Pending {
 			return false, nil
 		}
@@ -425,7 +418,7 @@ func (s *RepoServerControllerSuite) waitOnRepositoryServerState(c *C, reposerver
 		}
 		return false, errors.New(fmt.Sprintf("Unexpected Repository server state: %s", repoServerCR.Status.Progress))
 	})
-	return err
+	return repoServerState, err
 }
 
 func setRepositoryServerSecretsInCR(secrets *repositoryServerSecrets, repoServerCR *crv1alpha1.RepositoryServer) {


### PR DESCRIPTION
## Change Overview

The repository server CR state changes to `Pending` when next reconcilation executes, so that the process starts again. Hence whenever the CR state is changed to  `Failed` a reconcilation is run and the status of the CR is changed to `Pending`. In the unit tests, after `waitOnRepositoryServerState` is called if we receive a `Failed` state, we return to the calling function. After that we get the latest repository Server CR object using `kubecli.GET` function. Meanwhile if the reconcilation is run, the repository server CR's status is changed to `Pending`. Hence the tests fail with following error:

```
repositoryserver_controller_test.go:377: 
        error:
          values are not equal
        got:
          "Pending"
        want:
          "Failed"
        stack:
```
This PR fixes the flakyness by returning the status field's value at the moment when its changed to `Failed` rather than depending on the next `kubecli.GET` call


## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E

Test output:

https://gist.github.com/kale-amruta/ade024a88ba9b982bed4f79d9b3efea8

