### PR TITLE
support Azure sovereign clouds

### DIFF
--- a/pkg/blockstorage/azure/azuredisk.go
+++ b/pkg/blockstorage/azure/azuredisk.go
@@ -52,7 +52,7 @@ func (s *AdStorage) Type() blockstorage.Type {
 
 // NewProvider returns a provider for the Azure blockstorage type
 func NewProvider(ctx context.Context, config map[string]string) (blockstorage.Provider, error) {
-	azCli, err := NewClient(ctx, config)
+	azCli, err := NewClient(ctx, config, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -54,3 +54,10 @@ const KanisterToolsImage = "ghcr.io/kanisterio/kanister-tools:0.107.0"
 
 // KanisterToolsImageEnvName is used to set up a custom kanister-tools image
 const KanisterToolsImageEnvName = "KANISTER_TOOLS"
+
+// Azure Clouds
+const (
+	AzureChinaCloud        = "AzureChinaCloud"
+	AzureUSGovernmentCloud = "AzureUSGovernmentCloud"
+	AzurePublic            = "AzurePublic"
+)


### PR DESCRIPTION
## Change Overview

Currently it's not possible to create these clients in sovereign clouds e.g. AzureChina because the cloud isn't specified and defaults to the Public cloud. This leads to errors like `adal: Failed to execute the refresh request. Error = 'Post \https://login.microsoftonline.com/****/oauth2/token` when the URL for AzureChina is `https://login.chinacloudapi.cn/`

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
