### PR TITLE
Fix RepositoryServer datamover tests

### DIFF
--- a/pkg/datamover/repository_server_test.go
+++ b/pkg/datamover/repository_server_test.go
@@ -124,6 +124,7 @@ func (rss *RepositoryServerSuite) setupKopiaRepositoryServer(c *C) {
 
 	// Create Test ConfigMap
 	rss.envSecret, err = createRepositoryServerTestPodEnvSecret(rss.ctx, rss.cli, rss.namespace.GetName())
+	c.Assert(err, IsNil)
 
 	// Create Test Pod
 	rss.pod, err = createRepositoryServerTestPod(rss.ctx, rss.cli, rss.namespace.GetName(), rss.envSecret.GetName(), repositoryServerAddressPort, rss.tlsSecret)
@@ -215,5 +216,4 @@ func (rss *RepositoryServerSuite) TearDownSuite(c *C) {
 		err := rss.cli.CoreV1().Namespaces().Delete(rss.ctx, rss.namespace.GetName(), metav1.DeleteOptions{})
 		c.Assert(err, IsNil)
 	}
-
 }

--- a/pkg/datamover/repository_server_test.go
+++ b/pkg/datamover/repository_server_test.go
@@ -201,32 +201,10 @@ func (rss *RepositoryServerSuite) TestLocationOperationsForRepositoryServerDataM
 }
 
 func (rss *RepositoryServerSuite) TearDownSuite(c *C) {
-	// Delete Secrets
-	rss.cleanupTestSecrets(c)
-
-	// Delete Service
-	err := rss.cli.CoreV1().Services(rss.namespace.GetName()).Delete(rss.ctx, rss.service.GetName(), metav1.DeleteOptions{})
-	c.Assert(err, IsNil)
-
-	// Delete Test Pod
-	err = rss.cli.CoreV1().Pods(rss.namespace.GetName()).Delete(rss.ctx, rss.pod.GetName(), metav1.DeleteOptions{})
-	c.Assert(err, IsNil)
-
 	// Delete Namespace
-	err = rss.cli.CoreV1().Namespaces().Delete(rss.ctx, rss.namespace.GetName(), metav1.DeleteOptions{})
-	c.Assert(err, IsNil)
-}
+	if rss.namespace.GetName() != "" {
+		err := rss.cli.CoreV1().Namespaces().Delete(rss.ctx, rss.namespace.GetName(), metav1.DeleteOptions{})
+		c.Assert(err, IsNil)
+	}
 
-func (rss *RepositoryServerSuite) cleanupTestSecrets(c *C) {
-	err := rss.cli.CoreV1().Secrets(rss.namespace.GetName()).Delete(rss.ctx, rss.tlsSecret.GetName(), metav1.DeleteOptions{})
-	c.Assert(err, IsNil)
-
-	err = rss.cli.CoreV1().Secrets(rss.namespace.GetName()).Delete(rss.ctx, rss.userAccessSecret.GetName(), metav1.DeleteOptions{})
-	c.Assert(err, IsNil)
-
-	err = rss.cli.CoreV1().Secrets(rss.namespace.GetName()).Delete(rss.ctx, rss.s3Creds.GetName(), metav1.DeleteOptions{})
-	c.Assert(err, IsNil)
-
-	err = rss.cli.CoreV1().Secrets(rss.namespace.GetName()).Delete(rss.ctx, rss.s3Location.GetName(), metav1.DeleteOptions{})
-	c.Assert(err, IsNil)
 }

