### PR TITLE
Add kopia azure storage flags

### DIFF
--- a/pkg/kopia/cli/internal/command/commands.go
+++ b/pkg/kopia/cli/internal/command/commands.go
@@ -4,4 +4,5 @@ package command
 var (
 	FileSystem = Command{"filesystem"}
 	GCS        = Command{"gcs"}
+	Azure      = Command{"azure"}
 )

--- a/pkg/kopia/cli/internal/flag/storage/azure/azure.go
+++ b/pkg/kopia/cli/internal/flag/storage/azure/azure.go
@@ -1,0 +1,31 @@
+// Copyright 2024 The Kanister Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package azure
+
+import (
+	"github.com/kanisterio/safecli"
+
+	"github.com/kanisterio/kanister/pkg/kopia/cli/internal/command"
+	"github.com/kanisterio/kanister/pkg/kopia/cli/internal/flag/storage/model"
+)
+
+// New returns a builder for the Azure subcommand storage.
+func New(f model.StorageFlag) (*safecli.Builder, error) {
+	prefix := model.GenerateFullRepoPath(f.Location.Prefix(), f.RepoPathPrefix)
+	return command.NewCommandBuilder(command.Azure,
+		Countainer(f.Location.BucketName()),
+		Prefix(prefix),
+	)
+}

--- a/pkg/kopia/cli/internal/flag/storage/azure/azure_flags.go
+++ b/pkg/kopia/cli/internal/flag/storage/azure/azure_flags.go
@@ -1,0 +1,31 @@
+// Copyright 2024 The Kanister Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package azure
+
+import "github.com/kanisterio/kanister/pkg/kopia/cli/internal/flag"
+
+//
+// Azure flags.
+//
+
+// Prefix creates a new Azure prefix flag with a given prefix.
+func Prefix(prefix string) flag.Applier {
+	return flag.NewStringFlag("--prefix", prefix)
+}
+
+// Countainer creates a new Azure container flag with a given container name.
+func Countainer(name string) flag.Applier {
+	return flag.NewStringFlag("--container", name)
+}

--- a/pkg/kopia/cli/internal/flag/storage/azure/azure_flags_test.go
+++ b/pkg/kopia/cli/internal/flag/storage/azure/azure_flags_test.go
@@ -1,0 +1,45 @@
+// Copyright 2024 The Kanister Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package azure
+
+import (
+	"testing"
+
+	"github.com/kanisterio/kanister/pkg/kopia/cli/internal/test"
+	"gopkg.in/check.v1"
+)
+
+func TestStorageAzureFlags(t *testing.T) { check.TestingT(t) }
+
+var _ = check.Suite(test.NewFlagSuite([]test.FlagTest{
+	{
+		Name: "Empty Prefix should not generate a flag",
+		Flag: Prefix(""),
+	},
+	{
+		Name:        "Prefix with value should generate a flag with the given value",
+		Flag:        Prefix("prefix"),
+		ExpectedCLI: []string{"--prefix=prefix"},
+	},
+	{
+		Name: "Empty AzureCountainer should not generate a flag",
+		Flag: Countainer(""),
+	},
+	{
+		Name:        "AzureCountainer with value should generate a flag with the given value",
+		Flag:        Countainer("container"),
+		ExpectedCLI: []string{"--container=container"},
+	},
+}))

--- a/pkg/kopia/cli/internal/flag/storage/azure/azure_test.go
+++ b/pkg/kopia/cli/internal/flag/storage/azure/azure_test.go
@@ -1,0 +1,57 @@
+// Copyright 2024 The Kanister Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package azure
+
+import (
+	"testing"
+
+	"gopkg.in/check.v1"
+
+	"github.com/kanisterio/safecli"
+
+	rs "github.com/kanisterio/kanister/pkg/secrets/repositoryserver"
+
+	"github.com/kanisterio/kanister/pkg/kopia/cli/internal/flag/storage/model"
+	"github.com/kanisterio/kanister/pkg/kopia/cli/internal/test"
+)
+
+func TestStorageAzure(t *testing.T) { check.TestingT(t) }
+
+var _ = check.Suite(test.NewCommandSuite([]test.CommandTest{
+	{
+		Name: "Empty Azure storage flag should generate subcommand with default flags",
+		CLI: func() (safecli.CommandBuilder, error) {
+			return New(model.StorageFlag{})
+		},
+		ExpectedCLI: []string{"azure"},
+	},
+	{
+		Name: "Azure with values should generate subcommand with specific flags",
+		CLI: func() (safecli.CommandBuilder, error) {
+			return New(model.StorageFlag{
+				RepoPathPrefix: "repo/path/prefix",
+				Location: model.Location{
+					rs.PrefixKey: []byte("prefix"),
+					rs.BucketKey: []byte("container"),
+				},
+			})
+		},
+		ExpectedCLI: []string{
+			"azure",
+			"--container=container",
+			"--prefix=prefix/repo/path/prefix/",
+		},
+	},
+}))

--- a/pkg/kopia/cli/internal/flag/storage/storage.go
+++ b/pkg/kopia/cli/internal/flag/storage/storage.go
@@ -22,6 +22,7 @@ import (
 
 	cmdlog "github.com/kanisterio/kanister/pkg/kopia/cli/internal/log"
 
+	"github.com/kanisterio/kanister/pkg/kopia/cli/internal/flag/storage/azure"
 	"github.com/kanisterio/kanister/pkg/kopia/cli/internal/flag/storage/fs"
 	"github.com/kanisterio/kanister/pkg/kopia/cli/internal/flag/storage/gcs"
 	"github.com/kanisterio/kanister/pkg/kopia/cli/internal/flag/storage/model"
@@ -57,6 +58,7 @@ func Storage(location model.Location, repoPathPrefix string, opts ...Option) mod
 		// Register storage builders.
 		factory[rs.LocTypeFilestore] = fs.New
 		factory[rs.LocTypeGCS] = gcs.New
+		factory[rs.LocTypeAzure] = azure.New
 	})
 	// create a new storage with the given location, repo path prefix and defaults.
 	s := model.StorageFlag{

--- a/pkg/kopia/cli/internal/flag/storage/storage_test.go
+++ b/pkg/kopia/cli/internal/flag/storage/storage_test.go
@@ -178,6 +178,22 @@ func (s *StorageSuite) TestStorageFlag(c *check.C) {
 				"--prefix=/path/to/prefix/prefixfs/",
 			},
 		},
+		{
+			name: "Azure should generate azure args",
+			storage: Storage(
+				model.Location{
+					rs.TypeKey:   []byte("azure"),
+					rs.BucketKey: []byte("bucket"),
+					rs.PrefixKey: []byte("/path/to/prefix"),
+				},
+				"prefixfs",
+			),
+			expCLI: []string{
+				"azure",
+				"--container=bucket",
+				"--prefix=/path/to/prefix/prefixfs/",
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Change Overview

This PR is the sixth in the series of PRs that will add a new way to build Kopia CLI commands.   

Previous PRs:
1. [PR-2653](https://github.com/kanisterio/kanister/pull/2653)
1. [PR-2654](https://github.com/kanisterio/kanister/pull/2654)
1. [PR-2655](https://github.com/kanisterio/kanister/pull/2655)
1. [PR-2656](https://github.com/kanisterio/kanister/pull/2656)
1. [PR-2657](https://github.com/kanisterio/kanister/pull/2657)

This PR introduces storage *azure* flag structures which will be used to build storage flags for azure storage.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [x] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [x] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
