### PR TITLE
refactor: Satisfy linter in `zonesToRegion`

### DIFF
--- a/pkg/kube/volume/volume.go
+++ b/pkg/kube/volume/volume.go
@@ -348,16 +348,16 @@ func zoneToRegion(zone string) string {
 }
 
 func zonesToRegions(zone string) []string {
-	reg := map[string]struct{}{}
+	reg := map[string]bool{}
+	var regions []string
 	r := regexp.MustCompile("-?[a-z]$")
 	for _, z := range strings.Split(zone, RegionZoneSeparator) {
 		zone = r.ReplaceAllString(z, "")
-		reg[zone] = struct{}{}
+		if _, ok := reg[zone]; !ok {
+			reg[zone] = true
+			regions = append(regions, zone)
+		}
 	}
 
-	var regions []string
-	for k := range reg {
-		regions = append(regions, k)
-	}
 	return regions
 }

--- a/pkg/kube/volume/volume.go
+++ b/pkg/kube/volume/volume.go
@@ -349,10 +349,7 @@ func zoneToRegion(zone string) string {
 
 func zonesToRegions(zone string) []string {
 	reg := map[string]struct{}{}
-	// TODO: gocritic rule below suggests to use regexp.MustCompile but it
-	// panics if regex cannot be compiled. We should add proper test before
-	// enabling this below so that no change to this regex results in a panic
-	r, _ := regexp.Compile("-?[a-z]$") //nolint:gocritic
+	r := regexp.MustCompile("-?[a-z]$")
 	for _, z := range strings.Split(zone, RegionZoneSeparator) {
 		zone = r.ReplaceAllString(z, "")
 		reg[zone] = struct{}{}

--- a/pkg/kube/volume/volume_test.go
+++ b/pkg/kube/volume/volume_test.go
@@ -203,7 +203,7 @@ func (s *TestVolSuite) fakeUnstructuredSnasphotWSize(vsName, namespace, size str
 }
 
 func (s *TestVolSuite) TestZoneToRegion(c *C) {
-	for _, tc := range []struct {
+	for idx, tc := range []struct {
 		zone           string
 		expectedRegion []string
 	}{
@@ -237,6 +237,6 @@ func (s *TestVolSuite) TestZoneToRegion(c *C) {
 		},
 	} {
 		reg := zonesToRegions(tc.zone)
-		c.Assert(reg, DeepEquals, tc.expectedRegion)
+		c.Assert(reg, DeepEquals, tc.expectedRegion, Commentf("Case #%d", idx))
 	}
 }

--- a/pkg/kube/volume/volume_test.go
+++ b/pkg/kube/volume/volume_test.go
@@ -237,27 +237,6 @@ func (s *TestVolSuite) TestZoneToRegion(c *C) {
 		},
 	} {
 		reg := zonesToRegions(tc.zone)
-		c.Assert(slicesEqual(reg, tc.expectedRegion), Equals, true)
+		c.Assert(reg, DeepEquals, tc.expectedRegion)
 	}
-}
-
-// slicesEqual compares two unordered slices and returns true if
-// both of them have same elements
-func slicesEqual(one, two []string) bool {
-	if len(one) != len(two) {
-		return false
-	}
-
-	for _, o := range one {
-		var found bool
-		for _, t := range two {
-			if o == t {
-				found = true
-			}
-		}
-		if !found {
-			return false
-		}
-	}
-	return true
 }


### PR DESCRIPTION
## Change Overview

There was annotation which disables `gocritic`. This linter could be enabled now, since we do have test which will detect panic.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [x] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
