### PR TITLE
Change mongoDB helm chart version in integration test

### DIFF
--- a/pkg/app/mongodb.go
+++ b/pkg/app/mongodb.go
@@ -61,6 +61,7 @@ func NewMongoDB(name string) HelmApp {
 			RepoURL:  helm.BitnamiRepoURL,
 			RepoName: helm.BitnamiRepoName,
 			Chart:    "mongodb",
+			Version:  "14.11.1",
 			Values: map[string]string{
 				"architecture":     "replicaset",
 				"image.pullPolicy": "Always",


### PR DESCRIPTION
## Change Overview

Integration test for mongoDB started failing because upstream helm chart seems to be broken. The installation fails with `signal killed`, because arbiter sts doesn't come up properly.
This PR makes sure that we install older version of chart to install the app successfully.


## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

```
make integration-test 
make[1]: Entering directory '/home/vivek/work/opensource/kanister'

application.","time":"2024-02-22T18:23:27.100279813Z"}
OK: 1 passed
--- PASS: Test (78.70s)

```


- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [x] :green_heart: E2E
