### PR TITLE
Feature flagging for exporting of Kanister prometheus metrics

### DIFF
--- a/helm/kanister-operator/templates/deployment.yaml
+++ b/helm/kanister-operator/templates/deployment.yaml
@@ -41,6 +41,8 @@ spec:
           value: {{ .Values.controller.logLevel }}
         - name: DATA_STORE_PARALLEL_UPLOAD
           value: {{ .Values.controller.parallelism | quote }}
+        - name: KANISTER_METRICS_ENABLED
+          value: {{ .Values.metrics.enabled | quote }}
 {{- if .Values.resources }}
         resources:
 {{ toYaml .Values.resources | indent 12 }}

--- a/helm/kanister-operator/templates/deployment.yaml
+++ b/helm/kanister-operator/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
         - name: DATA_STORE_PARALLEL_UPLOAD
           value: {{ .Values.controller.parallelism | quote }}
         - name: KANISTER_METRICS_ENABLED
-          value: {{ .Values.metrics.enabled | quote }}
+          value: {{ .Values.controller.metrics.enabled | quote }}
 {{- if .Values.resources }}
         resources:
 {{ toYaml .Values.resources | indent 12 }}

--- a/helm/kanister-operator/values.yaml
+++ b/helm/kanister-operator/values.yaml
@@ -53,3 +53,5 @@ resources:
 # requests:
 #  cpu: 100m
 #  memory: 128Mi
+metrics:
+  enabled: false

--- a/helm/kanister-operator/values.yaml
+++ b/helm/kanister-operator/values.yaml
@@ -28,6 +28,11 @@ controller:
   # true : CRDs would be created by kanister controller
   updateCRDs: true
   parallelism: 8
+  metrics:
+    # metrics.enabled specified if the kanister-prometheus framework has been enabled
+    # false : kanister-prometheus framework has been disabled
+    # true: kanister-prometheus framework has been enabled
+    enabled: false
 bpValidatingWebhook:
   enabled: true
   tls:
@@ -53,5 +58,3 @@ resources:
 # requests:
 #  cpu: 100m
 #  memory: 128Mi
-metrics:
-  enabled: false


### PR DESCRIPTION
## Change Overview

Adding a new helm flag and environment variable for feature toggling of the new Kanister prometheus metrics integration. 
1. Added new boolean helm flag called `controller.metrics.enabled` in the Values.yaml
2. Added new environment variable called `KANISTER_METRICS_ENABLED` in deployment.yaml to capture the metrics.enabled flag in our codebase. 


End goal: In order to switch on prometheus metrics, the end user can install the local helm chart with the following command: 
`helm install kanister ./helm/kanister-operator \
  --create-namespace \
  --namespace kanister \
  --set image.repository=<your_registry>/<your_controller_image> \
  --set image.tag=<your_image_tag>
  --controller.metrics.enabled=true`

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [x] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes N/A

## Test Plan

After the above changes were made, the following tests were performed: 
1.  `helm uninstall kanister -n kanister` to uninstall existing kanister deployment
2. `helm install kanister ./helm/kanister-operator --create-namespace --namespace kanister` to run the local helm chart for kanister
4. `k get pods -n kanister` to identify the new kanister operator pod that's running
5. `kubectl exec -n kanister -it <pod-name> -- /bin/bash` to exec into the pod. 
6. `echo $KANISTER_METRICS_ENABLED` - the output should be a false.

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
