### PR TITLE
Disable networkpolicies creation for postgresql test app

### DIFF
--- a/pkg/app/postgresql.go
+++ b/pkg/app/postgresql.go
@@ -54,6 +54,7 @@ func NewPostgresDB(name string, subPath string) App {
 				"auth.postgresPassword":                                "test@54321",
 				"volumePermissions.enabled":                            "true",
 				"persistence.subPath":                                  subPath,
+				"primary.networkPolicy.enabled":                        "false",
 				"primary.containerSecurityContext.seccompProfile.type": "Unconfined",
 				"primary.containerSecurityContext.capabilities.add[0]": "CHOWN",
 				"primary.containerSecurityContext.capabilities.add[1]": "FOWNER",


### PR DESCRIPTION
## Change Overview

This PR disables networkpolicy creation for postgresql test app.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
