### PR TITLE
Add ability to override kanister-tools image in repo controller

### DIFF
--- a/helm/kanister-operator/templates/_helpers.tpl
+++ b/helm/kanister-operator/templates/_helpers.tpl
@@ -83,3 +83,10 @@ on the value of bpValidatingWebhook.enabled
     {{ .Values.controller.service.insecuredPort }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Define a custom kanister-tools image
+*/}}
+{{- define "kanister-tools.image" -}}
+    {{- printf "%s:%s" (.Values.kanisterToolsImage.image) (.Values.kanisterToolsImage.tag) -}}
+{{- end -}}

--- a/helm/kanister-operator/templates/deployment.yaml
+++ b/helm/kanister-operator/templates/deployment.yaml
@@ -60,7 +60,7 @@ spec:
           value: {{ .Values.controller.updateCRDs | quote }}
 {{- if .Values.kanisterToolsImage.override }}
         - name: KANISTER_TOOLS
-          value: {{ include kanister-tools.image . }}
+          value: {{ include "kanister-tools.image" . }}
 {{- end }}
 {{- if .Values.resources }}
         resources:

--- a/helm/kanister-operator/templates/deployment.yaml
+++ b/helm/kanister-operator/templates/deployment.yaml
@@ -58,6 +58,10 @@ spec:
           value: {{ .Values.repositoryServerController.logLevel }}
         - name: CREATEORUPDATE_CRDS
           value: {{ .Values.controller.updateCRDs | quote }}
+{{- if .Values.kanisterToolsImage.override }}
+        - name: KANISTER_TOOLS
+          value: {{ include kanister-tools.image . }}
+{{- end }}
 {{- if .Values.resources }}
         resources:
 {{ toYaml .Values.resources | indent 12 }}

--- a/helm/kanister-operator/values.yaml
+++ b/helm/kanister-operator/values.yaml
@@ -10,6 +10,10 @@ repositoryServerControllerImage:
   name: repo-server-controller
   tag: 0.93.0
   pullPolicy: IfNotPresent
