### PR TITLE
Optimizations for main build workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,3 +1,4 @@
+name: Build and test
 on:
   push:
     branches:
@@ -8,37 +9,52 @@ on:
 jobs:
   gomod:
     runs-on: ubuntu-20.04
+    outputs:
+      gomod: ${{ steps.gomod.outputs.gomod }}
+      gosum: ${{ steps.gosum.outputs.gosum }}
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
     - run: make go-mod-tidy
-    - run: make go-mod-download
-    - run: tar -cvf ./src.tar.gz ./ # preserve file permissions
-    - uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
-      with:
-        name: src
-        path: ./src.tar.gz
+    - id: gomod
+      run: |
+        {
+          echo 'gomod<<FILE'
+          cat go.mod
+          echo
+          echo FILE
+        } >> "$GITHUB_OUTPUT"
+    - id: gosum
+      run: |
+        {
+          echo 'gosum<<FILE'
+          cat go.sum
+          echo
+          echo FILE
+        } >> "$GITHUB_OUTPUT"
   lint:
     runs-on: ubuntu-20.04
     needs: gomod
     steps:
-    - uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
-      with:
-        name: src
-    - run: tar -xvf ./src.tar.gz
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    - name: restore_gomod
+      run: echo "${{needs.gomod.outputs.gomod}}" > go.mod
+    - name: restore_gosum
+      run: echo "${{needs.gomod.outputs.gosum}}" > go.sum
     - run: make golint
   test:
     runs-on: ubuntu-20.04
-    needs: [gomod, lint]
+    needs: gomod
     strategy:
       fail-fast: false
       matrix:
         testSuite: [test, integration-test, helm-test]
     steps:
-    - uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
-      with:
-        name: src
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    - name: restore_gomod
+      run: echo "${{needs.gomod.outputs.gomod}}" > go.mod
+    - name: restore_gosum
+      run: echo "${{needs.gomod.outputs.gosum}}" > go.sum
     - uses: helm/kind-action@v1.8.0
-    - run: tar -xvf ./src.tar.gz
     - run: |
         make install-csi-hostpath-driver
         make install-minio
@@ -53,35 +69,31 @@ jobs:
     - run: make ${{ matrix.testSuite }}
   build:
     runs-on: ubuntu-20.04
-    needs: [gomod, lint, test]
+    needs: gomod
     strategy:
       matrix:
         bin: [controller, kanctl, kando]
     steps:
-    - uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
-      with:
-        name: src
-    - run: tar -xvf ./src.tar.gz
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    - name: restore_gomod
+      run: echo "${{needs.gomod.outputs.gomod}}" > go.mod
+    - name: restore_gosum
+      run: echo "${{needs.gomod.outputs.gosum}}" > go.sum
     - run: make build BIN=${{ matrix.bin }} GOBORING=true
   docs:
     runs-on: ubuntu-20.04
-    needs: gomod
     steps:
-    - uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
-      with:
-        name: src
-    - run: tar -xvf ./src.tar.gz
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
     - run: make docs
   release:
     runs-on: ubuntu-20.04
-    needs: [test, build]
+    needs: [lint, test, build, docs]
     if: github.ref_name == 'master' || startsWith(github.ref, 'refs/tags')
     permissions:
       packages: write
     steps:
-    - uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
-      with:
-        name: src
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    - run: make go-mod-tidy
     - uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
       with:
         registry: ghcr.io
@@ -89,6 +101,5 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     - run: sudo rm -rf /usr/share/dotnet
     - run: sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-    - run: tar -xvf ./src.tar.gz
     - run: make release-snapshot
     - run: ./build/push_images.sh

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -7,6 +7,8 @@ on:
     branches:
     - master
 jobs:
+  ## Make sure go.mod and go.sum files are up-to-date with the code
+  ## TODO: make this fail if they're not up-to-date to inform the committer to udpate them
   gomod:
     runs-on: ubuntu-20.04
     outputs:
@@ -36,6 +38,7 @@ jobs:
     needs: gomod
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    ## Sync go.mod and go.sum files from gomod job
     - name: restore_gomod
       run: echo "${{needs.gomod.outputs.gomod}}" > go.mod
     - name: restore_gosum
@@ -50,6 +53,7 @@ jobs:
         testSuite: [test, integration-test, helm-test]
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    ## Sync go.mod and go.sum files from gomod job
     - name: restore_gomod
       run: echo "${{needs.gomod.outputs.gomod}}" > go.mod
     - name: restore_gosum
@@ -75,6 +79,7 @@ jobs:
         bin: [controller, kanctl, kando]
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    ## Sync go.mod and go.sum files from gomod job
     - name: restore_gomod
       run: echo "${{needs.gomod.outputs.gomod}}" > go.mod
     - name: restore_gosum

--- a/build/test.sh
+++ b/build/test.sh
@@ -78,7 +78,6 @@ check_dependencies() {
 check_dependencies
 
 echo "Running tests:"
-go test -v -installsuffix "static" ${TARGETS}
 go test -v ${TARGETS} -list .
 go test -v -installsuffix "static" ${TARGETS} -check.v
 echo


### PR DESCRIPTION
## Change Overview

Trying to reduce time it takes to run the CI workflow. 
Currently packing and unpacking entire directory takes a long time. It's faster to just download the go dependencies.

Current changes:
- Don't pack entire dir on gomod job, only pass the go.mod and go.sum files as outputs
- Make `lint`, `test`, `build` and `docs` steps run in parallel
- Remove double invocation of `go test` in `test.sh`, this was left over from the time when test build was separate from test run, no longer required

These changes do not include any caching proposed in https://github.com/kanisterio/kanister/pull/2352 but already cut the pipeline time more then 2 times so it make sense to merge that first and then work on caching as a follow-up

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [x] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test


## Test Plan

Run the pipeline.

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
