### PR TITLE
fix build arguments in goreleaser yaml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -63,8 +63,8 @@ dockers:
   build_flag_templates:
   - "--build-arg=kan_tools_version={{ .Tag }}"
 # Refers to https://github.com/kopia/kopia/commit/3551f743d762f2ffe669523272d1c8d734120b79
-  - "--build-arg=kopiaBuildCommit=3551f74"
-  - "--build-arg=kopiaRepoOrg=kopia"
+  - "--build-arg=kopia_build_commit=3551f74"
+  - "--build-arg=kopia_repo_org=kopia"
   extra_files:
   - 'LICENSE'
 - ids:


### PR DESCRIPTION
## Change Overview

As discussed in https://github.com/kanisterio/kanister/pull/2343#discussion_r1330599009, the `--build-arg` in `.goreleaser.yml` are incorrect. This PR change them to correct variable.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
