### PR TITLE
Update golangci-lint to v1.55, fix lint errors

### DIFF
--- a/build/run_container.sh
+++ b/build/run_container.sh
@@ -23,7 +23,7 @@ set -o nounset
 PWD="${PWD:-$(pwd)}"
 
 DOCS_BUILD_IMAGE="${DOCS_BUILD_IMAGE:-ghcr.io/kanisterio/docker-sphinx:0.2.0}"
-BUILD_IMAGE="${BUILD_IMAGE:-ghcr.io/kanisterio/build:v0.0.25}"
+BUILD_IMAGE="${BUILD_IMAGE:-ghcr.io/kanisterio/build:v0.0.26}"
 PKG="${PKG:-github.com/kanisterio/kanister}"
 
 ARCH="${ARCH:-amd64}"

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -16,7 +16,7 @@ COPY --from=goreleaser/goreleaser:v1.12.3 /usr/bin/goreleaser /usr/local/bin/
 
 COPY --from=alpine/helm:3.12.2 /usr/bin/helm /usr/local/bin/
 
-COPY --from=golangci/golangci-lint:v1.51.2 /usr/bin/golangci-lint /usr/local/bin/
+COPY --from=golangci/golangci-lint:v1.55 /usr/bin/golangci-lint /usr/local/bin/
 
 RUN wget -O /usr/local/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/v0.18.0/kind-linux-amd64 \
     && chmod +x /usr/local/bin/kind

--- a/pkg/controllers/repositoryserver/handler.go
+++ b/pkg/controllers/repositoryserver/handler.go
@@ -341,47 +341,47 @@ func (h *RepoServerHandler) updateRepoServerProgress(ctx context.Context, progre
 	return nil
 }
 
-func (h *RepoServerHandler) setupKopiaRepositoryServer(ctx context.Context, logger logr.Logger) (ctrl.Result, error) {
+func (h *RepoServerHandler) setupKopiaRepositoryServer(ctx context.Context, logger logr.Logger) error {
 	logger.Info("Start Kopia Repository Server")
 	if err := h.startRepoProxyServer(ctx); err != nil {
 		condition := getCondition(metav1.ConditionFalse, conditionReasonServerInitializedErr, "", crkanisteriov1alpha1.ServerInitialized)
 		if uerr := h.setCondition(ctx, condition, crkanisteriov1alpha1.Failed); uerr != nil {
-			return ctrl.Result{}, uerr
+			return uerr
 		}
-		return ctrl.Result{}, err
+		return err
 	}
 
 	condition := getCondition(metav1.ConditionTrue, conditionReasonServerInitializedSuccess, "", crkanisteriov1alpha1.ServerInitialized)
 	if uerr := h.setCondition(ctx, condition, crkanisteriov1alpha1.Pending); uerr != nil {
-		return ctrl.Result{}, uerr
+		return uerr
 	}
 
 	logger.Info("Add/Update users in Kopia Repository Server")
 	if err := h.createOrUpdateClientUsers(ctx); err != nil {
 		condition := getCondition(metav1.ConditionFalse, conditionReasonClientInitializedErr, err.Error(), crkanisteriov1alpha1.ClientUserInitialized)
 		if uerr := h.setCondition(ctx, condition, crkanisteriov1alpha1.Failed); uerr != nil {
-			return ctrl.Result{}, uerr
+			return uerr
 		}
-		return ctrl.Result{}, err
+		return err
 	}
 
 	condition = getCondition(metav1.ConditionTrue, conditionReasonClientInitializedSuccess, "", crkanisteriov1alpha1.ClientUserInitialized)
 	if uerr := h.setCondition(ctx, condition, crkanisteriov1alpha1.Pending); uerr != nil {
-		return ctrl.Result{}, uerr
+		return uerr
 	}
 
 	logger.Info("Refresh Kopia Repository Server")
 	if err := h.refreshServer(ctx); err != nil {
 		condition := getCondition(metav1.ConditionFalse, conditionReasonServerRefreshedErr, err.Error(), crkanisteriov1alpha1.ServerRefreshed)
 		if uerr := h.setCondition(ctx, condition, crkanisteriov1alpha1.Failed); uerr != nil {
-			return ctrl.Result{}, uerr
+			return uerr
 		}
-		return ctrl.Result{}, err
+		return err
 	}
 
 	condition = getCondition(metav1.ConditionTrue, conditionReasonServerRefreshedSuccess, "", crkanisteriov1alpha1.ServerRefreshed)
 	if uerr := h.setCondition(ctx, condition, crkanisteriov1alpha1.Ready); uerr != nil {
-		return ctrl.Result{}, uerr
+		return uerr
 	}
-	return ctrl.Result{}, nil
+	return nil
 }

--- a/pkg/controllers/repositoryserver/repositoryserver_controller.go
+++ b/pkg/controllers/repositoryserver/repositoryserver_controller.go
@@ -118,8 +118,8 @@ func (r *RepositoryServerReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, uerr
 	}
 
-	if result, err := repoServerHandler.setupKopiaRepositoryServer(ctx, logger); err != nil {
-		return result, err
+	if err := repoServerHandler.setupKopiaRepositoryServer(ctx, logger); err != nil {
+		return ctrl.Result{}, err
 	}
 
 	return ctrl.Result{}, nil

--- a/pkg/kanctl/helper.go
+++ b/pkg/kanctl/helper.go
@@ -16,13 +16,12 @@ package kanctl
 
 import (
 	"math/rand"
-	"time"
 )
 
 const characters = "abcdefghijklmnopqrstuvwxyz0123456789"
 
 func init() {
-	rand.Seed(time.Now().UnixNano())
+
 }
 
 func randString(length int) string {


### PR DESCRIPTION
## Change Overview

Currently golangci-lint is built with go version older than the go1.21 This can cause weird linter false-positives (e.g. https://github.com/kanisterio/kanister/actions/runs/7202258335/job/19620056020)

Updated version of golangci-lint in the build image Fixed linter warnings:
- deprecated rand.Seed
- non-sensical return in setupKopiaRepositoryServer

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [x] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
