### PR TITLE
Change  go directive in go.mod to 1.21.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kanisterio/kanister
 
-go 1.21.3
+go 1.21.5
 
 replace (
 	github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.4.1


### PR DESCRIPTION
## Change Overview

This PR to changes the go directive of go.mod to 1.21.5, this PR along with https://github.com/kanisterio/kanister/pull/2545 would make sure that the kanister is built with go version 1.21.5.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

Build the binaries 

```
make release-snapshot
```
and make sure the go version in kanctl is 1.21.5.

```
go version -m dist/kanctl_linux_amd64_v1/kanctl
dist/kanctl_linux_amd64_v1/kanctl: go1.21.5 X:boringcrypto

```

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
