### PR TITLE
Add ephemeral package with environment variable registration

### DIFF
--- a/pkg/controllers/repositoryserver/utils.go
+++ b/pkg/controllers/repositoryserver/utils.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/kanisterio/kanister/pkg/consts"
+	"github.com/kanisterio/kanister/pkg/ephemeral"
 	"github.com/kanisterio/kanister/pkg/format"
 	"github.com/kanisterio/kanister/pkg/kopia/command/storage"
 	"github.com/kanisterio/kanister/pkg/kube"
@@ -213,7 +214,8 @@ func getPodOptions(namespace string, svc *corev1.Service, vols map[string]kube.V
 			RunAsUser:    &uidguid,
 			RunAsNonRoot: &nonRootBool,
 		},
-		Volumes: vols,
+		Volumes:              vols,
+		EnvironmentVariables: ephemeral.GlobalEnvVars(),
 	}
 }
 

--- a/pkg/ephemeral/ephemeral.go
+++ b/pkg/ephemeral/ephemeral.go
@@ -1,0 +1,28 @@
+package ephemeral
+
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/kanisterio/kanister/pkg/ephemeral/internal/envvar"
+)
+
+// NewEnvironmentVariables creates a new slice of k8s environment variables
+// based on the current registered configuration.
+func GlobalEnvVars() []corev1.EnvVar {
+	return envvar.EnabledEnvVars()
+}
+
+// RegisterOSEnvVar registers an environment variable to be injected into
+// ephemeral pods conditionally if already present on the OS.
+func RegisterOSEnvVar(envName string) {
+	envvar.Register(envvar.OSEnvVar(envName))
+}
+
+// RegisterStaticEnvVar registers an environment variable and value to be
+// injected into ephemeral pods.
+func RegisterStaticEnvVar(envName, envValue string) {
+	envvar.Register(envvar.StaticEnvVar{
+		EnvName:  envName,
+		EnvValue: envValue,
+	})
+}

--- a/pkg/ephemeral/internal/envvar/envvar.go
+++ b/pkg/ephemeral/internal/envvar/envvar.go
@@ -1,0 +1,115 @@
+package envvar
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+var (
+	ErrNameNotAvailable = errors.New("environment variable name is not available")
+)
+
+// EnvVar is the interface which registers environment variables to be used in the
+// ephemeral pod.
+type EnvVar interface {
+	Enabled() bool
+
+	Name() string
+	Value() string
+}
+
+// StaticEnvVar implements the EnvVar interface and is used when specifying an
+// environment variable that does not come directly from the parent pod environment
+// variables.
+type StaticEnvVar struct {
+	EnvName  string
+	EnvValue string
+}
+
+var _ EnvVar = StaticEnvVar{}
+
+func (v StaticEnvVar) Enabled() bool { return true }
+func (v StaticEnvVar) Name() string  { return v.EnvName }
+func (v StaticEnvVar) Value() string { return v.EnvValue }
+
+// ConditionalEnvVar implements the EnvVar interface and is used when mapping an
+// parent pods environment variable into the ephemeral pod.
+type ConditionalEnvVar struct {
+	EnvName string
+
+	EnabledFunc  func() bool
+	EnvValueFunc func() string
+}
+
+var _ EnvVar = ConditionalEnvVar{}
+
+func (v ConditionalEnvVar) Enabled() bool {
+	if v.EnabledFunc != nil {
+		return v.EnabledFunc()
+	}
+
+	return true
+}
+
+func (v ConditionalEnvVar) Name() string {
+	return v.EnvName
+}
+
+func (v ConditionalEnvVar) Value() string {
+	if v.EnvValueFunc != nil {
+		return v.EnvValueFunc()
+	}
+
+	return ""
+}
+
+var (
+	// EnvironmentVariables is the map holding all the registered environment
+	// variables.
+	EnvironmentVariables = map[string]EnvVar{}
+)
+
+// OSEnvVar is a helper function which creates a ConditionalVar and uses the
+// OS's environment variable to compare against the input variable to see whether
+// the EnvVar is enabled.
+func OSEnvVar(envName string) ConditionalEnvVar {
+	return ConditionalEnvVar{
+		EnvName: envName,
+		EnabledFunc: func() bool {
+			_, present := os.LookupEnv(envName)
+			return present
+		},
+		EnvValueFunc: func() string {
+			return os.Getenv(envName)
+		},
+	}
+}
+
+// Register adds support for constructing k8s environment variables with the
+// given name.
+func Register(envVar EnvVar) {
+	if _, present := EnvironmentVariables[envVar.Name()]; present {
+		panic(fmt.Sprintf("environment variables named %s already registered", envVar.Name()))
+	}
+
+	EnvironmentVariables[envVar.Name()] = envVar
+}
+
+// EnabledEnvVars constructs a slice of k8s environment variables if they've
+// been enabled.
+func EnabledEnvVars() []corev1.EnvVar {
+	var envvars []corev1.EnvVar
+	for _, envvar := range EnvironmentVariables {
+		if envvar.Enabled() {
+			envvars = append(envvars, corev1.EnvVar{
+				Name:  envvar.Name(),
+				Value: envvar.Value(),
+			})
+		}
+	}
+
+	return envvars
+}

