### PR TITLE
pprof and metrics server args for kopia server start cmd

### DIFF
--- a/pkg/kopia/command/const.go
+++ b/pkg/kopia/command/const.go
@@ -76,6 +76,8 @@ const (
 	tlsGenerateCertFlag       = "--tls-generate-cert"
 	tlsKeyFilePath            = "--tls-key-file"
 	userPasswordFlag          = "--user-password"
+	enablePprof               = "--enable-pprof"
+	metricsListerAddress      = "--metrics-listen-addr"
 
 	// Repository specific
 	repositorySubCommand      = "repository"

--- a/pkg/kopia/command/server.go
+++ b/pkg/kopia/command/server.go
@@ -16,13 +16,15 @@ package command
 
 type ServerStartCommandArgs struct {
 	*CommandArgs
-	ServerAddress    string
-	TLSCertFile      string
-	TLSKeyFile       string
-	ServerUsername   string
-	ServerPassword   string
-	AutoGenerateCert bool
-	Background       bool
+	ServerAddress        string
+	TLSCertFile          string
+	TLSKeyFile           string
+	ServerUsername       string
+	ServerPassword       string
+	AutoGenerateCert     bool
+	Background           bool
+	EnablePprof          bool
+	MetricsListenAddress string
 }
 
 // ServerStart returns the kopia command for starting the Kopia API Server
@@ -45,6 +47,14 @@ func ServerStart(cmdArgs ServerStartCommandArgs) []string {
 
 	// TODO: Remove when GRPC support is added
 	args = args.AppendLoggable(noGrpcFlag)
+
+	if cmdArgs.EnablePprof {
+		args = args.AppendLoggable(enablePprof)
+	}
+
+	if cmdArgs.MetricsListenAddress != "" {
+		args = args.AppendLoggableKV(metricsListerAddress, cmdArgs.MetricsListenAddress)
+	}
 
 	if cmdArgs.Background {
 		// To start the server and run in the background

--- a/pkg/kopia/command/server_test.go
+++ b/pkg/kopia/command/server_test.go
@@ -38,6 +38,24 @@ func (kServer *KopiaServerTestSuite) TestServerCommands(c *C) {
 		{
 			f: func() []string {
 				args := ServerStartCommandArgs{
+					CommandArgs:          commandArgs,
+					ServerAddress:        "a-server-address",
+					TLSCertFile:          "/path/to/cert/tls.crt",
+					TLSKeyFile:           "/path/to/key/tls.key",
+					ServerUsername:       "a-username@a-hostname",
+					ServerPassword:       "a-user-password",
+					AutoGenerateCert:     true,
+					Background:           true,
+					EnablePprof:          true,
+					MetricsListenAddress: "a-server-address:51516",
+				}
+				return ServerStart(args)
+			},
+			expectedLog: "bash -o errexit -c kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log server start --tls-generate-cert --address=a-server-address --tls-cert-file=/path/to/cert/tls.crt --tls-key-file=/path/to/key/tls.key --server-username=a-username@a-hostname --server-password=a-user-password --server-control-username=a-username@a-hostname --server-control-password=a-user-password --no-grpc --enable-pprof --metrics-listen-addr=a-server-address:51516 > /dev/null 2>&1 &",
+		},
+		{
+			f: func() []string {
+				args := ServerStartCommandArgs{
 					CommandArgs:      commandArgs,
 					ServerAddress:    "a-server-address",
 					TLSCertFile:      "/path/to/cert/tls.crt",


### PR DESCRIPTION
## Change Overview

Expanding kopia server start command by adding metrics and profile flags.

`--enable-pprof` will enable pprof handler in kopia
`--metrics-listen-addr` address for pprof handler + prometheus handler

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [x] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
