### PR TITLE
Refactor: Move JobID label suffix to constants  

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -26,7 +26,7 @@ const (
 	LabelKeyCreatedBy        = "createdBy"
 	LabelValueKanister       = "kanister"
 	LabelPrefix              = "kanister.io/"
-	JobIDLabelSuffix         = "JobID"
+	LabelSuffixJobID         = "JobID"
 )
 
 // These names are used to query ActionSet API objects.

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -26,6 +26,7 @@ const (
 	LabelKeyCreatedBy        = "createdBy"
 	LabelValueKanister       = "kanister"
 	LabelPrefix              = "kanister.io/"
+	JobIDLabelSuffix         = "JobID"
 )
 
 // These names are used to query ActionSet API objects.

--- a/pkg/function/kube_task.go
+++ b/pkg/function/kube_task.go
@@ -67,7 +67,7 @@ func kubeTask(ctx context.Context, cli kubernetes.Interface, namespace, image st
 		PodOverride:  podOverride,
 	}
 	// Mark pod with label having key `kanister.io/JobID`, the value of which is a reference to the origin of the pod.
-	kube.AddLabelsToPodOptionsFromContext(ctx, options, path.Join(consts.LabelPrefix, consts.JobIDLabelSuffix))
+	kube.AddLabelsToPodOptionsFromContext(ctx, options, path.Join(consts.LabelPrefix, consts.LabelSuffixJobID))
 	pr := kube.NewPodRunner(cli, options)
 	podFunc := kubeTaskPodFunc()
 	return pr.Run(ctx, podFunc)

--- a/pkg/function/kube_task.go
+++ b/pkg/function/kube_task.go
@@ -34,8 +34,7 @@ import (
 )
 
 const (
-	jobPrefix   = "kanister-job-"
-	jobIDSuffix = "JobID"
+	jobPrefix = "kanister-job-"
 
 	// KubeTaskFuncName gives the function name
 	KubeTaskFuncName       = "KubeTask"
@@ -68,7 +67,7 @@ func kubeTask(ctx context.Context, cli kubernetes.Interface, namespace, image st
 		PodOverride:  podOverride,
 	}
 	// Mark pod with label having key `kanister.io/JobID`, the value of which is a reference to the origin of the pod.
-	kube.AddLabelsToPodOptionsFromContext(ctx, options, path.Join(consts.LabelPrefix, jobIDSuffix))
+	kube.AddLabelsToPodOptionsFromContext(ctx, options, path.Join(consts.LabelPrefix, consts.JobIDLabelSuffix))
 	pr := kube.NewPodRunner(cli, options)
 	podFunc := kubeTaskPodFunc()
 	return pr.Run(ctx, podFunc)

--- a/pkg/kube/pod_runner_test.go
+++ b/pkg/kube/pod_runner_test.go
@@ -117,7 +117,7 @@ func (s *PodRunnerTestSuite) TestPodRunnerForSuccessCase(c *C) {
 // TestPodRunnerWithDebugLabelForSuccessCase adds a debug entry into the context and verifies the
 // pod got created with corresponding label using the entry or not.
 func (s *PodRunnerTestSuite) TestPodRunnerWithDebugLabelForSuccessCase(c *C) {
-	jobIDSuffix := "JobID"
+	jobIDSuffix := consts.JobIDLabelSuffix
 	for _, tc := range []struct {
 		name            string
 		targetKey       string

--- a/pkg/kube/pod_runner_test.go
+++ b/pkg/kube/pod_runner_test.go
@@ -117,7 +117,7 @@ func (s *PodRunnerTestSuite) TestPodRunnerForSuccessCase(c *C) {
 // TestPodRunnerWithDebugLabelForSuccessCase adds a debug entry into the context and verifies the
 // pod got created with corresponding label using the entry or not.
 func (s *PodRunnerTestSuite) TestPodRunnerWithDebugLabelForSuccessCase(c *C) {
-	jobIDSuffix := consts.JobIDLabelSuffix
+	jobIDSuffix := consts.LabelSuffixJobID
 	for _, tc := range []struct {
 		name            string
 		targetKey       string


### PR DESCRIPTION
## Change Overview

<!-- Insert PR description-->
String `JobID` is used as static constant text at different places by basically re-declaring. In order to make it uniformly accessible from within the project  as well others importing it.
This PR addresses the above constraint and make it available as a public const.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [x] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