--- a/pkg/function/backup_data_stats.go
+++ b/pkg/function/backup_data_stats.go
@@ -26,6 +26,7 @@ import (
 	kanister "github.com/kanisterio/kanister/pkg"
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	"github.com/kanisterio/kanister/pkg/consts"
+	"github.com/kanisterio/kanister/pkg/ephemeral"
 	"github.com/kanisterio/kanister/pkg/format"
 	"github.com/kanisterio/kanister/pkg/kube"
 	"github.com/kanisterio/kanister/pkg/param"
@@ -69,11 +70,12 @@ func (*BackupDataStatsFunc) Name() string {
 
 func backupDataStats(ctx context.Context, cli kubernetes.Interface, tp param.TemplateParams, namespace, encryptionKey, backupArtifactPrefix, backupID, mode, jobPrefix string, podOverride crv1alpha1.JSONMap) (map[string]interface{}, error) {
 	options := &kube.PodOptions{
-		Namespace:    namespace,
-		GenerateName: jobPrefix,
-		Image:        consts.GetKanisterToolsImage(),
-		Command:      []string{"sh", "-c", "tail -f /dev/null"},
-		PodOverride:  podOverride,
+		Namespace:            namespace,
+		GenerateName:         jobPrefix,
+		Image:                consts.GetKanisterToolsImage(),
+		Command:              []string{"sh", "-c", "tail -f /dev/null"},
+		PodOverride:          podOverride,
+		EnvironmentVariables: ephemeral.GlobalEnvVars(),
 	}
 	pr := kube.NewPodRunner(cli, options)
 	podFunc := backupDataStatsPodFunc(tp, encryptionKey, backupArtifactPrefix, backupID, mode)

--- a/pkg/function/checkRepository.go
+++ b/pkg/function/checkRepository.go
@@ -12,6 +12,7 @@ import (
 	kanister "github.com/kanisterio/kanister/pkg"
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	"github.com/kanisterio/kanister/pkg/consts"
+	"github.com/kanisterio/kanister/pkg/ephemeral"
 	"github.com/kanisterio/kanister/pkg/kube"
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/progress"
@@ -52,11 +53,12 @@ func CheckRepository(ctx context.Context, cli kubernetes.Interface, tp param.Tem
 		return nil, errors.Wrapf(err, "Failed to get controller namespace")
 	}
 	options := &kube.PodOptions{
-		Namespace:    namespace,
-		GenerateName: jobPrefix,
-		Image:        consts.GetKanisterToolsImage(),
-		Command:      []string{"sh", "-c", "tail -f /dev/null"},
-		PodOverride:  podOverride,
+		Namespace:            namespace,
+		GenerateName:         jobPrefix,
+		Image:                consts.GetKanisterToolsImage(),
+		Command:              []string{"sh", "-c", "tail -f /dev/null"},
+		PodOverride:          podOverride,
+		EnvironmentVariables: ephemeral.GlobalEnvVars(),
 	}
 	pr := kube.NewPodRunner(cli, options)
 	podFunc := CheckRepositoryPodFunc(cli, tp, encryptionKey, targetPaths, insecureTLS)

--- a/pkg/function/copy_volume_data.go
+++ b/pkg/function/copy_volume_data.go
@@ -28,6 +28,7 @@ import (
 	kanister "github.com/kanisterio/kanister/pkg"
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	"github.com/kanisterio/kanister/pkg/consts"
+	"github.com/kanisterio/kanister/pkg/ephemeral"
 	"github.com/kanisterio/kanister/pkg/format"
 	"github.com/kanisterio/kanister/pkg/kube"
 	"github.com/kanisterio/kanister/pkg/log"
@@ -97,7 +98,8 @@ func copyVolumeData(
 			MountPath: mountPoint,
 			ReadOnly:  kube.PVCContainsReadOnlyAccessMode(pvc),
 		}},
-		PodOverride: podOverride,
+		PodOverride:          podOverride,
+		EnvironmentVariables: ephemeral.GlobalEnvVars(),
 	}
 	pr := kube.NewPodRunner(cli, options)
 	podFunc := copyVolumeDataPodFunc(cli, tp, mountPoint, targetPath, encryptionKey, insecureTLS)

--- a/pkg/function/delete_data.go
+++ b/pkg/function/delete_data.go
@@ -29,6 +29,7 @@ import (
 	kanister "github.com/kanisterio/kanister/pkg"
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	"github.com/kanisterio/kanister/pkg/consts"
+	"github.com/kanisterio/kanister/pkg/ephemeral"
 	"github.com/kanisterio/kanister/pkg/format"
 	"github.com/kanisterio/kanister/pkg/kube"
 	"github.com/kanisterio/kanister/pkg/param"
@@ -91,11 +92,12 @@ func deleteData(
 	}
 
 	options := &kube.PodOptions{
-		Namespace:    namespace,
-		GenerateName: jobPrefix,
-		Image:        consts.GetKanisterToolsImage(),
-		Command:      []string{"sh", "-c", "tail -f /dev/null"},
-		PodOverride:  podOverride,
+		Namespace:            namespace,
+		GenerateName:         jobPrefix,
+		Image:                consts.GetKanisterToolsImage(),
+		Command:              []string{"sh", "-c", "tail -f /dev/null"},
+		PodOverride:          podOverride,
+		EnvironmentVariables: ephemeral.GlobalEnvVars(),
 	}
 	pr := kube.NewPodRunner(cli, options)
 	podFunc := deleteDataPodFunc(tp, reclaimSpace, encryptionKey, insecureTLS, targetPaths, deleteTags, deleteIdentifiers)

--- a/pkg/function/delete_data_using_kopia_server.go
+++ b/pkg/function/delete_data_using_kopia_server.go
@@ -25,6 +25,7 @@ import (
 
 	kanister "github.com/kanisterio/kanister/pkg"
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
+	"github.com/kanisterio/kanister/pkg/ephemeral"
 	"github.com/kanisterio/kanister/pkg/format"
 	kankopia "github.com/kanisterio/kanister/pkg/kopia"
 	kopiacmd "github.com/kanisterio/kanister/pkg/kopia/command"
@@ -153,10 +154,11 @@ func deleteDataFromServer(
 	userPassphrase string,
 ) (map[string]any, error) {
 	options := &kube.PodOptions{
-		Namespace:    namespace,
-		GenerateName: jobPrefix,
-		Image:        image,
-		Command:      []string{"bash", "-c", "tail -f /dev/null"},
+		Namespace:            namespace,
+		GenerateName:         jobPrefix,
+		Image:                image,
+		Command:              []string{"bash", "-c", "tail -f /dev/null"},
+		EnvironmentVariables: ephemeral.GlobalEnvVars(),
 	}
 	pr := kube.NewPodRunner(cli, options)
 	podFunc := deleteDataFromServerPodFunc(

--- a/pkg/function/kube_task.go
+++ b/pkg/function/kube_task.go
@@ -26,6 +26,7 @@ import (
 	kanister "github.com/kanisterio/kanister/pkg"
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	"github.com/kanisterio/kanister/pkg/consts"
+	"github.com/kanisterio/kanister/pkg/ephemeral"
 	"github.com/kanisterio/kanister/pkg/field"
 	"github.com/kanisterio/kanister/pkg/kube"
 	"github.com/kanisterio/kanister/pkg/output"
@@ -60,11 +61,12 @@ func (*kubeTaskFunc) Name() string {
 
 func kubeTask(ctx context.Context, cli kubernetes.Interface, namespace, image string, command []string, podOverride crv1alpha1.JSONMap) (map[string]interface{}, error) {
 	options := &kube.PodOptions{
-		Namespace:    namespace,
-		GenerateName: jobPrefix,
-		Image:        image,
-		Command:      command,
-		PodOverride:  podOverride,
+		Namespace:            namespace,
+		GenerateName:         jobPrefix,
+		Image:                image,
+		Command:              command,
+		PodOverride:          podOverride,
+		EnvironmentVariables: ephemeral.GlobalEnvVars(),
 	}
 	// Mark pod with label having key `kanister.io/JobID`, the value of which is a reference to the origin of the pod.
 	kube.AddLabelsToPodOptionsFromContext(ctx, options, path.Join(consts.LabelPrefix, consts.LabelSuffixJobID))

--- a/pkg/function/prepare_data.go
+++ b/pkg/function/prepare_data.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/kanisterio/kanister/pkg/consts"
+	"github.com/kanisterio/kanister/pkg/ephemeral"
 	"github.com/kanisterio/kanister/pkg/field"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -99,13 +100,14 @@ func prepareData(ctx context.Context, cli kubernetes.Interface, namespace, servi
 	}
 
 	options := &kube.PodOptions{
-		Namespace:          namespace,
-		GenerateName:       prepareDataJobPrefix,
-		Image:              image,
-		Command:            command,
-		Volumes:            validatedVols,
-		ServiceAccountName: serviceAccount,
-		PodOverride:        podOverride,
+		Namespace:            namespace,
+		GenerateName:         prepareDataJobPrefix,
+		Image:                image,
+		Command:              command,
+		Volumes:              validatedVols,
+		ServiceAccountName:   serviceAccount,
+		PodOverride:          podOverride,
+		EnvironmentVariables: ephemeral.GlobalEnvVars(),
 	}
 	pr := kube.NewPodRunner(cli, options)
 	podFunc := prepareDataPodFunc(cli)

--- a/pkg/function/restore_data.go
+++ b/pkg/function/restore_data.go
@@ -25,6 +25,7 @@ import (
 
 	kanister "github.com/kanisterio/kanister/pkg"
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
+	"github.com/kanisterio/kanister/pkg/ephemeral"
 	"github.com/kanisterio/kanister/pkg/format"
 	"github.com/kanisterio/kanister/pkg/kube"
 	"github.com/kanisterio/kanister/pkg/param"
@@ -133,12 +134,13 @@ func restoreData(ctx context.Context, cli kubernetes.Interface, tp param.Templat
 	}
 
 	options := &kube.PodOptions{
-		Namespace:    namespace,
-		GenerateName: jobPrefix,
-		Image:        image,
-		Command:      []string{"sh", "-c", "tail -f /dev/null"},
-		Volumes:      validatedVols,
-		PodOverride:  podOverride,
+		Namespace:            namespace,
+		GenerateName:         jobPrefix,
+		Image:                image,
+		Command:              []string{"sh", "-c", "tail -f /dev/null"},
+		Volumes:              validatedVols,
+		PodOverride:          podOverride,
+		EnvironmentVariables: ephemeral.GlobalEnvVars(),
 	}
 	pr := kube.NewPodRunner(cli, options)
 	podFunc := restoreDataPodFunc(tp, encryptionKey, backupArtifactPrefix, restorePath, backupTag, backupID, insecureTLS)

--- a/pkg/function/restore_data_using_kopia_server.go
+++ b/pkg/function/restore_data_using_kopia_server.go
@@ -26,6 +26,7 @@ import (
 
 	kanister "github.com/kanisterio/kanister/pkg"
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
+	"github.com/kanisterio/kanister/pkg/ephemeral"
 	"github.com/kanisterio/kanister/pkg/format"
 	kankopia "github.com/kanisterio/kanister/pkg/kopia"
 	kopiacmd "github.com/kanisterio/kanister/pkg/kopia/command"
@@ -199,12 +200,13 @@ func restoreDataFromServer(
 	}
 
 	options := &kube.PodOptions{
-		Namespace:    namespace,
-		GenerateName: jobPrefix,
-		Image:        image,
-		Command:      []string{"bash", "-c", "tail -f /dev/null"},
-		Volumes:      validatedVols,
-		PodOverride:  podOverride,
+		Namespace:            namespace,
+		GenerateName:         jobPrefix,
+		Image:                image,
+		Command:              []string{"bash", "-c", "tail -f /dev/null"},
+		Volumes:              validatedVols,
+		PodOverride:          podOverride,
+		EnvironmentVariables: ephemeral.GlobalEnvVars(),
 	}
 
 	pr := kube.NewPodRunner(cli, options)


### PR DESCRIPTION
## Change Overview

This PR introduces the `ephemeral` package meant to handle registering and applying ephemeral pod specific fields. 

The first use-case was to introduce FIPS related environment variables that need to be set on all ephemeral pods to ensure the crypto backend (OpenSSL in this case) is started with the FIPS provider enabled and fails otherwise. 

The registration mechanism leaves it open to register conditional or static environment variables with the appropriate helper functions to help apply them. The only conditional environment variable helper at this point is the `OSEnvVar` which looks to see if the environment variable is set on the OS and applies it to the ephemeral pod if so. This usage is the main need for setting the FIPS environment variables since they're already present on the parent pod launching the ephemeral pods.

All places that used the `kube.PodOptions` type had the `ephemeral.GlobalEnvVars()` function added which adds all registered environment variables to the pod.

Two convenience functions `RegisterOSEnvVar` and `RegisterStaticEnvVar` were added to help facilitate the registering of environment variables from packages which import this.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [X] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #2856 

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
