### PR TITLE
docs: Rename `new_docs` to `docs_new` in BUILD.md

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -158,7 +158,7 @@ This requires the documentation files to be written in
 This new documentation system offers a live-dev server that will dynamically
 render Markdown documentation files as you are making changes to them on your
 local machine/branch.
-To start this development server, place yourself in the `new_docs` folder, then
+To start this development server, place yourself in the `docs_new` folder, then
 run the following commands:
 
 ```sh


### PR DESCRIPTION
## Change Overview

Between the time https://github.com/kanisterio/kanister/pull/2675 was created/merged, and https://github.com/kanisterio/kanister/pull/2642 was created/merged, the folder name changed from `new_docs` to `docs_new`.

Amending the `BUILD.md` file to reflect that change.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [x] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [x] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
