### PR TITLE
Update client API server connect retry condition

### DIFF
--- a/pkg/kopia/repository/client.go
+++ b/pkg/kopia/repository/client.go
@@ -33,8 +33,19 @@ import (
 
 const (
 	defaultConnectMaxListCacheDuration time.Duration = time.Second * 600
-	kopiaGetRepoParametersError                      = "unable to get repository parameters"
+	connectionRefusedError                           = "connection refused"
+
+	// maxConnectRetries with value 100 results in ~23 total minutes of
+	// retries with the apiConnectBackoff settings defined below.
+	maxConnectionRetries = 100
 )
+
+var apiConnectBackoff = backoff.Backoff{
+	Factor: 2,
+	Jitter: false,
+	Min:    100 * time.Millisecond,
+	Max:    15 * time.Second,
+}
 
 // ConnectToAPIServer connects to the Kopia API server running at the given address
 func ConnectToAPIServer(
@@ -73,19 +84,11 @@ func ConnectToAPIServer(
 		},
 	}
 
-	err = poll.WaitWithBackoff(ctx, backoff.Backoff{
-		Factor: 2,
-		Jitter: false,
-		Min:    100 * time.Millisecond,
-		Max:    15 * time.Second,
-	}, func(c context.Context) (bool, error) {
+	err = poll.WaitWithBackoffWithRetries(ctx, apiConnectBackoff, maxConnectionRetries, isErrConnectionRefused, func(c context.Context) (bool, error) {
 		// TODO(@pavan): Modify this to use custom config file path, if required
 		err := repo.ConnectAPIServer(ctx, kopia.DefaultClientConfigFilePath, serverInfo, userPassphrase, opts)
-		switch {
-		case isGetRepoParametersError(err):
+		if err != nil {
 			log.Debug().WithError(err).Print("Connecting to the Kopia API Server")
-			return false, nil
-		case err != nil:
 			return false, err
 		}
 		return true, nil
@@ -126,6 +129,6 @@ func repositoryConfigFileName(configFile string) string {
 	return filepath.Join(os.Getenv("HOME"), ".config", "kopia", "repository.config")
 }
 
-func isGetRepoParametersError(err error) bool {
-	return err != nil && strings.Contains(err.Error(), kopiaGetRepoParametersError)
+func isErrConnectionRefused(err error) bool {
+	return err != nil && strings.Contains(err.Error(), connectionRefusedError)
 }


### PR DESCRIPTION
## Change Overview

The previous poll retry condition, when the error matches `unable to get repository parameters`, is no longer applicable. That error message was removed along with the http API deprecation in kopia. When a gRPC kopia server is not yet ready to serve a request, we expect `connection refused` instead.

https://github.com/kopia/kopia/pull/3745/files#diff-ca09e623adbc81f1968b51d8933b485b7a972150382b44f5ce56c379bf281485L330

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
