### PR TITLE
Makefile fixed for M1 Macs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,9 @@ REGISTRY ?= kanisterio
 # Which architecture to build - see $(ALL_ARCH) for options.
 ARCH ?= amd64
 
+# Which platform to build.
+PLATFORM ?= linux/$(ARCH)
+
 # This version-strategy uses git tags to set the version string
 VERSION := $(shell git describe --tags --always --dirty)
 #
@@ -119,6 +122,7 @@ bin/$(ARCH)/$(BIN):
 shell: build-dirs
 	@echo "launching a shell in the containerized build environment"
 	@docker run                                      \
+		--platform $(PLATFORM)                       \
 		-ti                                          \
 		--rm                                         \
 		--privileged                                 \
@@ -202,6 +206,7 @@ docs:
 ifeq ($(DOCKER_BUILD),"true")
 	@echo "running DOCS_CMD in the containerized build environment"
 	@docker run             \
+		--platform $(PLATFORM) \
 		--entrypoint ''     \
 		--rm                \
 		-v "$(PWD):/repo"   \
@@ -223,6 +228,7 @@ crd_docs:
 ifeq ($(DOCKER_BUILD),"true")
 	@echo "running API_DOCS_CMD in the containerized build environment"
 	@docker run             \
+		--platform $(PLATFORM) \
 		--entrypoint ''     \
 		--rm                \
 		-v "$(PWD):/repo"   \
@@ -241,6 +247,7 @@ run: build-dirs
 ifeq ($(DOCKER_BUILD),"true")
 	@echo "running CMD in the containerized build environment"
 	@docker run                                                     \
+		--platform $(PLATFORM)                                      \
 		--rm                                                        \
 		--net host                                                  \
 		-e GITHUB_TOKEN=$(GITHUB_TOKEN)                             \


### PR DESCRIPTION
## Change Overview

Attempt to run `make golint` or `make build`, as described [here](https://github.com/k0taperk0t/kanister/blob/master/BUILD.md), on Mac with M1 chip causes the error:

> % make golint
> running CMD in the containerized build environment
> Unable to find image 'ghcr.io/kanisterio/build:v0.0.24' locally
> v0.0.24: Pulling from kanisterio/build
> docker: no matching manifest for linux/arm64/v8 in the manifest list entries.
> See 'docker run --help'.
> make[1]: *** [run] Error 125
> make: *** [golint] Error 2

This PR fixes that error.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
