### PR TITLE
deps(go): exclude kopia from automatic dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
     commit-message:
       prefix: "deps(go):"
     ignore:
+      # kopia requires explicit updates
+      - dependency-name: "github.com/kopia/kopia"
       # Dependabot opens PRs for older versions of openshift that would downgrade the version in use.
       - dependency-name: "github.com/openshift/api"
       - dependency-name: "k8s.io/*"


### PR DESCRIPTION
## Change Overview

kopia dependency updates require updates in multiple places, including the kanister tools container image, and thus additional qualification.

## Pull request type

- [x] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [x] :robot: Dependabot


## Test Plan

- [x] :green_heart: dependabot syntax validation
