### PR TITLE
Update build image's base image version to 1.21.5

### DIFF
--- a/build/run_container.sh
+++ b/build/run_container.sh
@@ -23,7 +23,7 @@ set -o nounset
 PWD="${PWD:-$(pwd)}"
 
 DOCS_BUILD_IMAGE="${DOCS_BUILD_IMAGE:-ghcr.io/kanisterio/docker-sphinx:0.2.0}"
-BUILD_IMAGE="${BUILD_IMAGE:-ghcr.io/kanisterio/build:v0.0.26}"
+BUILD_IMAGE="${BUILD_IMAGE:-ghcr.io/kanisterio/build:v0.0.27}"
 PKG="${PKG:-github.com/kanisterio/kanister}"
 
 ARCH="${ARCH:-amd64}"

--- a/build/run_container.sh
+++ b/build/run_container.sh
@@ -23,7 +23,7 @@ set -o nounset
 PWD="${PWD:-$(pwd)}"
 
 DOCS_BUILD_IMAGE="${DOCS_BUILD_IMAGE:-ghcr.io/kanisterio/docker-sphinx:0.2.0}"
-BUILD_IMAGE="${BUILD_IMAGE:-ghcr.io/kanisterio/build:v0.0.25}"
+BUILD_IMAGE="${BUILD_IMAGE:-ghcr.io/kanisterio/build:v0.0.26}"
 PKG="${PKG:-github.com/kanisterio/kanister}"
 
 ARCH="${ARCH:-amd64}"

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21-bullseye
+FROM golang:1.21.5-bullseye
 LABEL maintainer="Tom Manville<tom@kasten.io>"
 
 RUN apt-get update && apt-get -y install apt-transport-https ca-certificates bash git gnupg2 software-properties-common curl jq wget \


### PR DESCRIPTION
## Change Overview

This PR updates the base image version of our build image to 1.21.5, in order to properly update the go version of the project to 1.21.5.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

NA

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
