### PR TITLE
Fix `CreateRDSSnapshot` function by correcting arguments to `createSnapshot`

### DIFF
--- a/pkg/function/create_rds_snapshot.go
+++ b/pkg/function/create_rds_snapshot.go
@@ -139,8 +139,8 @@ func createRDSSnapshot(ctx context.Context, instanceID string, dbEngine RDSDBEng
 	return output, nil
 }
 
-func createSnapshot(ctx context.Context, rdsCli *rds.RDS, snapshotID, dbEngine, instanceID string) (int64, error) {
-	log.WithContext(ctx).Print("Creating RDS snapshot", field.M{"SnapshotID": snapshotID})
+func createSnapshot(ctx context.Context, rdsCli *rds.RDS, snapshotID, instanceID, dbEngine string) (int64, error) {
+	log.WithContext(ctx).Print("Creating RDS snapshot", field.M{"SnapshotID": snapshotID, "InstanceID": instanceID})
 	var allocatedStorage int64
 	if !isAuroraCluster(dbEngine) {
 		dbSnapshotOutput, err := rdsCli.CreateDBSnapshot(ctx, instanceID, snapshotID)


### PR DESCRIPTION
## Change Overview

While refactoring in one of the previous PRs we interchanged two params of a function and because of that we started getting into a problem of `DBInstanceIdentifier` not specified.
This PR fixes that.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
