### PR TITLE
build(docker): fix typo in postgres-kanister-tools dockerfile

### DIFF
--- a/docker/postgres-kanister-tools/Dockerfile
+++ b/docker/postgres-kanister-tools/Dockerfile
@@ -13,7 +13,7 @@ USER root
 RUN apt-get update && apt-get -y install curl python3 groff less jq python3-pip && \
     pip3 install --upgrade pip setuptools wheel && \
     pip3 install --upgrade awscli && \
-    apt-get remove -y python3-setuptools python3-wheel \
+    apt-get remove -y python3-setuptools python3-wheel && \
     apt-get clean
 
 # Install restic to take backups


### PR DESCRIPTION
## Change Overview

Missing `&&` in command chain

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
