### PR TITLE
[WIP] chore(ci): speedup CI

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -49,7 +49,7 @@ jobs:
         skip-cache: true
   test:
     runs-on: ubuntu-20.04
-    needs: [gomod, lint]
+    needs: gomod
     strategy:
       fail-fast: false
       matrix:
@@ -84,7 +84,7 @@ jobs:
       run: make ${{ matrix.testSuite }}
   build:
     runs-on: ubuntu-20.04
-    needs: [gomod, lint, test]
+    needs: gomod
     strategy:
       matrix:
         bin: [controller, kanctl, kando]
@@ -112,7 +112,7 @@ jobs:
       run: make docs
   release:
     runs-on: ubuntu-20.04
-    needs: [test, build]
+    needs: [test, build, lint]
     if: github.ref_name == 'master' || startsWith(github.ref, 'refs/tags')
     permissions:
       packages: write

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -43,7 +43,7 @@ jobs:
         go-version-file: 'go.mod'
     -
       name: Lint
-      run: make golint
+      run: ./build/golint.sh
   test:
     runs-on: ubuntu-20.04
     needs: [gomod, lint]

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -105,13 +105,6 @@ jobs:
     -
       name: Checkout repository
       uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
-    # Leverage the GHA cache managed by the setup Go action.
-    # This should use the cache from the `gomod` job
-    -
-      name: Setup Go
-      uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
-      with:
-        go-version-file: 'go.mod'
     -
       run: make docs
   release:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -25,8 +25,8 @@ jobs:
     -
       name: Populate Go mod caches
       run: |
-        make go-mod-download
-        make go-mod-tidy
+        go mod download
+        go mod tidy
   lint:
     runs-on: ubuntu-20.04
     needs: gomod

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,23 +11,39 @@ jobs:
   gomod:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
-    - run: make go-mod-tidy
-    - run: make go-mod-download
-    - run: tar -cvf ./src.tar.gz ./ # preserve file permissions
-    - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+    -
+      name: Checkout repository
+      uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+    # Leverage the GHA cache managed by the setup Go action.
+    # It should do "the right thing"
+    -
+      name: Setup Go
+      uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
       with:
-        name: src
-        path: ./src.tar.gz
+        go-version-file: 'go.mod'
+        check-latest: true
+    -
+      name: Populate Go mod caches
+      run: |
+        make go-mod-download
+        make go-mod-tidy
   lint:
     runs-on: ubuntu-20.04
     needs: gomod
     steps:
-    - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+    -
+      name: Checkout repository
+      uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+    # Leverage the GHA cache managed by the setup Go action.
+    # This should use the cache from the `gomod` job
+    -
+      name: Setup Go
+      uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
       with:
-        name: src
-    - run: tar -xvf ./src.tar.gz
-    - run: make golint
+        go-version-file: 'go.mod'
+    -
+      name: Lint
+      run: make golint
   test:
     runs-on: ubuntu-20.04
     needs: [gomod, lint]
@@ -36,23 +52,33 @@ jobs:
       matrix:
         testSuite: [test, integration-test, helm-test]
     steps:
-    - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+    -
+      name: Checkout repository
+      uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+    # Leverage the GHA cache managed by the setup Go action.
+    # This should use the cache from the `gomod` job
+    -
+      name: Setup Go
+      uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
       with:
-        name: src
-    - uses: helm/kind-action@v1.8.0
-    - run: tar -xvf ./src.tar.gz
-    - run: |
+        go-version-file: 'go.mod'
+    -
+      uses: helm/kind-action@v1.8.0
+    -
+      run: |
         make install-csi-hostpath-driver
         make install-minio
       if: matrix.testSuite == 'integration-test' || matrix.testSuite == 'helm-test'
     # A test (CRDSuite) that runs as part of `make test` requies atleast one CRD to
     # be present on the cluster. That's why we are only installing csi-hostpath-driver
     # before running `make test`, to create some CRDs on the cluster.
-    - run: |
+    -
+      run: |
         make install-csi-hostpath-driver
         make install-minio
       if: matrix.testSuite == 'test'
-    - run: make ${{ matrix.testSuite }}
+    -
+      run: make ${{ matrix.testSuite }}
   build:
     runs-on: ubuntu-20.04
     needs: [gomod, lint, test]
@@ -60,20 +86,34 @@ jobs:
       matrix:
         bin: [controller, kanctl, kando]
     steps:
-    - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+    -
+      name: Checkout repository
+      uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+    # Leverage the GHA cache managed by the setup Go action.
+    # This should use the cache from the `gomod` job
+    -
+      name: Setup Go
+      uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
       with:
-        name: src
-    - run: tar -xvf ./src.tar.gz
-    - run: make build BIN=${{ matrix.bin }} GOBORING=true
+        go-version-file: 'go.mod'
+    -
+      run: make build BIN=${{ matrix.bin }} GOBORING=true
   docs:
     runs-on: ubuntu-20.04
     needs: gomod
     steps:
-    - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+    -
+      name: Checkout repository
+      uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+    # Leverage the GHA cache managed by the setup Go action.
+    # This should use the cache from the `gomod` job
+    -
+      name: Setup Go
+      uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
       with:
-        name: src
-    - run: tar -xvf ./src.tar.gz
-    - run: make docs
+        go-version-file: 'go.mod'
+    -
+      run: make docs
   release:
     runs-on: ubuntu-20.04
     needs: [test, build]
@@ -81,16 +121,24 @@ jobs:
     permissions:
       packages: write
     steps:
-    - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+    -
+      name: Checkout repository
+      uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+    # Leverage the GHA cache managed by the setup Go action.
+    # This should use the cache from the `gomod` job
+    -
+      name: Setup Go
+      uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
       with:
-        name: src
-    - uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        go-version-file: 'go.mod'
+    -
+      uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-    - run: sudo rm -rf /usr/share/dotnet
-    - run: sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-    - run: tar -xvf ./src.tar.gz
+    - run: |
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf "$AGENT_TOOLSDIRECTORY"
     - run: make release-snapshot
     - run: ./build/push_images.sh

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -42,8 +42,11 @@ jobs:
       with:
         go-version-file: 'go.mod'
     -
-      name: Lint
-      run: ./build/golint.sh
+      name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
+      with:
+        version: v1.54
+        skip-cache: true
   test:
     runs-on: ubuntu-20.04
     needs: [gomod, lint]

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,3 +1,5 @@
+name: "Build & Test"
+
 on:
   push:
     branches:


### PR DESCRIPTION
## Change Overview

Leverages the GH cache managed by the @actions/setup-go action to speed up CI. This avoids the step for creating, uploading and downloading the artifacts.

The GH cache can be shared across jobs, workflows and multiple executions of workflows, be it in the same PR, separate PRs or branch push events.

This should be faster since caches are more easily reused across jobs and worker instances.

This approach also requires less storage space, since the cache can be easily reused across multiple executions, so it does not require creating artifacts per workflow execution.


## Pull request type

- [x] :construction: Work in Progress
- [x] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :robot: Test speedup


## Test Plan

- [x] :green_heart: CI workflow execution in GH
