### PR TITLE
Retry on transient error when waiting for snapshot to be ready

### DIFF
--- a/pkg/kube/snapshot/snapshot_alpha.go
+++ b/pkg/kube/snapshot/snapshot_alpha.go
@@ -320,8 +320,10 @@ func (sna *SnapshotAlpha) CreateContentFromSource(ctx context.Context, source *S
 
 // WaitOnReadyToUse will block until the Volumesnapshot in namespace 'namespace' with name 'snapshotName'
 // has status 'ReadyToUse' or 'ctx.Done()' is signalled.
+// FIXME: merge this with beta wait
 func (sna *SnapshotAlpha) WaitOnReadyToUse(ctx context.Context, snapshotName, namespace string) error {
-	return poll.Wait(ctx, func(context.Context) (bool, error) {
+	retries := 100
+	return poll.WaitWithRetries(ctx, retries, isTransientError, func(context.Context) (bool, error) {
 		us, err := sna.dynCli.Resource(v1alpha1.VolSnapGVR).Namespace(namespace).Get(ctx, snapshotName, metav1.GetOptions{})
 		if err != nil {
 			return false, err

--- a/pkg/kube/snapshot/snapshot_beta.go
+++ b/pkg/kube/snapshot/snapshot_beta.go
@@ -305,7 +305,8 @@ func (sna *SnapshotBeta) WaitOnReadyToUse(ctx context.Context, snapshotName, nam
 }
 
 func waitOnReadyToUse(ctx context.Context, dynCli dynamic.Interface, snapGVR schema.GroupVersionResource, snapshotName, namespace string) error {
-	return poll.Wait(ctx, func(context.Context) (bool, error) {
+	retries := 100
+	return poll.WaitWithRetries(ctx, retries, isTransientError, func(context.Context) (bool, error) {
 		us, err := dynCli.Resource(snapGVR).Namespace(namespace).Get(ctx, snapshotName, metav1.GetOptions{})
 		if err != nil {
 			return false, err

--- a/pkg/kube/snapshot/snapshot_test.go
+++ b/pkg/kube/snapshot/snapshot_test.go
@@ -364,6 +364,157 @@ func (s *SnapshotTestSuite) TestVolumeSnapshotCloneFake(c *C) {
 	}
 }
 
+func (s *SnapshotTestSuite) TestWaitOnReadyToUse(c *C) {
+	snapshotName := "snap-1-fake"
+	volName := "pvc-1-fake"
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: "snapshot.storage.k8s.io", Version: "v1alpha1", Kind: "VolumeSnapshotClassList"}, &unstructured.UnstructuredList{})
+	scheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: "snapshot.storage.k8s.io", Version: "v1beta1", Kind: "VolumeSnapshotClassList"}, &unstructured.UnstructuredList{})
+	scheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: "snapshot.storage.k8s.io", Version: "v1", Kind: "VolumeSnapshotClassList"}, &unstructured.UnstructuredList{})
+
+	fakeCli := fake.NewSimpleClientset()
+
+	size, err := resource.ParseQuantity("1Gi")
+	c.Assert(err, IsNil)
+
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: volName,
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: size,
+				},
+			},
+		},
+	}
+	_, err = fakeCli.CoreV1().PersistentVolumeClaims(defaultNamespace).Create(context.TODO(), pvc, metav1.CreateOptions{})
+	c.Assert(err, IsNil)
+
+	dynCli := dynfake.NewSimpleDynamicClient(scheme)
+
+	for _, fakeSs := range []snapshot.Snapshotter{
+		snapshot.NewSnapshotAlpha(fakeCli, dynCli),
+		snapshot.NewSnapshotBeta(fakeCli, dynCli),
+		snapshot.NewSnapshotStable(fakeCli, dynCli),
+	} {
+		ctx := context.Background()
+
+		var volumeSnapshotGVR schema.GroupVersionResource
+		switch fakeSs.(type) {
+		case *snapshot.SnapshotAlpha:
+			volumeSnapshotGVR = v1alpha1.VolSnapGVR
+			snapshotName = snapshotName + "-alpha"
+		case *snapshot.SnapshotBeta:
+			volumeSnapshotGVR = v1beta1.VolSnapGVR
+			snapshotName = snapshotName + "-beta"
+		case *snapshot.SnapshotStable:
+			volumeSnapshotGVR = snapshot.VolSnapGVR
+			snapshotName = snapshotName + "-stable"
+		}
+
+		err = fakeSs.Create(ctx, snapshotName, defaultNamespace, volName, &fakeClass, false, nil)
+		c.Assert(err, IsNil)
+
+		// This function should timeout
+		timeout := 500 * time.Millisecond
+		bgTimeout := 5 * time.Second
+		// We don't have readyToUse and no error, waiting indefinitely
+		err = waitOnReadyToUseWithTimeout(c, ctx, fakeSs, snapshotName, defaultNamespace, timeout)
+		c.Assert(err, NotNil)
+		c.Assert(err.Error(), Matches, ".*context deadline exceeded*")
+
+		reply := waitOnReadyToUseInBackground(c, ctx, fakeSs, snapshotName, defaultNamespace, bgTimeout)
+		setReadyStatus(c, dynCli, volumeSnapshotGVR, snapshotName, defaultNamespace)
+		select {
+		case err = <-reply:
+			c.Assert(err, IsNil)
+		case <-time.After(2 * time.Second):
+			c.Error("timeout waiting on ready to use")
+		}
+
+		setVolumeSnapshotStatus(c, dynCli, volumeSnapshotGVR, snapshotName, defaultNamespace, nil)
+
+		// Set non-transient error
+		message := "some error"
+		setErrorStatus(c, dynCli, volumeSnapshotGVR, snapshotName, defaultNamespace, message)
+
+		// If there is non-transient error, exit right away
+		err = waitOnReadyToUseWithTimeout(c, ctx, fakeSs, snapshotName, defaultNamespace, timeout)
+		c.Assert(err, NotNil)
+		c.Assert(err.Error(), Matches, ".*some error.*")
+
+		// Set transient error
+		message = "the object has been modified; please apply your changes to the latest version and try again"
+		setErrorStatus(c, dynCli, volumeSnapshotGVR, snapshotName, defaultNamespace, message)
+
+		// If there is a transient error, wait with exp backoff which is long
+		err = waitOnReadyToUseWithTimeout(c, ctx, fakeSs, snapshotName, defaultNamespace, timeout)
+		c.Assert(err, NotNil)
+		c.Assert(err.Error(), Matches, ".*context deadline exceeded*")
+
+		reply = waitOnReadyToUseInBackground(c, ctx, fakeSs, snapshotName, defaultNamespace, bgTimeout)
+		setReadyStatus(c, dynCli, volumeSnapshotGVR, snapshotName, defaultNamespace)
+		select {
+		case err = <-reply:
+			c.Assert(err, IsNil)
+		case <-time.After(2 * time.Second):
+			c.Error("timeout waiting on ready to use")
+		}
+	}
+}
+
+// Helpers to work with volume snapshot status used in TestWaitOnReadyToUse
+// ----------------------------------------------------------------------------
+
+func waitOnReadyToUseInBackground(c *C, ctx context.Context, fakeSs snapshot.Snapshotter, snapshotName string, namespace string, timeout time.Duration) chan error {
+	reply := make(chan error)
+	go func() {
+		err := waitOnReadyToUseWithTimeout(c, ctx, fakeSs, snapshotName, namespace, timeout)
+		reply <- err
+	}()
+	return reply
+}
+
+func waitOnReadyToUseWithTimeout(c *C, ctx context.Context, fakeSs snapshot.Snapshotter, snapshotName string, namespace string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	deadlineCtx, cancel := context.WithDeadline(ctx, deadline)
+	defer cancel()
+
+	err := fakeSs.WaitOnReadyToUse(deadlineCtx, snapshotName, defaultNamespace)
+	return err
+}
+
+func setReadyStatus(c *C, dynCli *dynfake.FakeDynamicClient, volumeSnapshotGVR schema.GroupVersionResource, snapshotName string, namespace string) {
+	status := make(map[string]interface{})
+	status["readyToUse"] = true
+	status["creationTime"] = time.Now().Format(time.RFC3339)
+
+	setVolumeSnapshotStatus(c, dynCli, volumeSnapshotGVR, snapshotName, namespace, status)
+}
+
+func setErrorStatus(c *C, dynCli *dynfake.FakeDynamicClient, volumeSnapshotGVR schema.GroupVersionResource, snapshotName string, namespace string, message string) {
+	status := make(map[string]interface{})
+	status["Error"] = map[string]interface{}{
+		"Message": message,
+	}
+	setVolumeSnapshotStatus(c, dynCli, volumeSnapshotGVR, snapshotName, namespace, status)
+}
+
+func setVolumeSnapshotStatus(c *C, dynCli *dynfake.FakeDynamicClient, volumeSnapshotGVR schema.GroupVersionResource, snapshotName string, namespace string, status map[string]interface{}) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	us, err := dynCli.Resource(volumeSnapshotGVR).Namespace(namespace).Get(ctx, snapshotName, metav1.GetOptions{})
+	c.Assert(err, IsNil)
+	us.Object["status"] = status
+	_, err = dynCli.Resource(volumeSnapshotGVR).Namespace(namespace).UpdateStatus(ctx, us, metav1.UpdateOptions{})
+	c.Assert(err, IsNil)
+}
+
+// ----------------------------------------------------------------------------
+
 func (s *SnapshotTestSuite) TestVolumeSnapshotAlpha(c *C) {
 	if s.snapshotClassAlpha == nil {
 		c.Skip("No v1alpha1 Volumesnapshotclass in the cluster")


### PR DESCRIPTION
## Change Overview

CSI snapshot controller might add errors to the snapshot status which it will recover from.

Make snapshotter.WaitOnReadyToUse retry (up to 100 times) on those errors. Backoff mechanism makes it so 100 retries is minutes, hopefuly should be enough for most cases.

Unfortunately CSI snapshotter uses strings to inform of error reason and does not provide error code or type when reporting, hence for now we use regexp to match on transient error. If CSI snapshotter uses better error format in the future, we can also change that.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test


## Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E

## Follow up

Need to run some integration tests and monitor future issues in case we need to adjust the backoff retries count.
Monitor https://github.com/kubernetes-csi/external-snapshotter/issues/748 as those improvements could reduce the chance of errors (probably won't eliminate them completely though)
Monitor https://github.com/kubernetes-csi/external-snapshotter/issues/970 if there are improvements to the format of error
