### PR TITLE
build(docker): rollback break-system-packages flag for some images

### DIFF
--- a/docker/postgres-kanister-tools/Dockerfile
+++ b/docker/postgres-kanister-tools/Dockerfile
@@ -4,15 +4,15 @@ ARG TOOLS_IMAGE
 FROM ${TOOLS_IMAGE} AS TOOLS_IMAGE
 
 # Actual image base
-FROM postgres:16.1-bullseye
+FROM postgres:16-bullseye
 
 ENV DEBIAN_FRONTEND noninteractive
 
 USER root
 
 RUN apt-get update && apt-get -y install curl python3 groff less jq python3-pip && \
-    pip3 install --break-system-packages --upgrade pip && \
-    pip3 install --break-system-packages --upgrade awscli && \
+    pip3 install --upgrade pip && \
+    pip3 install --upgrade awscli && \
     apt-get clean
 
 # Install restic to take backups

--- a/examples/postgres-RDS/Dockerfile
+++ b/examples/postgres-RDS/Dockerfile
@@ -5,8 +5,8 @@ ENV DEBIAN_FRONTEND noninteractive
 USER root
 
 RUN apt-get update && apt-get -y install curl python3-pip && \
-    pip3 install --break-system-packages --upgrade pip && \
-    pip3 install --break-system-packages --upgrade awscli && \
+    pip3 install --upgrade pip && \
+    pip3 install --upgrade awscli && \
     apt-get clean
 
 RUN curl https://raw.githubusercontent.com/kanisterio/kanister/master/scripts/get.sh | bash


### PR DESCRIPTION
## Change Overview

Follow up to https://github.com/kanisterio/kanister/pull/2682
Apparently some debian base imaged do not support the flag to override debian dependencies.

This should address the failure in https://github.com/kanisterio/kanister/actions/runs/8009600074/job/21879136904

Tested locally.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
