### PR TITLE
Implement Kopia core flag handling data structures and flag testing suite

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -216,6 +216,8 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 )
 
+require github.com/kanisterio/safecli v0.0.3
+
 require (
 	github.com/Azure/go-autorest/autorest v0.11.27 // indirect
 	github.com/Azure/go-autorest/autorest/adal v0.9.18 // indirect

--- a/go.sum
+++ b/go.sum
@@ -359,6 +359,8 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
+github.com/kanisterio/safecli v0.0.3 h1:ts3oRVSoRexFBv9pOdWYZsN4k068pWx5Cl4zN54mQro=
+github.com/kanisterio/safecli v0.0.3/go.mod h1:fK3Mcbeiso+NtkUdhGugK0Vf4S2l8ObvFf564ry1W5A=
 github.com/kastenhq/check v0.0.0-20180626002341-0264cfcea734 h1:qulsCaCv+O2y9/sQ9nd5KChnAgFOWakTHQ9ZADjs6DQ=
 github.com/kastenhq/check v0.0.0-20180626002341-0264cfcea734/go.mod h1:rdqSnvOJuKCPFW/h2rVLuXOAkRnHHdp9PZcKx4HCoDM=
 github.com/kastenhq/stow v0.2.6-kasten.1.0.20231101232131-9321daa23aae h1:2cl4yuAJpdmLCx7G8eIsfNlQBLEfw0JDj6mTTyqc5qg=

--- a/pkg/kopia/cli/errors.go
+++ b/pkg/kopia/cli/errors.go
@@ -1,0 +1,25 @@
+// Copyright 2024 The Kanister Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"github.com/pkg/errors"
+)
+
+// flag errors
+var (
+	// ErrInvalidFlag is returned when the flag name is empty.
+	ErrInvalidFlag = errors.New("invalid flag")
+)

--- a/pkg/kopia/cli/internal/flag/bool_flag.go
+++ b/pkg/kopia/cli/internal/flag/bool_flag.go
@@ -1,0 +1,45 @@
+// Copyright 2024 The Kanister Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flag
+
+import (
+	"github.com/kanisterio/safecli"
+
+	"github.com/kanisterio/kanister/pkg/kopia/cli"
+)
+
+// boolFlag defines a boolean flag with a given flag name.
+// If enabled is set to true, the flag is applied; otherwise, it is not.
+type boolFlag struct {
+	flag    string
+	enabled bool
+}
+
+// Apply appends the flag to the command if the flag is enabled.
+func (f boolFlag) Apply(cli safecli.CommandAppender) error {
+	if f.enabled {
+		cli.AppendLoggable(f.flag)
+	}
+	return nil
+}
+
+// NewBoolFlag creates a new bool flag with a given flag name.
+// If the flag name is empty, cli.ErrInvalidFlag is returned.
+func NewBoolFlag(flag string, enabled bool) Applier {
+	if flag == "" {
+		return ErrorFlag(cli.ErrInvalidFlag)
+	}
+	return boolFlag{flag, enabled}
+}

--- a/pkg/kopia/cli/internal/flag/flag.go
+++ b/pkg/kopia/cli/internal/flag/flag.go
@@ -68,7 +68,7 @@ func (f simpleFlag) Apply(safecli.CommandAppender) error {
 }
 
 // EmptyFlag creates a new flag that does nothing.
