### PR TITLE
Enforce FIPS compatible Sprig functions for template rendering

### DIFF
--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -55,9 +55,9 @@ standard go template functions, Kanister imports all the `sprig
     }
     return ras, nil
 
-Kanister will error during template rendering if FIPS non compliant
-sprig functions are used. The unsupported functions include: ``bcrypt``,
-``derivePassword``, ``htpasswd`` and ``genPrivateKey`` for key type ``dsa``.
+.. note:: Kanister will error during template rendering if FIPS non-compliant
+  sprig functions are used. The unsupported functions include: ``bcrypt``,
+  ``derivePassword``, ``htpasswd``, and ``genPrivateKey`` for key type ``dsa``.
 
 
 Objects

--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -55,6 +55,10 @@ standard go template functions, Kanister imports all the `sprig
     }
     return ras, nil
 
+Kanister will error during template rendering if FIPS non compliant
+sprig functions are used. The unsupported functions include: ``bcrypt``,
+``derivePassword``, ``htpasswd`` and ``genPrivateKey`` for key type ``dsa``.
+
 
 Objects
 =======

--- a/pkg/function/wait.go
+++ b/pkg/function/wait.go
@@ -22,7 +22,6 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/Masterminds/sprig"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -33,6 +32,7 @@ import (
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	"github.com/kanisterio/kanister/pkg/field"
 	"github.com/kanisterio/kanister/pkg/jsonpath"
+	"github.com/kanisterio/kanister/pkg/ksprig"
 	"github.com/kanisterio/kanister/pkg/kube"
 	"github.com/kanisterio/kanister/pkg/log"
 	"github.com/kanisterio/kanister/pkg/param"
@@ -189,7 +189,7 @@ func evaluateWaitCondition(ctx context.Context, dynCli dynamic.Interface, cond C
 		return false, err
 	}
 	log.Debug().Print(fmt.Sprintf("Resolved jsonpath: %s", rcondition))
-	t, err := template.New("config").Option("missingkey=zero").Funcs(sprig.TxtFuncMap()).Parse(rcondition)
+	t, err := template.New("config").Option("missingkey=zero").Funcs(ksprig.TxtFuncMap()).Parse(rcondition)
 	if err != nil {
 		return false, errors.WithStack(err)
 	}

--- a/pkg/ksprig/fipsonly_sprig.go
+++ b/pkg/ksprig/fipsonly_sprig.go
@@ -56,7 +56,7 @@ var fipsNonCompliantFuncs = map[string]interface{}{
 			}
 			return fn(typ), nil
 		}
