### PR TITLE
Enable wait for RepositoryServer CR to get ready functionality for actionsets

### DIFF
--- a/pkg/kanctl/actionset.go
+++ b/pkg/kanctl/actionset.go
@@ -678,7 +678,7 @@ func verifyParams(ctx context.Context, p *PerformParams, cli kubernetes.Interfac
 	// RepositoryServer
 	go func() {
 		defer wg.Done()
-		err := verifyRepositoryServerParams(waitForRepoServerReady, p.RepositoryServer, crCli, ctx)
+		err := verifyRepositoryServerParams(ctx, crCli, p.RepositoryServer, waitForRepoServerReady)
 		if err != nil {
 			msgs <- err
 		}
@@ -759,7 +759,7 @@ func generateActionSetName(p *PerformParams) (string, error) {
 	return "", errMissingFieldActionName
 }
 
-func verifyRepositoryServerParams(waitForRepoServerReady bool, repoServer *crv1alpha1.ObjectReference, crCli versioned.Interface, ctx context.Context) error {
+func verifyRepositoryServerParams(ctx context.Context, crCli versioned.Interface, repoServer *crv1alpha1.ObjectReference, waitForRepoServerReady bool) error {
 	if repoServer != nil {
 		rs, err := crCli.CrV1alpha1().RepositoryServers(repoServer.Namespace).Get(ctx, repoServer.Name, metav1.GetOptions{})
 		if err != nil {

--- a/pkg/kanctl/actionset.go
+++ b/pkg/kanctl/actionset.go
@@ -787,7 +787,7 @@ func waitForKopiaRepositoryServerReady(ctx context.Context, crCli versioned.Inte
 		return repositoryServer.Status.Progress == crv1alpha1.Ready, err
 	})
 	if pollErr != nil {
-		return errors.Wrapf(pollErr, "Repository Server %s/%s could not become Ready", rs.GetNamespace(), rs.GetName())
+		return errors.Wrapf(pollErr, "Failed while waiting for Repository Server %s/%s to be Ready", rs.GetNamespace(), rs.GetName())
 	}
 	return nil
 }

--- a/pkg/kanctl/actionset.go
+++ b/pkg/kanctl/actionset.go
@@ -34,6 +34,7 @@ import (
 	"github.com/kanisterio/kanister/pkg/client/clientset/versioned"
 	"github.com/kanisterio/kanister/pkg/kube"
 	"github.com/kanisterio/kanister/pkg/param"
+	"github.com/kanisterio/kanister/pkg/poll"
 	osversioned "github.com/openshift/client-go/apps/clientset/versioned"
 )
 
@@ -56,6 +57,7 @@ const (
 	selectorNamespaceFlag    = "selector-namespace"
 	namespaceTargetsFlagName = "namespacetargets"
 	objectsFlagName          = "objects"
+	waitForReadyFlagName     = "wait"
 )
 
 var (
@@ -105,6 +107,7 @@ func newActionSetCmd() *cobra.Command {
 	cmd.Flags().String(selectorNamespaceFlag, "", "namespace to apply selector on. Used along with the selector specified using --selector/-l")
 	cmd.Flags().StringSliceP(namespaceTargetsFlagName, "T", []string{}, "namespaces for the action set, comma separated list of namespaces (eg: --namespacetargets namespace1,namespace2)")
 	cmd.Flags().StringSliceP(objectsFlagName, "O", []string{}, "objects for the action set, comma separated list of object references (eg: --objects group/version/resource/namespace1/name1,group/version/resource/namespace2/name2)")
+	cmd.Flags().BoolP(waitForReadyFlagName, "w", false, "wait for resources to get in ready state")
 	return cmd
 }
 
@@ -121,7 +124,7 @@ func initializeAndPerform(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 	valFlag, _ := cmd.Flags().GetBool(skipValidationFlag)
 	if !valFlag {
-		err = verifyParams(ctx, params, cli, crCli, osCli)
+		err = verifyParams(cmd, ctx, params, cli, crCli, osCli)
 		if err != nil {
 			return err
 		}
@@ -643,7 +646,7 @@ func parseName(k string, r string) (namespace, name string, err error) {
 	return m[1], m[2], nil
 }
 
-func verifyParams(ctx context.Context, p *PerformParams, cli kubernetes.Interface, crCli versioned.Interface, osCli osversioned.Interface) error {
+func verifyParams(cmd *cobra.Command, ctx context.Context, p *PerformParams, cli kubernetes.Interface, crCli versioned.Interface, osCli osversioned.Interface) error {
 	const notFoundTmpl = "Please make sure '%s' with name '%s' exists in namespace '%s'"
 	msgs := make(chan error)
 	wg := sync.WaitGroup{}
@@ -674,7 +677,7 @@ func verifyParams(ctx context.Context, p *PerformParams, cli kubernetes.Interfac
 	// RepositoryServer
 	go func() {
 		defer wg.Done()
-		err := verifyRepositoryServerParams(p.RepositoryServer, crCli, ctx)
+		err := verifyRepositoryServerParams(cmd, p.RepositoryServer, crCli, ctx)
 		if err != nil {
 			msgs <- err
 		}
@@ -755,7 +758,7 @@ func generateActionSetName(p *PerformParams) (string, error) {
 	return "", errMissingFieldActionName
 }
 
-func verifyRepositoryServerParams(repoServer *crv1alpha1.ObjectReference, crCli versioned.Interface, ctx context.Context) error {
+func verifyRepositoryServerParams(cmd *cobra.Command, repoServer *crv1alpha1.ObjectReference, crCli versioned.Interface, ctx context.Context) error {
 	if repoServer != nil {
 		rs, err := crCli.CrV1alpha1().RepositoryServers(repoServer.Namespace).Get(ctx, repoServer.Name, metav1.GetOptions{})
 		if err != nil {
@@ -764,10 +767,34 @@ func verifyRepositoryServerParams(repoServer *crv1alpha1.ObjectReference, crCli 
 			}
 			return errors.New("error while fetching repo server")
 		}
-		if rs.Status.Progress != crv1alpha1.Ready {
-			err = errors.New("Repository Server Not Ready")
-			return errors.Wrapf(err, "Please make sure that Repository Server CR '%s' is in Ready State", repoServer.Name)
+		wait, _ := cmd.Flags().GetBool(waitForReadyFlagName)
+		if wait {
+			err = waitForKopiaRepositoryServerReady(ctx, crCli, rs)
+			if err != nil {
+				return err
+			}
+		} else {
+			if rs.Status.Progress != crv1alpha1.Ready {
+				err = errors.New("Repository Server Not Ready")
+				return errors.Wrapf(err, "Please make sure that Repository Server CR '%s' is in Ready State", repoServer.Name)
+			}
 		}
+	}
+	return nil
+}
+
+func waitForKopiaRepositoryServerReady(ctx context.Context, crCli versioned.Interface, rs *crv1alpha1.RepositoryServer) error {
+	timeoutCtx, waitCancel := context.WithTimeout(ctx, contextWaitTimeout)
+	defer waitCancel()
+	pollErr := poll.Wait(timeoutCtx, func(ctx context.Context) (bool, error) {
+		repositoryServer, err := crCli.CrV1alpha1().RepositoryServers(rs.GetNamespace()).Get(ctx, rs.GetName(), metav1.GetOptions{})
+		if repositoryServer.Status.Progress == crv1alpha1.Ready && err == nil {
+			return true, nil
+		}
+		return false, err
+	})
+	if pollErr != nil {
+		return errors.Wrapf(pollErr, "Repository Server %s/%s could not become Ready", rs.GetNamespace(), rs.GetName())
 	}
 	return nil
 }


### PR DESCRIPTION
## Change Overview

Enable wait for resources to get ready functionality for actionsets

Add `--wait-for-repository-server` flag while Actionset creation, if provided waits for `RepositoryServer` to get in `Ready` state before creating Actionsets

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [x] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E

### Manual Testing Steps

#### 1) Build `kando` command line tool

```bash
$ go build -o kanctl ./cmd/kanctl/main.go
```

#### 2) Create Actionset

```bash
./kanctl create actionset --action backup --namespace kanister --blueprint mysql-blueprint --statefulset mysql-test/mysql-release --secrets mysql=mysql-test/mysql-release --repository-server=kanister/kopia-repo-server-2 --wait-for-repository-server

<waits for repository server to get ready>
actionset backup-9b74s created
```