### PR TITLE
Change deprecated zone and region label with new labels

### DIFF
--- a/pkg/blockstorage/zone/zone_test.go
+++ b/pkg/blockstorage/zone/zone_test.go
@@ -55,7 +55,7 @@ func (s ZoneSuite) TestNodeZoneAndRegionGCP(c *C) {
 	node2 := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "node2",
-			Labels: map[string]string{kube.FDRegionLabelName: "us-west2", kube.FDZoneLabelName: "us-west2-b"},
+			Labels: map[string]string{kube.TopologyRegionLabelName: "us-west2", kube.TopologyZoneLabelName: "us-west2-b"},
 		},
 		Status: corev1.NodeStatus{
 			Conditions: []corev1.NodeCondition{
@@ -69,7 +69,7 @@ func (s ZoneSuite) TestNodeZoneAndRegionGCP(c *C) {
 	node3 := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "node3",
-			Labels: map[string]string{kube.FDRegionLabelName: "us-west2", kube.FDZoneLabelName: "us-west2-c"},
+			Labels: map[string]string{kube.TopologyRegionLabelName: "us-west2", kube.TopologyZoneLabelName: "us-west2-c"},
 		},
 		Status: corev1.NodeStatus{
 			Conditions: []corev1.NodeCondition{
@@ -84,7 +84,7 @@ func (s ZoneSuite) TestNodeZoneAndRegionGCP(c *C) {
 	node4 := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "node4",
-			Labels: map[string]string{kube.FDRegionLabelName: "us-west2", kube.FDZoneLabelName: "us-west2-c"},
+			Labels: map[string]string{kube.TopologyRegionLabelName: "us-west2", kube.TopologyZoneLabelName: "us-west2-c"},
 		},
 		Status: corev1.NodeStatus{
 			Conditions: []corev1.NodeCondition{
@@ -98,7 +98,7 @@ func (s ZoneSuite) TestNodeZoneAndRegionGCP(c *C) {
 	node5 := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "node5",
-			Labels: map[string]string{kube.FDRegionLabelName: "us-west2", kube.FDZoneLabelName: "us-west2-c"},
+			Labels: map[string]string{kube.TopologyRegionLabelName: "us-west2", kube.TopologyZoneLabelName: "us-west2-c"},
 		},
 		Spec: corev1.NodeSpec{
 			Unschedulable: true,
@@ -132,7 +132,7 @@ func (s ZoneSuite) TestNodeZoneAndRegionEBS(c *C) {
 	node1 := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "node1",
-			Labels: map[string]string{kube.FDRegionLabelName: "us-west-2", kube.FDZoneLabelName: "us-west-2a"},
+			Labels: map[string]string{kube.TopologyRegionLabelName: "us-west-2", kube.TopologyZoneLabelName: "us-west-2a"},
 		},
 		Status: corev1.NodeStatus{
 			Conditions: []corev1.NodeCondition{
@@ -146,7 +146,7 @@ func (s ZoneSuite) TestNodeZoneAndRegionEBS(c *C) {
 	node2 := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "node2",
-			Labels: map[string]string{kube.FDRegionLabelName: "us-west-2", kube.FDZoneLabelName: "us-west-2b"},
+			Labels: map[string]string{kube.TopologyRegionLabelName: "us-west-2", kube.TopologyZoneLabelName: "us-west-2b"},
 		},
 		Status: corev1.NodeStatus{
 			Conditions: []corev1.NodeCondition{
@@ -160,7 +160,7 @@ func (s ZoneSuite) TestNodeZoneAndRegionEBS(c *C) {
 	node3 := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "node3",
-			Labels: map[string]string{kube.FDRegionLabelName: "us-west-2", kube.FDZoneLabelName: "us-west-2c"},
+			Labels: map[string]string{kube.TopologyRegionLabelName: "us-west-2", kube.TopologyZoneLabelName: "us-west-2c"},
 		},
 		Status: corev1.NodeStatus{
 			Conditions: []corev1.NodeCondition{
@@ -175,7 +175,7 @@ func (s ZoneSuite) TestNodeZoneAndRegionEBS(c *C) {
 	node4 := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "node4",
-			Labels: map[string]string{kube.FDRegionLabelName: "us-west-2", kube.FDZoneLabelName: "us-west-2c"},
+			Labels: map[string]string{kube.TopologyRegionLabelName: "us-west-2", kube.TopologyZoneLabelName: "us-west-2c"},
 		},
 		Status: corev1.NodeStatus{
 			Conditions: []corev1.NodeCondition{
@@ -223,7 +223,7 @@ func (s ZoneSuite) TestNodeZoneAndRegionAD(c *C) {
 	node1 := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "node1",
-			Labels: map[string]string{kube.FDRegionLabelName: "westus2", kube.FDZoneLabelName: "westus2-1"},
+			Labels: map[string]string{kube.TopologyRegionLabelName: "westus2", kube.TopologyZoneLabelName: "westus2-1"},
 		},
 		Status: corev1.NodeStatus{
 			Conditions: []corev1.NodeCondition{
@@ -251,7 +251,7 @@ func (s ZoneSuite) TestNodeZoneAndRegionAD(c *C) {
 	node3 := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "node3",
-			Labels: map[string]string{kube.FDRegionLabelName: "westus2", kube.FDZoneLabelName: "westus2-3"},
+			Labels: map[string]string{kube.TopologyRegionLabelName: "westus2", kube.TopologyZoneLabelName: "westus2-3"},
 		},
 		Status: corev1.NodeStatus{
 			Conditions: []corev1.NodeCondition{
@@ -266,7 +266,7 @@ func (s ZoneSuite) TestNodeZoneAndRegionAD(c *C) {
 	node4 := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "node4",
-			Labels: map[string]string{kube.FDRegionLabelName: "westus", kube.FDZoneLabelName: "0"},
+			Labels: map[string]string{kube.TopologyRegionLabelName: "westus", kube.TopologyZoneLabelName: "0"},
 		},
 		Status: corev1.NodeStatus{
 			Conditions: []corev1.NodeCondition{
@@ -281,7 +281,7 @@ func (s ZoneSuite) TestNodeZoneAndRegionAD(c *C) {
 	node5 := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "node5",
-			Labels: map[string]string{kube.FDRegionLabelName: "us-west2", kube.FDZoneLabelName: "us-west2-4"},
+			Labels: map[string]string{kube.TopologyRegionLabelName: "us-west2", kube.TopologyZoneLabelName: "us-west2-4"},
 		},
 		Status: corev1.NodeStatus{
 			Conditions: []corev1.NodeCondition{
@@ -431,7 +431,7 @@ func (s ZoneSuite) TestFromSourceRegionZone(c *C) {
 	node1 := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "node1",
-			Labels: map[string]string{kube.FDRegionLabelName: "us-west-2", kube.FDZoneLabelName: "us-west-2a"},
+			Labels: map[string]string{kube.TopologyRegionLabelName: "us-west-2", kube.TopologyZoneLabelName: "us-west-2a"},
 		},
 		Status: corev1.NodeStatus{
 			Conditions: []corev1.NodeCondition{
@@ -445,7 +445,7 @@ func (s ZoneSuite) TestFromSourceRegionZone(c *C) {
 	node2 := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "node2",
-			Labels: map[string]string{kube.FDRegionLabelName: "us-west-2", kube.FDZoneLabelName: "us-west-2b"},
+			Labels: map[string]string{kube.TopologyRegionLabelName: "us-west-2", kube.TopologyZoneLabelName: "us-west-2b"},
 		},
 		Status: corev1.NodeStatus{
 			Conditions: []corev1.NodeCondition{
@@ -459,7 +459,7 @@ func (s ZoneSuite) TestFromSourceRegionZone(c *C) {
 	node3 := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "node3",
-			Labels: map[string]string{kube.FDRegionLabelName: "us-west-2", kube.FDZoneLabelName: "us-west-2c"},
+			Labels: map[string]string{kube.TopologyRegionLabelName: "us-west-2", kube.TopologyZoneLabelName: "us-west-2c"},
 		},
 		Status: corev1.NodeStatus{
 			Conditions: []corev1.NodeCondition{
@@ -474,7 +474,7 @@ func (s ZoneSuite) TestFromSourceRegionZone(c *C) {
 	gceNode1 := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "node1",
-			Labels: map[string]string{kube.FDRegionLabelName: "us-west2", kube.FDZoneLabelName: "us-west2-a"},
+			Labels: map[string]string{kube.TopologyRegionLabelName: "us-west2", kube.TopologyZoneLabelName: "us-west2-a"},
 		},
 		Status: corev1.NodeStatus{
 			Conditions: []corev1.NodeCondition{
@@ -489,7 +489,7 @@ func (s ZoneSuite) TestFromSourceRegionZone(c *C) {
 	gceNode2 := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "node2",
-			Labels: map[string]string{kube.FDRegionLabelName: "us-west2", kube.FDZoneLabelName: "us-west2-b"},
+			Labels: map[string]string{kube.TopologyRegionLabelName: "us-west2", kube.TopologyZoneLabelName: "us-west2-b"},
 		},
 		Status: corev1.NodeStatus{
 			Conditions: []corev1.NodeCondition{
@@ -504,7 +504,7 @@ func (s ZoneSuite) TestFromSourceRegionZone(c *C) {
 	gceNode3 := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "node3",
-			Labels: map[string]string{kube.FDRegionLabelName: "us-west2", kube.FDZoneLabelName: "us-west2-c"},
+			Labels: map[string]string{kube.TopologyRegionLabelName: "us-west2", kube.TopologyZoneLabelName: "us-west2-c"},
 		},
 		Status: corev1.NodeStatus{
 			Conditions: []corev1.NodeCondition{
@@ -675,7 +675,7 @@ func (s ZoneSuite) TestGetReadySchedulableNodes(c *C) {
 	node1 := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "node1",
-			Labels: map[string]string{kube.FDRegionLabelName: "westus2", kube.FDZoneLabelName: "westus2-1"},
+			Labels: map[string]string{kube.TopologyRegionLabelName: "westus2", kube.TopologyZoneLabelName: "westus2-1"},
 		},
 		Status: corev1.NodeStatus{
 			Conditions: []corev1.NodeCondition{
@@ -689,7 +689,7 @@ func (s ZoneSuite) TestGetReadySchedulableNodes(c *C) {
 	node2 := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "node2",
-			Labels: map[string]string{kube.FDRegionLabelName: "westus2", kube.FDZoneLabelName: "westus2-2"},
+			Labels: map[string]string{kube.TopologyRegionLabelName: "westus2", kube.TopologyZoneLabelName: "westus2-2"},
 		},
 		Spec: corev1.NodeSpec{
 			Unschedulable: true,

--- a/pkg/function/create_volume_snapshot_test.go
+++ b/pkg/function/create_volume_snapshot_test.go
@@ -67,8 +67,8 @@ func (s *CreateVolumeSnapshotTestSuite) TestGetPVCInfo(c *C) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "pv-test-1",
 				Labels: map[string]string{
-					kube.FDZoneLabelName:   "us-west-2a",
-					kube.FDRegionLabelName: "us-west-2",
+					kube.TopologyZoneLabelName:   "us-west-2a",
+					kube.TopologyRegionLabelName: "us-west-2",
 				},
 			},
 			Spec: corev1.PersistentVolumeSpec{
@@ -119,7 +119,7 @@ func (s *CreateVolumeSnapshotTestSuite) TestGetPVCInfo(c *C) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "pv-test-3",
 				Labels: map[string]string{
-					kube.FDZoneLabelName: "us-west-2a",
+					kube.TopologyZoneLabelName: "us-west-2a",
 				},
 			},
 			Spec: corev1.PersistentVolumeSpec{

--- a/pkg/kube/volume/volume.go
+++ b/pkg/kube/volume/volume.go
@@ -277,14 +277,14 @@ func CreatePV(
 		pv.Spec.PersistentVolumeSource.AWSElasticBlockStore = &corev1.AWSElasticBlockStoreVolumeSource{
 			VolumeID: vol.ID,
 		}
-		pv.ObjectMeta.Labels[kube.FDZoneLabelName] = vol.Az
-		pv.ObjectMeta.Labels[kube.FDRegionLabelName] = zoneToRegion(vol.Az)
+		pv.ObjectMeta.Labels[kube.TopologyZoneLabelName] = vol.Az
+		pv.ObjectMeta.Labels[kube.TopologyRegionLabelName] = zoneToRegion(vol.Az)
 	case blockstorage.TypeGPD:
 		pv.Spec.PersistentVolumeSource.GCEPersistentDisk = &corev1.GCEPersistentDiskVolumeSource{
 			PDName: vol.ID,
 		}
-		pv.ObjectMeta.Labels[kube.FDZoneLabelName] = vol.Az
-		pv.ObjectMeta.Labels[kube.FDRegionLabelName] = zoneToRegion(vol.Az)
+		pv.ObjectMeta.Labels[kube.TopologyZoneLabelName] = vol.Az
+		pv.ObjectMeta.Labels[kube.TopologyRegionLabelName] = zoneToRegion(vol.Az)
 
 	default:
 		return "", errors.Errorf("Volume type %v(%T) not supported ", volType, volType)


### PR DESCRIPTION
## Change Overview

While creating PV we set annotations to define the topology of the PV. The annotations that were being used are deprecated and this PR makes sure that we change them and use the new respective annotations.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E


```
kanister/pkg/function (use-correct-topology-labels*) » go test -check.f "CreateVolumeSnapshotTestSuite"                  
OK: 1 passed
PASS
ok  	github.com/kanisterio/kanister/pkg/function	39.246s


kanister/pkg/blockstorage/zone (use-correct-topology-labels*) » go test -check.f "ZoneSuite"
...
...
OK: 7 passed, 1 skipped
PASS
ok  	github.com/kanisterio/kanister/pkg/blockstorage/zone	30.058s

```
