### PR TITLE
Set original replica count as op artifact for `ScaleWorkload` fun

### DIFF
--- a/docs/functions.rst
+++ b/docs/functions.rst
@@ -147,7 +147,9 @@ Example:
 ScaleWorkload
 -------------
 
-ScaleWorkload is used to scale up or scale down a Kubernetes workload.
+ScaleWorkload is used to scale up or scale down a Kubernetes workload. It
+also sets the original replica count of the workload as output artifact with
+the key ``originalReplicaCount``.
 The function only returns after the desired replica state is achieved:
 
 * When reducing the replica count, wait until all terminating pods
@@ -155,7 +157,8 @@ The function only returns after the desired replica state is achieved:
 
 * When increasing the replica count, wait until all pods are ready.
 
-Currently the function supports Deployments and StatefulSets.
+Currently the function supports Deployments, StatefulSets and
+DeploymentConfigs.
 
 It is similar to running
 
@@ -165,7 +168,8 @@ It is similar to running
 
 This can be useful if the workload needs to be shutdown before processing
 certain data operations. For example, it may be useful to use ``ScaleWorkload``
-to stop a database process before restoring files.
+to stop a database process before restoring files. See
+:ref:`scaleworkloadexample` for an example with new ``ScaleWorkload`` function.
 
 .. csv-table::
    :header: "Argument", "Required", "Type", "Description"

--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -8,3 +8,4 @@ Tasks
    tasks/argo.rst
    tasks/logs_level.rst
    tasks/logs.rst
+   tasks/scaleworkload.rst

--- a/docs/tasks/scaleworkload.rst
+++ b/docs/tasks/scaleworkload.rst
@@ -1,0 +1,50 @@
+.. _scaleworkloadexample:
+
+Using ScaleWorkload function with output artifact
+-------------------------------------------------
+
+Traditionally, when ``ScaleWorkload`` functions were used to scale down the
+workload, it was required to get the original replica count of the workload and
+set it as output artifact. So that it can later be used to scale up the
+workload to same number of replicas.
+
+After the new changes, the ``ScaleWorkload`` function automatically sets the
+original replica count of the workload as output artifact, which makes using
+``ScaleWorkload`` function in blueprints a lot easier.
+
+Below is an example of how this function can be used
+
+
+.. code-block:: yaml
+
+  apiVersion: cr.kanister.io/v1alpha1
+  kind: Blueprint
+  metadata:
+    name: my-blueprint
+  actions:
+    backup:
+      outputArtifacts:
+        backupOutput:
+          keyValue:
+            origReplicas: "{{ .Phases.shutdownPod.Output.originalReplicaCount }}"
+      phases:
+      # before scaling replicas 0, ScaleWorkload will get the original replica count
+      # to set that as output artifact (originalReplicaCount)
+      - func: ScaleWorkload
+        name: shutdownPod
+        args:
+          namespace: "{{ .StatefulSet.Namespace }}"
+          name: "{{ .StatefulSet.Name }}"
+          kind: StatefulSet
+          replicas: 0 # this is the replica count, the STS will scaled to
+    restore:
+      inputArtifactNames:
+        - backupOutput
+      phases:
+      - func: ScaleWorkload
+        name: bringUpPod
+        args:
+          namespace: "{{ .StatefulSet.Namespace }}"
+          name: "{{ .StatefulSet.Name }}"
+          kind: StatefulSet
+          replicas: "{{ .ArtifactsIn.backupOutput.KeyValue.origReplicas }}"

--- a/docs/tasks/scaleworkload.rst
+++ b/docs/tasks/scaleworkload.rst
@@ -3,14 +3,10 @@
 Using ScaleWorkload function with output artifact
 -------------------------------------------------
 
