### PR TITLE
GoLand settings added to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /bin
 /dist
 **/*.swp
+/.idea


### PR DESCRIPTION
## Change Overview

Many of us are using GoLand as default IDE for golang. This PR adds directory with settings of GoLand to `gitignore` file.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
