### PR TITLE
deps(go): bump go version to 1.21.9 to address GO-2024-2687

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kanisterio/kanister
 
-go 1.21.8
+go 1.21.9
 
 replace (
 	github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.4.1


### PR DESCRIPTION
## Change Overview

Detected by govulncheck https://github.com/kanisterio/kanister/actions/runs/8731273484/job/23956405543

https://pkg.go.dev/vuln/GO-2024-2687

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [x] :lock: Security

## Test Plan

Govulncheck should pass

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
