### PR TITLE
Helper method to bound an ActionSet's "action type" to a fixed set for Prometheus Metrics

### DIFF
--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -1022,3 +1022,78 @@ func (s *ControllerSuite) TestProgressRunningPhase(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(runningPhases, HasLen, 0)
 }
+
+func (s *ControllerSuite) TestGetActionTypeBucket(c *C) {
+	for _, tc := range []struct {
+		actionType string
+	}{
+		{
+			actionType: "backup",
+		},
+		{
+			actionType: "restore",
+		},
+		{
+			actionType: "delete",
+		},
+		{
+			actionType: "pre-backup",
+		},
+		{
+			actionType: "post-backup-success",
+		},
+		{
+			actionType: "post-backup-failure",
+		},
+		{
+			actionType: "pre-restore",
+		},
+		{
+			actionType: "post-restore-success",
+		},
+		{
+			actionType: "post-restore-failure",
+		},
+		{
+			actionType: "pre-delete",
+		},
+		{
+			actionType: "post-delete-success",
+		},
+		{
+			actionType: "post-delete-failure",
+		},
+		{
+			actionType: "random-action",
+		},
+	} {
+		switch tc.actionType {
+		case "backup":
+			c.Assert(getActionTypeBucket(tc.actionType), Equals, "backup")
+		case "restore":
+			c.Assert(getActionTypeBucket(tc.actionType), Equals, "restore")
+		case "delete":
+			c.Assert(getActionTypeBucket(tc.actionType), Equals, "delete")
+		case "pre-backup":
+			c.Assert(getActionTypeBucket(tc.actionType), Equals, "pre-backup")
+		case "post-backup-success":
+			c.Assert(getActionTypeBucket(tc.actionType), Equals, "post-backup-success")
+		case "post-backup-failure":
+			c.Assert(getActionTypeBucket(tc.actionType), Equals, "post-backup-failure")
+		case "pre-restore":
+			c.Assert(getActionTypeBucket(tc.actionType), Equals, "pre-restore")
+		case "post-restore-success":
+			c.Assert(getActionTypeBucket(tc.actionType), Equals, "post-restore-success")
+		case "post-restore-failure":
+			c.Assert(getActionTypeBucket(tc.actionType), Equals, "post-restore-failure")
+		case "pre-delete":
+			c.Assert(getActionTypeBucket(tc.actionType), Equals, "pre-delete")
+		case "post-delete-success":
+			c.Assert(getActionTypeBucket(tc.actionType), Equals, "post-delete-success")
+		case "post-delete-failure":
+			c.Assert(getActionTypeBucket(tc.actionType), Equals, "post-delete-failure")
+		default:
+			c.Assert(getActionTypeBucket(tc.actionType), Equals, "other")
+		}
+	}
+}

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -1028,70 +1028,75 @@ func (s *ControllerSuite) TestGetActionTypeBucket(c *C) {
 		actionType string
 	}{
 		{
-			actionType: "backup",
+			actionType: ACTION_TYPE_BACKUP,
 		},
 		{
-			actionType: "restore",
+			actionType: ACTION_TYPE_RESTORE,
 		},
 		{
-			actionType: "delete",
+			actionType: ACTION_TYPE_DELETE,
 		},
 		{
-			actionType: "pre-backup",
+			actionType: ACTION_TYPE_BACKUP_TO_SERVER,
 		},
 		{
-			actionType: "post-backup-success",
+			actionType: ACTION_TYPE_RESTORE_FROM_SERVER,
 		},
 		{
-			actionType: "post-backup-failure",
+			actionType: ACTION_TYPE_BEFORE_BACKUP,
 		},
 		{
-			actionType: "pre-restore",
+			actionType: ACTION_TYPE_ON_SUCCESS,
 		},
 		{
-			actionType: "post-restore-success",
+			actionType: ACTION_TYPE_ON_FAILURE,
 		},
 		{
-			actionType: "post-restore-failure",
+			actionType: ACTION_TYPE_PRE_RESTORE,
 		},
 		{
-			actionType: "pre-delete",
+			actionType: ACTION_TYPE_POST_RESTORE,
 		},
 		{
-			actionType: "post-delete-success",
+			actionType: ACTION_TYPE_POST_RESTORE_FAILED,
 		},
 		{
-			actionType: "post-delete-failure",
+			actionType: ACTION_TYPE_BACKUP_PREHOOK,
+		},
+		{
+			actionType: ACTION_TYPE_BACKUP_POSTHOOK,
 		},
 		{
 			actionType: "random-action",
 		},
 	} {
 		switch tc.actionType {
-		case "backup":
-			c.Assert(getActionTypeBucket(tc.actionType), Equals, "backup")
-		case "restore":
-			c.Assert(getActionTypeBucket(tc.actionType), Equals, "restore")
-		case "delete":
-			c.Assert(getActionTypeBucket(tc.actionType), Equals, "delete")
-		case "pre-backup":
-			c.Assert(getActionTypeBucket(tc.actionType), Equals, "pre-backup")
-		case "post-backup-success":
-			c.Assert(getActionTypeBucket(tc.actionType), Equals, "post-backup-success")
-		case "post-backup-failure":
-			c.Assert(getActionTypeBucket(tc.actionType), Equals, "post-backup-failure")
-		case "pre-restore":
-			c.Assert(getActionTypeBucket(tc.actionType), Equals, "pre-restore")
-		case "post-restore-success":
-			c.Assert(getActionTypeBucket(tc.actionType), Equals, "post-restore-success")
-		case "post-restore-failure":
-			c.Assert(getActionTypeBucket(tc.actionType), Equals, "post-restore-failure")
-		case "pre-delete":
-			c.Assert(getActionTypeBucket(tc.actionType), Equals, "pre-delete")
-		case "post-delete-success":
-			c.Assert(getActionTypeBucket(tc.actionType), Equals, "post-delete-success")
-		case "post-delete-failure":
-			c.Assert(getActionTypeBucket(tc.actionType), Equals, "post-delete-failure")
+		case ACTION_TYPE_BACKUP:
+			c.Assert(getActionTypeBucket(tc.actionType), Equals, ACTION_TYPE_BACKUP)
+		case ACTION_TYPE_RESTORE:
+			c.Assert(getActionTypeBucket(tc.actionType), Equals, ACTION_TYPE_RESTORE)
+		case ACTION_TYPE_DELETE:
+			c.Assert(getActionTypeBucket(tc.actionType), Equals, ACTION_TYPE_DELETE)
+		case ACTION_TYPE_BACKUP_TO_SERVER:
+			c.Assert(getActionTypeBucket(tc.actionType), Equals, ACTION_TYPE_BACKUP_TO_SERVER)
+		case ACTION_TYPE_RESTORE_FROM_SERVER:
+			c.Assert(getActionTypeBucket(tc.actionType), Equals, ACTION_TYPE_RESTORE_FROM_SERVER)
+		case ACTION_TYPE_BEFORE_BACKUP:
+			c.Assert(getActionTypeBucket(tc.actionType), Equals, ACTION_TYPE_BEFORE_BACKUP)
+		case ACTION_TYPE_ON_SUCCESS:
+			c.Assert(getActionTypeBucket(tc.actionType), Equals, ACTION_TYPE_ON_SUCCESS)
+		case ACTION_TYPE_ON_FAILURE:
+			c.Assert(getActionTypeBucket(tc.actionType), Equals, ACTION_TYPE_ON_FAILURE)
+		case ACTION_TYPE_PRE_RESTORE:
+			c.Assert(getActionTypeBucket(tc.actionType), Equals, ACTION_TYPE_PRE_RESTORE)
+		case ACTION_TYPE_POST_RESTORE:
+			c.Assert(getActionTypeBucket(tc.actionType), Equals, ACTION_TYPE_POST_RESTORE)
+		case ACTION_TYPE_POST_RESTORE_FAILED:
+			c.Assert(getActionTypeBucket(tc.actionType), Equals, ACTION_TYPE_POST_RESTORE_FAILED)
+		case ACTION_TYPE_BACKUP_PREHOOK:
+			c.Assert(getActionTypeBucket(tc.actionType), Equals, ACTION_TYPE_BACKUP_PREHOOK)
+		case ACTION_TYPE_BACKUP_POSTHOOK:
+			c.Assert(getActionTypeBucket(tc.actionType), Equals, ACTION_TYPE_BACKUP_POSTHOOK)
 		default:
 			c.Assert(getActionTypeBucket(tc.actionType), Equals, "other")
 		}

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -1098,7 +1098,7 @@ func (s *ControllerSuite) TestGetActionTypeBucket(c *C) {
 		case ACTION_TYPE_BACKUP_POSTHOOK:
 			c.Assert(getActionTypeBucket(tc.actionType), Equals, ACTION_TYPE_BACKUP_POSTHOOK)
 		default:
-			c.Assert(getActionTypeBucket(tc.actionType), Equals, "other")
+			c.Assert(getActionTypeBucket(tc.actionType), Equals, ACTION_TYPE_BACKUP_OTHER)
 		}
 	}
 }

