### PR TITLE
Retry on updating already existing CRD definitions

### DIFF
--- a/pkg/customresource/customresource.go
+++ b/pkg/customresource/customresource.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
 
 	// importing go check to bypass the testing flags
 	_ "gopkg.in/check.v1"
@@ -130,16 +131,22 @@ func createCRD(context Context, resource CustomResource) error {
 			return errors.Errorf("Failed to create %s CRD. %+v", resource.Name, err)
 		}
 
-		// if CRD already exists, get the resource version and create the CRD with that resource version
-		c, err := context.APIExtensionClientset.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, crd.Name, metav1.GetOptions{})
-		if err != nil {
-			return fmt.Errorf("Failed to get CRD to get resource version: %s\n", err.Error())
-		}
+		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			// if CRD already exists, get the resource version and create the CRD with that resource version
+			c, err := context.APIExtensionClientset.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, crd.Name, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
 
-		crd.ResourceVersion = c.ResourceVersion
-		_, err = context.APIExtensionClientset.ApiextensionsV1().CustomResourceDefinitions().Update(ctx, crd, metav1.UpdateOptions{})
+			crd.ResourceVersion = c.ResourceVersion
+			_, err = context.APIExtensionClientset.ApiextensionsV1().CustomResourceDefinitions().Update(ctx, crd, metav1.UpdateOptions{})
+			if err != nil {
+				return err
+			}
+			return nil
+		})
 		if err != nil {
-			return fmt.Errorf("Failed to delete already present CRD: %s\n", err.Error())
+			return fmt.Errorf("Failed to update existing CRD: %s\n", err.Error())
 		}
 	}
 	return nil


### PR DESCRIPTION
## Change Overview

When updating existing CRD definition we can run into conflict error. This happens often in the test cases. For example: https://github.com/kanisterio/kanister/actions/runs/7146506992/job/19464663550#step:7:753

Added `RetryOnConflict` from `client-go` with default parameters for update operation.
This should be good enough to reduce test flakes and should not impact the live installations.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
