### PR TITLE
Improve TransformUnstructured; Log GVK, type value

### DIFF
--- a/pkg/kube/snapshot/snapshot_alpha.go
+++ b/pkg/kube/snapshot/snapshot_alpha.go
@@ -443,13 +443,17 @@ func UnstructuredVolumeSnapshotClassAlpha(name, driver, deletionPolicy string, p
 	}
 }
 
-// TransformUnstructured maps Unstructured object to object pointed by value
-func TransformUnstructured(u *unstructured.Unstructured, value interface{}) error {
+// TransformUnstructured maps Unstructured object to object pointed by obj
+func TransformUnstructured(u *unstructured.Unstructured, obj metav1.Object) error {
+	if u == nil {
+		return errors.Errorf("Cannot deserialize nil unstructured")
+	}
 	b, err := json.Marshal(u.Object)
 	if err != nil {
-		return errors.Wrapf(err, "Failed to Marshal unstructured object")
+		gvk := u.GetObjectKind().GroupVersionKind()
+		return errors.Wrapf(err, "Failed to Marshal unstructured object GroupVersionKind: %v", gvk)
 	}
-	err = json.Unmarshal(b, value)
+	err = json.Unmarshal(b, obj)
 	return errors.Wrapf(err, "Failed to Unmarshal unstructured object")
 }
 

--- a/pkg/kube/snapshot/snapshot_test.go
+++ b/pkg/kube/snapshot/snapshot_test.go
@@ -288,7 +288,7 @@ func (s *SnapshotTestSuite) TestVolumeSnapshotCloneFake(c *C) {
 		contentGVR        schema.GroupVersionResource
 		snapSpec          *unstructured.Unstructured
 		snapGVR           schema.GroupVersionResource
-		snapContentObject interface{}
+		snapContentObject metav1.Object
 		fakeSs            snapshot.Snapshotter
 	}{
 		{
@@ -1466,4 +1466,16 @@ func fakePVC(name, namespace string) *corev1.PersistentVolumeClaim {
 			Namespace: namespace,
 		},
 	}
+}
+
+type SnapshotTransformUnstructuredTestSuite struct{}
+
+var _ = Suite(&SnapshotTransformUnstructuredTestSuite{})
+
+func (s *SnapshotTransformUnstructuredTestSuite) TestNilUnstructured(c *C) {
+	err := snapshot.TransformUnstructured(nil, nil)
+	c.Check(err, ErrorMatches, "Cannot deserialize nil unstructured")
+	u := &unstructured.Unstructured{}
+	err = snapshot.TransformUnstructured(u, nil)
+	c.Check(err, ErrorMatches, "Failed to Unmarshal unstructured object: json: Unmarshal\\(nil\\)")
 }


### PR DESCRIPTION
## Change Overview

Improves TransformUnstructured
* Adds a nil check for `u`
* Logs the GroupdVersionKind on Serialization errors
* Types the struct as `metav1.Object` instead of `interface{}`

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Test Plan
```
kanister/pkg/kube/snapshot/ go test -check.f TestNilUnstructured
OK: 1 passed
PASS
ok      github.com/kanisterio/kanister/pkg/kube/snapshot        0.029s
```
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
