### PR TITLE
Add functionality to create Kanister job pods with custom labels and annotations

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -117,6 +117,8 @@ and annotations can be separated via ``,``.
 
 .. substitution-code-block:: bash
 
+  # \ before , is used as escape sequence and it's not required if these helm fields are being
+  # provided using values file
   helm upgrade --install kanister kanister/kanister-operator --namespace kanister --create-namespace \
     --set controller.kanisterPodCustomLabels="key=value\,kyeone=valueone" \
     --set controller.kanisterPodCustomAnnotations="annone=valone"

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -104,6 +104,23 @@ like below:
     --set bpValidatingWebhook.tls.secretName=tls-secret
 
 
+Setting labels and annotations to Kanister function pods
+========================================================
+
+Kanister pods launched during the Kanister actionset operations can be
+configured to have custom labels and annotations, through helm fields.
+
+Helm fields ``controller.kanisterPodCustomLabels`` and
+``controller.kanisterPodCustomAnnotations`` can be used to set the custom
+labels and annotations respectively using the below command. Multiple labels
+and annotations can be separated via ``,``.
+
+.. substitution-code-block:: bash
+
+  helm upgrade --install kanister kanister/kanister-operator --namespace kanister --create-namespace \
+    --set controller.kanisterPodCustomLabels="key=value\,kyeone=valueone" \
+    --set controller.kanisterPodCustomAnnotations="annone=valone"
+
 Building and Deploying from Source
 ==================================
 

--- a/helm/kanister-operator/templates/deployment.yaml
+++ b/helm/kanister-operator/templates/deployment.yaml
@@ -43,6 +43,10 @@ spec:
           value: {{ .Values.controller.parallelism | quote }}
         - name: KANISTER_METRICS_ENABLED
           value: {{ .Values.controller.metrics.enabled | quote }}
+        - name: KANISTER_POD_CUSTOM_LABELS
+          value: {{ .Values.controller.kanisterPodCustomLabels | quote }}
+        - name: KANISTER_POD_CUSTOM_ANNOTATIONS
+          value: {{ .Values.controller.kanisterPodCustomAnnotations | quote }}
 {{- if .Values.resources }}
         resources:
 {{ toYaml .Values.resources | indent 12 }}

--- a/helm/kanister-operator/values.yaml
+++ b/helm/kanister-operator/values.yaml
@@ -37,9 +37,9 @@ controller:
     # false : kanister-prometheus framework has been disabled
     # true: kanister-prometheus framework has been enabled
     enabled: false
-  # labels to set on the pods created by kanister functions
+  # labels to set on the pods created by kanister functions, labels (key=value) are separated by ,
   kanisterPodCustomLabels : ""
-  # annotations to set on the pods created by kanister functions
+  # annotations to set on the pods created by kanister functions, annotations (key=value) are separated by ,
   kanisterPodCustomAnnotations : ""
 bpValidatingWebhook:
   enabled: true

--- a/helm/kanister-operator/values.yaml
+++ b/helm/kanister-operator/values.yaml
@@ -37,6 +37,10 @@ controller:
     # false : kanister-prometheus framework has been disabled
     # true: kanister-prometheus framework has been enabled
     enabled: false
+  # labels to set on the pods created by kanister functions
+  kanisterPodCustomLabels : ""
+  # annotations to set on the pods created by kanister functions
+  kanisterPodCustomAnnotations : ""
 bpValidatingWebhook:
   enabled: true
   tls:

--- a/pkg/function/backup_data_stats.go
+++ b/pkg/function/backup_data_stats.go
@@ -70,6 +70,10 @@ func backupDataStats(ctx context.Context, cli kubernetes.Interface, tp param.Tem
 		Command:      []string{"sh", "-c", "tail -f /dev/null"},
 		PodOverride:  podOverride,
 	}
+
+	SetLabelsToPodOptionsIfRequired(options)
+	SetAnnotationsToPodOptionsIfRequired(options)
+
 	pr := kube.NewPodRunner(cli, options)
 	podFunc := backupDataStatsPodFunc(cli, tp, namespace, encryptionKey, backupArtifactPrefix, backupID, mode)
 	return pr.Run(ctx, podFunc)

--- a/pkg/function/checkRepository.go
+++ b/pkg/function/checkRepository.go
@@ -54,6 +54,10 @@ func CheckRepository(ctx context.Context, cli kubernetes.Interface, tp param.Tem
 		Command:      []string{"sh", "-c", "tail -f /dev/null"},
 		PodOverride:  podOverride,
 	}
