### PR TITLE
Remove `--pull` from images using kanister-tools as base

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -80,7 +80,6 @@ dockers:
   - 'ghcr.io/kanisterio/postgres-kanister-tools:{{ .Tag }}'
   dockerfile: 'docker/postgres-kanister-tools/Dockerfile'
   build_flag_templates:
-  - "--pull"
   - "--build-arg=TOOLS_IMAGE=ghcr.io/kanisterio/kanister-tools:{{ .Tag }}"
 - image_templates:
   - 'ghcr.io/kanisterio/postgresql:{{ .Tag }}'
@@ -93,7 +92,6 @@ dockers:
   - 'ghcr.io/kanisterio/es-sidecar:{{ .Tag }}'
   dockerfile: 'docker/kanister-elasticsearch/image/Dockerfile'
   build_flag_templates:
-  - "--pull"
   - "--build-arg=TOOLS_IMAGE=ghcr.io/kanisterio/kanister-tools:{{ .Tag }}"
 - ids:
   - kando
@@ -101,13 +99,11 @@ dockers:
   - 'ghcr.io/kanisterio/mysql-sidecar:{{ .Tag }}'
   dockerfile: 'docker/kanister-mysql/image/Dockerfile'
   build_flag_templates:
-  - "--pull"
   - "--build-arg=TOOLS_IMAGE=ghcr.io/kanisterio/kanister-tools:{{ .Tag }}"
 - image_templates:
   - 'ghcr.io/kanisterio/kanister-kubectl-1.18:{{ .Tag }}'
   dockerfile: 'docker/kanister-kubectl/Dockerfile'
   build_flag_templates:
-  - "--pull"
   - "--build-arg=TOOLS_IMAGE=ghcr.io/kanisterio/kanister-tools:{{ .Tag }}"
 - ids:
   - kando
@@ -115,7 +111,6 @@ dockers:
   - 'ghcr.io/kanisterio/mongodb:{{ .Tag }}'
   dockerfile: 'docker/mongodb/Dockerfile'
   build_flag_templates:
-  - "--pull"
   - "--build-arg=TOOLS_IMAGE=ghcr.io/kanisterio/kanister-tools:{{ .Tag }}"
 - ids:
   - kando
@@ -123,7 +118,6 @@ dockers:
   - 'ghcr.io/kanisterio/cassandra:{{ .Tag }}'
   dockerfile: 'docker/cassandra/Dockerfile'
   build_flag_templates:
-  - "--pull"
   - "--build-arg=TOOLS_IMAGE=ghcr.io/kanisterio/kanister-tools:{{ .Tag }}"
 - image_templates:
   - 'ghcr.io/kanisterio/kafka-adobe-s3-source-connector:{{ .Tag }}'


### PR DESCRIPTION
## Change Overview

Using `--pull` flag when building docker images that try to pull `kanister-tools:{RELEASE_TAG}` from upstream fails. The image doesn't exist yet since the release job first builds all the images and then pushes them to `ghcr`.

