### PR TITLE
Fix golang vulnerabilities in kanister-tools image

### DIFF
--- a/docker/tools/Dockerfile
+++ b/docker/tools/Dockerfile
@@ -1,11 +1,26 @@
 # Build Kopia binary
-FROM golang:1.19-bullseye AS builder
+FROM golang:1.21-bullseye AS builder
 
 ARG kopia_build_commit=master
 ARG kopia_repo_org=kopia
 ENV CGO_ENABLED=1 GOEXPERIMENT=boringcrypto GO_EXTLINK_ENABLED=0
 RUN apt-get install git
 
+# Build restic binary from source - released version
+# This will allow us to bring in security fixes without relying on the official
+# image which is released once every quarter
+WORKDIR /
+
+RUN git clone https://github.com/restic/restic.git
+
+ENV GITHUB_REPOSITORY=https://github.com/restic/restic
+
+WORKDIR /restic
+
+RUN git checkout v0.16.0
+RUN go run build.go
+
+# Build kopia binary from specific commit
 WORKDIR /
 
 RUN git clone https://github.com/${kopia_repo_org}/kopia.git
@@ -14,7 +29,6 @@ ENV GITHUB_REPOSITORY=https://github.com/${kopia_repo_org}/kopia
 
 WORKDIR /kopia
 
-# Build kopia binary from specific commit
 RUN git checkout ${kopia_build_commit}
 RUN GO111MODULE=on GOOS=linux GOARCH=amd64 go build -o kopia \
   -ldflags="-X github.com/kopia/kopia/repo.BuildVersion=$(git show --no-patch --format='%cs-%h') \
@@ -45,11 +59,11 @@ LABEL name="kanister-tools" \
     vendor="Kanister" \
     version="${kan_tools_version}" \
     release="${kan_tools_version}" \
-    summary="Microservice for application-specific data management for Kubernetes" \
-    maintainer="Tom Manville<tom@kasten.io>" \
-    description="Kanister tools for application-specific data management"
+    summary="Operator for data protection workflow management on Kubernetes" \
+    maintainer="Pavan N Devaraj<pavan.n.devaraj@veeam.com>" \
+    description="Tools for application-specific data protection"
 
-COPY --from=restic/restic:0.15.2 /usr/bin/restic /usr/local/bin/restic
+COPY --from=builder /restic/restic /usr/local/bin/restic
 COPY --from=builder /kopia/kopia /usr/local/bin/kopia
 COPY LICENSE /licenses/LICENSE
 


### PR DESCRIPTION
## Change Overview

- Fixed golang vulnerabilities in restic - now building from source since restic does not have a new image with fixes
```
CVE-2023-29404 
CVE-2023-29402
CVE-2023-29405
CVE-2023-24540
CVE-2023-29400 
CVE-2023-24539   
CVE-2023-29403 
CVE-2023-39533
CVE-2023-29409
CVE-2023-29406
CVE-2023-39318
CVE-2023-39319
```
- Updated the builder base-image to Go 1.21
- Updated maintainer and description to reflect latest information

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
