### PR TITLE
build: bump build image tag

### DIFF
--- a/build/run_container.sh
+++ b/build/run_container.sh
@@ -23,7 +23,7 @@ set -o nounset
 PWD="${PWD:-$(pwd)}"
 
 DOCS_BUILD_IMAGE="${DOCS_BUILD_IMAGE:-ghcr.io/kanisterio/docker-sphinx:0.2.0}"
-BUILD_IMAGE="${BUILD_IMAGE:-ghcr.io/kanisterio/build:v0.0.26}"
+BUILD_IMAGE="${BUILD_IMAGE:-ghcr.io/kanisterio/build:v0.0.28}"
 PKG="${PKG:-github.com/kanisterio/kanister}"
 
 ARCH="${ARCH:-amd64}"


### PR DESCRIPTION
## Change Overview

Bump `kanisterio/build` image tag used for build tasks to `v0.0.28`

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
