### PR TITLE
Specify platform as `linux/${ARCH}` when cross-building docker images

### DIFF
--- a/build/package.sh
+++ b/build/package.sh
@@ -30,7 +30,12 @@ build_licenses_info_image() {
     elif grep docker /proc/1/cgroup -qa; then
         mount_cmd="--volumes-from $(grep docker -m 1 /proc/self/cgroup|cut -d/ -f3)"
     fi
+    if [ -z "${ARCH:-""}" ]; then
+        echo "ARCH must be set"
+        exit 1
+    fi
     docker run --rm ${mount_cmd} \
+        --platform linux/${ARCH}\
         "ghcr.io/kanisterio/license-extractor:4e0a91a" \
         --mode merge \
         --source ${src_dir} \
@@ -66,5 +71,5 @@ sed                                \
     -e "s|ARG_ARCH|${ARCH}|g"      \
     -e "s|ARG_SOURCE_BIN|${SOURCE_BIN}|g" \
     Dockerfile.in > .dockerfile-${ARCH}
-docker buildx build --push --pull --sbom=true ${baseimagearg:-} --build-arg kanister_version=${VERSION} -t ${IMAGE}:${VERSION} -f .dockerfile-${ARCH} .
+docker buildx build --push --pull --sbom=true ${baseimagearg:-} --build-arg kanister_version=${VERSION} -t ${IMAGE}:${VERSION} --platform linux/${ARCH}  -f .dockerfile-${ARCH} .
 docker images -q ${IMAGE}:${VERSION}


### PR DESCRIPTION
## Change Overview

When using arch specific dockerfiles it's also necessary to specify `--platform` flag. Otherwise dockerx can build arm image with x86_64 binaries, which may not work properly in deployment.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #2091 (potentially)

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E

To test run on arm64 arch (M1/M2 mac):
```
make build-controller
make release-controller VERSION=test_arch
```

Then check produced image:
```
docker image inspect kanisterio/controller:test_arch  | grep architecture
```
Without changes:
```
"architecture": "aarch64",
```
With changes
```
"architecture": "x86_64",
```

To run full test follow the steps in https://github.com/kanisterio/kanister/issues/2091