--- a/pkg/datamover/testutils.go
+++ b/pkg/datamover/testutils.go
@@ -17,8 +17,6 @@ package datamover
 import (
 	"context"
 	"fmt"
-	awsconfig "github.com/kanisterio/kanister/pkg/aws"
-	"github.com/kanisterio/kanister/pkg/testutil"
 	"os"
 	"time"
 
@@ -29,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/kubernetes"
 
+	awsconfig "github.com/kanisterio/kanister/pkg/aws"
 	"github.com/kanisterio/kanister/pkg/consts"
 	"github.com/kanisterio/kanister/pkg/controllers/repositoryserver"
 	"github.com/kanisterio/kanister/pkg/format"
@@ -36,6 +35,7 @@ import (
 	kopiacmd "github.com/kanisterio/kanister/pkg/kopia/command"
 	"github.com/kanisterio/kanister/pkg/kopia/repository"
 	"github.com/kanisterio/kanister/pkg/kube"
+	"github.com/kanisterio/kanister/pkg/testutil"
 )
 
 const (

--- a/pkg/datamover/testutils.go
+++ b/pkg/datamover/testutils.go
@@ -17,6 +17,8 @@ package datamover
 import (
 	"context"
 	"fmt"
+	awsconfig "github.com/kanisterio/kanister/pkg/aws"
+	"github.com/kanisterio/kanister/pkg/testutil"
 	"os"
 	"time"
 
@@ -27,7 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/kubernetes"
 
-	awsconfig "github.com/kanisterio/kanister/pkg/aws"
 	"github.com/kanisterio/kanister/pkg/consts"
 	"github.com/kanisterio/kanister/pkg/controllers/repositoryserver"
 	"github.com/kanisterio/kanister/pkg/format"
@@ -35,11 +36,11 @@ import (
 	kopiacmd "github.com/kanisterio/kanister/pkg/kopia/command"
 	"github.com/kanisterio/kanister/pkg/kopia/repository"
 	"github.com/kanisterio/kanister/pkg/kube"
-	"github.com/kanisterio/kanister/pkg/testutil"
 )
 
 const (
 	repositoryServerTestNamespace    = "repository-server-test-namespace-"
+	repositoryServerTestPodEnvSecret = "repository-server-test-pod-env-secret-"
 	repositoryServerTestPod          = "repository-server-test-pod-"
 	repositoryServerTestService      = "repository-server-test-service-"
 	defaultKopiaRepositoryPassword   = "test1234"
@@ -68,7 +69,24 @@ func createRepositoryServerTestNamespace(ctx context.Context, cli kubernetes.Int
 	return nsCreated, nil
 }
 
-func createRepositoryServerTestPod(ctx context.Context, cli kubernetes.Interface, namespace string, secret *corev1.Secret) (*corev1.Pod, error) {
+func createRepositoryServerTestPodEnvSecret(ctx context.Context, cli kubernetes.Interface, namespace string) (*corev1.Secret, error) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: repositoryServerTestPodEnvSecret,
+			Namespace:    namespace,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			awsconfig.AccessKeyID:     []byte(os.Getenv(testutil.S3CompliantAccessKeyIDEnv)),
+			awsconfig.SecretAccessKey: []byte(os.Getenv(testutil.S3CompliantSecretAccessKeyEnv)),
+			awsconfig.Region:          []byte(testutil.TestS3Region),
+			"LOCATION_ENDPOINT":       []byte(os.Getenv(testutil.S3CompliantLocationEndpointEnv)),
+		},
+	}
+	return cli.CoreV1().Secrets(namespace).Create(ctx, secret, metav1.CreateOptions{})
+}
+
+func createRepositoryServerTestPod(ctx context.Context, cli kubernetes.Interface, namespace, envSecret string, port int, secret *corev1.Secret) (*corev1.Pod, error) {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: repositoryServerTestPod,
@@ -82,26 +100,17 @@ func createRepositoryServerTestPod(ctx context.Context, cli kubernetes.Interface
 					Image: consts.LatestKanisterToolsImage,
 					Ports: []corev1.ContainerPort{
 						{
-							HostPort:      51515,
-							ContainerPort: 51515,
+							HostPort:      int32(port),
+							ContainerPort: int32(port),
 						},
 					},
-					Env: []corev1.EnvVar{
+					EnvFrom: []corev1.EnvFromSource{
 						{
-							Name:  awsconfig.AccessKeyID,
-							Value: os.Getenv(testutil.S3CompliantAccessKeyIDEnv),
-						},
-						{
-							Name:  awsconfig.SecretAccessKey,
-							Value: os.Getenv(testutil.S3CompliantSecretAccessKeyEnv),
-						},
-						{
-							Name:  awsconfig.Region,
-							Value: testutil.TestS3Region,
-						},
-						{
-							Name:  "LOCATION_ENDPOINT",
-							Value: os.Getenv(testutil.S3CompliantLocationEndpointEnv),
+							SecretRef: &corev1.SecretEnvSource{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: envSecret,
+								},
+							},
 						},
 					},
 					VolumeMounts: []corev1.VolumeMount{
@@ -133,7 +142,7 @@ func createRepositoryServerTestPod(ctx context.Context, cli kubernetes.Interface
 	return podCreated, nil
 }
 
-func createRepositoryServerTestService(ctx context.Context, cli kubernetes.Interface, namespace string) (*corev1.Service, error) {
+func createRepositoryServerTestService(ctx context.Context, cli kubernetes.Interface, namespace string, port int) (*corev1.Service, error) {
 	name := fmt.Sprintf("%s%s", repositoryServerTestService, rand.String(5))
 
 	service := &corev1.Service{
@@ -152,7 +161,7 @@ func createRepositoryServerTestService(ctx context.Context, cli kubernetes.Inter
 					Port:     51515,
 					// Selects Random Port from NodePort Range
 					NodePort:   int32(rand.IntnRange(30000, 32767)),
-					TargetPort: intstr.FromInt(51515),
+					TargetPort: intstr.FromInt(port),
 				},
 			},
 		},
@@ -192,7 +201,7 @@ func createTestKopiaRepository(location *corev1.Secret, cli kubernetes.Interface
 	)
 }
 
-func startTestKopiaRepositoryServer(cli kubernetes.Interface, namespace string, pod *corev1.Pod) error {
+func startTestKopiaRepositoryServer(cli kubernetes.Interface, namespace, serverAddress string, pod *corev1.Pod) error {
 	cmd := kopiacmd.ServerStart(
 		kopiacmd.ServerStartCommandArgs{
 			CommandArgs: &kopiacmd.CommandArgs{
@@ -200,7 +209,7 @@ func startTestKopiaRepositoryServer(cli kubernetes.Interface, namespace string, 
 				ConfigFilePath: kopiacmd.DefaultConfigFilePath,
 				LogDirectory:   kopiacmd.DefaultLogDirectory,
 			},
-			ServerAddress:    "https://0.0.0.0:51515",
+			ServerAddress:    serverAddress,
 			TLSCertFile:      testTLSCertPath,
 			TLSKeyFile:       testTLSKeyPath,
 			ServerUsername:   testKopiaRepoServerAdminUsername,
@@ -218,7 +227,7 @@ func startTestKopiaRepositoryServer(cli kubernetes.Interface, namespace string, 
 	return nil
 }
 
-func getServerStatusCommand(ctx context.Context, cli kubernetes.Interface, namespace string, tlsSecret *corev1.Secret) ([]string, error) {
+func getServerStatusCommand(ctx context.Context, cli kubernetes.Interface, namespace, serverAddress string, tlsSecret *corev1.Secret) ([]string, error) {
 	fingerprint, err := kopia.ExtractFingerprintFromCertSecret(ctx, cli, tlsSecret.GetName(), namespace)
 	if err != nil {
 		return nil, errors.Wrap(err, "Error Extracting Fingerprint from the TLS Certificates")
@@ -231,7 +240,7 @@ func getServerStatusCommand(ctx context.Context, cli kubernetes.Interface, names
 				ConfigFilePath: kopiacmd.DefaultConfigFilePath,
 				LogDirectory:   kopiacmd.DefaultLogDirectory,
 			},
-			ServerAddress:  "https://0.0.0.0:51515",
+			ServerAddress:  serverAddress,
 			ServerUsername: testKopiaRepoServerAdminUsername,
 			ServerPassword: testKopiaRepoServerAdminPassword,
 			Fingerprint:    fingerprint,
@@ -239,8 +248,8 @@ func getServerStatusCommand(ctx context.Context, cli kubernetes.Interface, names
 	return cmd, nil
 }
 
-func waitForServerReady(ctx context.Context, cli kubernetes.Interface, namespace string, pod *corev1.Pod, tlsSecret *corev1.Secret) error {
-	cmd, err := getServerStatusCommand(ctx, cli, namespace, tlsSecret)
+func waitForServerReady(ctx context.Context, cli kubernetes.Interface, namespace, serverAddress string, pod *corev1.Pod, tlsSecret *corev1.Secret) error {
+	cmd, err := getServerStatusCommand(ctx, cli, namespace, serverAddress, tlsSecret)
 	if err != nil {
 		return errors.Wrap(err, "Error Getting Server Status Command")
 	}
@@ -272,7 +281,7 @@ func addTestUserInKopiaRepositoryServer(cli kubernetes.Interface, namespace stri
 	return nil
 }
 
-func refreshTestKopiaRepositoryServer(ctx context.Context, cli kubernetes.Interface, namespace string, pod *corev1.Pod, tlsSecret *corev1.Secret) error {
+func refreshTestKopiaRepositoryServer(ctx context.Context, cli kubernetes.Interface, namespace, serverAddress string, pod *corev1.Pod, tlsSecret *corev1.Secret) error {
 	fingerprint, err := kopia.ExtractFingerprintFromCertSecret(ctx, cli, tlsSecret.GetName(), namespace)
 	if err != nil {
 		return errors.Wrap(err, "Error Extracting Fingerprint from the TLS Certificates")
@@ -285,7 +294,7 @@ func refreshTestKopiaRepositoryServer(ctx context.Context, cli kubernetes.Interf
 				ConfigFilePath: kopiacmd.DefaultConfigFilePath,
 				LogDirectory:   kopiacmd.DefaultLogDirectory,
 			},
-			ServerAddress:  "https://0.0.0.0:51515",
+			ServerAddress:  serverAddress,
 			ServerUsername: testKopiaRepoServerAdminUsername,
 			ServerPassword: testKopiaRepoServerAdminPassword,
 			Fingerprint:    fingerprint,


### PR DESCRIPTION
## Change Overview

Refactored following 

- Delete whole namespace instead of individual resources in cleanup
- Setting Environmental Variables for the repo-server container via secrets instead directly

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [x] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [x] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

```
$ make install-minio
```

```
$ export S3_COMPLIANT_AWS_ACCESS_KEY_ID="AKIAIOSFODNN7EXAMPLE"
$ export S3_COMPLIANT_AWS_SECRET_ACCESS_KEY="wJad@9gkeFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
$ export S3_COMPLIANT_LOCATION_ENDPOINT="http://minio.minio.svc.cluster.local:9000"
```

```
$ cd pkg/datamover

$ go test

...
...
...
...
OK: 2 passed
PASS
ok      github.com/kanisterio/kanister/pkg/datamover    16.737s
```

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
