### PR TITLE
Add method to identify group version in the snapshotter interface

### DIFF
--- a/pkg/kube/snapshot/mocks/mock_snapshotter.go
+++ b/pkg/kube/snapshot/mocks/mock_snapshotter.go
@@ -11,6 +11,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	snapshot "github.com/kanisterio/kanister/pkg/kube/snapshot"
 	v1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
+	schema "k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // MockSnapshotter is a mock of Snapshotter interface.
@@ -178,6 +179,20 @@ func (m *MockSnapshotter) GetVolumeSnapshotClass(arg0 context.Context, arg1, arg
 func (mr *MockSnapshotterMockRecorder) GetVolumeSnapshotClass(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVolumeSnapshotClass", reflect.TypeOf((*MockSnapshotter)(nil).GetVolumeSnapshotClass), arg0, arg1, arg2, arg3)
+}
+
+// GroupVersion mocks base method.
+func (m *MockSnapshotter) GroupVersion(arg0 context.Context) schema.GroupVersion {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GroupVersion", arg0)
+	ret0, _ := ret[0].(schema.GroupVersion)
+	return ret0
+}
+
+// GroupVersion indicates an expected call of GroupVersion.
+func (mr *MockSnapshotterMockRecorder) GroupVersion(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GroupVersion", reflect.TypeOf((*MockSnapshotter)(nil).GroupVersion), arg0)
 }
 
 // List mocks base method.

--- a/pkg/kube/snapshot/snapshot.go
+++ b/pkg/kube/snapshot/snapshot.go
@@ -112,6 +112,7 @@ type Snapshotter interface {
 	// List will list the volumesnapshots in a namespace that match search. If labels aren't provided,
 	// it will list all the snapshots in the namespace
 	List(ctx context.Context, namespace string, labels map[string]string) (*v1.VolumeSnapshotList, error)
+	// GroupVersion returns the group and version according to snapshotter version
 	GroupVersion(ctx context.Context) schema.GroupVersion
 }
 

--- a/pkg/kube/snapshot/snapshot.go
+++ b/pkg/kube/snapshot/snapshot.go
@@ -19,6 +19,7 @@ import (
 
 	v1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
 	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 
@@ -111,6 +112,7 @@ type Snapshotter interface {
 	// List will list the volumesnapshots in a namespace that match search. If labels aren't provided,
 	// it will list all the snapshots in the namespace
 	List(ctx context.Context, namespace string, labels map[string]string) (*v1.VolumeSnapshotList, error)
+	GroupVersion(ctx context.Context) schema.GroupVersion
 }
 
 // Source represents the CSI source of the Volumesnapshot.

--- a/pkg/kube/snapshot/snapshot_alpha.go
+++ b/pkg/kube/snapshot/snapshot_alpha.go
@@ -338,6 +338,12 @@ func (sna *SnapshotAlpha) WaitOnReadyToUse(ctx context.Context, snapshotName, na
 	})
 }
 
