### PR TITLE
added resourcesPreset: xlarge for cassandra app

### DIFF
--- a/pkg/app/cassandra.go
+++ b/pkg/app/cassandra.go
@@ -62,6 +62,7 @@ func NewCassandraInstance(name string) App {
 				"image.tag":        "v9.99.9-dev",
 				"image.pullPolicy": "Always",
 				"replicaCount":     "1",
+				"resourcesPreset":  "xlarge",
 			},
 		},
 	}


### PR DESCRIPTION
added resourcesPreset: xlarge for cassandra app because it failed to start with default large preset

## Change Overview

With current helm chart settings Cassandra is started with ["large" resource preset](https://github.com/bitnami/charts/blob/fb2eebed1ae3c3c6546fadb72bf70e2258e66db6/bitnami/cassandra/values.yaml#L337C1-L337C16)

[List of available presets](https://github.com/bitnami/charts/blob/e54bf09ea259a53292d247fd10fa4d782fd1c421/bitnami/common/templates/_resources.tpl#L15)

With 3Gi of memory limit Cassandra pod OOMKilled on start, and only with 5Gi it is starting and running. So setting 6Gi as per xlarge preset look reasonable.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [X] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [X] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan


- [X] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
