### PR TITLE
Do not apply kopia retention policy on `kando location push`

### DIFF
--- a/pkg/kopia/snapshot/snapshot.go
+++ b/pkg/kopia/snapshot/snapshot.go
@@ -67,10 +67,11 @@ func SnapshotSource(
 		return "", 0, errors.Wrap(err, "Failed to save kopia manifest")
 	}
 
-	_, err = policy.ApplyRetentionPolicy(ctx, rep, sourceInfo, true)
-	if err != nil {
-		return "", 0, errors.Wrap(err, "Failed to apply kopia retention policy")
-	}
+	// TODO: https://github.com/kanisterio/kanister/issues/2441
+	// _, err = policy.ApplyRetentionPolicy(ctx, rep, sourceInfo, true)
+	// if err != nil {
+	// 	return "", 0, errors.Wrap(err, "Failed to apply kopia retention policy")
+	// }
 
 	if err = policy.SetManual(ctx, rep, sourceInfo); err != nil {
 		return "", 0, errors.Wrap(err, "Failed to set manual field in kopia scheduling policy for source")


### PR DESCRIPTION
## Change Overview

- With kopia v0.14.1, repository clients are not allowed to apply retention policy during snapshot creation without appropriate permissions/ACLs. This causes the clients to hit a `403` error.
- This PR temporarily removes the retention part.
- We should explore the right ACLs for repository server users and re-enable the retention. Created #2441 for tracking.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
