### PR TITLE
Revert "Run postgresql integration test on latest chart"

### DIFF
--- a/pkg/app/postgresql.go
+++ b/pkg/app/postgresql.go
@@ -49,6 +49,7 @@ func NewPostgresDB(name string, subPath string) App {
 			RepoName: helm.BitnamiRepoName,
 			RepoURL:  helm.BitnamiRepoURL,
 			Chart:    "postgresql",
+			Version:  "12.6.0", // TODO: Revert once #2155 is addressed
 			Values: map[string]string{
 				"image.pullPolicy":          "Always",
 				"auth.postgresPassword":     "test@54321",


### PR DESCRIPTION
Reverts kanisterio/kanister#2196

@mabhi This has not fixed all the downstream test cases. We'll have to do more E2E testing.