### PR TITLE
Tests optimizations

### DIFF
--- a/build/test.sh
+++ b/build/test.sh
@@ -77,9 +77,12 @@ check_dependencies() {
 
 check_dependencies
 
+echo "Listing tests:"
+go test -v ${TARGETS} -check.list .
+echo
+
 echo "Running tests:"
-go test -v ${TARGETS} -list .
-go test -v -installsuffix "static" ${TARGETS} -check.v
+go test -v -installsuffix "static" ${TARGETS} -check.v -check.suitep $(nproc --all)
 echo
 
 echo "PASS"

--- a/pkg/controller/controller_exec_action_set_test.go
+++ b/pkg/controller/controller_exec_action_set_test.go
@@ -1,0 +1,219 @@
+// This is a split from controller_test.go in order to allow
+// parallel execution of test suites
+package controller
+
+import (
+	"context"
+	"time"
+
+	kanister "github.com/kanisterio/kanister/pkg"
+	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
+	"github.com/kanisterio/kanister/pkg/poll"
+	"github.com/kanisterio/kanister/pkg/testutil"
+	"github.com/prometheus/client_golang/prometheus"
+	. "gopkg.in/check.v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type ControllerExecActionSetSuite struct {
+	base ControllerSuite
+}
+
+var _ = Suite(&ControllerExecActionSetSuite{})
+
+// This suite is a split from controller_test.go
+// We use setup and teardown functions from ControllerSuite
+func (s *ControllerExecActionSetSuite) SetUpSuite(c *C) {
+	s.base.SetUpSuite(c)
+}
+func (s *ControllerExecActionSetSuite) TearDownSuite(c *C) {
+	s.base.TearDownSuite(c)
+}
+func (s *ControllerExecActionSetSuite) SetUpTest(c *C) {
+	s.base.SetUpTest(c)
+}
+func (s *ControllerExecActionSetSuite) TearDownTest(c *C) {
+	s.base.TearDownTest(c)
+}
+
+func (s *ControllerExecActionSetSuite) TestExecActionSet(c *C) {
+	for _, pok := range []string{"StatefulSet", "Deployment"} {
+		for _, tc := range []struct {
+			funcNames        []string
+			args             [][]string
+			name             string
+			version          string
+			metricResolution string
+		}{
+			{
+				funcNames:        []string{testutil.WaitFuncName},
+				name:             "WaitFunc",
+				version:          kanister.DefaultVersion,
+				metricResolution: ACTION_SET_COUNTER_VEC_LABEL_RES_SUCCESS,
+			},
+			{
+				funcNames:        []string{testutil.WaitFuncName, testutil.WaitFuncName},
+				name:             "WaitWait",
+				version:          kanister.DefaultVersion,
+				metricResolution: ACTION_SET_COUNTER_VEC_LABEL_RES_SUCCESS,
+			},
+			{
+				funcNames:        []string{testutil.FailFuncName},
+				name:             "FailFunc",
+				version:          kanister.DefaultVersion,
+				metricResolution: ACTION_SET_COUNTER_VEC_LABEL_RES_FAILURE,
+			},
+			{
+				funcNames:        []string{testutil.WaitFuncName, testutil.FailFuncName},
+				name:             "WaitFail",
+				version:          kanister.DefaultVersion,
+				metricResolution: ACTION_SET_COUNTER_VEC_LABEL_RES_FAILURE,
+			},
+			{
+				funcNames:        []string{testutil.FailFuncName, testutil.WaitFuncName},
+				name:             "FailWait",
+				version:          kanister.DefaultVersion,
+				metricResolution: ACTION_SET_COUNTER_VEC_LABEL_RES_FAILURE,
+			},
+			{
+				funcNames:        []string{testutil.ArgFuncName},
+				name:             "ArgFunc",
+				version:          kanister.DefaultVersion,
+				metricResolution: ACTION_SET_COUNTER_VEC_LABEL_RES_SUCCESS,
+			},
+			{
+				funcNames:        []string{testutil.ArgFuncName, testutil.FailFuncName},
+				name:             "ArgFail",
+				version:          kanister.DefaultVersion,
+				metricResolution: ACTION_SET_COUNTER_VEC_LABEL_RES_FAILURE,
+			},
+			{
+				funcNames:        []string{testutil.OutputFuncName},
+				name:             "OutputFunc",
+				version:          kanister.DefaultVersion,
+				metricResolution: ACTION_SET_COUNTER_VEC_LABEL_RES_SUCCESS,
+			},
+			{
+				funcNames:        []string{testutil.CancelFuncName},
+				name:             "CancelFunc",
+				version:          kanister.DefaultVersion,
+				metricResolution: ACTION_SET_COUNTER_VEC_LABEL_RES_FAILURE,
+			},
+			{
+				funcNames:        []string{testutil.ArgFuncName},
+				name:             "ArgFuncVersion",
+				version:          testutil.TestVersion,
+				metricResolution: ACTION_SET_COUNTER_VEC_LABEL_RES_SUCCESS,
+			},
+			{
+				funcNames:        []string{testutil.ArgFuncName},
+				name:             "ArgFuncVersionFallback",
+				version:          "v1.2.3",
+				metricResolution: ACTION_SET_COUNTER_VEC_LABEL_RES_SUCCESS,
+			},
+			{
+				funcNames:        []string{testutil.ArgFuncName},
+				name:             "ArgFuncNoActionSetVersion",
+				version:          "",
+				metricResolution: ACTION_SET_COUNTER_VEC_LABEL_RES_SUCCESS,
+			},
+			{
+				funcNames:        []string{testutil.VersionMismatchFuncName},
+				name:             "VersionMismatchFunc",
+				version:          "v1.2.3",
+				metricResolution: ACTION_SET_COUNTER_VEC_LABEL_RES_FAILURE,
+			},
+			{
+				funcNames:        []string{testutil.ArgFuncName, testutil.OutputFuncName},
+				name:             "ArgOutputFallbackOnlyOutput",
+				version:          testutil.TestVersion,
+				metricResolution: ACTION_SET_COUNTER_VEC_LABEL_RES_SUCCESS,
+			},
+		} {
+			var err error
+			// Add a blueprint with a mocked kanister function.
+			bp := testutil.NewTestBlueprint(pok, tc.funcNames...)
+			bp = testutil.BlueprintWithConfigMap(bp)
+			ctx := context.Background()
+			bp, err = s.base.crCli.Blueprints(s.base.namespace).Create(ctx, bp, metav1.CreateOptions{})
+			c.Assert(err, IsNil)
+
+			oldValue := getCounterVecValue(s.base.ctrl.metrics.actionSetResolutionCounterVec, []string{tc.metricResolution})
+
+			var n string
+			switch pok {
+			case "StatefulSet":
+				n = s.base.ss.GetName()
+			case "Deployment":
+				n = s.base.deployment.GetName()
+			default:
+				c.FailNow()
+			}
+
+			// Add an actionset that references that blueprint.
+			as := testutil.NewTestActionSet(s.base.namespace, bp.GetName(), pok, n, s.base.namespace, tc.version, testAction)
+			as = testutil.ActionSetWithConfigMap(as, s.base.confimap.GetName())
+			as, err = s.base.crCli.ActionSets(s.base.namespace).Create(ctx, as, metav1.CreateOptions{})
+			c.Assert(err, IsNil, Commentf("Failed case: %s", tc.name))
+
+			final := crv1alpha1.StateComplete
+			cancel := false
+		Loop:
+			for _, fn := range tc.funcNames {
+				switch fn {
+				case testutil.FailFuncName:
+					final = crv1alpha1.StateFailed
+					c.Assert(testutil.FailFuncError().Error(), DeepEquals, "Kanister function failed", Commentf("Failed case: %s", tc.name))
+					break Loop
+				case testutil.WaitFuncName:
+					testutil.ReleaseWaitFunc()
+				case testutil.ArgFuncName:
+					c.Assert(testutil.ArgFuncArgs(), DeepEquals, map[string]interface{}{"key": "myValue"}, Commentf("Failed case: %s", tc.name))
+				case testutil.OutputFuncName:
+					c.Assert(testutil.OutputFuncOut(), DeepEquals, map[string]interface{}{"key": "myValue"}, Commentf("Failed case: %s", tc.name))
+				case testutil.CancelFuncName:
+					testutil.CancelFuncStarted()
+					err = s.base.crCli.ActionSets(s.base.namespace).Delete(context.TODO(), as.GetName(), metav1.DeleteOptions{})
+					c.Assert(err, IsNil)
+					c.Assert(testutil.CancelFuncOut().Error(), DeepEquals, "context canceled")
+					cancel = true
+				case testutil.VersionMismatchFuncName:
+					final = crv1alpha1.StateFailed
+					c.Assert(err, IsNil)
+				}
+			}
+
+			if !cancel {
+				err = s.base.waitOnActionSetState(c, as, final)
+				c.Assert(err, IsNil, Commentf("Failed case: %s", tc.name))
+				expectedValue := oldValue + 1
+				err = waitForMetrics(s.base.ctrl.metrics.actionSetResolutionCounterVec, []string{tc.metricResolution}, expectedValue, time.Second)
+				c.Assert(err, IsNil, Commentf("Failed case: %s, failed waiting for metric update to %v", tc.name, expectedValue))
+			}
+			err = s.base.crCli.Blueprints(s.base.namespace).Delete(context.TODO(), bp.GetName(), metav1.DeleteOptions{})
+			c.Assert(err, IsNil)
+			err = s.base.crCli.ActionSets(s.base.namespace).Delete(context.TODO(), as.GetName(), metav1.DeleteOptions{})
+			if !cancel {
+				c.Assert(err, IsNil)
+			} else {
+				c.Assert(err, NotNil)
+			}
+		}
+	}
+}
+
+func waitForMetrics(metrics prometheus.CounterVec, labels []string, expected float64, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	err := poll.Wait(ctx, func(context.Context) (bool, error) {
+		current := getCounterVecValue(metrics, labels)
+		if current == expected {
+			return true, nil
+		} else {
+			return false, nil
+		}
+	})
+
+	return err
+}

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -121,6 +121,8 @@ func (s *ControllerSuite) SetUpSuite(c *C) {
 	cm, err = s.cli.CoreV1().ConfigMaps(s.namespace).Create(ctx, cm, metav1.CreateOptions{})
 	c.Assert(err, IsNil)
 	s.confimap = cm
+	// We don't unset this env because we have multiple suites which would have conflicting unsetenv
+	os.Setenv(kube.PodNSEnvVar, "test")
 }
 
 func (s *ControllerSuite) TearDownSuite(c *C) {
@@ -284,7 +286,7 @@ func newBPWithDeferPhaseAndErrInDeferPhase() *crv1alpha1.Blueprint {
 					*phaseWithNameAndCMD("backupPhaseOne", []string{"kando", "output", "value", "mainValue"}),
 					*phaseWithNameAndCMD("backupPhaseTwo", []string{"kando", "output", "value", "mainValueTwo"}),
 				},
-				DeferPhase: phaseWithNameAndCMD("deferPhase", []string{"exit", "1"}),
+				DeferPhase: phaseWithNameAndCMD("deferPhase", []string{"sh", "-c", "exit 1"}),
 			},
 		},
 	}
