### PR TITLE
docs: Mention github security advisories tool in security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,6 +7,8 @@ Current known vulnerabilities are listed in the
 You can report a new vulnerability using
 [Report a vulnerability](https://github.com/kanisterio/kanister/security/advisories/new) tool.
 
+Alternatively you can report it via kanisterio google group "Contact owners and managers" button: https://groups.google.com/g/kanisterio/about
+
 The maintainers will help diagnose the severity of the issue and determine how
 to address the issue. Issues deemed to be non-critical will be filed as GitHub
 issues. Critical issues will receive immediate attention and be fixed as quickly

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,8 +2,10 @@
 
 ## Reporting a Vulnerability
 
-To report a security problem in Kanister, please contact the maintainers listed
-in the [MAINTAINERS.md](MAINTAINERS.md) file.
+Current known vulnerabilities are listed in the
+[github security advisories](https://github.com/kanisterio/kanister/security/advisories) section for the repo.
+You can report a new vulnerability using
+[Report a vulnerability](https://github.com/kanisterio/kanister/security/advisories/new) tool.
 
 The maintainers will help diagnose the severity of the issue and determine how
 to address the issue. Issues deemed to be non-critical will be filed as GitHub
@@ -15,7 +17,7 @@ as possible. The maintainers will then coordinate a release date with you.
 When serious security problems in Kanister are discovered and corrected, the
 maintainers issue a security advisory, describing the problem and containing a
 pointer to the fix. These will be announced on the Kanister's mailing list and
-websites.
+websites and be visible in [github security advisories](https://github.com/kanisterio/kanister/security/advisories).
 
 Security issues are fixed as soon as possible, and the fixes are propagated to
 the stable branches as fast as possible. However, when a vulnerability is found


### PR DESCRIPTION
## Change Overview

Github provides more convenient way to report security vulnerabilities than writing an email to maintainers.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [x] :world_map: Documentation
- [ ] :robot: Test

