### PR TITLE
Running `make test` locally using `minio` & `minikube` fixed

### DIFF
--- a/build/run_container.sh
+++ b/build/run_container.sh
@@ -71,7 +71,6 @@ run_build_container() {
       -v "${PWD}:/go/src/${PKG}"                                  \
       -v "${PWD}/bin/${ARCH}:/go/bin"                             \
       -v "${PWD}/.go/std/${ARCH}:/usr/local/go/pkg/linux_${ARCH}" \
-      -v "${HOME}/.docker:/root/.docker"                          \
       -v /var/run/docker.sock:/var/run/docker.sock                \
       -w /go/src/${PKG}                                           \
       ${BUILD_IMAGE}                                              \

--- a/build/run_container.sh
+++ b/build/run_container.sh
@@ -52,9 +52,9 @@ run_build_container() {
   # In case of `minikube`, kube config stores full path to a certificates,
   # thus the simples way to get working minikube in the build container is
   # to bind original path to minikube settings to the container.
-  local path_to_minikube_dir="${HOME}/.minikube"
-  local minikube_dir_binding="-v ${path_to_minikube_dir}:${path_to_minikube_dir}"
-  if [ ! -d "${path_to_minikube_dir}" ]; then
+  local minikube_dir_path="${HOME}/.minikube"
+  local minikube_dir_binding="-v ${minikube_dir_path}:${minikube_dir_path}"
+  if [ ! -d "${minikube_dir_path}" ]; then
       minikube_dir_binding=""
   fi
 

--- a/build/run_container.sh
+++ b/build/run_container.sh
@@ -49,12 +49,22 @@ run_build_container() {
       cmd=(/bin/bash)
   fi
 
+  # In case of `minikube`, kube config stores full path to a certificates,
+  # thus the simples way to get working minikube in the build container is
+  # to bind original path to minikube settings to the container.
+  local path_to_minikube_dir="${HOME}/.minikube"
+  local minikube_dir_binding="-v ${path_to_minikube_dir}:${path_to_minikube_dir}"
+  if [ ! -d "${path_to_minikube_dir}" ]; then
+      minikube_dir_binding=""
+  fi
+
   docker run                                                      \
       --platform ${PLATFORM}                                      \
       ${extra_params}                                             \
       --rm                                                        \
       --net host                                                  \
       -e GITHUB_TOKEN="${github_token}"                           \
+      ${minikube_dir_binding}                                     \
       -v "${HOME}/.kube:/root/.kube"                              \
       -v "${PWD}/.go/pkg:/go/pkg"                                 \
       -v "${PWD}/.go/cache:/go/.cache"                            \

--- a/build/test.sh
+++ b/build/test.sh
@@ -69,7 +69,8 @@ check_dependencies() {
     # be present on the cluster. That's why we are checking that `csi-hostpath-driver`
     # installed before running tests.
     if ! ${SCRIPT_DIR}/local_kubernetes.sh check_csi_hostpath_driver_installed ; then
-        echo "Please install CSI hostpath driver using 'make install-csi-hostpath-driver' and try again."
+        echo "CRDs are not installed on the cluster but a test (CRDSuite) requires at least one CRD to be available on the cluster."\
+        " One can be installed by running 'make install-csi-hostpath-driver' command."
         exit 1
     fi
 }

--- a/build/test.sh
+++ b/build/test.sh
@@ -19,6 +19,7 @@
 set -o errexit
 set -o nounset
 
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
 export CGO_ENABLED=0
 export GO111MODULE=on
@@ -63,9 +64,18 @@ check_dependencies() {
         echo "Please install MinIO using 'make install-minio' and try again."
         exit 1
     fi
+
+    # A test (CRDSuite) that runs as part of `make test` requires at least one CRD to
+    # be present on the cluster. That's why we are checking that `csi-hostpath-driver`
+    # installed before running tests.
+    if ! ${SCRIPT_DIR}/local_kubernetes.sh check_csi_hostpath_driver_installed ; then
+        echo "Please install CSI hostpath driver using 'make install-csi-hostpath-driver' and try again."
+        exit 1
+    fi
 }
 
 check_dependencies
+
 echo "Running tests:"
 go test -v -installsuffix "static" -i ${TARGETS}
 go test -v ${TARGETS} -list .


### PR DESCRIPTION
## Change Overview

This PR fixes running `make test` locally using `minio` & `minikube`.

**Note: This is draft just because these changes have to be based on https://github.com/kanisterio/kanister/pull/2377, but it's not merged yet.**

PR series:
* https://github.com/kanisterio/kanister/pull/2376
* https://github.com/kanisterio/kanister/pull/2366
* https://github.com/kanisterio/kanister/pull/2378
* https://github.com/kanisterio/kanister/pull/2377
* => https://github.com/kanisterio/kanister/pull/2379
* https://github.com/kanisterio/kanister/pull/2383
* https://github.com/kanisterio/kanister/pull/2386
* https://github.com/kanisterio/kanister/pull/2365

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

