### PR TITLE
[WIP] Introduce a new package to enable using logrus easily

### DIFF
--- a/pkg/kando/kando.go
+++ b/pkg/kando/kando.go
@@ -18,10 +18,10 @@ import (
 	"os"
 
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
-	"github.com/kanisterio/kanister/pkg/log"
+	_ "github.com/kanisterio/kanister/pkg/logrus"
 	"github.com/kanisterio/kanister/pkg/version"
 )
 
@@ -44,7 +44,7 @@ func newRootCommand() *cobra.Command {
 	}
 
 	var v string
-	rootCmd.PersistentFlags().StringVarP(&v, "verbosity", "v", logrus.WarnLevel.String(), "Log level (debug, info, warn, error, fatal, panic)")
+	rootCmd.PersistentFlags().StringVarP(&v, "verbosity", "v", log.WarnLevel.String(), "Log level (debug, info, warn, error, fatal, panic)")
 	rootCmd.PersistentPreRunE = func(*cobra.Command, []string) error {
 		return setLogLevel(v)
 	}
@@ -57,10 +57,10 @@ func newRootCommand() *cobra.Command {
 }
 
 func setLogLevel(v string) error {
-	l, err := logrus.ParseLevel(v)
+	l, err := log.ParseLevel(v)
 	if err != nil {
 		return errors.Wrap(err, "Invalid log level: "+v)
 	}
-	logrus.SetLevel(l)
+	log.SetLevel(l)
 	return nil
 }

--- a/pkg/logrus/log.go
+++ b/pkg/logrus/log.go
@@ -1,0 +1,15 @@
+package logrus
+
+import "github.com/sirupsen/logrus"
+
+// The logging library in package `pkg/log` tries to figure out the cluster ID
+// by getting the default namespace from K8S cluster. People who are using a
+// kanister utility that doesn't necessarily need to communicate with K8S,
+// would get confused by why that utility (`kando` for example) is trying to
+// communicate with K8S.
+// Thats the reason from those utilities, instead of using our loggging library
+// we can directly use logrus to log something.
+func init() {
+	logrus.SetFormatter(&logrus.JSONFormatter{})
+	logrus.SetReportCaller(true)
+}


### PR DESCRIPTION

## Change Overview

This PR introduces a new package that just sets up upstream logrus logging API so that we can use `logrus` directly in the places where we don't need to log the clusterID in the logs.

This is how it can be used

```
import (
	log "github.com/sirupsen/logrus"

	_ "github.com/kanisterio/kanister/pkg/logrus"
)

func main() {
	log.WithFields(log.Fields{
		"purpose": "test",
		"day":     "one",
	}).Info("Main was called")
}
```

and this is how the output looks like

```
{"day":"one","file":"/home/vivek/work/opensource/kanister/pkg/main/main.go:13","func":"main.main","level":"info","msg":"Main was called","purpose":"test","time":"2024-03-20T12:53:10+01:00"}
```


## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [x] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan


- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
