### PR TITLE
Build kanister-tools Go binaries in fipsonly mode

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,9 +24,11 @@ builds:
   - amd64
 - id: kando
   binary: kando
-  main: cmd/kando/main.go
+  main: ./cmd/kando
   ldflags: *ldflags
   env: *env
+  tags:
+  - fipsonly
   goos: &goos
   - linux
   goarch: *goarch

--- a/cmd/kando/fipsonly.go
+++ b/cmd/kando/fipsonly.go
@@ -1,0 +1,19 @@
+// Copyright 2019 The Kanister Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build fipsonly
+
+package main
+
+import _ "crypto/tls/fipsonly" // Required for enabling fips only mode

--- a/docker/tools/Dockerfile
+++ b/docker/tools/Dockerfile
@@ -17,8 +17,11 @@ ENV GITHUB_REPOSITORY=https://github.com/restic/restic
 
 WORKDIR /restic
 
-RUN git checkout v0.16.2
-RUN go run build.go
+RUN git checkout v0.16.2 && \
+    echo 'package main' > cmd/restic/fipsonly.go && \
+    echo 'import _ "crypto/tls/fipsonly"' >> cmd/restic/fipsonly.go
+# use debug flag to preserve symbols
+RUN go run build.go --tags debug
 
 # Build kopia binary from specific commit
 WORKDIR /

--- a/docker/tools/Dockerfile
+++ b/docker/tools/Dockerfile
@@ -32,7 +32,9 @@ ENV GITHUB_REPOSITORY=https://github.com/${kopia_repo_org}/kopia
 
 WORKDIR /kopia
 
-RUN git checkout ${kopia_build_commit}
+RUN git checkout ${kopia_build_commit} && \
+    echo 'package main' > fipsonly.go && \
+    echo 'import _ "crypto/tls/fipsonly"' >> fipsonly.go
 
 RUN GO111MODULE=on GOOS=linux GOARCH=amd64 go build -o kopia \
   -ldflags="-X github.com/kopia/kopia/repo.BuildVersion=$(git show --no-patch --format='%cs-%h') \


### PR DESCRIPTION
## Change Overview

The `kanister-tools` image is shipped with 3 binaries - `restic`, `kopia` and `kando`. They are already built to use the
`goboring` library. This PR makes changes to restrict all TLS configurations to FIPS-approved settings for these binaries.

- Modified `docker/tools/Dockerfile` for building `restic` and  `kopia` in fipsonly mode
- Added `cmd/kando/fipsonly.go` and updated `.goreleaser.yaml` for building `kando` in fipsonly mode

## Pull request type

- [X] :rainbow: Refactoring (no functional changes, no api changes)
- [X] :hamster: Trivial/Minor

## Test Plan

- [X] :muscle: Manual

Manually verified that the `kanister-tools` binaries were built in fipsonly mode using the `goversion` tool.

- Built `kando` in a Linux container:
  ```
  $ goreleaser build --id kando --rm-dist --debug --snapshot
  ```
- Copied newly built `kando` and `LICENSE` (from root folder) to `docker/tools` folder
- Built fipsonly `kanister-tools` image:
  ```
  $ docker build -t kanister-tools docker/tools
  ```
- Copied binaries over from `kanister-tools` container:
  ```
  $ docker create --name debug kanister-tools
  
  $ docker cp debug:/usr/local/bin/restic .
  $ docker cp debug:/usr/local/bin/kopia .
  $ docker cp debug:/usr/local/bin/kando .
  ```
- Verified binaries were in fipsonly mode:
  ```
  $ goversion --crypto restic | grep fips     
  restic go1.21.4 X:boringcrypto (standard crypto) +crypto/tls/fipsonly
  
  $ goversion --crypto kando | grep fips
  kando go1.21.3 X:boringcrypto (boring crypto) +crypto/tls/fipsonly
  
  $ goversion --crypto kopia | grep fips
  kopia go1.21.4 X:boringcrypto (boring crypto) +crypto/tls/fipsonly
  ```
  The `goversion` tool was installed from the `master` branch of `https://github.com/rsc/goversion`.
