### PR TITLE
Remove `cluster_name` field from kanister controller logs

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -12,7 +12,6 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/kanisterio/kanister/pkg/caller"
-	"github.com/kanisterio/kanister/pkg/config"
 	"github.com/kanisterio/kanister/pkg/field"
 )
 
@@ -92,10 +91,6 @@ func initEnvVarFields() {
 		if ev, ok := os.LookupEnv(e); ok {
 			envVarFields = field.Add(envVarFields, strings.ToLower(e), ev)
 		}
-	}
-
-	if clsName, err := config.GetClusterName(nil); err == nil {
-		envVarFields = field.Add(envVarFields, "cluster_name", clsName)
 	}
 }
 

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -43,7 +43,11 @@ func (s *LogSuite) TestWithNilContext(c *C) {
 }
 
 func (s *LogSuite) TestInitEnvVarFields(c *C) {
-	os.Setenv("HOSTNAME", "host")
+	// HOSTNAME is set automatically when the test is run from CI
+	host := os.Getenv("HOSTNAME")
+	if host == "" {
+		os.Setenv("HOSTNAME", "host")
+	}
 	os.Setenv("SERVICE_NAME", "sservice")
 	os.Setenv("VERSION", "v0.0.1")
 

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -42,6 +42,21 @@ func (s *LogSuite) TestWithNilContext(c *C) {
 	WithContext(nil).Print("Message")
 }
 
+func (s *LogSuite) TestInitEnvVarFields(c *C) {
+	os.Setenv("HOSTNAME", "host")
+	os.Setenv("SERVICE_NAME", "sservice")
+	os.Setenv("VERSION", "v0.0.1")
+
+	initEnvVarFields()
+	fields := envVarFields.Fields()
+	fmt.Println(fields)
+	c.Assert(len(fields), Equals, 3)
+
+	c.Assert(fields[0].Key(), Equals, "hostname")
+	c.Assert(fields[1].Key(), Equals, "service_name")
+	c.Assert(fields[2].Key(), Equals, "version")
+}
+
 func (s *LogSuite) TestLogMessage(c *C) {
 	const text = "Some useful text."
 	testLogMessage(c, text, Print)

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -53,7 +53,7 @@ func (s *LogSuite) TestInitEnvVarFields(c *C) {
 
 	initEnvVarFields()
 	fields := envVarFields.Fields()
-	fmt.Println(fields)
+
 	c.Assert(len(fields), Equals, 3)
 
 	c.Assert(fields[0].Key(), Equals, "hostname")

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -58,7 +58,9 @@ func (s *LogSuite) TestInitEnvVarFields(c *C) {
 
 	c.Assert(fields[0].Key(), Equals, "hostname")
 	c.Assert(fields[1].Key(), Equals, "service_name")
+	c.Assert(fields[1].Value(), Equals, "sservice")
 	c.Assert(fields[2].Key(), Equals, "version")
+	c.Assert(fields[2].Value(), Equals, "v0.0.1")
 }
 
 func (s *LogSuite) TestLogMessage(c *C) {


### PR DESCRIPTION
## Change Overview

When we use kanister log package `pkg/log` as part of the init function we try to set some variables that are used while logging a message. `cluster_name` is one of those variables, and to figure out `cluster_name` we get the `default` namespace and then use its `UID` field.
If someone just uses kando to let's say
- Set an output artifact
- Or to upload and object to object store

And they see that kando is trying to communicate with k8s apiserver, they might get confused because those operations don't involve communication with k8s apiserver. And if they have some security measures (network policies) in place to not let application namespace communicate with k8s apiserver, they would see a lot of warning messages about connection being dropped.

This PR fixes that by not logging the `cluster_name` field in kanister logs and this would result into log package not talking k8s apiserver.

*Note:*
We have been printing the cluster_name in the logs from quite some time, even though we don't expect this to have any side effects, if we think that the cluster_name field is important part of logs, I will figure out other solution.


## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

Build new `kando` binary and run it in a pod and use `tcpdump` in the same pod to make sure no connections are being made to apiserver.

```
kanister/pkg/log (unset_cluster_name_env*) » go test -check.f "LogSuite"            
{"level":"info","msg":"Test message","time":"2024-03-18T13:41:58.69816758+01:00"}
["hostname":"host" "service_name":"sservice" "version":"v0.0.1"]
OK: 13 passed
PASS
ok  	github.com/kanisterio/kanister/pkg/log	0.003s


```

- [x] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
