### PR TITLE
update kopia commit in kanister-tools image kastenhq 663cbad

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -62,8 +62,8 @@ dockers:
   dockerfile: 'docker/tools/Dockerfile'
   build_flag_templates:
   - "--build-arg=kan_tools_version={{ .Tag }}"
-# Refers to https://github.com/kopia/kopia/commit/3551f743d762f2ffe669523272d1c8d734120b79
-  - "--build-arg=kopia_build_commit=3551f74"
+# Refers to https://github.com/kopia/kastenhq/commit/663cbad414207f077c666637fabfb22b47855959
+  - "--build-arg=kopia_build_commit=663cbad"
   - "--build-arg=kopia_repo_org=kopia"
   extra_files:
   - 'LICENSE'


### PR DESCRIPTION
## Change Overview

This PR modifies kopia commit to https://github.com/kastenhq/kopia/commit/663cbad414207f077c666637fabfb22b47855959 in kanister-tools image after Kopia binary upgrade changes.

The commit used here is from forked repo https://github.com/kastenhq/kopia/tree/kopia-at-edfa9ee-minus-32193f7 that is relatively in-sync with upstream at the time of this PR. The same commit is used for go.mod file for kansiter which provides the benefit of synced-context.

_Note: maintaining commit-parity for kopia between sdk in `go.mo` and `kanister-tools` image_ :
* https://github.com/kanisterio/kanister/pull/2344 
* * => https://github.com/kanisterio/kanister/pull/2412


## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [x] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
