### PR TITLE
Update package versions in mysql docker image

### DIFF
--- a/docker/kanister-mysql/image/Dockerfile
+++ b/docker/kanister-mysql/image/Dockerfile
@@ -1,12 +1,12 @@
 ARG TOOLS_IMAGE
-FROM registry.access.redhat.com/ubi9/ubi:9.1.0-1646.1669627755 as builder
+FROM registry.access.redhat.com/ubi9/ubi:9.3-1476 as builder
 
 RUN dnf clean all && rm -rf /var/cache/dnf
 RUN dnf -y upgrade
 # Download the RPM file to avoid timeouts during install
-RUN curl -LO https://dev.mysql.com/get/mysql80-community-release-el9-1.noarch.rpm
+RUN curl -LO https://dev.mysql.com/get/mysql80-community-release-el9-5.noarch.rpm
 # Install from the local file
-RUN dnf install -y mysql80-community-release-el9-1.noarch.rpm
+RUN dnf install -y mysql80-community-release-el9-5.noarch.rpm
 
 RUN dnf install -y mysql-community-client
 


### PR DESCRIPTION
## Change Overview

- New version ([8.0.36](https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-36.html)) of MySQL updated the GnuPG build key. This is causing the docker [builds](https://github.com/kanisterio/kanister/actions/runs/7549171179/job/20595380211) to fail for the past two days. Updated the RPM version to the latest version to pull in the new keys.
- Additionally, updated the UBI base image to the [latest](https://catalog.redhat.com/software/containers/ubi9/ubi/615bcf606feffc5384e8452e?architecture=amd64&image=6571494b4a249787e97aa1bf) version.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
Built the docker image successfully.

```
$ docker build --platform=linux/amd64 --build-arg TOOLS_IMAGE=ghcr.io/kanisterio/kanister-tools:v9.99.9-dev --tag=pavanndev/mysql:test-118 .
[+] Building 25.6s (15/15) FINISHED                                                                                                                                                                                      docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                                                                                                     0.0s
 => => transferring dockerfile: 652B                                                                                                                                                                                                     0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                        0.0s
 => => transferring context: 2B                                                                                                                                                                                                          0.0s
 => [internal] load metadata for ghcr.io/kanisterio/kanister-tools:v9.99.9-dev                                                                                                                                                           0.8s
 => [internal] load metadata for registry.access.redhat.com/ubi9/ubi:9.3-1476                                                                                                                                                            0.8s
 => [builder 1/6] FROM registry.access.redhat.com/ubi9/ubi:9.3-1476@sha256:fc300be6adbdf2ca812ad01efd0dee2a3e3f5d33958ad6cd99159e25e9ee1398                                                                                              0.0s
 => [stage-1 1/4] FROM ghcr.io/kanisterio/kanister-tools:v9.99.9-dev@sha256:583bd395d5abe9c1f3dd1305813bf1fa68a0d454c250ddeb73bcd2ac9e87334f                                                                                             0.0s
 => CACHED [builder 2/6] RUN dnf clean all && rm -rf /var/cache/dnf                                                                                                                                                                      0.0s
 => CACHED [builder 3/6] RUN dnf -y upgrade                                                                                                                                                                                              0.0s
 => [builder 4/6] RUN curl -LO https://dev.mysql.com/get/mysql80-community-release-el9-5.noarch.rpm                                                                                                                                      1.1s
 => CACHED [stage-1 2/4] RUN microdnf -y update && microdnf -y install tar gzip &&     microdnf clean all                                                                                                                                0.0s
 => [builder 5/6] RUN dnf install -y mysql80-community-release-el9-5.noarch.rpm                                                                                                                                                          3.1s
 => [builder 6/6] RUN dnf install -y mysql-community-client                                                                                                                                                                             20.1s
 => [stage-1 3/4] COPY --from=builder /usr/lib64/mysql /usr/lib64/                                                                                                                                                                       0.0s
 => [stage-1 4/4] COPY --from=builder /usr/bin/mysql* /usr/bin/                                                                                                                                                                          0.1s
 => exporting to image                                                                                                                                                                                                                   0.1s
 => => exporting layers                                                                                                                                                                                                                  0.1s
 => => writing image sha256:fc42118dbccd91e85b6feb6d9d5edc7dc20fef1d6d9a3e25f5243cc35580dba9                                                                                                                                             0.0s
 => => naming to docker.io/pavanndev/mysql:test-118
```

- [ ] :zap: Unit test
- [ ] :green_heart: E2E
