### PR TITLE
Replace the soft limit fields to hard limit fields in the kopia client struct(PR#3)

### DIFF
--- a/pkg/kopia/repository/client.go
+++ b/pkg/kopia/repository/client.go
@@ -62,10 +62,10 @@ func ConnectToAPIServer(
 
 	opts := &repo.ConnectOptions{
 		CachingOptions: content.CachingOptions{
-			CacheDirectory:         kopia.DefaultClientCacheDirectory,
-			ContentCacheSizeBytes:  int64(contentCacheMB << 20),
-			MetadataCacheSizeBytes: int64(metadataCacheMB << 20),
-			MaxListCacheDuration:   content.DurationSeconds(defaultConnectMaxListCacheDuration.Seconds()),
+			CacheDirectory:              kopia.DefaultClientCacheDirectory,
+			ContentCacheSizeLimitBytes:  int64(contentCacheMB << 20),
+			MetadataCacheSizeLimitBytes: int64(metadataCacheMB << 20),
+			MaxListCacheDuration:        content.DurationSeconds(defaultConnectMaxListCacheDuration.Seconds()),
 		},
 		ClientOptions: repo.ClientOptions{
 			Hostname: hostname,


### PR DESCRIPTION
## Change Overview

This PR sets hard limit fields for cache while connecting to kopia API server and ignores the soft limit fields.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