-		return "", NewUnsupportedSprigUsageErr(fmt.Sprintf("genPrivateKey for %s key", typ))
+		return "", NewUnsupportedSprigUsageErr(fmt.Sprintf("genPrivateKey for %s", typ))
 	},
 
 	"htpasswd": func(username string, password string) (string, error) {

--- a/pkg/ksprig/fipsonly_sprig.go
+++ b/pkg/ksprig/fipsonly_sprig.go
@@ -40,11 +40,11 @@ func replaceNonCompliantFuncs(m map[string]interface{}) map[string]interface{} {
 // Functions identified for Sprig v3.2.3.
 var fipsNonCompliantFuncs = map[string]interface{}{
 	"bcrypt": func(input string) (string, error) {
-		return "", NewUnsupportedSprigFuncErr("bcrypt")
+		return "", NewUnsupportedSprigUsageErr("bcrypt")
 	},
 
 	"derivePassword": func(counter uint32, password_type, password, user, site string) (string, error) {
-		return "", NewUnsupportedSprigFuncErr("derivePassword")
+		return "", NewUnsupportedSprigUsageErr("derivePassword")
 	},
 
 	"genPrivateKey": func(typ string) (string, error) {
@@ -52,29 +52,29 @@ var fipsNonCompliantFuncs = map[string]interface{}{
 		case "rsa", "ecdsa", "ed25519":
 			fn, ok := sprig.TxtFuncMap()["genPrivateKey"].(func(string) string)
 			if !ok {
-				return "", NewUnsupportedSprigFuncErr("genPrivateKey")
+				return "", NewUnsupportedSprigUsageErr("genPrivateKey")
 			}
 			return fn(typ), nil
 		}
-		return "", NewUnsupportedSprigFuncErr(fmt.Sprintf("genPrivateKey for %s key", typ))
+		return "", NewUnsupportedSprigUsageErr(fmt.Sprintf("genPrivateKey for %s key", typ))
 	},
 
 	"htpasswd": func(username string, password string) (string, error) {
-		return "", NewUnsupportedSprigFuncErr("htpasswd")
+		return "", NewUnsupportedSprigUsageErr("htpasswd")
 	},
 }
 
-// NewUnsupportedSprigFuncErr returns an UnsupportedSprigFuncErr.
-func NewUnsupportedSprigFuncErr(function string) UnsupportedSprigFuncErr {
-	return UnsupportedSprigFuncErr{function: function}
+// NewUnsupportedSprigUsageErr returns an UnsupportedSprigUsageErr.
+func NewUnsupportedSprigUsageErr(usage string) UnsupportedSprigUsageErr {
+	return UnsupportedSprigUsageErr{Usage: usage}
 }
 
-// UnsupportedSprigFuncErr indicates the usage of a FIPS non-compatible function.
-type UnsupportedSprigFuncErr struct {
-	function string
+// UnsupportedSprigUsageErr indicates a FIPS non-compatible sprig usage.
+type UnsupportedSprigUsageErr struct {
+	Usage string
 }
 
 // Error returns an error string indicating the unsupported function.
-func (err UnsupportedSprigFuncErr) Error() string {
-	return fmt.Sprintf("sprig function '%s' is not allowed by kanister as it is not FIPS compatible", err.function)
+func (err UnsupportedSprigUsageErr) Error() string {
+	return fmt.Sprintf("sprig usage of '%s' is not allowed by kanister as it is not FIPS compatible", err.Usage)
 }

--- a/pkg/ksprig/fipsonly_sprig.go
+++ b/pkg/ksprig/fipsonly_sprig.go
@@ -1,0 +1,66 @@
+package ksprig
+
+import (
+	"fmt"
+	"html/template"
+
+	"github.com/Masterminds/sprig"
+)
+
+// TxtFuncMap provides a FIPS compliant version of sprig.TxtFuncMap().
+// Usage of a FIPS non-compatible function from the function map will result in an error.
+func TxtFuncMap() template.FuncMap {
+	return replaceNonCompliantFuncs(sprig.TxtFuncMap())
+}
+
+func replaceNonCompliantFuncs(m map[string]interface{}) map[string]interface{} {
+	for name, fn := range fipsNonCompliantFuncs {
+		if _, ok := m[name]; ok {
+			m[name] = fn
+		}
+	}
+	return m
+}
+
+// fipsNonCompliantFuncs is a map of sprig function name to its replacement function.
+// Functions identified for Sprig v3.2.3.
+var fipsNonCompliantFuncs = map[string]interface{}{
+	"bcrypt": func(input string) (string, error) {
+		return "", NewUnsupportedSprigFuncErr("bcrypt")
+	},
+
+	"derivePassword": func(counter uint32, password_type, password, user, site string) (string, error) {
+		return "", NewUnsupportedSprigFuncErr("derivePassword")
+	},
+
+	"genPrivateKey": func(typ string) (string, error) {
+		switch typ {
+		case "rsa", "ecdsa", "ed25519":
+			fn, ok := sprig.TxtFuncMap()["genPrivateKey"].(func(string) string)
+			if !ok {
+				return "", NewUnsupportedSprigFuncErr("genPrivateKey")
+			}
+			return fn(typ), nil
+		}
+		return "", NewUnsupportedSprigFuncErr(fmt.Sprintf("genPrivateKey for %s key", typ))
+	},
+
+	"htpasswd": func(username string, password string) (string, error) {
+		return "", NewUnsupportedSprigFuncErr("htpasswd")
+	},
+}
+
+// NewUnsupportedSprigFuncErr returns an UnsupportedSprigFuncErr.
+func NewUnsupportedSprigFuncErr(function string) UnsupportedSprigFuncErr {
+	return UnsupportedSprigFuncErr{function: function}
+}
+
+// UnsupportedSprigFuncErr indicates the usage of a FIPS non-compatible function.
+type UnsupportedSprigFuncErr struct {
+	function string
+}
+
+// Error returns an error string indicating the unsupported function.
+func (err UnsupportedSprigFuncErr) Error() string {
+	return fmt.Sprintf("sprig function '%s' is not allowed by kanister as it is not FIPS compatible", err.function)
+}

--- a/pkg/ksprig/fipsonly_sprig.go
+++ b/pkg/ksprig/fipsonly_sprig.go
@@ -1,3 +1,17 @@
+// Copyright 2024 The Kanister Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package ksprig
 
 import (

--- a/pkg/ksprig/fipsonly_sprig_test.go
+++ b/pkg/ksprig/fipsonly_sprig_test.go
@@ -64,7 +64,7 @@ func TestTemplateErrorsForUnsupportedFuncs(t *testing.T) {
 				t.Fatal("Unexpected success for template execution")
 			}
 
-			if !errors.As(err, &ksprig.UnsupportedSprigFuncErr{}) {
+			if !errors.As(err, &ksprig.UnsupportedSprigUsageErr{}) {
 				t.Fatalf("Expected error of type UnsupportedSprigFuncErr")
 			}
 		})

--- a/pkg/ksprig/fipsonly_sprig_test.go
+++ b/pkg/ksprig/fipsonly_sprig_test.go
@@ -1,3 +1,17 @@
+// Copyright 2024 The Kanister Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package ksprig_test
 
 import (

--- a/pkg/ksprig/fipsonly_sprig_test.go
+++ b/pkg/ksprig/fipsonly_sprig_test.go
@@ -1,0 +1,103 @@
+package ksprig_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"text/template"
+
+	"github.com/kanisterio/kanister/pkg/ksprig"
+)
+
+func TestTemplateErrorsForUnsupportedFuncs(t *testing.T) {
+	testCases := []struct {
+		function     string
+		templateText string
+	}{
+		{
+			function:     "bcrypt",
+			templateText: "{{bcrypt \"password\"}}",
+		},
+		{
+			function:     "derivePassword",
+			templateText: "{{derivePassword 1 \"long\" \"password\" \"user\" \"example.com\"}}",
+		},
+		{
+			function:     "genPrivateKey",
+			templateText: "{{genPrivateKey \"dsa\"}}",
+		},
+		{
+			function:     "htpasswd",
+			templateText: "{{htpasswd \"username\" \"password\"}}",
+		},
+	}
+
+	for _, tc := range testCases {
+		funcMap := ksprig.TxtFuncMap()
+
+		t.Run(tc.function, func(t *testing.T) {
+			if _, ok := funcMap[tc.function]; !ok {
+				t.Skipf("Function %s is not supported by sprig.TxtFuncMap()", tc.function)
+			}
+
+			temp, err := template.New("test").Funcs(funcMap).Parse(tc.templateText)
+			if err != nil {
+				t.Fatalf("Unexpected template parse error: %s", err)
+			}
+
+			err = temp.Execute(nil, "")
+			if err == nil {
+				t.Fatal("Unexpected success for template execution")
+			}
+
+			if !errors.As(err, &ksprig.UnsupportedSprigFuncErr{}) {
+				t.Fatalf("Expected error of type UnsupportedSprigFuncErr")
+			}
+		})
+	}
+}
+
+func TestTemplateWorksForSupportedFuncs(t *testing.T) {
+	testCases := []struct {
+		description  string
+		function     string
+		templateText string
+	}{
+		// The supported funcs are not limited to these test cases
+		{
+			description:  "genPrivateKey for rsa key",
+			function:     "genPrivateKey",
+			templateText: "{{genPrivateKey \"rsa\"}}",
+		},
+		{
+			description:  "genPrivateKey for ecdsa key",
+			function:     "genPrivateKey",
+			templateText: "{{genPrivateKey \"ecdsa\"}}",
+		},
+		{
+			description:  "genPrivateKey for ed25519 key",
+			function:     "genPrivateKey",
+			templateText: "{{genPrivateKey \"ed25519\"}}",
+		},
+	}
+
+	for _, tc := range testCases {
+		funcMap := ksprig.TxtFuncMap()
+
+		t.Run(tc.description, func(t *testing.T) {
+			if _, ok := funcMap[tc.function]; !ok {
+				t.Skipf("Function %s is not supported by sprig.TxtFuncMap()", tc.function)
+			}
+
+			temp, err := template.New("test").Funcs(funcMap).Parse(tc.templateText)
+			if err != nil {
+				t.Fatalf("Unexpected template parse error: %s", err)
+			}
+
+			err = temp.Execute(&strings.Builder{}, "")
+			if err != nil {
+				t.Fatalf("Unexpected error: %s", err)
+			}
+		})
+	}
+}

--- a/pkg/kube/unstructured_test.go
+++ b/pkg/kube/unstructured_test.go
@@ -20,9 +20,9 @@ import (
 	"text/template"
 
 	. "gopkg.in/check.v1"
-
-	"github.com/Masterminds/sprig"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/kanisterio/kanister/pkg/ksprig"
 )
 
 type UnstructuredSuite struct{}
@@ -52,7 +52,7 @@ func (s *UnstructuredSuite) TestFetch(c *C) {
 		{"{{ .Unstructured.metadata.name }}"},
 		{"{{ .Unstructured.spec.clusterIP }}"},
 	} {
-		t, err := template.New("config").Option("missingkey=error").Funcs(sprig.TxtFuncMap()).Parse(tc.arg)
+		t, err := template.New("config").Option("missingkey=error").Funcs(ksprig.TxtFuncMap()).Parse(tc.arg)
 		c.Assert(err, IsNil)
 		err = t.Execute(buf, tp)
 		c.Assert(err, IsNil)

--- a/pkg/param/param_test.go
+++ b/pkg/param/param_test.go
@@ -23,7 +23,6 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/Masterminds/sprig"
 	. "gopkg.in/check.v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -38,6 +37,7 @@ import (
 
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	crfake "github.com/kanisterio/kanister/pkg/client/clientset/versioned/fake"
+	"github.com/kanisterio/kanister/pkg/ksprig"
 	"github.com/kanisterio/kanister/pkg/kube"
 	osapps "github.com/openshift/api/apps/v1"
 	osversioned "github.com/openshift/client-go/apps/clientset/versioned"
@@ -772,7 +772,7 @@ func (s *ParamsSuite) TestRenderingPhaseParams(c *C) {
 			"bar",
 		},
 	} {
-		t, err := template.New("config").Option("missingkey=error").Funcs(sprig.TxtFuncMap()).Parse(tc.arg)
+		t, err := template.New("config").Option("missingkey=error").Funcs(ksprig.TxtFuncMap()).Parse(tc.arg)
 		c.Assert(err, IsNil)
 		buf := bytes.NewBuffer(nil)
 		err = t.Execute(buf, tp)

--- a/pkg/param/render.go
+++ b/pkg/param/render.go
@@ -21,10 +21,10 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/Masterminds/sprig"
 	"github.com/pkg/errors"
 
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
+	"github.com/kanisterio/kanister/pkg/ksprig"
 )
 
 const (
@@ -119,7 +119,7 @@ func RenderArtifacts(arts map[string]crv1alpha1.Artifact, tp TemplateParams) (ma
 }
 
 func renderStringArg(arg string, tp TemplateParams) (string, error) {
-	t, err := template.New("config").Option("missingkey=error").Funcs(sprig.TxtFuncMap()).Parse(arg)
+	t, err := template.New("config").Option("missingkey=error").Funcs(ksprig.TxtFuncMap()).Parse(arg)
 	if err != nil {
 		return "", errors.WithStack(err)
 	}


### PR DESCRIPTION
## Change Overview

This is part of the effort to enable a FIPS-compatible Kanister. The `github.com/Masterminds/sprig` library is used by
Kanister for rendering blueprint templates. Some of the available sprig template functions are not FIPS-compatible and
therefore their usage has been disallowed.

- Added a FIPS-compatible TxtFuncMap()
- Updated usages of TxtFuncMap() to use the FIPS-compatible version
- Updated docs to indicate unsupported functions

## Pull request type

- [X] :rainbow: Refactoring
- [X] :sunflower: Feature

## Test Plan

- [X] :zap: Unit test

Verified the newly added unit tests for template rendering pass:
```
=== RUN   TestFipsOnlySprigSuite
OK: 2 passed
--- PASS: TestFipsOnlySprigSuite (1.63s)
PASS
```