### PR TITLE
fix: Updated tutorial.rst to use official amazon/aws-cli image

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -52,7 +52,7 @@ application is installed in the ``default`` namespace.
       spec:
         containers:
         - name: test-container
-          image: containerlabs/aws-sdk
+          image: amazon/aws-cli
           command: ["sh", "-c"]
           args: ["while true; do for x in $(seq 1200); do date >> /var/log/time.log; sleep 1; done; truncate /var/log/time.log --size 0; done"]
   EOF


### PR DESCRIPTION
## Change Overview

The `tutorial.rst` file referred to an old, unmaintained `containerlabs/aws-sdk` container image.
This PR changes that to leverage `amazon/aws-cli` instead.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [X] :hamster: Trivial/Minor
- [X] :bug: Bugfix
- [ ] :sunflower: Feature
- [X] :world_map: Documentation
- [ ] :robot: Test

## Issues 

- fixes #2779 : "Fix Tutorial docs to work with current s3"

## Test Plan

Manually confirmed the `amazon/aws-cli` behave the same
as `containerlabs/aws-sdk` for the purpose of this tutorial.

- [X] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
