### PR TITLE
Error reporting fixed for checking status of `minio`

### DIFF
--- a/build/test.sh
+++ b/build/test.sh
@@ -51,8 +51,8 @@ fi
 echo
 
 check_dependencies() {
-    # Check if minio is already deployed
-    if helm status minio -n minio > /dev/null 2>&1 ; then
+    # Check if minio is already deployed. We suppress only StdOut for watching error if check will fail.
+    if helm status minio -n minio 1> /dev/null ; then
         # Setting env vars to access MinIO
         export S3_COMPLIANT_AWS_ACCESS_KEY_ID="AKIAIOSFODNN7EXAMPLE"
         export S3_COMPLIANT_AWS_SECRET_ACCESS_KEY="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"

--- a/build/test.sh
+++ b/build/test.sh
@@ -51,7 +51,7 @@ fi
 echo
 
 check_dependencies() {
-    # Check if minio is already deployed. We suppress only StdOut for watching error if check will fail.
+    # Check if minio is already deployed. We suppress only `stdout` and not `stderr` to make sure we catch errors if `helm status` fails
     if helm status minio -n minio 1> /dev/null ; then
         # Setting env vars to access MinIO
         export S3_COMPLIANT_AWS_ACCESS_KEY_ID="AKIAIOSFODNN7EXAMPLE"


### PR DESCRIPTION
## Change Overview

This PR fixes error reporting for checking status of `minio`. Currently, if `minio` is not available or broken we will get the same error:
> Please install MinIO using 'make install-minio' and try again.

Which is pretty weird, when you have installed `minio` and it works fine in local environment. With this change we will able to understand what's wrong with `minio`. In my case it reports this:

> Error: Kubernetes cluster unreachable: invalid configuration: [unable to read client-cert /Users/sergey.aksenov/.minikube/profiles/minikube/client.crt for minikube due to open /Users/sergey.aksenov/.minikube/profiles/minikube/client.crt: no such file or directory, unable to read client-key /Users/sergey.aksenov/.minikube/profiles/minikube/client.key for minikube due to open /Users/sergey.aksenov/.minikube/profiles/minikube/client.key: no such file or directory, unable to read certificate-authority /Users/sergey.aksenov/.minikube/ca.crt for minikube due to open /Users/sergey.aksenov/.minikube/ca.crt: no such file or directory]

PR series:
* https://github.com/kanisterio/kanister/pull/2376
* https://github.com/kanisterio/kanister/pull/2366
* https://github.com/kanisterio/kanister/pull/2377
* => https://github.com/kanisterio/kanister/pull/2378
* https://github.com/kanisterio/kanister/pull/2379
* https://github.com/kanisterio/kanister/pull/2365

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

