### PR TITLE
build(ci): cleanup docker images in gha runner before building new images

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -104,5 +104,6 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     - run: sudo rm -rf /usr/share/dotnet
     - run: sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+    - run: docker image prune -af
     - run: make release-snapshot
     - run: ./build/push_images.sh


### PR DESCRIPTION
## Change Overview

Follow up to #2711 and #2727

Github keeps some image cache in the GHA runners which keeps around base containers with vulnerabilities.

We can't use --pull because we use local-built tools image.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
