### PR TITLE
Getting of incorrect frame depth during logging fixed

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -198,7 +198,7 @@ func (l *logger) entry(fields ...field.M) *logrus.Entry {
 		}
 	}
 
-	frame := caller.GetFrame(3)
+	frame := caller.GetFrame(4)
 	logFields["Function"] = frame.Function
 	logFields["File"] = frame.File
 	logFields["Line"] = frame.Line


### PR DESCRIPTION
## Change Overview

With this change instead of

> {"File":"pkg/log/log.go","Function":"github.com/kanisterio/kanister/pkg/log.Print","Line":165,"app":"mongo","cluster_name":"85854027-f7b2-41e5-a820-92177102961c","hostname":"orbstack","level":"info","msg":"Uninstalling application.","time":"2023-10-09T09:18:02.612923122Z"}

We will get

> {"File":"pkg/app/mongodb.go","Function":"github.com/kanisterio/kanister/pkg/app.(*MongoDB).Uninstall","Line":142,"app":"mongo","cluster_name":"85854027-f7b2-41e5-a820-92177102961c","hostname":"orbstack","level":"info","msg":"Uninstalling application.","time":"2023-10-09T09:49:07.884559847Z"}

Thus this PR fixes getting of incorrect frame depth during logging, because of that we logged incorrect path to file and function where log message emitted from.

PR series:
* https://github.com/kanisterio/kanister/pull/2376
* https://github.com/kanisterio/kanister/pull/2366
* https://github.com/kanisterio/kanister/pull/2378
* https://github.com/kanisterio/kanister/pull/2377
* https://github.com/kanisterio/kanister/pull/2379
* => https://github.com/kanisterio/kanister/pull/2383
* https://github.com/kanisterio/kanister/pull/2386
* https://github.com/kanisterio/kanister/pull/2365

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

