### PR TITLE
Running of containerized commands refactored

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,7 +207,7 @@ build-dirs:
 run: build-dirs
 ifeq ($(DOCKER_BUILD),"true")
 	@echo "running CMD in the containerized build environment"
-	@PWD=$(PWD) ARCH=$(ARCH) PKG=$(PKG) GITHUB_TOKEN=$(GITHUB_TOKEN) CMD="/bin/bash $(CMD)" /bin/bash ./build/run_container.sh build
+	@PWD=$(PWD) ARCH=$(ARCH) PKG=$(PKG) GITHUB_TOKEN=$(GITHUB_TOKEN) CMD="$(CMD)" /bin/bash ./build/run_container.sh build
 else
 	@/bin/bash $(CMD)
 endif

--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,7 @@ build-dirs:
 run: build-dirs
 ifeq ($(DOCKER_BUILD),"true")
 	@echo "running CMD in the containerized build environment"
-	@PWD=$(PWD) ARCH=$(ARCH) PKG=$(PKG) GITHUB_TOKEN=$(GITHUB_TOKEN) CMD="$(CMD)" /bin/bash ./build/run_container.sh build
+	@PWD=$(PWD) ARCH=$(ARCH) PKG=$(PKG) GITHUB_TOKEN=$(GITHUB_TOKEN) CMD="$(CMD)" /bin/bash ./build/run_container.sh run
 else
 	@/bin/bash $(CMD)
 endif

--- a/Makefile
+++ b/Makefile
@@ -174,13 +174,12 @@ codegen:
 
 DOCS_CMD = "cd docs && make clean &&          \
                 doc8 --max-line-length 90 --ignore D000 . && \
-                make spelling && make html           \
-	   "
+                make spelling && make html"
 
 docs:
 ifeq ($(DOCKER_BUILD),"true")
 	@echo "running DOCS_CMD in the containerized build environment"
-	PWD=$(PWD) ARCH=$(ARCH) CMD=$(DOCS_CMD) /bin/bash ./build/run_container.sh docs
+	@PWD=$(PWD) ARCH=$(ARCH) CMD=$(DOCS_CMD) /bin/bash ./build/run_container.sh docs
 else
 	@/bin/bash -c $(DOCS_CMD)
 endif
@@ -189,13 +188,12 @@ API_DOCS_CMD = "gen-crd-api-reference-docs 			\
 		-config docs/api_docs/config.json 	\
 		-api-dir ./pkg/apis/cr/v1alpha1 	\
 		-template-dir docs/api_docs/template 		\
-		-out-file API.md 	\
-"
+		-out-file API.md"
 
 crd_docs:
 ifeq ($(DOCKER_BUILD),"true")
 	@echo "running API_DOCS_CMD in the containerized build environment"
-	PWD=$(PWD) ARCH=$(ARCH) CMD=$(API_DOCS_CMD) /bin/bash ./build/run_container.sh crd_docs
+	@PWD=$(PWD) ARCH=$(ARCH) CMD=$(API_DOCS_CMD) /bin/bash ./build/run_container.sh crd_docs
 else
 	@/bin/bash -c $(API_DOCS_CMD)
 endif