+
+	SetLabelsToPodOptionsIfRequired(options)
+	SetAnnotationsToPodOptionsIfRequired(options)
+
 	pr := kube.NewPodRunner(cli, options)
 	podFunc := CheckRepositoryPodFunc(cli, tp, namespace, encryptionKey, targetPaths)
 	return pr.Run(ctx, podFunc)

--- a/pkg/function/copy_volume_data.go
+++ b/pkg/function/copy_volume_data.go
@@ -79,6 +79,10 @@ func copyVolumeData(ctx context.Context, cli kubernetes.Interface, tp param.Temp
 		Volumes:      map[string]string{pvc: mountPoint},
 		PodOverride:  podOverride,
 	}
+
+	SetLabelsToPodOptionsIfRequired(options)
+	SetAnnotationsToPodOptionsIfRequired(options)
+
 	pr := kube.NewPodRunner(cli, options)
 	podFunc := copyVolumeDataPodFunc(cli, tp, namespace, mountPoint, targetPath, encryptionKey)
 	return pr.RunEx(ctx, podFunc)

--- a/pkg/function/delete_data.go
+++ b/pkg/function/delete_data.go
@@ -74,6 +74,10 @@ func deleteData(ctx context.Context, cli kubernetes.Interface, tp param.Template
 		Command:      []string{"sh", "-c", "tail -f /dev/null"},
 		PodOverride:  podOverride,
 	}
+
+	SetLabelsToPodOptionsIfRequired(options)
+	SetAnnotationsToPodOptionsIfRequired(options)
+
 	pr := kube.NewPodRunner(cli, options)
 	podFunc := deleteDataPodFunc(cli, tp, reclaimSpace, namespace, encryptionKey, targetPaths, deleteTags, deleteIdentifiers)
 	return pr.Run(ctx, podFunc)

--- a/pkg/function/delete_data_using_kopia_server.go
+++ b/pkg/function/delete_data_using_kopia_server.go
@@ -140,6 +140,10 @@ func deleteDataFromServer(
 		Image:        image,
 		Command:      []string{"bash", "-c", "tail -f /dev/null"},
 	}
