### PR TITLE
Restic related functions deprecation warning in documentation

### DIFF
--- a/docs/functions.rst
+++ b/docs/functions.rst
@@ -342,6 +342,10 @@ BackupDataAll
 This function concurrently backs up data from one or more pods into an any
 object store supported by Kanister.
 
+.. warning::
+   The *BackupDataAll* will be deprecated soon.
+   However, :ref:`restoredataall` and :ref:`deletedataall` will continue to be available, ensuring you retain control over your existing backups.
+
 .. note::
    It is important that the application includes a ``kanister-tools``
    sidecar container. This sidecar is necessary to run the
@@ -629,6 +633,8 @@ For this phase, we will use the ``backupInfo`` Artifact provided by backup funct
       namespace: "{{ .Namespace.Name }}"
       backupArtifactPrefix: s3-bucket/path/artifactPrefix
       backupTag: "{{ .ArtifactsIn.backupInfo.KeyValue.backupIdentifier }}"
+
+.. _deletedataall:
 
 DeleteDataAll
 -------------

--- a/docs/functions.rst
+++ b/docs/functions.rst
@@ -280,6 +280,10 @@ BackupData
 This function backs up data from a container into any object store
 supported by Kanister.
 
+.. warning::
+   The *BackupData* will be deprecated soon. We recommend using :ref:`copyvolumedata` instead.
+   However, :ref:`restoredata` and :ref:`deletedata` will continue to be available, ensuring you retain control over your existing backups.
+
 .. note::
    It is important that the application includes a ``kanister-tools``
    sidecar container. This sidecar is necessary to run the
@@ -391,7 +395,7 @@ Example:
 RestoreData
 -----------
 
-This function restores data backed up by the BackupData function.
+This function restores data backed up by the :ref:`backupdata` function.
 It creates a new Pod that mounts the PVCs referenced by the specified Pod
 and restores data to the specified path.
 
@@ -536,6 +540,7 @@ BackupDataAll function.
       kind: Deployment
       replicas: 2
 
+.. _copyvolumedata:
 
 CopyVolumeData
 --------------
@@ -589,10 +594,12 @@ If the ActionSet ``Object`` is a PersistentVolumeClaim:
       volume: "{{ .PVC.Name }}"
       dataArtifactPrefix: s3-bucket-name/path
 
+.. _deletedata:
+
 DeleteData
 ----------
 
-This function deletes the snapshot data backed up by the BackupData function.
+This function deletes the snapshot data backed up by the :ref:`backupdata` function.
 
 
 .. csv-table::


### PR DESCRIPTION
## Change Overview

Since we are expecting to deprecate usage of Restic, we need to announce that some Restic related functions will be deprecated soon. This PR contains changes in documentation.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [x] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
