### PR TITLE
fix(ci): use correct dependabot user for checks

### DIFF
--- a/.github/workflows/triage-prs.yaml
+++ b/.github/workflows/triage-prs.yaml
@@ -12,7 +12,8 @@ permissions:
 jobs:
   pull-requests-comment:
     name: Comment and Triage
-    if: github.repository == 'kanisterio/kanister' && github.actor != 'dependabot'
+    # The entire job is skipped for @dependabot
+    if: github.repository == 'kanisterio/kanister' && github.actor != 'dependabot[bot]'
     permissions:
       pull-requests: write
     runs-on: ubuntu-latest
@@ -33,7 +34,7 @@ jobs:
       uses: alex-page/github-project-automation-plus@v0.8.3
       # This only works for PRs opened in the same repo and not by dependabot.
       # Other PRs don't get the necessary credentials.
-      if: github.repository == 'kanisterio/kanister' && !github.event.pull_request.head.repo.fork && github.actor != 'dependabot'
+      if: github.repository == 'kanisterio/kanister' && !github.event.pull_request.head.repo.fork
       with:
         repo-token: ${{ secrets.GH_TOKEN }}
         project: Kanister


### PR DESCRIPTION
## Change Overview

It seems that the previous check for the dependabot user was incorrect.

## Pull request type

- [x] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [x] :bug: Bugfix


## Test Plan

- [x] :zap: CI 

Need to merge first and then check with a Dependabot-generated PR.