-Traditionally, when ``ScaleWorkload`` functions were used to scale down the
-workload, it was required to get the original replica count of the workload and
-set it as output artifact. So that it can later be used to scale up the
-workload to same number of replicas.
-
-After the new changes, the ``ScaleWorkload`` function automatically sets the
-original replica count of the workload as output artifact, which makes using
-``ScaleWorkload`` function in blueprints a lot easier.
+``ScaleWorkload`` function can be used to scale a workload to specified
+replicas. It automatically sets the original replica count of the workload
+as output artifact, which makes using ``ScaleWorkload`` function in blueprints
+a lot easier.
 
 Below is an example of how this function can be used
 

--- a/pkg/function/scale_workload.go
+++ b/pkg/function/scale_workload.go
@@ -85,33 +85,33 @@ func (s *scaleWorkloadFunc) Exec(ctx context.Context, tp param.TemplateParams, a
 	}
 	switch strings.ToLower(s.kind) {
 	case param.StatefulSetKind:
-		count, err := kube.StatefulSetReplicas(ctx, cli, namespace, name)
+		count, err := kube.StatefulSetReplicas(ctx, cli, s.namespace, s.name)
 		if err != nil {
 			return nil, err
 		}
 		return map[string]interface{}{
 			outputArtifactOriginalReplicaCount: count,
-		}, kube.ScaleStatefulSet(ctx, cli, namespace, name, replicas, waitForReady)
+		}, kube.ScaleStatefulSet(ctx, cli, s.namespace, s.name, s.replicas, s.waitForReady)
 	case param.DeploymentKind:
-		count, err := kube.DeploymentReplicas(ctx, cli, namespace, name)
+		count, err := kube.DeploymentReplicas(ctx, cli, s.namespace, s.name)
 		if err != nil {
 			return nil, err
 		}
 		return map[string]interface{}{
 			outputArtifactOriginalReplicaCount: count,
-		}, kube.ScaleDeployment(ctx, cli, namespace, name, replicas, waitForReady)
+		}, kube.ScaleDeployment(ctx, cli, s.namespace, s.name, s.replicas, s.waitForReady)
 	case param.DeploymentConfigKind:
 		osCli, err := osversioned.NewForConfig(cfg)
 		if err != nil {
 			return nil, errors.Wrapf(err, "Failed to create OpenShift client")
 		}
-		count, err := kube.DeploymentConfigReplicas(ctx, osCli, namespace, name)
+		count, err := kube.DeploymentConfigReplicas(ctx, osCli, s.namespace, s.name)
 		if err != nil {
 			return nil, err
 		}
 		return map[string]interface{}{
 			outputArtifactOriginalReplicaCount: count,
-		}, kube.ScaleDeploymentConfig(ctx, cli, osCli, namespace, name, replicas, waitForReady)
+		}, kube.ScaleDeploymentConfig(ctx, cli, osCli, s.namespace, s.name, s.replicas, s.waitForReady)
 	}
 	return nil, errors.New("Workload type not supported " + s.kind)
 }

--- a/pkg/function/scale_workload.go
+++ b/pkg/function/scale_workload.go
@@ -40,6 +40,8 @@ const (
 	ScaleWorkloadKindArg      = "kind"
 	ScaleWorkloadReplicas     = "replicas"
 	ScaleWorkloadWaitArg      = "waitForReady"
+
+	outputArtifactOriginalReplicaCount = "originalReplicaCount"
 )
 
 func init() {
@@ -83,15 +85,33 @@ func (s *scaleWorkloadFunc) Exec(ctx context.Context, tp param.TemplateParams, a
 	}
 	switch strings.ToLower(s.kind) {
 	case param.StatefulSetKind:
-		return nil, kube.ScaleStatefulSet(ctx, cli, s.namespace, s.name, s.replicas, s.waitForReady)
+		count, err := kube.StatefulSetReplicas(ctx, cli, namespace, name)
+		if err != nil {
+			return nil, err
+		}
+		return map[string]interface{}{
+			outputArtifactOriginalReplicaCount: count,
+		}, kube.ScaleStatefulSet(ctx, cli, namespace, name, replicas, waitForReady)
 	case param.DeploymentKind:
-		return nil, kube.ScaleDeployment(ctx, cli, s.namespace, s.name, s.replicas, s.waitForReady)
+		count, err := kube.DeploymentReplicas(ctx, cli, namespace, name)
+		if err != nil {
+			return nil, err
+		}
+		return map[string]interface{}{
+			outputArtifactOriginalReplicaCount: count,
+		}, kube.ScaleDeployment(ctx, cli, namespace, name, replicas, waitForReady)
 	case param.DeploymentConfigKind:
 		osCli, err := osversioned.NewForConfig(cfg)
 		if err != nil {
 			return nil, errors.Wrapf(err, "Failed to create OpenShift client")
 		}
-		return nil, kube.ScaleDeploymentConfig(ctx, cli, osCli, s.namespace, s.name, s.replicas, s.waitForReady)
+		count, err := kube.DeploymentConfigReplicas(ctx, osCli, namespace, name)
+		if err != nil {
+			return nil, err
+		}
+		return map[string]interface{}{
+			outputArtifactOriginalReplicaCount: count,
+		}, kube.ScaleDeploymentConfig(ctx, cli, osCli, namespace, name, replicas, waitForReady)
 	}
 	return nil, errors.New("Workload type not supported " + s.kind)
 }

