### PR TITLE
Change the way we figure out container to read the artifacts from

### DIFF
--- a/pkg/controllers/repositoryserver/utils.go
+++ b/pkg/controllers/repositoryserver/utils.go
@@ -156,7 +156,7 @@ func volumeSpecForName(podSpec corev1.PodSpec, podOverride map[string]interface{
 	}
 }
 
-func addTLSCertConfigurationInPodOverride(podOverride *map[string]interface{}, tlsCertSecretName string) error {
+func addTLSCertConfigurationInPodOverride(podOverride *map[string]interface{}, tlsCertSecretName string, po *kube.PodOptions) error {
 	podSpecBytes, err := json.Marshal(*podOverride)
 	if err != nil {
 		return errors.Wrap(err, "Failed to marshal Pod Override")
@@ -178,7 +178,7 @@ func addTLSCertConfigurationInPodOverride(podOverride *map[string]interface{}, t
 
 	if len(podOverrideSpec.Containers) == 0 {
 		podOverrideSpec.Containers = append(podOverrideSpec.Containers, corev1.Container{
-			Name: "container",
+			Name: kube.ContainerNameFromPodOpts(po),
 		})
 	}
 
@@ -199,7 +199,7 @@ func addTLSCertConfigurationInPodOverride(podOverride *map[string]interface{}, t
 	return nil
 }
 
-func getPodOptions(namespace string, podOverride map[string]interface{}, svc *corev1.Service, vols map[string]string) *kube.PodOptions {
+func getPodOptions(namespace string, svc *corev1.Service, vols map[string]string) *kube.PodOptions {
 	uidguid := int64(0)
 	nonRootBool := false
 	return &kube.PodOptions{
@@ -208,7 +208,6 @@ func getPodOptions(namespace string, podOverride map[string]interface{}, svc *co
 		Image:         consts.GetKanisterToolsImage(),
 		ContainerName: repoServerPodContainerName,
 		Command:       []string{"bash", "-c", "tail -f /dev/null"},
-		PodOverride:   podOverride,
 		Labels:        map[string]string{repoServerServiceNameKey: svc.Name},
 		PodSecurityContext: &corev1.PodSecurityContext{
 			RunAsUser:    &uidguid,

--- a/pkg/controllers/repositoryserver/utils.go
+++ b/pkg/controllers/repositoryserver/utils.go
@@ -178,7 +178,7 @@ func addTLSCertConfigurationInPodOverride(podOverride *map[string]interface{}, t
 
 	if len(podOverrideSpec.Containers) == 0 {
 		podOverrideSpec.Containers = append(podOverrideSpec.Containers, corev1.Container{
-			Name: kube.ContainerNameFromPodOpts(po),
+			Name: kube.ContainerNameFromPodOptsOrDefault(po),
 		})
 	}
 

--- a/pkg/kube/pod.go
+++ b/pkg/kube/pod.go
@@ -113,7 +113,7 @@ func GetPodObjectFromPodOptions(cli kubernetes.Interface, opts *PodOptions) (*v1
 	defaultSpecs := v1.PodSpec{
 		Containers: []v1.Container{
 			{
-				Name:            containerNameFromPodOpts(opts),
+				Name:            ContainerNameFromPodOpts(opts),
 				Image:           opts.Image,
 				Command:         opts.Command,
 				ImagePullPolicy: v1.PullPolicy(v1.PullIfNotPresent),
@@ -143,7 +143,7 @@ func GetPodObjectFromPodOptions(cli kubernetes.Interface, opts *PodOptions) (*v1
 
 	// Always put the main container the first
 	sort.Slice(patchedSpecs.Containers, func(i, j int) bool {
-		return patchedSpecs.Containers[i].Name == containerNameFromPodOpts(opts)
+		return patchedSpecs.Containers[i].Name == ContainerNameFromPodOpts(opts)
 	})
 
 	pod := &v1.Pod{

--- a/pkg/kube/pod.go
+++ b/pkg/kube/pod.go
@@ -113,7 +113,7 @@ func GetPodObjectFromPodOptions(cli kubernetes.Interface, opts *PodOptions) (*v1
 	defaultSpecs := v1.PodSpec{
 		Containers: []v1.Container{
 			{
-				Name:            ContainerNameFromPodOpts(opts),
+				Name:            ContainerNameFromPodOptsOrDefault(opts),
 				Image:           opts.Image,
 				Command:         opts.Command,
 				ImagePullPolicy: v1.PullPolicy(v1.PullIfNotPresent),
@@ -143,7 +143,7 @@ func GetPodObjectFromPodOptions(cli kubernetes.Interface, opts *PodOptions) (*v1
 
 	// Always put the main container the first
 	sort.Slice(patchedSpecs.Containers, func(i, j int) bool {
-		return patchedSpecs.Containers[i].Name == ContainerNameFromPodOpts(opts)
+		return patchedSpecs.Containers[i].Name == ContainerNameFromPodOptsOrDefault(opts)
 	})
 
 	pod := &v1.Pod{

--- a/pkg/kube/pod.go
+++ b/pkg/kube/pod.go
@@ -194,6 +194,17 @@ func GetPodObjectFromPodOptions(cli kubernetes.Interface, opts *PodOptions) (*v1
 	return pod, nil
 }
 
+// ContainerNameFromPodOptsOrDefault returns the container name if it's set in
+// the passed `podOptions` value. If not, it's returns the default container
+// name. This should be used whenever we create pods for Kanister functions.
+func ContainerNameFromPodOptsOrDefault(po *PodOptions) string {
+	if po.ContainerName != "" {
+		return po.ContainerName
+	}
+
+	return defaultContainerName
+}
+
 // CreatePod creates a pod with a single container based on the specified image
 func CreatePod(ctx context.Context, cli kubernetes.Interface, opts *PodOptions) (*v1.Pod, error) {
 	pod, err := GetPodObjectFromPodOptions(cli, opts)

--- a/pkg/kube/pod.go
+++ b/pkg/kube/pod.go
@@ -113,7 +113,7 @@ func GetPodObjectFromPodOptions(cli kubernetes.Interface, opts *PodOptions) (*v1
 	defaultSpecs := v1.PodSpec{
 		Containers: []v1.Container{
 			{
-				Name:            defaultContainerName,
+				Name:            containerNameFromPodOpts(opts),
 				Image:           opts.Image,
 				Command:         opts.Command,
 				ImagePullPolicy: v1.PullPolicy(v1.PullIfNotPresent),
@@ -143,7 +143,7 @@ func GetPodObjectFromPodOptions(cli kubernetes.Interface, opts *PodOptions) (*v1
 
 	// Always put the main container the first
 	sort.Slice(patchedSpecs.Containers, func(i, j int) bool {
-		return patchedSpecs.Containers[i].Name == defaultContainerName
+		return patchedSpecs.Containers[i].Name == containerNameFromPodOpts(opts)
 	})
 
 	pod := &v1.Pod{

--- a/pkg/kube/pod.go
+++ b/pkg/kube/pod.go
@@ -161,11 +161,6 @@ func GetPodObjectFromPodOptions(cli kubernetes.Interface, opts *PodOptions) (*v1
 		pod.Name = opts.Name
 	}
 
-	// Override default container name if applicable
-	if opts.ContainerName != "" {
-		pod.Spec.Containers[0].Name = opts.ContainerName
-	}
-
 	// Add Annotations and Labels, if specified
 	if opts.Annotations != nil {
 		pod.ObjectMeta.Annotations = opts.Annotations

--- a/pkg/kube/pod_controller.go
+++ b/pkg/kube/pod_controller.go
@@ -211,14 +211,6 @@ func (p *podController) StopPod(ctx context.Context, stopTimeout time.Duration, 
 	return nil
 }
 
-func ContainerNameFromPodOpts(po *PodOptions) string {
-	if po.ContainerName != "" {
-		return po.ContainerName
-	}
-
-	return defaultContainerName
-}
-
 func (p *podController) StreamPodLogs(ctx context.Context) (io.ReadCloser, error) {
 	if p.podName == "" {
 		return nil, ErrPodControllerPodNotStarted

--- a/pkg/kube/pod_controller.go
+++ b/pkg/kube/pod_controller.go
@@ -224,7 +224,7 @@ func (p *podController) StreamPodLogs(ctx context.Context) (io.ReadCloser, error
 		return nil, ErrPodControllerPodNotStarted
 	}
 
-	return StreamPodLogs(ctx, p.cli, p.pod.Namespace, p.pod.Name, ContainerNameFromPodOpts(p.podOptions))
+	return StreamPodLogs(ctx, p.cli, p.pod.Namespace, p.pod.Name, ContainerNameFromPodOptsOrDefault(p.podOptions))
 }
 
 func (p *podController) GetCommandExecutor() (PodCommandExecutor, error) {
@@ -240,7 +240,7 @@ func (p *podController) GetCommandExecutor() (PodCommandExecutor, error) {
 		cli:           p.cli,
 		namespace:     p.pod.Namespace,
 		podName:       p.podName,
-		containerName: ContainerNameFromPodOpts(p.podOptions),
+		containerName: ContainerNameFromPodOptsOrDefault(p.podOptions),
 	}
 
 	pce.pcep = pce
@@ -261,7 +261,7 @@ func (p *podController) GetFileWriter() (PodFileWriter, error) {
 		cli:           p.cli,
 		namespace:     p.podOptions.Namespace,
 		podName:       p.podName,
-		containerName: ContainerNameFromPodOpts(p.podOptions),
+		containerName: ContainerNameFromPodOptsOrDefault(p.podOptions),
 	}
 
 	pfw.fileWriterProcessor = pfw

--- a/pkg/kube/pod_controller.go
+++ b/pkg/kube/pod_controller.go
@@ -211,7 +211,7 @@ func (p *podController) StopPod(ctx context.Context, stopTimeout time.Duration, 
 	return nil
 }
 
-func containerNameFromPodOpts(po *PodOptions) string {
+func ContainerNameFromPodOpts(po *PodOptions) string {
 	if po.ContainerName != "" {
 		return po.ContainerName
 	}
@@ -224,7 +224,7 @@ func (p *podController) StreamPodLogs(ctx context.Context) (io.ReadCloser, error
 		return nil, ErrPodControllerPodNotStarted
 	}
 
-	return StreamPodLogs(ctx, p.cli, p.pod.Namespace, p.pod.Name, containerNameFromPodOpts(p.podOptions))
+	return StreamPodLogs(ctx, p.cli, p.pod.Namespace, p.pod.Name, ContainerNameFromPodOpts(p.podOptions))
 }
 
 func (p *podController) GetCommandExecutor() (PodCommandExecutor, error) {
@@ -240,7 +240,7 @@ func (p *podController) GetCommandExecutor() (PodCommandExecutor, error) {
 		cli:           p.cli,
 		namespace:     p.pod.Namespace,
 		podName:       p.podName,
-		containerName: containerNameFromPodOpts(p.podOptions),
+		containerName: ContainerNameFromPodOpts(p.podOptions),
 	}
 
 	pce.pcep = pce
@@ -261,7 +261,7 @@ func (p *podController) GetFileWriter() (PodFileWriter, error) {
 		cli:           p.cli,
 		namespace:     p.podOptions.Namespace,
 		podName:       p.podName,
-		containerName: containerNameFromPodOpts(p.podOptions),
+		containerName: ContainerNameFromPodOpts(p.podOptions),
 	}
 
 	pfw.fileWriterProcessor = pfw

--- a/pkg/kube/pod_controller_test.go
+++ b/pkg/kube/pod_controller_test.go
@@ -309,3 +309,27 @@ func (s *PodControllerTestSuite) TestPodControllerGetCommandExecutorAndFileWrite
 		tc(pcp, pc)
 	}
 }
+
+func (s *PodControllerTestSuite) TestContainerNameFromPodOpts(c *C) {
+	for _, tc := range []struct {
+		podOptsContainerName  string
+		expectedContainerName string
+	}{
+		{
+			podOptsContainerName:  "conone",
+			expectedContainerName: "conone",
+		},
+		{
+			podOptsContainerName:  "",
+			expectedContainerName: defaultContainerName,
+		},
+	} {
+		name := containerNameFromPodOpts(&PodOptions{
+			ContainerName: tc.podOptsContainerName,
+		})
+		c.Assert(name, Equals, tc.expectedContainerName)
+	}
+
+	name := containerNameFromPodOpts(&PodOptions{})
+	c.Assert(name, Equals, defaultContainerName)
+}

--- a/pkg/kube/pod_controller_test.go
+++ b/pkg/kube/pod_controller_test.go
@@ -309,27 +309,3 @@ func (s *PodControllerTestSuite) TestPodControllerGetCommandExecutorAndFileWrite
 		tc(pcp, pc)
 	}
 }
-
-func (s *PodControllerTestSuite) TestContainerNameFromPodOpts(c *C) {
-	for _, tc := range []struct {
-		podOptsContainerName  string
-		expectedContainerName string
-	}{
-		{
-			podOptsContainerName:  "conone",
-			expectedContainerName: "conone",
-		},
-		{
-			podOptsContainerName:  "",
-			expectedContainerName: defaultContainerName,
-		},
-	} {
-		name := ContainerNameFromPodOpts(&PodOptions{
-			ContainerName: tc.podOptsContainerName,
-		})
-		c.Assert(name, Equals, tc.expectedContainerName)
-	}
-
-	name := ContainerNameFromPodOpts(&PodOptions{})
-	c.Assert(name, Equals, defaultContainerName)
-}

--- a/pkg/kube/pod_controller_test.go
+++ b/pkg/kube/pod_controller_test.go
@@ -324,12 +324,12 @@ func (s *PodControllerTestSuite) TestContainerNameFromPodOpts(c *C) {
 			expectedContainerName: defaultContainerName,
 		},
 	} {
-		name := containerNameFromPodOpts(&PodOptions{
+		name := ContainerNameFromPodOpts(&PodOptions{
 			ContainerName: tc.podOptsContainerName,
 		})
 		c.Assert(name, Equals, tc.expectedContainerName)
 	}
 
-	name := containerNameFromPodOpts(&PodOptions{})
+	name := ContainerNameFromPodOpts(&PodOptions{})
 	c.Assert(name, Equals, defaultContainerName)
 }

--- a/pkg/kube/pod_test.go
+++ b/pkg/kube/pod_test.go
@@ -881,3 +881,27 @@ func (s *PodSuite) TestSetLifecycleHook(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(pod.Spec.Containers[0].Lifecycle, DeepEquals, lch)
 }
+
+func (s *PodControllerTestSuite) TestContainerNameFromPodOptsOrDefault(c *C) {
+	for _, tc := range []struct {
+		podOptsContainerName  string
+		expectedContainerName string
+	}{
+		{
+			podOptsContainerName:  "conone",
+			expectedContainerName: "conone",
+		},
+		{
+			podOptsContainerName:  "",
+			expectedContainerName: defaultContainerName,
+		},
+	} {
+		name := ContainerNameFromPodOptsOrDefault(&PodOptions{
+			ContainerName: tc.podOptsContainerName,
+		})
+		c.Assert(name, Equals, tc.expectedContainerName)
+	}
+
+	name := ContainerNameFromPodOptsOrDefault(&PodOptions{})
+	c.Assert(name, Equals, defaultContainerName)
+}


### PR DESCRIPTION


## Change Overview

While running the kanister function, to read the artifact that the phase has produced we get the logs of the kanister function pod (let's say `KubeTask`). If there is just one container in the KubeTask pod in that case things would work but if there are multiple contianers in the pod (let's say service mesh injected one), in that case the logic that we have to figure out the container name was not efficient. If was relying on the first container of the pod.

This PR changes that logic to read the container name from `podOptions` or fallback to the default container name. This should work in all the cases, if container name is not specified while creating `podOptions` we will use default container name everywhere otherwise we will use the container name that is specified in the podOptions.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

- [x] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
