### PR TITLE
[Don't Review] Add a utility to get container name from podoptions

### DIFF
--- a/pkg/kube/pod.go
+++ b/pkg/kube/pod.go
@@ -199,6 +199,17 @@ func GetPodObjectFromPodOptions(cli kubernetes.Interface, opts *PodOptions) (*v1
 	return pod, nil
 }
 
+// ContainerNameFromPodOptsOrDefault returns the container name if it's set in
+// the passed `podOptions` value. If not, it's returns the default container
+// name. This should be used whenever we create pods for Kanister functions.
+func ContainerNameFromPodOptsOrDefault(po *PodOptions) string {
+	if po.ContainerName != "" {
+		return po.ContainerName
+	}
+
+	return defaultContainerName
+}
+
 // CreatePod creates a pod with a single container based on the specified image
 func CreatePod(ctx context.Context, cli kubernetes.Interface, opts *PodOptions) (*v1.Pod, error) {
 	pod, err := GetPodObjectFromPodOptions(cli, opts)

--- a/pkg/kube/pod_test.go
+++ b/pkg/kube/pod_test.go
@@ -881,3 +881,27 @@ func (s *PodSuite) TestSetLifecycleHook(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(pod.Spec.Containers[0].Lifecycle, DeepEquals, lch)
 }
+
+func (s *PodControllerTestSuite) TestContainerNameFromPodOptsOrDefault(c *C) {
+	for _, tc := range []struct {
+		podOptsContainerName  string
+		expectedContainerName string
+	}{
+		{
+			podOptsContainerName:  "conone",
+			expectedContainerName: "conone",
+		},
+		{
+			podOptsContainerName:  "",
+			expectedContainerName: defaultContainerName,
+		},
+	} {
+		name := ContainerNameFromPodOptsOrDefault(&PodOptions{
+			ContainerName: tc.podOptsContainerName,
+		})
+		c.Assert(name, Equals, tc.expectedContainerName)
+	}
+
+	name := ContainerNameFromPodOptsOrDefault(&PodOptions{})
+	c.Assert(name, Equals, defaultContainerName)
+}


### PR DESCRIPTION
## Change Overview

This PR adds a utility in `pod.go` to get us container name from `podoptions` so that we can use this while creating the Pod and while getting the logs from pod and by doing so we would get the correct container name that was given while creating the pod .
In the next PRs this utility will be consumed by rest of the code.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E

```
/kanister/pkg/kube (container-from-po*) » go test
OK: 47 passed, 3 skipped
PASS
ok  	github.com/kanisterio/kanister/pkg/kube	194.999s


```