Example failure:
```
[2024-03-07T02:43:24.758Z]     • building docker image                          image=ghcr.io/kanisterio/mongodb:0.106.0
[2024-03-07T02:43:24.778Z]     • running                                        args=[. -t ghcr.io/kanisterio/mongodb:0.106.0 --pull --build-arg=TOOLS_IMAGE=ghcr.io/kanisterio/kanister-tools:0.106.0] cmd=[docker build] cwd=dist/goreleaserdocker4266236303
[2024-03-07T02:43:24.835Z]     • #0 building with "default" instance using docker driver cmd=[docker build] cwd=dist/goreleaserdocker4266236303
[2024-03-07T02:43:24.835Z]     •                                                cmd=[docker build] cwd=dist/goreleaserdocker4266236303
[2024-03-07T02:43:24.835Z]     • #1 [internal] load build definition from Dockerfile cmd=[docker build] cwd=dist/goreleaserdocker4266236303
[2024-03-07T02:43:24.835Z]     • #1 transferring dockerfile: 392B done          cmd=[docker build] cwd=dist/goreleaserdocker4266236303
[2024-03-07T02:43:24.835Z]     • #1 DONE 0.0s                                   cmd=[docker build] cwd=dist/goreleaserdocker4266236303
[2024-03-07T02:43:24.835Z]     •                                                cmd=[docker build] cwd=dist/goreleaserdocker4266236303
[2024-03-07T02:43:24.835Z]     • #2 [internal] load .dockerignore               cmd=[docker build] cwd=dist/goreleaserdocker4266236303
[2024-03-07T02:43:24.835Z]     • #2 transferring context: 2B done               cmd=[docker build] cwd=dist/goreleaserdocker4266236303
[2024-03-07T02:43:24.835Z]     • #2 DONE 0.0s                                   cmd=[docker build] cwd=dist/goreleaserdocker4266236303
[2024-03-07T02:43:24.835Z]     •                                                cmd=[docker build] cwd=dist/goreleaserdocker4266236303
[2024-03-07T02:43:24.835Z]     • #3 [internal] load metadata for ghcr.io/kanisterio/kanister-tools:0.106.0 cmd=[docker build] cwd=dist/goreleaserdocker4266236303
[2024-03-07T02:43:24.858Z]     • #3 ERROR: ghcr.io/kanisterio/kanister-tools:0.106.0: not found cmd=[docker build] cwd=dist/goreleaserdocker4266236303
[2024-03-07T02:43:24.858Z]     •                                                cmd=[docker build] cwd=dist/goreleaserdocker4266236303
[2024-03-07T02:43:24.858Z]     • #4 [internal] load metadata for docker.io/bitnami/mongodb:7.0-debian-12 cmd=[docker build] cwd=dist/goreleaserdocker4266236303
[2024-03-07T02:43:24.858Z]     • #4 CANCELED                                    cmd=[docker build] cwd=dist/goreleaserdocker4266236303
[2024-03-07T02:43:24.858Z]     • ------                                         cmd=[docker build] cwd=dist/goreleaserdocker4266236303
[2024-03-07T02:43:24.858Z]     •  > [internal] load metadata for ghcr.io/kanisterio/kanister-tools:0.106.0: cmd=[docker build] cwd=dist/goreleaserdocker4266236303
[2024-03-07T02:43:24.858Z]     • ------                                         cmd=[docker build] cwd=dist/goreleaserdocker4266236303
[2024-03-07T02:43:24.858Z]     • Dockerfile:4                                   cmd=[docker build] cwd=dist/goreleaserdocker4266236303
[2024-03-07T02:43:24.858Z]     • --------------------                           cmd=[docker build] cwd=dist/goreleaserdocker4266236303
[2024-03-07T02:43:24.859Z]     •    2 |     # Tools are not up to date in debian repos cmd=[docker build] cwd=dist/goreleaserdocker4266236303
[2024-03-07T02:43:24.859Z]     •    3 |     ARG TOOLS_IMAGE                     cmd=[docker build] cwd=dist/goreleaserdocker4266236303
[2024-03-07T02:43:24.859Z]     •    4 | >>> FROM ${TOOLS_IMAGE} AS TOOLS_IMAGE  cmd=[docker build] cwd=dist/goreleaserdocker4266236303
[2024-03-07T02:43:24.859Z]     •    5 |                                         cmd=[docker build] cwd=dist/goreleaserdocker4266236303
[2024-03-07T02:43:24.862Z]     •    6 |     FROM bitnami/mongodb:7.0-debian-12  cmd=[docker build] cwd=dist/goreleaserdocker4266236303
[2024-03-07T02:43:24.862Z]     • --------------------                           cmd=[docker build] cwd=dist/goreleaserdocker4266236303
[2024-03-07T02:43:24.862Z]     • ERROR: failed to solve: ghcr.io/kanisterio/kanister-tools:0.106.0: ghcr.io/kanisterio/kanister-tools:0.106.0: not found cmd=[docker build] cwd=dist/goreleaserdocker4266236303
```

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
