### PR TITLE
Add phase to wait for Cassandra to be ready before scale down

### DIFF
--- a/examples/cassandra/cassandra-blueprint.yaml
+++ b/examples/cassandra/cassandra-blueprint.yaml
@@ -118,6 +118,7 @@ actions:
               sleep 2
               timeout=$((timeout-2))
             done
+            nodetool scrub
     - func: ScaleWorkload
       name: shutdownPod
       args:

--- a/examples/cassandra/cassandra-blueprint.yaml
+++ b/examples/cassandra/cassandra-blueprint.yaml
@@ -92,7 +92,7 @@ actions:
       - params
     phases:
     - func: KubeExec
-      name: restoreSnapshot
+      name: waitForConnectionReady
       args:
         namespace: "{{ .StatefulSet.Namespace }}"
         pod: "{{ index .StatefulSet.Pods 0 }}"
@@ -106,7 +106,7 @@ actions:
           - errexit
           - -c
           - |
-            sleep 20
+            sleep 60
     - func: ScaleWorkload
       name: shutdownPod
       args:

--- a/examples/cassandra/cassandra-blueprint.yaml
+++ b/examples/cassandra/cassandra-blueprint.yaml
@@ -99,14 +99,25 @@ actions:
         command:
           - bash
           - -o
-          - xtrace
-          - -o
           - pipefail
-          - -o
-          - errexit
           - -c
           - |
-            sleep 60
+            timeout=300
+            while true
+            do
+              VAR=$((cqlsh -u cassandra -p $CASSANDRA_PASSWORD -e "DESCRIBE keyspaces;" --request-timeout=300) 2>&1)
+              if [[ $VAR != *"Unable to connect to any servers"* ]]
+              then
+                break
+              fi
+              if [[ $timeout -le 0 ]]
+              then
+                 echo "Timed out waiting for cqlsh to configure.."
+                 exit 1
+              fi
+              sleep 2
+              timeout=$((timeout-2))
+            done
     - func: ScaleWorkload
       name: shutdownPod
       args:

--- a/examples/cassandra/cassandra-blueprint.yaml
+++ b/examples/cassandra/cassandra-blueprint.yaml
@@ -91,6 +91,22 @@ actions:
     inputArtifactNames:
       - params
     phases:
+    - func: KubeExec
+      name: restoreSnapshot
+      args:
+        namespace: "{{ .StatefulSet.Namespace }}"
+        pod: "{{ index .StatefulSet.Pods 0 }}"
+        command:
+          - bash
+          - -o
+          - xtrace
+          - -o
+          - pipefail
+          - -o
+          - errexit
+          - -c
+          - |
+            sleep 20
     - func: ScaleWorkload
       name: shutdownPod
       args:

--- a/pkg/app/cassandra.go
+++ b/pkg/app/cassandra.go
@@ -206,7 +206,7 @@ func (cas *CassandraInstance) Reset(ctx context.Context) error {
 func (cas *CassandraInstance) Initialize(ctx context.Context) error {
 	// create the keyspace
 	createKS := []string{"sh", "-c", fmt.Sprintf("cqlsh -u cassandra -p $CASSANDRA_PASSWORD -e \"create keyspace "+
-		"restaurants with replication  = {'class':'SimpleStrategy', 'replication_factor': 3};\" --request-timeout=%s", cqlTimeout)}
+		"restaurants with replication  = {'class':'SimpleStrategy', 'replication_factor': 1};\" --request-timeout=%s", cqlTimeout)}
 	_, stderr, err := cas.execCommand(ctx, createKS)
 	if err != nil {
 		return errors.Wrapf(err, "Error %s while creating the keyspace for application.", stderr)

--- a/pkg/app/cassandra.go
+++ b/pkg/app/cassandra.go
@@ -57,11 +57,11 @@ func NewCassandraInstance(name string) App {
 			Chart:    "cassandra",
 			RepoName: helm.BitnamiRepoName,
 			Values: map[string]string{
-				"image.registry":       "ghcr.io",
-				"image.repository":     "kanisterio/cassandra",
-				"image.tag":            "v9.99.9-dev",
-				"image.pullPolicy":     "Always",
-				"cluster.replicaCount": "1",
+				"image.registry":   "ghcr.io",
+				"image.repository": "kanisterio/cassandra",
+				"image.tag":        "v9.99.9-dev",
+				"image.pullPolicy": "Always",
+				"replicaCount":     "1",
 			},
 		},
 	}


### PR DESCRIPTION
## Change Overview

In the integration tests, we have noticed an issue with the Cassandra BP where the Cassandra DB connection was failing after restore.
This PR updates the Blueprint to fix the Cassandra connection issue by introducing a new phase that waits for connections to be successful before executing scale down phase.


## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test


## Test Plan

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E

Manually varified backup and restore of Cassandra app
