### PR TITLE
docs: remove link to deleted doc section

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -5,8 +5,7 @@ blueprints, to make experimenting with Kanister easier.
 
 If you are new to Kanister, start with the `time-log` blueprint. After that,
 feel free to try out some of the more advanced examples like the blueprints for
-MySQL, PgSQL, MongoDB and ElasticSearch, following the instructions in the
-[Kanister documentation](https://docs.kanister.io/helm.html#kanister-enabled-applications).
+MySQL, PgSQL, MongoDB and ElasticSearch, following the instructions in the corresponding folder.
 
 Every example has its own README.md with information on how to set things up and
 commands to be run.


### PR DESCRIPTION
## Change Overview

Removed broken link.
The docs section no longer exists. Examples description are in the `examples/...` repo folders.

<!-- Insert PR description-->

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #2496

