### PR TITLE
modify the deployment for time-logger app in the tutorial docs

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -44,6 +44,9 @@ application is installed in the ``default`` namespace.
   metadata:
     name: time-logger
   spec:
+    selector:
+      matchLabels:
+        app: time-logger
     replicas: 1
     template:
       metadata:


### PR DESCRIPTION
## Change Overview

The time-logger deployment spec in the tutorial documentation was not valid and was giving error as 
```
The Deployment "time-logger" is invalid: 
* spec.selector: Required value
* spec.template.metadata.labels: Invalid value: map[string]string{"app":"time-logger"}: `selector` does not match template `labels`

```

The PR adds the required field in the spec

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [x] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
