### PR TITLE
Improve `NewPodControllerForExistingPod` to set `podReady` to true

### DIFF
--- a/pkg/kube/pod_controller.go
+++ b/pkg/kube/pod_controller.go
@@ -103,6 +103,9 @@ func NewPodController(cli kubernetes.Interface, options *PodOptions, opts ...Pod
 // running pod.
 // Invocation of StartPod of returned PodController instance will fail, since
 // the pod is expected to be running already.
+// Note:
+// If the pod is not in the ready state, it will wait for up to
+// KANISTER_POD_READY_WAIT_TIMEOUT (15 minutes by default) until the pod becomes ready.
 func NewPodControllerForExistingPod(cli kubernetes.Interface, pod *corev1.Pod) (PodController, error) {
 	err := WaitForPodReady(context.Background(), cli, pod.Namespace, pod.Name)
 	if err != nil {


### PR DESCRIPTION
## Change Overview

`NewPodControllerForExistingPod` function was supposed to return the podController for an existing pod. If this function is caleld, it would mean that the pod is already runnign and we are creating `podController` for that pod.
But this function didn't set `podReady` field of podController to true that was beign checked in some other methods (for example `GetCommandExecutor`) to make sure that the pod is running. And because of that those methods would see the pod to be not running and complain.
This PR fixes that by making sure that the pod is running and sets `podReady` to true.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

Create podController for an existing pod and make sure we are able to successfully call `GetCommandExecutor` that relies on `podReady` field.

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
