### PR TITLE
[vuln] Bumped restic to latest version for CVE-2023-48795

### DIFF
--- a/docker/kanister-mongodb-replicaset/image/Dockerfile
+++ b/docker/kanister-mongodb-replicaset/image/Dockerfile
@@ -7,6 +7,6 @@ ADD . /kanister
 
 RUN /kanister/install.sh && rm -rf /kanister && rm -rf /tmp && mkdir /tmp
 
-COPY --from=restic/restic:0.16.2 /usr/bin/restic /usr/local/bin/restic
+COPY --from=restic/restic:0.16.4 /usr/bin/restic /usr/local/bin/restic
 
 CMD ["tail", "-f", "/dev/null"]

--- a/docker/tools/Dockerfile
+++ b/docker/tools/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.21-bullseye AS builder
 
 ARG kopia_build_commit=master
 ARG kopia_repo_org=kopia
-ARG restic_vsn=v0.16.2
+ARG restic_vsn=v0.16.4
 ARG gosu_vsn=1.17
 ENV CGO_ENABLED=1 GOEXPERIMENT=boringcrypto GO_EXTLINK_ENABLED=0
 RUN apt-get install git


### PR DESCRIPTION
## Change Overview

This PR bumps `restic` to the latest version of `0.16.4` to fix CVE-2023-48795 which requires `golang.org/x/crypto` version be >= `0.17.0`.

The change logs for restic don't show anything that would be an issue:
- 0.16.3: https://github.com/restic/restic/releases/tag/v0.16.3
- 0.16.4: https://github.com/restic/restic/releases/tag/v0.16.4

## Pull request type

Please check the type of change your PR introduces:
- [X] 🔒 : Vulnerabilities
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