+kanisterToolsImage:
+  override: false
+  image: ghcr.io/kanisterio/kanister-tools
+  tag: 0.93.0
 rbac:
   create: true
 serviceAccount:

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -1,3 +1,17 @@
+// Copyright 2023 The Kanister Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package consts
 
 const (
@@ -30,3 +44,6 @@ const RepositoryServerResourceNamePlural = "repositoryservers"
 
 const LatestKanisterToolsImage = "ghcr.io/kanisterio/kanister-tools:v9.99.9-dev"
 const KanisterToolsImage = "ghcr.io/kanisterio/kanister-tools:0.93.0"
+
+// KanisterToolsImageEnvName is used to set up a custom kanister-tools image
+const KanisterToolsImageEnvName = "KANISTER_TOOLS"

--- a/pkg/consts/utils.go
+++ b/pkg/consts/utils.go
@@ -1,0 +1,27 @@
+// Copyright 2023 The Kanister Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package consts
+
+import "os"
+
+// GetKanisterToolsImage returns the KanisterTools image
+// Returns the value of the KANISTER_TOOLS env if set
+// Otherwise, returns the default released version.
+func GetKanisterToolsImage() string {
+	if val, ok := os.LookupEnv(KanisterToolsImageEnvName); ok {
+		return val
+	}
+	return KanisterToolsImage
+}

--- a/pkg/controllers/repositoryserver/repositoryserver_controller_test.go
+++ b/pkg/controllers/repositoryserver/repositoryserver_controller_test.go
@@ -140,6 +140,8 @@ func (s *RepoServerControllerSuite) SetUpSuite(c *C) {
 		// We need to set this up since we are not creating controller in a pod
 		os.Setenv("HOSTNAME", controllerPodName)
 		os.Setenv("POD_SERVICE_ACCOUNT", defaultServiceAccount)
+		// Set KANISTER_TOOLS env to override and use dev image
+		os.Setenv(consts.KanisterToolsImageEnvName, consts.LatestKanisterToolsImage)
 		err = mgr.Start(ctx)
 		c.Assert(err, IsNil)
 	}(ctx)
@@ -447,7 +449,7 @@ func (s *RepoServerControllerSuite) waitForRepoServerInfoUpdateInCR(repoServerNa
 }
 
 func (s *RepoServerControllerSuite) waitOnRepositoryServerState(c *C, reposerverName string) (v1alpha1.RepositoryServerProgress, error) {
-	ctxTimeout := 15 * time.Minute
+	ctxTimeout := 5 * time.Minute
 	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
 	defer cancel()
 	var repoServerState v1alpha1.RepositoryServerProgress
@@ -517,6 +519,8 @@ func getTestKanisterToolsPod(podName string) (pod *v1.Pod) {
 }
 
 func (s *RepoServerControllerSuite) TearDownSuite(c *C) {
+	err := os.Unsetenv(consts.KanisterToolsImageEnvName)
+	c.Assert(err, IsNil)
 	if s.repoServerControllerNamespace != "" {
 		err := s.kubeCli.CoreV1().Namespaces().Delete(context.TODO(), s.repoServerControllerNamespace, metav1.DeleteOptions{})
 		c.Assert(err, IsNil)

--- a/pkg/controllers/repositoryserver/utils.go
+++ b/pkg/controllers/repositoryserver/utils.go
@@ -205,7 +205,7 @@ func getPodOptions(namespace string, podOverride map[string]interface{}, svc *co
 	return &kube.PodOptions{
 		Namespace:     namespace,
 		GenerateName:  fmt.Sprintf("%s-", repoServerPod),
-		Image:         consts.KanisterToolsImage,
+		Image:         consts.GetKanisterToolsImage(),
 		ContainerName: repoServerPodContainerName,
 		Command:       []string{"bash", "-c", "tail -f /dev/null"},
 		PodOverride:   podOverride,

--- a/pkg/function/backup_data_stats.go
+++ b/pkg/function/backup_data_stats.go
@@ -23,6 +23,7 @@ import (
 
 	kanister "github.com/kanisterio/kanister/pkg"
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
+	"github.com/kanisterio/kanister/pkg/consts"
 	"github.com/kanisterio/kanister/pkg/format"
 	"github.com/kanisterio/kanister/pkg/kube"
 	"github.com/kanisterio/kanister/pkg/param"
@@ -65,7 +66,7 @@ func backupDataStats(ctx context.Context, cli kubernetes.Interface, tp param.Tem
 	options := &kube.PodOptions{
 		Namespace:    namespace,
 		GenerateName: jobPrefix,
-		Image:        getKanisterToolsImage(),
+		Image:        consts.GetKanisterToolsImage(),
 		Command:      []string{"sh", "-c", "tail -f /dev/null"},
 		PodOverride:  podOverride,
 	}

--- a/pkg/function/checkRepository.go
+++ b/pkg/function/checkRepository.go
@@ -10,6 +10,7 @@ import (
 
 	kanister "github.com/kanisterio/kanister/pkg"
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
+	"github.com/kanisterio/kanister/pkg/consts"
 	"github.com/kanisterio/kanister/pkg/kube"
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/restic"
@@ -49,7 +50,7 @@ func CheckRepository(ctx context.Context, cli kubernetes.Interface, tp param.Tem
 	options := &kube.PodOptions{
 		Namespace:    namespace,
 		GenerateName: jobPrefix,
-		Image:        getKanisterToolsImage(),
+		Image:        consts.GetKanisterToolsImage(),
 		Command:      []string{"sh", "-c", "tail -f /dev/null"},
 		PodOverride:  podOverride,
 	}

--- a/pkg/function/copy_volume_data.go
+++ b/pkg/function/copy_volume_data.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	kanister "github.com/kanisterio/kanister/pkg"
+	"github.com/kanisterio/kanister/pkg/consts"
 	"github.com/kanisterio/kanister/pkg/format"
 	"github.com/kanisterio/kanister/pkg/kube"
 	"github.com/kanisterio/kanister/pkg/log"
@@ -73,7 +74,7 @@ func copyVolumeData(ctx context.Context, cli kubernetes.Interface, tp param.Temp
 	options := &kube.PodOptions{
 		Namespace:    namespace,
 		GenerateName: CopyVolumeDataJobPrefix,
-		Image:        getKanisterToolsImage(),
+		Image:        consts.GetKanisterToolsImage(),
 		Command:      []string{"sh", "-c", "tail -f /dev/null"},
 		Volumes:      map[string]string{pvc: mountPoint},
 		PodOverride:  podOverride,

--- a/pkg/function/delete_data.go
+++ b/pkg/function/delete_data.go
@@ -25,6 +25,7 @@ import (
 
 	kanister "github.com/kanisterio/kanister/pkg"
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
+	"github.com/kanisterio/kanister/pkg/consts"
 	"github.com/kanisterio/kanister/pkg/format"
 	"github.com/kanisterio/kanister/pkg/kube"
 	"github.com/kanisterio/kanister/pkg/param"
@@ -69,7 +70,7 @@ func deleteData(ctx context.Context, cli kubernetes.Interface, tp param.Template
 	options := &kube.PodOptions{
 		Namespace:    namespace,
 		GenerateName: jobPrefix,
-		Image:        getKanisterToolsImage(),
+		Image:        consts.GetKanisterToolsImage(),
 		Command:      []string{"sh", "-c", "tail -f /dev/null"},
 		PodOverride:  podOverride,
 	}

--- a/pkg/function/describe_backups.go
+++ b/pkg/function/describe_backups.go
@@ -24,6 +24,7 @@ import (
 
 	kanister "github.com/kanisterio/kanister/pkg"
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
+	"github.com/kanisterio/kanister/pkg/consts"
 	"github.com/kanisterio/kanister/pkg/format"
 	"github.com/kanisterio/kanister/pkg/kube"
 	"github.com/kanisterio/kanister/pkg/param"
@@ -67,7 +68,7 @@ func describeBackups(ctx context.Context, cli kubernetes.Interface, tp param.Tem
 	options := &kube.PodOptions{
 		Namespace:    namespace,
 		GenerateName: jobPrefix,
-		Image:        getKanisterToolsImage(),
+		Image:        consts.GetKanisterToolsImage(),
 		Command:      []string{"sh", "-c", "tail -f /dev/null"},
 		PodOverride:  podOverride,
 	}

--- a/pkg/function/utils.go
+++ b/pkg/function/utils.go
@@ -3,7 +3,6 @@ package function
 import (
 	"bytes"
 	"context"
-	"os"
 	"path"
 	"strings"
 
@@ -27,17 +26,8 @@ import (
 
 const (
 	// FunctionOutputVersion returns version
-	FunctionOutputVersion     = "version"
-	kanisterToolsImage        = "ghcr.io/kanisterio/kanister-tools:0.93.0"
-	kanisterToolsImageEnvName = "KANISTER_TOOLS"
+	FunctionOutputVersion = "version"
 )
-
-func getKanisterToolsImage() string {
-	if val, ok := os.LookupEnv(kanisterToolsImageEnvName); ok {
-		return val
-	}
-	return kanisterToolsImage
-}
 
 // ValidateCredentials verifies if the given credentials have appropriate values set
 func ValidateCredentials(creds *param.Credential) error {


### PR DESCRIPTION
## Change Overview

- Add helpers to get kanister-tools image if set from env
- Add ability to set env in helm chart
- Use the utility added above
- Fix repo controller tests
- Modify existing functions to use the new utility

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [x] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #2259 

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [x] :zap: Unit test

```
=== RUN   Test
START: repositoryserver_controller_test.go:71: RepoServerControllerSuite.SetUpSuite
PASS: repositoryserver_controller_test.go:71: RepoServerControllerSuite.SetUpSuite	8.814s

START: repositoryserver_controller_test.go:317: RepoServerControllerSuite.TestInvalidRepositoryPassword
PASS: repositoryserver_controller_test.go:317: RepoServerControllerSuite.TestInvalidRepositoryPassword	43.223s

START: repositoryserver_controller_test.go:521: RepoServerControllerSuite.TearDownSuite
PASS: repositoryserver_controller_test.go:521: RepoServerControllerSuite.TearDownSuite	0.061s

OK: 1 passed
--- PASS: Test (52.10s)
PASS
ok  	github.com/kanisterio/kanister/pkg/controllers/repositoryserver	54.022s
```

- [ ] :green_heart: E2E
