### PR TITLE
When CreatePod fails, dump pod options

### DIFF
--- a/pkg/kube/pod.go
+++ b/pkg/kube/pod.go
@@ -491,6 +491,7 @@ func GetPodReadyWaitTimeout() time.Duration {
 }
 
 // getRedactedEnvVariables returns array of variables with removed values
+// This function should be used every time when env variables are logged
 func getRedactedEnvVariables(env []v1.EnvVar) []v1.EnvVar {
 	if len(env) == 0 {
 		return nil

--- a/pkg/kube/pod.go
+++ b/pkg/kube/pod.go
@@ -221,6 +221,7 @@ func CreatePod(ctx context.Context, cli kubernetes.Interface, opts *PodOptions) 
 
 	pod, err = cli.CoreV1().Pods(pod.Namespace).Create(ctx, pod, metav1.CreateOptions{})
 	if err != nil {
+		log.Error().WithContext(ctx).WithError(err).Print("Failed to create pod.", field.M{"pod": pod, "options": opts})
 		return nil, errors.Wrapf(err, "Failed to create pod. Namespace: %s, NameFmt: %s", opts.Namespace, opts.GenerateName)
 	}
 	return pod, nil


### PR DESCRIPTION
## Change Overview

We have a scenario when invoker can try to create pod with incorrect specification. It would be useful to log what exactly was passed and what pod configuration was built from passed options.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