--- a/build/run_container.sh
+++ b/build/run_container.sh
@@ -1,0 +1,139 @@
+#!/bin/sh
+
+# Copyright 2019 The Kanister Authors.
+#
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+set -o errexit
+set -o nounset
+
+PWD="${PWD:-$(pwd)}"
+
+# tag 0.1.0 is, 0.0.1 (latest) + gh + aws + helm binary
+DOCS_BUILD_IMAGE="${DOCS_BUILD_IMAGE:-ghcr.io/kanisterio/docker-sphinx:0.2.0}"
+BUILD_IMAGE="${BUILD_IMAGE:-ghcr.io/kanisterio/build:v0.0.24}"
+PKG="${PKG:-github.com/kanisterio/kanister}"
+
+ARCH="${ARCH:-amd64}"
+PLATFORM="linux/${ARCH}"
+
+check_param() {
+  local arg_name=${1}
+  local value_of_arg=""
+  eval value_of_arg=\$$arg_name
+  if [ -z "${value_of_arg}" ]; then
+      echo "$arg_name must be set"
+      exit 1
+  fi
+}
+
+
+run_build_container() {
+  local github_token="${GITHUB_TOKEN:-}"
+  local extra_params="${EXTRA_PARAMS:-}"
+  local cmd="${CMD:-command_is_not_set}"
+
+  docker run                                                      \
+      --platform ${PLATFORM}                                      \
+      ${extra_params}                                             \
+      --rm                                                        \
+      --net host                                                  \
+      -e GITHUB_TOKEN="${github_token}"                           \
+      -v "${HOME}/.kube:/root/.kube"                              \
+      -v "${PWD}/.go/pkg:/go/pkg"                                 \
+      -v "${PWD}/.go/cache:/go/.cache"                            \
+      -v "${PWD}:/go/src/${PKG}"                                  \
+      -v "${PWD}/bin/${ARCH}:/go/bin"                             \
+      -v "${PWD}/.go/std/${ARCH}:/usr/local/go/pkg/linux_${ARCH}" \
+      -v "${HOME}/.docker:/root/.docker"                         \
+      -v /var/run/docker.sock:/var/run/docker.sock                \
+      -w /go/src/${PKG}                                           \
+      ${BUILD_IMAGE}                                              \
+      ${cmd}
+}
+
+run_docs_container() {
+  check_param "IMAGE"
+  check_param "CMD"
+
+  docker run             \
+    		--platform ${PLATFORM} \
+    		--entrypoint ''     \
+    		--rm                \
+    		-v "${PWD}:/repo"   \
+    		-w /repo            \
+    		${IMAGE} \
+    		${CMD}
+}
+
+build() {
+  check_param "CMD"
+
+  echo "Running build container..."
+  run_build_container
+}
+
+shell() {
+  echo "Running build container in interactive shell mode..."
+  EXTRA_PARAMS="-ti" CMD="/bin/bash" run_build_container
+}
+
+docs() {
+  check_param "CMD"
+
+  echo "Running docs container..."
+  IMAGE=${DOCS_BUILD_IMAGE} run_docs_container
+}
+
+crd_docs() {
+  check_param "CMD"
+
+  echo "Running crd docs container..."
+  IMAGE=${BUILD_IMAGE} run_docs_container
+}
+
+usage() {
+    cat <<EOM
+Usage: ${0} <operation>
+Where operation is one of the following:
+  build: run some command within a build container
+  crd_docs: build API docs within a container
+  docs: build docs within a container
+  shell: run build container in interactive shell mode
+EOM
+    exit 1
+}
+
+[ ${#@} -gt 0 ] || usage
+case "${1}" in
+        # Alphabetically sorted
+        build)
+            time -p build
+            ;;
+        crd_docs)
+            time -p crd_docs
+            ;;
+        docs)
+            time -p docs
+            ;;
+        shell)
+            time -p shell
+            ;;
+        *)
+            usage
+            exit 1
+esac
+

--- a/build/run_container.sh
+++ b/build/run_container.sh
@@ -22,7 +22,6 @@ set -o nounset
 
 PWD="${PWD:-$(pwd)}"
 
-# tag 0.1.0 is, 0.0.1 (latest) + gh + aws + helm binary
 DOCS_BUILD_IMAGE="${DOCS_BUILD_IMAGE:-ghcr.io/kanisterio/docker-sphinx:0.2.0}"
 BUILD_IMAGE="${BUILD_IMAGE:-ghcr.io/kanisterio/build:v0.0.24}"
 PKG="${PKG:-github.com/kanisterio/kanister}"
@@ -140,4 +139,3 @@ case "${1}" in
             usage
             exit 1
 esac
-

--- a/build/run_container.sh
+++ b/build/run_container.sh
@@ -73,19 +73,19 @@ run_docs_container() {
   check_param "CMD"
 
   docker run                   \
-    		--platform ${PLATFORM} \
-    		--entrypoint ''        \
-    		--rm                   \
-    		-v "${PWD}:/repo"      \
-    		-w /repo               \
-    		${IMAGE} \
-    		/bin/bash -c "${CMD}"
+        --platform ${PLATFORM} \
+        --entrypoint ''        \
+        --rm                   \
+        -v "${PWD}:/repo"      \
+        -w /repo               \
+        ${IMAGE} \
+        /bin/bash -c "${CMD}"
 }
 
-build() {
+run() {
   check_param "CMD"
 
-  echo "Running build container..."
+  echo "Running command within build container..."
   run_build_container
 }
 
@@ -123,14 +123,14 @@ EOM
 [ ${#@} -gt 0 ] || usage
 case "${1}" in
         # Alphabetically sorted
-        build)
-            time -p build
-            ;;
         crd_docs)
             time -p crd_docs
             ;;
         docs)
             time -p docs
+            ;;
+        run)
+            time -p run
             ;;
         shell)
             time -p shell


### PR DESCRIPTION
## Change Overview

This PR removes code duplication and makes code of `Makefile` easier and clear. All commands for running containers moved to separated shell script. 
These changes required for https://github.com/kanisterio/kanister/pull/2379. Without these changes we will have to make changes from https://github.com/kanisterio/kanister/pull/2379 twice - for `shell` and `run` targets of `Makefile` separately.

PR series:
* https://github.com/kanisterio/kanister/pull/2376
* https://github.com/kanisterio/kanister/pull/2366
* => https://github.com/kanisterio/kanister/pull/2377
* https://github.com/kanisterio/kanister/pull/2378
* https://github.com/kanisterio/kanister/pull/2379
* https://github.com/kanisterio/kanister/pull/2365

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [x] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