-// It is useful for creating a no-op flag when a condition is not met 
+// It is useful for creating a no-op flag when a condition is not met
 // but Applier interface is required.
 func EmptyFlag() Applier {
 	return simpleFlag{}

--- a/pkg/kopia/cli/internal/flag/flag.go
+++ b/pkg/kopia/cli/internal/flag/flag.go
@@ -1,0 +1,81 @@
+// Copyright 2024 The Kanister Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flag
+
+import (
+	"github.com/kanisterio/safecli"
+)
+
+// Applier applies flags/args to the command.
+type Applier interface {
+	// Apply applies the flags/args to the command.
+	Apply(cli safecli.CommandAppender) error
+}
+
+// Apply appends multiple flags to the CLI.
+// If any of the flags encounter an error during the Apply process,
+// the error is returned and no changes are made to the CLI.
+// If no error, the flags are appended to the CLI.
+func Apply(cli safecli.CommandAppender, flags ...Applier) error {
+	// create a new sub builder which will be used to apply the flags
+	// to avoid mutating the CLI if an error is encountered.
+	sub := safecli.NewBuilder()
+	for _, flag := range flags {
+		if flag == nil { // if the flag is nil, skip it
+			continue
+		}
+		if err := flag.Apply(cli); err != nil {
+			return err
+		}
+	}
+	cli.Append(sub)
+	return nil
+}
+
+// flags defines a collection of Flags.
+type flags []Applier
+
+// Apply applies the flags to the CLI.
+func (flags flags) Apply(cli safecli.CommandAppender) error {
+	return Apply(cli, flags...)
+}
+
+// NewFlags creates a new collection of flags.
+func NewFlags(fs ...Applier) Applier {
+	return flags(fs)
+}
+
+// simpleFlag is a simple implementation of the Applier interface.
+type simpleFlag struct {
+	err error
+}
+
+// Apply does nothing except return an error if one is set.
+func (f simpleFlag) Apply(safecli.CommandAppender) error {
+	return f.err
+}
+
+// EmptyFlag creates a new flag that does nothing.
+// It is useful for creating a no-op flag when a condition is not met 
+// but Applier interface is required.
+func EmptyFlag() Applier {
+	return simpleFlag{}
+}
+
+// ErrorFlag creates a new flag that returns an error when applied.
+// It is useful for creating a flag validation if a condition is not met.
+func ErrorFlag(err error) Applier {
+	return simpleFlag{err}
+}

--- a/pkg/kopia/cli/internal/flag/flag_test.go
+++ b/pkg/kopia/cli/internal/flag/flag_test.go
@@ -1,0 +1,171 @@
+// Copyright 2024 The Kanister Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flag_test
+
+import (
+	"errors"
+	"testing"
+
+	"gopkg.in/check.v1"
+
+	"github.com/kanisterio/safecli"
+
+	"github.com/kanisterio/kanister/pkg/kopia/cli"
+	"github.com/kanisterio/kanister/pkg/kopia/cli/internal/flag"
+	"github.com/kanisterio/kanister/pkg/kopia/cli/internal/test"
+)
+
+var (
+	ErrFlag = errors.New("flag error")
+)
+
+// MockFlagApplier is a mock implementation of the FlagApplier interface.
+type MockFlagApplier struct {
+	flagName string
+	applyErr error
+}
+
+func (m *MockFlagApplier) Apply(cli safecli.CommandAppender) error {
+	cli.AppendLoggable(m.flagName)
+	return m.applyErr
+}
+
+func TestApply(t *testing.T) { check.TestingT(t) }
+
+var _ = check.Suite(&test.FlagSuite{Cmd: "cmd", Tests: []test.FlagTest{
+	{
+		Name:        "Apply with no flags should generate only the command",
+		ExpectedCLI: []string{"cmd"},
+	},
+	{
+		Name:        "Apply with nil flags should generate only the command",
+		Flag:        flag.NewFlags(nil, nil),
+		ExpectedCLI: []string{"cmd"},
+	},
+	{
+		Name: "Apply with flags should generate the command and flags",
+		Flag: flag.NewFlags(
+			&MockFlagApplier{flagName: "--flag1", applyErr: nil},
+			&MockFlagApplier{flagName: "--flag2", applyErr: nil},
+		),
+		ExpectedCLI: []string{"cmd", "--flag1", "--flag2"},
+	},
+	{
+		Name: "Apply with one error flag should not modify the command and return the error",
+		Flag: flag.NewFlags(
+			&MockFlagApplier{flagName: "flag1", applyErr: nil},
+			&MockFlagApplier{flagName: "flag2", applyErr: ErrFlag},
+		),
+		ExpectedCLI: []string{"cmd"},
+		ExpectedErr: ErrFlag,
+	},
+	{
+		Name: "NewBoolFlag",
+		Flag: flag.NewFlags(
+			flag.NewBoolFlag("--flag1", true),
+			flag.NewBoolFlag("--flag2", false),
+		),
+		ExpectedCLI: []string{"cmd", "--flag1"},
+	},
+	{
+		Name: "NewBoolFlag with empty flag name should return an error",
+		Flag: flag.NewFlags(
+			flag.NewBoolFlag("", true),
+		),
+		ExpectedCLI: []string{"cmd"},
+		ExpectedErr: cli.ErrInvalidFlag,
+	},
+	{
+		Name: "NewStringFlag",
+		Flag: flag.NewFlags(
+			flag.NewStringFlag("--flag1", "value1"),
+			flag.NewStringFlag("--flag2", ""),
+		),
+		ExpectedCLI: []string{"cmd", "--flag1=value1"},
+	},
+	{
+		Name: "NewStringFlag with all empty values should return an error",
+		Flag: flag.NewFlags(
+			flag.NewStringFlag("--flag1", "value1"),
+			flag.NewStringFlag("", ""),
+		),
+		ExpectedCLI: []string{"cmd"},
+		ExpectedErr: cli.ErrInvalidFlag,
+	},
+	{
+		Name: "NewRedactedStringFlag",
+		Flag: flag.NewFlags(
+			flag.NewRedactedStringFlag("--flag1", "value1"),
+			flag.NewRedactedStringFlag("--flag2", ""),
+			flag.NewRedactedStringFlag("", "value3"),
+		),
+		ExpectedCLI: []string{"cmd", "--flag1=value1", "value3"},
+		ExpectedLog: "cmd --flag1=<****> <****>",
+	},
+	{
+		Name: "NewRedactedStringFlag with all empty values should return an error",
+		Flag: flag.NewFlags(
+			flag.NewRedactedStringFlag("--flag1", "value1"),
+			flag.NewRedactedStringFlag("", ""),
+		),
+		ExpectedCLI: []string{"cmd"},
+		ExpectedErr: cli.ErrInvalidFlag,
+	},
+	{
+		Name: "NewStringValue",
+		Flag: flag.NewFlags(
+			flag.NewStringArgument("value1"),
+		),
+		ExpectedCLI: []string{"cmd", "value1"},
+	},
+	{
+		Name: "NewStringValue with empty value should return an error",
+		Flag: flag.NewFlags(
+			flag.NewStringArgument(""),
+		),
+		ExpectedCLI: []string{"cmd"},
+		ExpectedErr: cli.ErrInvalidFlag,
+	},
+	{
+		Name: "NewFlags should generate multiple flags",
+		Flag: flag.NewFlags(
+			flag.NewStringFlag("--flag1", "value1"),
+			flag.NewRedactedStringFlag("--flag2", "value2"),
+			flag.NewStringArgument("value3"),
+		),
+		ExpectedCLI: []string{"cmd", "--flag1=value1", "--flag2=value2", "value3"},
+		ExpectedLog: "cmd --flag1=value1 --flag2=<****> value3",
+	},
+	{
+		Name: "NewFlags should generate no flags if one of them returns an error",
+		Flag: flag.NewFlags(
+			flag.NewStringFlag("--flag1", "value1"),
+			&MockFlagApplier{flagName: "flag2", applyErr: ErrFlag},
+		),
+		ExpectedCLI: []string{"cmd"},
+		ExpectedErr: ErrFlag,
+	},
+	{
+		Name:        "EmptyFlag should not generate any flags",
+		Flag:        flag.EmptyFlag(),
+		ExpectedCLI: []string{"cmd"},
+	},
+	{
+		Name:        "ErrorFlag should return an error",
+		Flag:        flag.ErrorFlag(ErrFlag),
+		ExpectedCLI: []string{"cmd"},
+		ExpectedErr: ErrFlag,
+	},
+}})

--- a/pkg/kopia/cli/internal/flag/string_flag.go
+++ b/pkg/kopia/cli/internal/flag/string_flag.go
@@ -1,0 +1,78 @@
+// Copyright 2024 The Kanister Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flag
+
+import (
+	"github.com/kanisterio/safecli"
+
+	"github.com/kanisterio/kanister/pkg/kopia/cli"
+)
+
+// stringFlag defines a string flag with a given flag name and value.
+// If the value is empty, the flag is not applied.
+type stringFlag struct {
+	flag     string // flag name
+	value    string // flag value
+	redacted bool   // output the value as redacted
+}
+
+// appenderFunc is a function that appends strings to a command.
+type appenderFunc func(...string) *safecli.Builder
+
+// Apply appends the flag to the command if the value is not empty.
+// If the value is redacted, it is appended as redacted.
+func (f stringFlag) Apply(cli safecli.CommandAppender) error {
+	if f.value == "" {
+		return nil
+	}
+	appendValue, appendFlagValue := f.selectAppenderFuncs(cli)
+	if f.flag == "" {
+		appendValue(f.value)
+	} else {
+		appendFlagValue(f.flag, f.value)
+	}
+	return nil
+}
+
+// selectAppenderFuncs returns the appropriate appender functions based on the redacted flag.
+func (f stringFlag) selectAppenderFuncs(cli safecli.CommandAppender) (appenderFunc, appenderFunc) {
+	if f.redacted {
+		return cli.AppendRedacted, cli.AppendRedactedKV
+	}
+	return cli.AppendLoggable, cli.AppendLoggableKV
+}
+
+// newStringFlag creates a new string flag with a given flag name and value.
+func newStringFlag(flag, val string, redacted bool) Applier {
+	if flag == "" && val == "" {
+		return ErrorFlag(cli.ErrInvalidFlag)
+	}
+	return stringFlag{flag: flag, value: val, redacted: redacted}
+}
+
+// NewStringFlag creates a new string flag with a given flag name and value.
+func NewStringFlag(flag, val string) Applier {
+	return newStringFlag(flag, val, false)
+}
+
+// NewRedactedStringFlag creates a new string flag with a given flag name and value.
+func NewRedactedStringFlag(flag, val string) Applier {
+	return newStringFlag(flag, val, true)
+}
+
+// NewStringArgument creates a new string argument with a given value.
+func NewStringArgument(val string) Applier {
+	return newStringFlag("", val, false)
+}

--- a/pkg/kopia/cli/internal/test/flag_suite.go
+++ b/pkg/kopia/cli/internal/test/flag_suite.go
@@ -1,0 +1,112 @@
+package test
+
+import (
+	"strings"
+
+	"gopkg.in/check.v1"
+
+	"github.com/pkg/errors"
+
+	"github.com/kanisterio/safecli"
+
+	"github.com/kanisterio/kanister/pkg/kopia/cli/internal/flag"
+)
+
+// FlagTest defines a single test for a flag.
+type FlagTest struct {
+	// Name of the test. (required)
+	Name string
+
+	// Flag to test. (required)
+	Flag flag.Applier
+
+	// Expected CLI arguments. (optional)
+	ExpectedCLI []string
+
+	// Expected log output. (optional)
+	// if empty, it will be set to ExpectedCLI joined with space.
+	// if empty and ExpectedCLI is empty, it will be ignored.
+	ExpectedLog string
+
+	// Expected error. (optional)
+	// If nil, no error is expected and
+	// ExpectedCLI and ExpectedLog are checked.
+	ExpectedErr error
+}
+
+// CheckCommentString implements check.CommentInterface
+func (t *FlagTest) CheckCommentString() string {
+	return t.Name
+}
+
+// setDefaultExpectedLog sets the default value for ExpectedLog based on ExpectedCLI.
+func (t *FlagTest) setDefaultExpectedLog() {
+	if len(t.ExpectedLog) == 0 && len(t.ExpectedCLI) > 0 {
+		t.ExpectedLog = strings.Join(t.ExpectedCLI, " ")
+	}
+}
+
+// assertError checks the error against ExpectedErr.
+func (t *FlagTest) assertError(c *check.C, err error) {
+	if actualErr := errors.Cause(err); actualErr != nil {
+		c.Assert(actualErr, check.Equals, t.ExpectedErr, t)
+	} else {
+		c.Assert(err, check.Equals, t.ExpectedErr, t)
+	}
+}
+
+// assertNoError makes sure there is no error.
+func (t *FlagTest) assertNoError(c *check.C, err error) {
+	c.Assert(err, check.IsNil, t)
+}
+
+// assertCLI asserts the builder's CLI output against ExpectedCLI.
+func (t *FlagTest) assertCLI(c *check.C, b *safecli.Builder) {
+	c.Check(b.Build(), check.DeepEquals, t.ExpectedCLI, t)
+}
+
+// assertLog asserts the builder's log output against ExpectedLog.
+func (t *FlagTest) assertLog(c *check.C, b *safecli.Builder) {
+	t.setDefaultExpectedLog()
+	c.Check(b.String(), check.Equals, t.ExpectedLog, t)
+}
+
+// Test runs the flag test.
+func (ft *FlagTest) Test(c *check.C, b *safecli.Builder) {
+	err := flag.Apply(b, ft.Flag)
+	if ft.ExpectedErr != nil {
+		ft.assertError(c, err)
+	} else {
+		ft.assertNoError(c, err)
+		ft.assertCLI(c, b)
+		ft.assertLog(c, b)
+	}
+}
+
+// FlagSuite defines a test suite for flags.
+type FlagSuite struct {
+	Cmd   string     // Cmd appends to the safecli.Builder before test if not empty.
+	Tests []FlagTest // Tests to run.
+}
+
+// TestFlags runs all tests in the flag suite.
+func (s *FlagSuite) TestFlags(c *check.C) {
+	for _, test := range s.Tests {
+		b := newBuilder(s.Cmd)
+		test.Test(c, b)
+	}
+}
+
+// NewFlagSuite creates a new FlagSuite.
+func NewFlagSuite(tests []FlagTest) *FlagSuite {
+	return &FlagSuite{Tests: tests}
+}
+
+// newBuilder creates a new safecli.Builder with the given command.
+func newBuilder(cmd string) *safecli.Builder {
+	builder := safecli.NewBuilder()
+	if cmd != "" {
+		builder.AppendLoggable(cmd)
+	}
+	return builder
+}


### PR DESCRIPTION
## Change Overview

This PR is the first in the series of PRs that will add a new way to build Kopia CLI commands. 
The functionality of this PR provides the foundation for subsequent PRs and introduces a implementation of Kopia parameters handling in the CLI using the [safecli](https://github.com/kanisterio/safecli) package.

The Kopia flags can be represented in three ways:

- As an argument, i.e., `/restore/dir` or `01234566789abcdef`.
- As a string flag, i.e., `--flag=value`, where the value can be a sensitive field for log output.
- As a boolean/switch flag, i.e., `--readonly`, where the flag is present without any value.

To support this behavior, this PR introduces two primary data structures:

- The `pkg/kopia/cli/internal/flag/stringFlag` and `pkg/kopia/cli/internal/flag/boolFlag` structs provide a structured approach to managing flags, encapsulating their properties and behaviors.
- The redacted flag handling in `stringFlag` ensures that sensitive information is managed safely.

Functions such as `pkg/kopia/cli/internal/flag/NewStringFlag`, `pkg/kopia/cli/internal/flag/NewBoolFlag`, etc will be utilized in upcoming PRs for creating Kopia CLI commands.

`pkg/kopia/cli/internal/flag/test/FlagTest` struct and related methods provide a framework for defining and executing flag tests (see `pkg/kopia/cli/internal/flag/flag_test.go`).

`pkg/kopia/cli/errors.go` will serve as a centralized location for error definitions.

Looking forward for any feedback/suggestions!

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [x] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [x] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