+
+	SetLabelsToPodOptionsIfRequired(options)
+	SetAnnotationsToPodOptionsIfRequired(options)
+
 	pr := kube.NewPodRunner(cli, options)
 	podFunc := deleteDataFromServerPodFunc(
 		cli,

--- a/pkg/function/describe_backups.go
+++ b/pkg/function/describe_backups.go
@@ -72,6 +72,10 @@ func describeBackups(ctx context.Context, cli kubernetes.Interface, tp param.Tem
 		Command:      []string{"sh", "-c", "tail -f /dev/null"},
 		PodOverride:  podOverride,
 	}
+
+	SetLabelsToPodOptionsIfRequired(options)
+	SetAnnotationsToPodOptionsIfRequired(options)
+
 	pr := kube.NewPodRunner(cli, options)
 	podFunc := describeBackupsPodFunc(cli, tp, namespace, encryptionKey, targetPaths)
 	return pr.Run(ctx, podFunc)

--- a/pkg/function/kube_task.go
+++ b/pkg/function/kube_task.go
@@ -60,6 +60,9 @@ func kubeTask(ctx context.Context, cli kubernetes.Interface, namespace, image st
 		PodOverride:  podOverride,
 	}
 
+	SetAnnotationsToPodOptionsIfRequired(options)
+	SetLabelsToPodOptionsIfRequired(options)
+
 	pr := kube.NewPodRunner(cli, options)
 	podFunc := kubeTaskPodFunc()
 	return pr.RunEx(ctx, podFunc)

--- a/pkg/function/prepare_data.go
+++ b/pkg/function/prepare_data.go
@@ -93,6 +93,10 @@ func prepareData(ctx context.Context, cli kubernetes.Interface, namespace, servi
 		ServiceAccountName: serviceAccount,
 		PodOverride:        podOverride,
 	}
+
+	SetLabelsToPodOptionsIfRequired(options)
+	SetAnnotationsToPodOptionsIfRequired(options)
+
 	pr := kube.NewPodRunner(cli, options)
 	podFunc := prepareDataPodFunc(cli)
 	return pr.Run(ctx, podFunc)

--- a/pkg/function/restore_data.go
+++ b/pkg/function/restore_data.go
@@ -124,6 +124,10 @@ func restoreData(ctx context.Context, cli kubernetes.Interface, tp param.Templat
 		Volumes:      vols,
 		PodOverride:  podOverride,
 	}
+
+	SetLabelsToPodOptionsIfRequired(options)
+	SetAnnotationsToPodOptionsIfRequired(options)
+
 	pr := kube.NewPodRunner(cli, options)
 	podFunc := restoreDataPodFunc(cli, tp, namespace, encryptionKey, backupArtifactPrefix, restorePath, backupTag, backupID)
 	return pr.Run(ctx, podFunc)

--- a/pkg/function/restore_data_using_kopia_server.go
+++ b/pkg/function/restore_data_using_kopia_server.go
@@ -183,6 +183,9 @@ func restoreDataFromServer(
 		PodOverride:  podOverride,
 	}
 
+	SetLabelsToPodOptionsIfRequired(options)
+	SetAnnotationsToPodOptionsIfRequired(options)
+
 	pr := kube.NewPodRunner(cli, options)
 	podFunc := restoreDataFromServerPodFunc(
 		cli,

--- a/pkg/function/utils.go
+++ b/pkg/function/utils.go
@@ -33,30 +33,30 @@ const (
 	KanisterPodCustomAnnotationsEnv = "KANISTER_POD_CUSTOM_ANNOTATIONS"
 )
 
-func parseToLabelSelector(envKey string) (bool, *map[string]string) {
+func parseToLabelSelector(envKey string) *map[string]string {
 	val, ok := os.LookupEnv(envKey)
 	if !ok || val == "" {
-		return false, nil
+		return nil
 	}
 	ls, err := metav1.ParseToLabelSelector(val)
 	if err != nil {
-		return false, nil
+		return nil
 	}
-	return true, &ls.MatchLabels
+	return &ls.MatchLabels
 }
 
-func getKanisterPodLabels() (bool, *map[string]string) {
+func getKanisterPodLabels() *map[string]string {
 	return parseToLabelSelector(KanisterPodCustomLabelsEnv)
 }
 
-func getKanisterPodAnnotations() (bool, *map[string]string) {
+func getKanisterPodAnnotations() *map[string]string {
 	return parseToLabelSelector(KanisterPodCustomAnnotationsEnv)
 }
 
 // SetLabelsToPodOptionsIfRequired sets labels to PodOptions
 func SetLabelsToPodOptionsIfRequired(options *kube.PodOptions) {
-	updateNeeded, labels := getKanisterPodLabels()
-	if updateNeeded {
+	labels := getKanisterPodLabels()
+	if labels != nil {
 		if options.Labels == nil {
 			options.Labels = make(map[string]string)
 		}
@@ -68,8 +68,8 @@ func SetLabelsToPodOptionsIfRequired(options *kube.PodOptions) {
 
 // SetAnnotationsToPodOptionsIfRequired sets annotations to PodOptions
 func SetAnnotationsToPodOptionsIfRequired(options *kube.PodOptions) {
-	updateNeeded, annotations := getKanisterPodAnnotations()
-	if updateNeeded {
+	annotations := getKanisterPodAnnotations()
+	if annotations != nil {
 		if options.Annotations == nil {
 			options.Annotations = make(map[string]string)
 		}


### PR DESCRIPTION
## Change Overview

Up until now there wasn't a way to set labels and annotations to the pod that kanister action set creates for the functions that are configured in the Kanister blueprint.
This PR introduces new helm fields that can be used to set custom labels and annotations to the Kanister job pods that get crated by Kanister actionset.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [x] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

```
go test -check.f "UtilsTestSuite"
OK: 5 passed
PASS
ok  	github.com/kanisterio/kanister/pkg/function	0.036s
```

Install Kanister using below command

```
helm install kanister -n kanister helm/kanister-operator --create-namespace --set controller.kanisterPodCustomLabels="a=b\,c=d" --set controller.kanisterPodCustomAnnotations="e=f\,g=h"
```
and look at the label and annotations for the KubeTask pod

```
 k get pods -n mysql kanister-job-wh8rm -oyaml
apiVersion: v1
kind: Pod
metadata:
  annotations:
    e: f
    g: h
  creationTimestamp: "2023-08-31T14:14:43Z"
  generateName: kanister-job-
  labels:
    a: b
    c: d
    createdBy: kanister
  name: kanister-job-wh8rm
  namespace: mysql
  resourceVersion: "134753"
  uid: 42e997b9-0209-4856-8db9-fdb2a9880d6d
spec:
```

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