--- a/pkg/kube/workload.go
+++ b/pkg/kube/workload.go
@@ -514,3 +514,28 @@ func IsPodRunning(cli kubernetes.Interface, podName, podNamespace string) (bool,
 
 	return true, nil
 }
+
+func StatefulSetReplicas(ctx context.Context, kubeCli kubernetes.Interface, namespace, name string) (int32, error) {
+	sts, err := kubeCli.AppsV1().StatefulSets(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return 0, errors.Wrapf(err, "Could not get STS{Namespace %s, Name: %s}, to figure out replicas", namespace, name)
+	}
+	return *sts.Spec.Replicas, nil
+}
+
+func DeploymentReplicas(ctx context.Context, kubeCli kubernetes.Interface, namespace, name string) (int32, error) {
+	d, err := kubeCli.AppsV1().Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return 0, errors.Wrapf(err, "Could not get Deployment{Namespace %s, Name: %s}, to figure out replicas", namespace, name)
+	}
+	return *d.Spec.Replicas, nil
+}
+
+func DeploymentConfigReplicas(ctx context.Context, osCli osversioned.Interface, namespace, name string) (int32, error) {
+	dc, err := osCli.AppsV1().DeploymentConfigs(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return 0, errors.Wrapf(err, "Could not get DeploymentConfig{Namespace %s, Name: %s}, to figure out replicas", namespace, name)
+	}
+
+	return dc.Spec.Replicas, nil
+}

--- a/pkg/kube/workload.go
+++ b/pkg/kube/workload.go
@@ -518,7 +518,7 @@ func IsPodRunning(cli kubernetes.Interface, podName, podNamespace string) (bool,
 func StatefulSetReplicas(ctx context.Context, kubeCli kubernetes.Interface, namespace, name string) (int32, error) {
 	sts, err := kubeCli.AppsV1().StatefulSets(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
-		return 0, errors.Wrapf(err, "Could not get STS{Namespace %s, Name: %s}, to figure out replicas", namespace, name)
+		return 0, errors.Wrapf(err, "Could not get StatefulSet{Namespace %s, Name: %s}, to figure out replicas", namespace, name)
 	}
 	return *sts.Spec.Replicas, nil
 }
@@ -536,6 +536,5 @@ func DeploymentConfigReplicas(ctx context.Context, osCli osversioned.Interface, 
 	if err != nil {
 		return 0, errors.Wrapf(err, "Could not get DeploymentConfig{Namespace %s, Name: %s}, to figure out replicas", namespace, name)
 	}
-
 	return dc.Spec.Replicas, nil
 }


### PR DESCRIPTION
## Change Overview

This PR updates the `ScaleWorkload` function in such a way that it now outputs the original replica count of the workload
as output artifact.
After this change, users don't need to figure out the replica count of the workload and set that as output artifact using kando. This will simplify how we use `ScaleWorkload` function in blueprints.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #2443 

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
