### PR TITLE
Generation of Job name for tests fixed

### DIFF
--- a/pkg/kube/job_test.go
+++ b/pkg/kube/job_test.go
@@ -36,7 +36,9 @@ type JobSuite struct{}
 
 var _ = Suite(&JobSuite{})
 
-var testJobName = "kanister-test-job"
+// Name of test job for this suite.
+// Initially it contains incorrect name of job for catching errors.
+var testJobName = "<unknown name>"
 
 const testJobNamespace = "default"
 const testJobImage = "busybox"
@@ -47,7 +49,7 @@ func (s *JobSuite) SetUpSuite(c *C) {
 }
 
 func (s *JobSuite) SetUpTest(c *C) {
-	testJobName = testJobName + rand.String(5)
+	testJobName = "kanister-test-job" + rand.String(5)
 }
 
 // Verifies that the Job object is not created if the job name is not specified.


### PR DESCRIPTION
## Change Overview

Instead of generating job name using format `template + 5_random_symbols`, we used this format only for first job, but for all next jobs format `previous_name_of_job + 5_random_symbols` has been used. As result sometime we could even to exceed limit in 64 symbols of K8s entity name.

Watch `JobName` field:

> {"File":"pkg/log/log.go","Function":"github.com/kanisterio/kanister/pkg/log.Print","JobName":"kanister-test-job7t2t9","Line":165,"cluster_name":"85854027-f7b2-41e5-a820-92177102961c","hostname":"orbstack","level":"info","msg":"Deleted job","time":"2023-10-09T14:58:23.494576497Z"}
> ...
> PASS: job_test.go:135: JobSuite.TestJobsBasic	10.399s
> {"File":"pkg/log/log.go","Function":"github.com/kanisterio/kanister/pkg/log.Print","JobName":"kanister-test-job7t2t97fnq4","Line":165,"cluster_name":"85854027-f7b2-41e5-a820-92177102961c","hostname":"orbstack","level":"info","msg":"New job created","time":"2023-10-09T14:58:23.605349865Z"}
> ...
> {"File":"pkg/log/log.go","Function":"github.com/kanisterio/kanister/pkg/log.Print","JobName":"kanister-test-job7t2t97fnq48s7k8js7h5jtz9k6nglff2b9tr5bhm","Line":165,"cluster_name":"85854027-f7b2-41e5-a820-92177102961c","hostname":"orbstack","level":"info","msg":"New job created","time":"2023-10-09T14:59:14.937041886Z"}
> PASS: job_test.go:255: JobSuite.TestJobsReadOnlyVolumes	0.005s
> {"File":"pkg/log/log.go","Function":"github.com/kanisterio/kanister/pkg/log.Print","JobName":"kanister-test-job7t2t97fnq48s7k8js7h5jtz9k6nglff2b9tr5bhm58bd9","Line":165,"cluster_name":"85854027-f7b2-41e5-a820-92177102961c","hostname":"orbstack","level":"info","msg":"New job created","time":"2023-10-09T14:59:14.93850743Z"}
> PASS: job_test.go:235: JobSuite.TestJobsVolumes	0.000s
> 
> ----------------------------------------------------------------------
> FAIL: job_test.go:194: JobSuite.TestJobsWaitAfterDelete
> 
> job_test.go:209:
>     c.Assert(err, IsNil)
> ... value *errors.StatusError = &errors.StatusError{ErrStatus:v1.Status{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ListMeta:v1.ListMeta{SelfLink:"", ResourceVersion:"", Continue:"", RemainingItemCount:(*int64)(nil)}, Status:"Failure", Message:"unable to parse requirement: values[0][job-name]: Invalid value: \"kanister-test-job7t2t97fnq48s7k8js7h5jtz9k6nglff2b9tr5bhm58bd9dj8cz\": must be no more than 63 characters", Reason:"BadRequest", Details:(*v1.StatusDetails)(nil), Code:400}} ("unable to parse requirement: values[0][job-name]: Invalid value: \"kanister-test-job7t2t97fnq48s7k8js7h5jtz9k6nglff2b9tr5bhm58bd9dj8cz\": must be no more than 63 characters")

PR series:
* https://github.com/kanisterio/kanister/pull/2376
* https://github.com/kanisterio/kanister/pull/2366
* https://github.com/kanisterio/kanister/pull/2378
* https://github.com/kanisterio/kanister/pull/2377
* https://github.com/kanisterio/kanister/pull/2379
* https://github.com/kanisterio/kanister/pull/2383
* => https://github.com/kanisterio/kanister/pull/2386
* https://github.com/kanisterio/kanister/pull/2365

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [x] :robot: Test

## Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
