### PR TITLE
Expose DefaultContainerName

### DIFF
--- a/pkg/kube/pod.go
+++ b/pkg/kube/pod.go
@@ -45,7 +45,7 @@ const (
 	// PodReadyWaitTimeoutEnv is the env var to get pod ready wait timeout
 	PodReadyWaitTimeoutEnv = "KANISTER_POD_READY_WAIT_TIMEOUT"
 	errAccessingNode       = "Failed to get node"
-	defaultContainerName   = "container"
+	DefaultContainerName   = "container"
 )
 
 type VolumeMountOptions struct {
@@ -204,7 +204,7 @@ func GetPodObjectFromPodOptions(ctx context.Context, cli kubernetes.Interface, o
 // name. This should be used whenever we create pods for Kanister functions.
 func ContainerNameFromPodOptsOrDefault(po *PodOptions) string {
 	if po == nil || po.ContainerName == "" {
-		return defaultContainerName
+		return DefaultContainerName
 	}
 
 	return po.ContainerName

--- a/pkg/kube/pod_test.go
+++ b/pkg/kube/pod_test.go
@@ -239,7 +239,7 @@ func (s *PodSuite) TestPod(c *C) {
 		case po.ContainerName != "":
 			c.Assert(pod.Spec.Containers[0].Name, Equals, po.ContainerName)
 		default:
-			c.Assert(pod.Spec.Containers[0].Name, Equals, defaultContainerName)
+			c.Assert(pod.Spec.Containers[0].Name, Equals, DefaultContainerName)
 		}
 
 		switch {
@@ -1018,7 +1018,7 @@ func (s *PodControllerTestSuite) TestContainerNameFromPodOptsOrDefault(c *C) {
 		},
 		{
 			podOptsContainerName:  "",
-			expectedContainerName: defaultContainerName,
+			expectedContainerName: DefaultContainerName,
 		},
 	} {
 		name := ContainerNameFromPodOptsOrDefault(&PodOptions{
@@ -1028,8 +1028,8 @@ func (s *PodControllerTestSuite) TestContainerNameFromPodOptsOrDefault(c *C) {
 	}
 
 	name := ContainerNameFromPodOptsOrDefault(&PodOptions{})
-	c.Assert(name, Equals, defaultContainerName)
+	c.Assert(name, Equals, DefaultContainerName)
 
 	name = ContainerNameFromPodOptsOrDefault(nil)
-	c.Assert(name, Equals, defaultContainerName)
+	c.Assert(name, Equals, DefaultContainerName)
 }


### PR DESCRIPTION
## Change Overview

Expose DefaultContainerName so that it could be used by external consumers.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