--- a/pkg/controller/metrics.go
+++ b/pkg/controller/metrics.go
@@ -46,29 +46,30 @@ const (
 	ACTION_TYPE_POST_RESTORE_FAILED = "post-restore-failed"
 	ACTION_TYPE_BACKUP_PREHOOK      = "backupPrehook"
 	ACTION_TYPE_BACKUP_POSTHOOK     = "backupPosthook"
+	ACTION_TYPE_BACKUP_OTHER        = "other"
 )
 
+var knownActionsList = map[string]bool{
+	ACTION_TYPE_BACKUP:              true,
+	ACTION_TYPE_RESTORE:             true,
+	ACTION_TYPE_DELETE:              true,
+	ACTION_TYPE_BACKUP_TO_SERVER:    true,
+	ACTION_TYPE_RESTORE_FROM_SERVER: true,
+	ACTION_TYPE_BEFORE_BACKUP:       true,
+	ACTION_TYPE_ON_SUCCESS:          true,
+	ACTION_TYPE_ON_FAILURE:          true,
+	ACTION_TYPE_PRE_RESTORE:         true,
+	ACTION_TYPE_POST_RESTORE:        true,
+	ACTION_TYPE_POST_RESTORE_FAILED: true,
+	ACTION_TYPE_BACKUP_PREHOOK:      true,
+	ACTION_TYPE_BACKUP_POSTHOOK:     true,
+	ACTION_TYPE_BACKUP_OTHER:        true,
+}
+
 func getActionTypeBucket(aType string) string {
-	actionTypes := []string{
-		ACTION_TYPE_BACKUP,
-		ACTION_TYPE_RESTORE,
-		ACTION_TYPE_DELETE,
-		ACTION_TYPE_BACKUP_TO_SERVER,
-		ACTION_TYPE_RESTORE_FROM_SERVER,
-		ACTION_TYPE_BEFORE_BACKUP,
-		ACTION_TYPE_ON_SUCCESS,
-		ACTION_TYPE_ON_FAILURE,
-		ACTION_TYPE_PRE_RESTORE,
-		ACTION_TYPE_POST_RESTORE,
-		ACTION_TYPE_POST_RESTORE_FAILED,
-		ACTION_TYPE_BACKUP_PREHOOK,
-		ACTION_TYPE_BACKUP_POSTHOOK,
-	}
-	actionTypeBucket := "other"
-	for _, actionType := range actionTypes {
-		if actionType == aType {
-			actionTypeBucket = actionType
-		}
+	actionTypeBucket := ACTION_TYPE_BACKUP_OTHER
+	if _, ok := knownActionsList[aType]; ok {
+		actionTypeBucket = aType
 	}
 	return actionTypeBucket
 }

--- a/pkg/controller/metrics.go
+++ b/pkg/controller/metrics.go
@@ -32,6 +32,39 @@ const (
 	ACTION_SET_COUNTER_VEC_LABEL_RES_FAILURE = "failure"
 )
 
+func getActionTypeBucket(actionType string) string {
+	actionTypeBucket := ""
+	switch actionType {
+	case "backup":
+		actionTypeBucket = "backup"
+	case "restore":
+		actionTypeBucket = "restore"
+	case "delete":
+		actionTypeBucket = "delete"
+	case "pre-backup":
+		actionTypeBucket = "pre-backup"
+	case "post-backup-success":
+		actionTypeBucket = "post-backup-success"
+	case "post-backup-failure":
+		actionTypeBucket = "post-backup-failure"
+	case "pre-restore":
+		actionTypeBucket = "pre-restore"
+	case "post-restore-success":
+		actionTypeBucket = "post-restore-success"
+	case "post-restore-failure":
+		actionTypeBucket = "post-restore-failure"
+	case "pre-delete":
+		actionTypeBucket = "pre-delete"
+	case "post-delete-success":
+		actionTypeBucket = "post-delete-success"
+	case "post-delete-failure":
+		actionTypeBucket = "post-delete-failure"
+	default:
+		actionTypeBucket = "other"
+	}
+	return actionTypeBucket
+}
+
 // getActionSetCounterVecLabels builds a new BoundedLabel list to construct
 // the labels permutations for the prometheus metric.
 func getActionSetCounterVecLabels() []kanistermetrics.BoundedLabel {

--- a/pkg/controller/metrics.go
+++ b/pkg/controller/metrics.go
@@ -32,35 +32,43 @@ const (
 	ACTION_SET_COUNTER_VEC_LABEL_RES_FAILURE = "failure"
 )
 
-func getActionTypeBucket(actionType string) string {
-	actionTypeBucket := ""
-	switch actionType {
-	case "backup":
-		actionTypeBucket = "backup"
-	case "restore":
-		actionTypeBucket = "restore"
-	case "delete":
-		actionTypeBucket = "delete"
-	case "pre-backup":
-		actionTypeBucket = "pre-backup"
-	case "post-backup-success":
-		actionTypeBucket = "post-backup-success"
-	case "post-backup-failure":
-		actionTypeBucket = "post-backup-failure"
-	case "pre-restore":
-		actionTypeBucket = "pre-restore"
-	case "post-restore-success":
-		actionTypeBucket = "post-restore-success"
-	case "post-restore-failure":
-		actionTypeBucket = "post-restore-failure"
-	case "pre-delete":
-		actionTypeBucket = "pre-delete"
-	case "post-delete-success":
-		actionTypeBucket = "post-delete-success"
-	case "post-delete-failure":
-		actionTypeBucket = "post-delete-failure"
-	default:
-		actionTypeBucket = "other"
+const (
+	ACTION_TYPE_BACKUP              = "backup"
+	ACTION_TYPE_RESTORE             = "restore"
+	ACTION_TYPE_DELETE              = "delete"
+	ACTION_TYPE_BACKUP_TO_SERVER    = "backupToServer"
+	ACTION_TYPE_RESTORE_FROM_SERVER = "restoreFromServer"
+	ACTION_TYPE_BEFORE_BACKUP       = "before-backup"
+	ACTION_TYPE_ON_SUCCESS          = "on-success"
+	ACTION_TYPE_ON_FAILURE          = "on-failure"
+	ACTION_TYPE_PRE_RESTORE         = "pre-restore"
+	ACTION_TYPE_POST_RESTORE        = "post-restore"
+	ACTION_TYPE_POST_RESTORE_FAILED = "post-restore-failed"
+	ACTION_TYPE_BACKUP_PREHOOK      = "backupPrehook"
+	ACTION_TYPE_BACKUP_POSTHOOK     = "backupPosthook"
+)
+
+func getActionTypeBucket(aType string) string {
+	actionTypes := []string{
+		ACTION_TYPE_BACKUP,
+		ACTION_TYPE_RESTORE,
+		ACTION_TYPE_DELETE,
+		ACTION_TYPE_BACKUP_TO_SERVER,
+		ACTION_TYPE_RESTORE_FROM_SERVER,
+		ACTION_TYPE_BEFORE_BACKUP,
+		ACTION_TYPE_ON_SUCCESS,
+		ACTION_TYPE_ON_FAILURE,
+		ACTION_TYPE_PRE_RESTORE,
+		ACTION_TYPE_POST_RESTORE,
+		ACTION_TYPE_POST_RESTORE_FAILED,
+		ACTION_TYPE_BACKUP_PREHOOK,
+		ACTION_TYPE_BACKUP_POSTHOOK,
+	}
+	actionTypeBucket := "other"
+	for _, actionType := range actionTypes {
+		if actionType == aType {
+			actionTypeBucket = actionType
+		}
 	}
 	return actionTypeBucket
 }

--- a/pkg/controller/metrics.go
+++ b/pkg/controller/metrics.go
@@ -63,7 +63,6 @@ var knownActionsList = map[string]bool{
 	ACTION_TYPE_POST_RESTORE_FAILED: true,
 	ACTION_TYPE_BACKUP_PREHOOK:      true,
 	ACTION_TYPE_BACKUP_POSTHOOK:     true,
-	ACTION_TYPE_BACKUP_OTHER:        true,
 }
 
 func getActionTypeBucket(aType string) string {


### PR DESCRIPTION
## Change Overview

The PR introduces a simple helper method  to bound an ActionSet's "action type" to a fixed set for Prometheus Metrics and avoid cardinality explosions in the Prometheus server. This PR is a WIP until we finalize the inputs we receive from adopters and downstream projects with regards to the set of action types passed. 

## Pull request type

Please check the type of change your PR introduces:
- [x] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [x] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

Added a new table driven test called: `TestGetActionTypeBucket` which tests different mappings. 

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