@@ -577,8 +579,6 @@ func (s *ControllerSuite) TestRuntimeObjEventLogs(c *C) {
 }
 
 func (s *ControllerSuite) TestDeferPhase(c *C) {
-	os.Setenv(kube.PodNSEnvVar, "test")
-
 	ctx := context.Background()
 	bp := newBPWithDeferPhase()
 
@@ -627,7 +627,6 @@ func (s *ControllerSuite) TestDeferPhase(c *C) {
 // 3. Phases have correct state in actionset status
 // 4. We don't render output artifacts if any of the phases failed
 func (s *ControllerSuite) TestDeferPhaseCoreErr(c *C) {
-	os.Setenv(kube.PodNSEnvVar, "test")
 	ctx := context.Background()
 
 	bp := newBPWithDeferPhaseAndErrInCorePhase()
@@ -662,7 +661,6 @@ func (s *ControllerSuite) TestDeferPhaseCoreErr(c *C) {
 }
 
 func (s *ControllerSuite) TestDeferPhaseDeferErr(c *C) {
-	os.Setenv(kube.PodNSEnvVar, "test")
 	ctx := context.Background()
 
 	bp := newBPWithDeferPhaseAndErrInDeferPhase()
@@ -832,7 +830,6 @@ func (s *ControllerSuite) TestRenderArtifactsFailure(c *C) {
 }
 
 func (s *ControllerSuite) TestProgressRunningPhase(c *C) {
-	os.Setenv(kube.PodNSEnvVar, "test")
 	ctx := context.Background()
 
 	bp := newBPForProgressRunningPhase()

--- a/pkg/function/data_test.go
+++ b/pkg/function/data_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/resource"
 	"github.com/kanisterio/kanister/pkg/testutil"
+	"github.com/kanisterio/kanister/pkg/testutil/testmutex"
 	osversioned "github.com/openshift/client-go/apps/clientset/versioned"
 )
 
@@ -105,7 +106,7 @@ func (s *DataSuite) SetUpSuite(c *C) {
 	location.Prefix = "testBackupRestoreLocDelete"
 	location.Bucket = testBucketName
 	s.profile = testutil.ObjectStoreProfileOrSkip(c, s.providerType, location)
-
+	testmutex.PodNamespaceMutex.Lock()
 	os.Setenv("POD_NAMESPACE", s.namespace)
 	os.Setenv("POD_SERVICE_ACCOUNT", "default")
 }
@@ -119,6 +120,8 @@ func (s *DataSuite) TearDownSuite(c *C) {
 	if s.namespace != "" {
 		_ = s.cli.CoreV1().Namespaces().Delete(ctx, s.namespace, metav1.DeleteOptions{})
 	}
+	testmutex.PodNamespaceMutex.TryLock()
+	testmutex.PodNamespaceMutex.Unlock()
 }
 
 func newRestoreDataBlueprint(pvc, identifierArg, identifierVal string) *crv1alpha1.Blueprint {

--- a/pkg/function/scale_test.go
+++ b/pkg/function/scale_test.go
@@ -135,17 +135,8 @@ func (s *ScaleSuite) TestScaleDeployment(c *C) {
 	ctx := context.Background()
 	var originalReplicaCount int32 = 1
 	d := testutil.NewTestDeployment(originalReplicaCount)
-	d.Spec.Template.Spec.Containers[0].Lifecycle = &corev1.Lifecycle{
-		PreStop: &corev1.LifecycleHandler{
-			Exec: &corev1.ExecAction{
-				Command: []string{"sleep", "30"},
-			},
-		},
-	}
-
 	d, err := s.cli.AppsV1().Deployments(s.namespace).Create(ctx, d, metav1.CreateOptions{})
 	c.Assert(err, IsNil)
-
 	err = kube.WaitOnDeploymentReady(ctx, s.cli, d.GetNamespace(), d.GetName())
 	c.Assert(err, IsNil)
 
@@ -197,16 +188,8 @@ func (s *ScaleSuite) TestScaleStatefulSet(c *C) {
 	ctx := context.Background()
 	var originalReplicaCount int32 = 1
 	ss := testutil.NewTestStatefulSet(originalReplicaCount)
-	ss.Spec.Template.Spec.Containers[0].Lifecycle = &corev1.Lifecycle{
-		PreStop: &corev1.LifecycleHandler{
-			Exec: &corev1.ExecAction{
-				Command: []string{"sleep", "30"},
-			},
-		},
-	}
 	ss, err := s.cli.AppsV1().StatefulSets(s.namespace).Create(ctx, ss, metav1.CreateOptions{})
 	c.Assert(err, IsNil)
-
 	err = kube.WaitOnStatefulSetReady(ctx, s.cli, ss.GetNamespace(), ss.GetName())
 	c.Assert(err, IsNil)
 

--- a/pkg/helm/client.go
+++ b/pkg/helm/client.go
@@ -205,8 +205,12 @@ func (h CliClient) RemoveRepo(ctx context.Context, name string) error {
 
 // RunCmdWithTimeout executes command on host with DefaultCommandTimeout timeout
 func RunCmdWithTimeout(ctx context.Context, command string, args []string) (string, error) {
+	return RunCmdWithCustomTimeout(ctx, command, args, DefaultCommandTimeout)
+}
+
+func RunCmdWithCustomTimeout(ctx context.Context, command string, args []string, timeout time.Duration) (string, error) {
 	log.Debug().Print("Executing command", field.M{"command": command, "args": args})
-	ctx, cancel := context.WithTimeout(ctx, DefaultCommandTimeout)
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	out, err := exec.CommandContext(ctx, command, args...).CombinedOutput()
 	return strings.TrimSpace(string(out)), err

--- a/pkg/helm/client_test.go
+++ b/pkg/helm/client_test.go
@@ -17,6 +17,7 @@ package helm
 import (
 	"context"
 	"testing"
+	"time"
 
 	. "gopkg.in/check.v1"
 )
@@ -53,7 +54,8 @@ func Test(t *testing.T) { TestingT(t) }
 
 func (s *ExecSuite) TestRunCmdWithTimeout(c *C) {
 	ctx := context.Background()
-	out, err := RunCmdWithTimeout(ctx, s.command, s.args)
+	customTimeout := 100 * time.Millisecond
+	out, err := RunCmdWithCustomTimeout(ctx, s.command, s.args, customTimeout)
 	if s.err {
 		c.Assert(err, NotNil)
 		return

--- a/pkg/kube/fips_test.go
+++ b/pkg/kube/fips_test.go
@@ -69,8 +69,8 @@ func (s *FIPSSuite) SetUpSuite(c *C) {
 	c.Assert(WaitForPodReady(ctxTimeout, s.cli, s.namespace, s.pod.Name), IsNil)
 	s.pod, err = s.cli.CoreV1().Pods(s.namespace).Get(ctx, s.pod.Name, metav1.GetOptions{})
 	c.Assert(err, IsNil)
-	// install go in kanister-tools pod
-	cmd := []string{"microdnf", "install", "-y", "go"}
+	// Install nm to pod
+	cmd := []string{"microdnf", "install", "-y", "binutils"}
 	for _, cs := range s.pod.Status.ContainerStatuses {
 		stdout, stderr, err := Exec(s.cli, s.pod.Namespace, s.pod.Name, cs.Name, cmd, nil)
 		c.Assert(err, IsNil)
@@ -92,7 +92,7 @@ func (s *FIPSSuite) TestFIPSBoringEnabled(c *C) {
 		"/usr/local/bin/kando",
 	} {
 		c.Logf("Testing %s", tool)
-		cmd := []string{"go", "tool", "nm", tool}
+		cmd := []string{"nm", tool}
 		for _, cs := range s.pod.Status.ContainerStatuses {
 			stdout, stderr, err := Exec(s.cli, s.pod.Namespace, s.pod.Name, cs.Name, cmd, nil)
 			c.Assert(err, IsNil)

--- a/pkg/kube/pod_command_executor_test.go
+++ b/pkg/kube/pod_command_executor_test.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/kanisterio/kanister/pkg/testutil/testmutex"
 	"github.com/pkg/errors"
 	. "gopkg.in/check.v1"
 	"k8s.io/client-go/kubernetes/fake"
@@ -37,7 +38,13 @@ const (
 )
 
 func (s *PodCommandExecutorTestSuite) SetUpSuite(c *C) {
+	testmutex.PodNamespaceMutex.Lock()
 	os.Setenv("POD_NAMESPACE", podCommandExecutorNS)
+}
+
+func (s *PodCommandExecutorTestSuite) TearDownSuite(c *C) {
+	testmutex.PodNamespaceMutex.TryLock()
+	testmutex.PodNamespaceMutex.Unlock()
 }
 
 // testBarrier supports race-free synchronization between a controller and a background goroutine.

--- a/pkg/kube/pod_controller_test.go
+++ b/pkg/kube/pod_controller_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/kanisterio/kanister/pkg/testutil/testmutex"
 	"github.com/pkg/errors"
 	. "gopkg.in/check.v1"
 	corev1 "k8s.io/api/core/v1"
@@ -37,7 +38,13 @@ const (
 )
 
 func (s *PodControllerTestSuite) SetUpSuite(c *C) {
+	testmutex.PodNamespaceMutex.Lock()
 	os.Setenv("POD_NAMESPACE", podControllerNS)
+}
+
+func (s *PodControllerTestSuite) TearDownSuite(c *C) {
+	testmutex.PodNamespaceMutex.TryLock()
+	testmutex.PodNamespaceMutex.Unlock()
 }
 
 func (s *PodControllerTestSuite) TestPodControllerStartPod(c *C) {

--- a/pkg/kube/pod_file_writer_test.go
+++ b/pkg/kube/pod_file_writer_test.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/kanisterio/kanister/pkg/testutil/testmutex"
 	"github.com/pkg/errors"
 	. "gopkg.in/check.v1"
 	"k8s.io/client-go/kubernetes/fake"
@@ -36,7 +37,13 @@ const (
 )
 
 func (s *PodFileWriterTestSuite) SetUpSuite(c *C) {
+	testmutex.PodNamespaceMutex.Lock()
 	os.Setenv("POD_NAMESPACE", podFileWriterNS)
+}
+
+func (s *PodFileWriterTestSuite) TearDownSuite(c *C) {
+	testmutex.PodNamespaceMutex.TryLock()
+	testmutex.PodNamespaceMutex.Unlock()
 }
 
 type fakePodFileWriterProcessor struct {

--- a/pkg/kube/pod_runner_test.go
+++ b/pkg/kube/pod_runner_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"os"
 
+	"github.com/kanisterio/kanister/pkg/testutil/testmutex"
 	. "gopkg.in/check.v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -35,7 +36,13 @@ const (
 )
 
 func (s *PodRunnerTestSuite) SetUpSuite(c *C) {
+	testmutex.PodNamespaceMutex.Lock()
 	os.Setenv("POD_NAMESPACE", podRunnerNS)
+}
+
+func (s *PodRunnerTestSuite) TearDownSuite(c *C) {
+	testmutex.PodNamespaceMutex.TryLock()
+	testmutex.PodNamespaceMutex.Unlock()
 }
 
 func (s *PodRunnerTestSuite) TestPodRunnerContextCanceled(c *C) {

--- a/pkg/kube/pod_test.go
+++ b/pkg/kube/pod_test.go
@@ -36,6 +36,7 @@ import (
 
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	"github.com/kanisterio/kanister/pkg/consts"
+	"github.com/kanisterio/kanister/pkg/testutil/testmutex"
 )
 
 type PodSuite struct {
@@ -62,7 +63,7 @@ func (s *PodSuite) SetUpSuite(c *C) {
 	ns, err = s.cli.CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})
 	c.Assert(err, IsNil)
 	s.namespace = ns.Name
-
+	testmutex.PodNamespaceMutex.Lock()
 	os.Setenv("POD_NAMESPACE", ns.Name)
 	os.Setenv("POD_SERVICE_ACCOUNT", controllerSA)
 
@@ -78,6 +79,8 @@ func (s *PodSuite) TearDownSuite(c *C) {
 		err := s.cli.CoreV1().Namespaces().Delete(context.TODO(), s.namespace, metav1.DeleteOptions{})
 		c.Assert(err, IsNil)
 	}
+	testmutex.PodNamespaceMutex.TryLock()
+	testmutex.PodNamespaceMutex.Unlock()
 }
 
 func (s *PodSuite) TestPod(c *C) {

--- a/pkg/kube/podinfo.go
+++ b/pkg/kube/podinfo.go
@@ -46,21 +46,30 @@ func GetControllerNamespace() (string, error) {
 }
 
 // GetControllerServiceAccount returns controller ServiceAccount
+// Deprecated: this function is not used anymore inside kanister
 func GetControllerServiceAccount(k8sclient kubernetes.Interface) (string, error) {
-	if ns, ok := os.LookupEnv(PodSAEnvVar); ok {
-		return ns, nil
+	if sa, ok := os.LookupEnv(PodSAEnvVar); ok {
+		return sa, nil
 	}
 	ns, err := GetControllerNamespace()
 	if err != nil {
 		return "", errors.Wrapf(err, "Failed to get Controller namespace")
 	}
+	return getControllerServiceAccountInNamespace(k8sclient, ns)
+}
 
+// getControllerServiceAccountInNamespace returns controller ServiceAccount
+// for a controller in the namespace
+func getControllerServiceAccountInNamespace(k8sclient kubernetes.Interface, namespace string) (string, error) {
+	if sa, ok := os.LookupEnv(PodSAEnvVar); ok {
+		return sa, nil
+	}
 	podName, err := GetControllerPodName()
 	if err != nil {
 		return "", errors.Wrapf(err, "Failed to get Controller pod name")
 	}
 
-	pod, err := k8sclient.CoreV1().Pods(ns).Get(context.TODO(), podName, metav1.GetOptions{})
+	pod, err := k8sclient.CoreV1().Pods(namespace).Get(context.TODO(), podName, metav1.GetOptions{})
 	if err != nil {
 		return "", errors.Wrapf(err, "Failed to get Controller pod object from k8s")
 	}

--- a/pkg/kube/podinfo_test.go
+++ b/pkg/kube/podinfo_test.go
@@ -17,6 +17,7 @@ package kube
 import (
 	"os"
 
+	"github.com/kanisterio/kanister/pkg/testutil/testmutex"
 	. "gopkg.in/check.v1"
 
 	"k8s.io/client-go/kubernetes/fake"
@@ -31,6 +32,8 @@ const testPodName = "test-pod-name"
 const testPodSA = "test-pod-sa"
 
 func (s *PodInfoSuite) TestGetControllerNamespaceFromEnv(c *C) {
+	testmutex.PodNamespaceMutex.Lock()
+	defer testmutex.PodNamespaceMutex.Unlock()
 	os.Setenv(PodNSEnvVar, testPodNamespace)
 	ns, err := GetControllerNamespace()
 	c.Assert(err, IsNil)
@@ -67,6 +70,8 @@ func (s *PodInfoSuite) TestGetControllerPodNameFromSystem(c *C) {
 }
 
 func (s *PodInfoSuite) TestGetControllerServiceAccountFromEnv(c *C) {
+	testmutex.PodNamespaceMutex.Lock()
+	defer testmutex.PodNamespaceMutex.Unlock()
 	os.Setenv(PodSAEnvVar, testPodSA)
 	saName, err := GetControllerServiceAccount(fake.NewSimpleClientset())
 	c.Assert(err, IsNil)

--- a/pkg/testutil/testmutex/testmutex.go
+++ b/pkg/testutil/testmutex/testmutex.go
@@ -1,0 +1,5 @@
+package testmutex
+
+import "sync"
+
+var PodNamespaceMutex sync.Mutex

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -120,8 +120,8 @@ func newTestPodTemplateSpec() corev1.PodTemplateSpec {
 				{
 					Name:            "test-container",
 					Image:           consts.LatestKanisterToolsImage,
-					Command:         []string{"tail"},
-					Args:            []string{"-f", "/dev/null"},
+					Command:         []string{"sh"},
+					Args:            []string{"-c", "trap true TERM; sleep infinity & wait"},
 					ImagePullPolicy: corev1.PullAlways,
 				},
 			},


### PR DESCRIPTION
## Change Overview

Follow-up to https://github.com/kanisterio/kanister/pull/2534

- Run test suites in parallel
- Handle sigterm in some test containers
- Optimize sleeps and timeouts

**NOTE:** We currently use env variables to configure kanister and that prevents some tests from running in parallel. Currently using `testmutex` mutex to block them. 
This is not ideal solution, but other options such as regex matching or build tags are just worse. 
We could rework controller and API configuration so it doesn't rely on environment variables, which can potentially make it safer.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [x] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [x] :robot: Test

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
