### PR TITLE
[2241] Fix path to valid_images.json

### DIFF
--- a/build/push_images.sh
+++ b/build/push_images.sh
@@ -19,9 +19,9 @@ set -o nounset
 
 IMAGE_REGISTRY="ghcr.io/kanisterio"
 
-IMAGES_NAME_PATH="valid_images.json"
+IMAGES_NAME_PATH="build/valid_images.json"
 
-IMAGES=(`cat $IMAGES_NAME_PATH | jq -r .images[]`)
+IMAGES=(`cat ${IMAGES_NAME_PATH} | jq -r .images[]`)
 
 TAG=${1:-"v9.99.9-dev"}
 


### PR DESCRIPTION
## Change Overview

The `push_images.sh` script is executed from the root directory. Requires `build/valid_images.json` to be able to get the image list. This has been failing silently for a while now.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #2241 

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
Changed `docker push` to `echo` to print the list
Before:
```
./build/push_images.sh
cat: valid_images.json: No such file or directory
./build/push_images.sh: line 31: IMAGES[@]: unbound variable
```

After:
```
./build/push_images.sh
ghcr.io/kanisterio/mysql-sidecar:v9.99.9-dev
ghcr.io/kanisterio/kafka-adobe-s3-sink-connector:v9.99.9-dev
ghcr.io/kanisterio/postgres-kanister-tools:v9.99.9-dev
ghcr.io/kanisterio/postgresql:v9.99.9-dev
ghcr.io/kanisterio/cassandra:v9.99.9-dev
ghcr.io/kanisterio/kanister-kubectl-1.18:v9.99.9-dev
ghcr.io/kanisterio/mongodb:v9.99.9-dev
ghcr.io/kanisterio/es-sidecar:v9.99.9-dev
ghcr.io/kanisterio/controller:v9.99.9-dev
ghcr.io/kanisterio/kanister-tools:v9.99.9-dev
ghcr.io/kanisterio/kafka-adobe-s3-source-connector:v9.99.9-dev
ghcr.io/kanisterio/mssql-tools:v9.99.9-dev
```
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