+func (sna *SnapshotAlpha) GroupVersion(ctx context.Context) schema.GroupVersion {
+	return schema.GroupVersion{
+		Group:   v1alpha1.GroupName,
+		Version: v1alpha1.Version,
+	}
+}
 func (sna *SnapshotAlpha) getContent(ctx context.Context, contentName string) (*v1alpha1.VolumeSnapshotContent, error) {
 	us, err := sna.dynCli.Resource(v1alpha1.VolSnapContentGVR).Get(ctx, contentName, metav1.GetOptions{})
 	if err != nil {

--- a/pkg/kube/snapshot/snapshot_beta.go
+++ b/pkg/kube/snapshot/snapshot_beta.go
@@ -265,6 +265,13 @@ func (sna *SnapshotBeta) UpdateVolumeSnapshotStatusBeta(ctx context.Context, nam
 	return updateVolumeSnapshotStatus(ctx, sna.dynCli, v1beta1.VolSnapGVR, namespace, snapshotName, readyToUse)
 }
 
+func (sna *SnapshotBeta) GroupVersion(ctx context.Context) schema.GroupVersion {
+	return schema.GroupVersion{
+		Group:   v1beta1.GroupName,
+		Version: v1beta1.Version,
+	}
+}
+
 func updateVolumeSnapshotStatus(ctx context.Context, dynCli dynamic.Interface, snapGVR schema.GroupVersionResource, namespace string, snapshotName string, readyToUse bool) error {
 	us, err := dynCli.Resource(snapGVR).Namespace(namespace).Get(ctx, snapshotName, metav1.GetOptions{})
 	if err != nil {

--- a/pkg/kube/snapshot/snapshot_stable.go
+++ b/pkg/kube/snapshot/snapshot_stable.go
@@ -169,3 +169,10 @@ func (sna *SnapshotStable) CreateContentFromSource(ctx context.Context, source *
 func (sna *SnapshotStable) WaitOnReadyToUse(ctx context.Context, snapshotName, namespace string) error {
 	return waitOnReadyToUse(ctx, sna.dynCli, VolSnapGVR, snapshotName, namespace)
 }
+
+func (sna *SnapshotStable) GroupVersion(ctx context.Context) schema.GroupVersion {
+	return schema.GroupVersion{
+		Group:   GroupName,
+		Version: Version,
+	}
+}

--- a/pkg/kube/volume/volume.go
+++ b/pkg/kube/volume/volume.go
@@ -27,6 +27,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 
@@ -116,6 +117,7 @@ type CreatePVCFromSnapshotArgs struct {
 	Annotations      map[string]string
 	VolumeMode       *v1.PersistentVolumeMode
 	AccessModes      []v1.PersistentVolumeAccessMode
+	GroupVersion     *schema.GroupVersion
 }
 
 // CreatePVCFromSnapshot will restore a volume and returns the resulting
@@ -131,6 +133,10 @@ func CreatePVCFromSnapshot(ctx context.Context, args *CreatePVCFromSnapshotArgs)
 	}
 	snapshotKind := "VolumeSnapshot"
 	snapshotAPIGroup := "snapshot.storage.k8s.io"
+	if args.GroupVersion != nil {
+		snapshotAPIGroup = args.GroupVersion.String()
+	}
+
 	pvc := &v1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels:      args.Labels,

--- a/pkg/kube/volume/volume.go
+++ b/pkg/kube/volume/volume.go
@@ -117,7 +117,7 @@ type CreatePVCFromSnapshotArgs struct {
 	Annotations      map[string]string
 	VolumeMode       *v1.PersistentVolumeMode
 	AccessModes      []v1.PersistentVolumeAccessMode
-	GroupVersion     *schema.GroupVersion
+	GroupVersion     schema.GroupVersion
 }
 
 // CreatePVCFromSnapshot will restore a volume and returns the resulting
@@ -133,7 +133,7 @@ func CreatePVCFromSnapshot(ctx context.Context, args *CreatePVCFromSnapshotArgs)
 	}
 	snapshotKind := "VolumeSnapshot"
 	snapshotAPIGroup := "snapshot.storage.k8s.io"
-	if args.GroupVersion != nil {
+	if !args.GroupVersion.Empty() {
 		snapshotAPIGroup = args.GroupVersion.String()
 	}
 

--- a/pkg/kube/volume/volume.go
+++ b/pkg/kube/volume/volume.go
@@ -132,6 +132,11 @@ func CreatePVCFromSnapshot(ctx context.Context, args *CreatePVCFromSnapshotArgs)
 		args.AccessModes = []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}
 	}
 	snapshotKind := "VolumeSnapshot"
+
+	// Group version is not specified here, it is figured out automatically
+	// while the PVC is being created, which can cause issues. Hence we should explicitly
+	// check if group api version is passed in the args, and use that
+	// to create the PVC
 	snapshotAPIGroup := "snapshot.storage.k8s.io"
 	if !args.GroupVersion.Empty() {
 		snapshotAPIGroup = args.GroupVersion.String()


### PR DESCRIPTION
## Change Overview

Add functionality to identify group and api version of volume snapshot using snapshotter interface

## Pull request type

Please check the type of change your PR introduces:
- [x] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
