### PR TITLE
Add new ephemeral package for registering and applying PodOptions changes

### DIFF
--- a/pkg/controllers/repositoryserver/utils.go
+++ b/pkg/controllers/repositoryserver/utils.go
@@ -139,6 +139,10 @@ func volumeMountSpecForName(podSpec corev1.PodSpec, podOverride map[string]inter
 				Name:         "container",
 				VolumeMounts: mountList,
 			}
+
+			// Apply the registered ephemeral pod changes.
+			ephemeral.Options.Apply(&ctr)
+
 			podOverride["containers"] = []corev1.Container{*ctr}
 			return mount.Name, true
 		}
@@ -178,9 +182,14 @@ func addTLSCertConfigurationInPodOverride(podOverride *map[string]interface{}, t
 	})
 
 	if len(podOverrideSpec.Containers) == 0 {
-		podOverrideSpec.Containers = append(podOverrideSpec.Containers, corev1.Container{
+		options := corev1.Container{
 			Name: kube.ContainerNameFromPodOptsOrDefault(po),
-		})
+		}
+
+		// Apply the registered ephemeral pod changes.
+		ephemeral.Options.Apply(&options)
+
+		podOverrideSpec.Containers = append(podOverrideSpec.Containers, options)
 	}
 
 	podOverrideSpec.Containers[0].VolumeMounts = append(podOverrideSpec.Containers[0].VolumeMounts, corev1.VolumeMount{

--- a/pkg/controllers/repositoryserver/utils.go
+++ b/pkg/controllers/repositoryserver/utils.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/kanisterio/kanister/pkg/consts"
+	"github.com/kanisterio/kanister/pkg/ephemeral"
 	"github.com/kanisterio/kanister/pkg/format"
 	"github.com/kanisterio/kanister/pkg/kopia/command/storage"
 	"github.com/kanisterio/kanister/pkg/kube"
@@ -202,7 +203,7 @@ func addTLSCertConfigurationInPodOverride(podOverride *map[string]interface{}, t
 func getPodOptions(namespace string, svc *corev1.Service, vols map[string]kube.VolumeMountOptions) *kube.PodOptions {
 	uidguid := int64(0)
 	nonRootBool := false
-	return &kube.PodOptions{
+	options := &kube.PodOptions{
 		Namespace:     namespace,
 		GenerateName:  fmt.Sprintf("%s-", repoServerPod),
 		Image:         consts.GetKanisterToolsImage(),
@@ -215,6 +216,10 @@ func getPodOptions(namespace string, svc *corev1.Service, vols map[string]kube.V
 		},
 		Volumes: vols,
 	}
+	// Apply the registered ephemeral pod changes.
+	ephemeral.Options.Apply(options)
+
+	return options
 }
 
 func getPodAddress(ctx context.Context, cli kubernetes.Interface, namespace, podName string) (string, error) {

--- a/pkg/controllers/repositoryserver/utils.go
+++ b/pkg/controllers/repositoryserver/utils.go
@@ -141,7 +141,7 @@ func volumeMountSpecForName(podSpec corev1.PodSpec, podOverride map[string]inter
 			}
 
 			// Apply the registered ephemeral pod changes.
-			ephemeral.Options.Apply(&ctr)
+			ephemeral.Container.Apply(ctr)
 
 			podOverride["containers"] = []corev1.Container{*ctr}
 			return mount.Name, true
@@ -182,14 +182,14 @@ func addTLSCertConfigurationInPodOverride(podOverride *map[string]interface{}, t
 	})
 
 	if len(podOverrideSpec.Containers) == 0 {
-		options := corev1.Container{
+		container := corev1.Container{
 			Name: kube.ContainerNameFromPodOptsOrDefault(po),
 		}
 
 		// Apply the registered ephemeral pod changes.
-		ephemeral.Options.Apply(&options)
+		ephemeral.Container.Apply(&container)
 
-		podOverrideSpec.Containers = append(podOverrideSpec.Containers, options)
+		podOverrideSpec.Containers = append(podOverrideSpec.Containers, container)
 	}
 
 	podOverrideSpec.Containers[0].VolumeMounts = append(podOverrideSpec.Containers[0].VolumeMounts, corev1.VolumeMount{
@@ -225,8 +225,9 @@ func getPodOptions(namespace string, svc *corev1.Service, vols map[string]kube.V
 		},
 		Volumes: vols,
 	}
+
 	// Apply the registered ephemeral pod changes.
-	ephemeral.Options.Apply(options)
+	ephemeral.PodOptions.Apply(options)
 
 	return options
 }

--- a/pkg/ephemeral/envvar.go
+++ b/pkg/ephemeral/envvar.go
@@ -1,13 +1,28 @@
+// Copyright 2024 The Kanister Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package ephemeral
 
 import (
 	"os"
 
-	"github.com/kanisterio/kanister/pkg/kube"
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/kanisterio/kanister/pkg/kube"
 )
 
-// OSEnvVar creates an ApplierSet to set an environment variable if its present
+// OSEnvVar creates an ApplierSet to set an environment variable if it's present
 // in the current environment.
 func OSEnvVar(name string) ApplierSet {
 	return ApplierSet{

--- a/pkg/ephemeral/envvar.go
+++ b/pkg/ephemeral/envvar.go
@@ -7,52 +7,55 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// OSEnvVar registers an environment variable if its present on the current OS to be applied to the PodOptions.
-func OSEnvVar(name string) Applier {
-	return ApplierFunc(func(options any) {
-		if val, present := os.LookupEnv(name); present {
-			switch v := options.(type) {
-			case *kube.PodOptions:
-				v.EnvironmentVariables = append(
-					v.EnvironmentVariables,
-					corev1.EnvVar{
-						Name:  name,
-						Value: val,
-					},
-				)
-			case *corev1.Container:
-				v.Env = append(
-					v.Env,
+// OSEnvVar creates an ApplierSet to set an environment variable if its present
+// in the current environment.
+func OSEnvVar(name string) ApplierSet {
+	return ApplierSet{
+		Container: ApplierFunc[corev1.Container](func(container *corev1.Container) {
+			if val, present := os.LookupEnv(name); present {
+				container.Env = append(
+					container.Env,
 					corev1.EnvVar{
 						Name:  name,
 						Value: val,
 					},
 				)
 			}
-		}
-	})
+		}),
+		PodOptions: ApplierFunc[kube.PodOptions](func(options *kube.PodOptions) {
+			if val, present := os.LookupEnv(name); present {
+				options.EnvironmentVariables = append(
+					options.EnvironmentVariables,
+					corev1.EnvVar{
+						Name:  name,
+						Value: val,
+					},
+				)
+			}
+		}),
+	}
 }
 
-// StaticEnvVar registers a static environment variable to be applied to the PodOptions.
-func StaticEnvVar(name, value string) Applier {
-	return ApplierFunc(func(options any) {
-		switch v := options.(type) {
-		case *kube.PodOptions:
-			v.EnvironmentVariables = append(
-				v.EnvironmentVariables,
+// StaticEnvVar creates an ApplierSet to set a static environment variable.
+func StaticEnvVar(name, value string) ApplierSet {
+	return ApplierSet{
+		Container: ApplierFunc[corev1.Container](func(container *corev1.Container) {
+			container.Env = append(
+				container.Env,
 				corev1.EnvVar{
 					Name:  name,
 					Value: value,
 				},
 			)
-		case *corev1.Container:
-			v.Env = append(
-				v.Env,
+		}),
+		PodOptions: ApplierFunc[kube.PodOptions](func(options *kube.PodOptions) {
+			options.EnvironmentVariables = append(
+				options.EnvironmentVariables,
 				corev1.EnvVar{
 					Name:  name,
 					Value: value,
 				},
 			)
-		}
-	})
+		}),
+	}
 }

--- a/pkg/ephemeral/envvar.go
+++ b/pkg/ephemeral/envvar.go
@@ -1,0 +1,58 @@
+package ephemeral
+
+import (
+	"os"
+
+	"github.com/kanisterio/kanister/pkg/kube"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// OSEnvVar registers an environment variable if its present on the current OS to be applied to the PodOptions.
+func OSEnvVar(name string) Applier {
+	return ApplierFunc(func(options any) {
+		if val, present := os.LookupEnv(name); present {
+			switch v := options.(type) {
+			case *kube.PodOptions:
+				v.EnvironmentVariables = append(
+					v.EnvironmentVariables,
+					corev1.EnvVar{
+						Name:  name,
+						Value: val,
+					},
+				)
+			case *corev1.Container:
+				v.Env = append(
+					v.Env,
+					corev1.EnvVar{
+						Name:  name,
+						Value: val,
+					},
+				)
+			}
+		}
+	})
+}
+
+// StaticEnvVar registers a static environment variable to be applied to the PodOptions.
+func StaticEnvVar(name, value string) Applier {
+	return ApplierFunc(func(options any) {
+		switch v := options.(type) {
+		case *kube.PodOptions:
+			v.EnvironmentVariables = append(
+				v.EnvironmentVariables,
+				corev1.EnvVar{
+					Name:  name,
+					Value: value,
+				},
+			)
+		case *corev1.Container:
+			v.Env = append(
+				v.Env,
+				corev1.EnvVar{
+					Name:  name,
+					Value: value,
+				},
+			)
+		}
+	})
+}

--- a/pkg/ephemeral/envvar_test.go
+++ b/pkg/ephemeral/envvar_test.go
@@ -1,0 +1,109 @@
+package ephemeral_test
+
+import (
+	"os"
+	"testing"
+
+	. "gopkg.in/check.v1"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/kanisterio/kanister/pkg/ephemeral"
+	"github.com/kanisterio/kanister/pkg/kube"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) { TestingT(t) }
+
+type EphemeralSuite struct{}
+
+var _ = Suite(&EphemeralSuite{})
+
+func (s *EphemeralSuite) TestRegisteringOSEnvVarKubePodOptions(c *C) {
+	expected := []corev1.EnvVar{
+		{
+			Name:  "KANISTER_REGISTERED_OS_ENVVAR",
+			Value: "1",
+		},
+	}
+
+	var options kube.PodOptions
+
+	// OS environment variable not set
+	var registeredAppliers ephemeral.ApplierList
+	registeredAppliers.Register(ephemeral.OSEnvVar(expected[0].Name))
+	registeredAppliers.Apply(&options)
+
+	c.Assert(options.EnvironmentVariables, DeepEquals, []corev1.EnvVar(nil))
+
+	// OS environment variable set
+	os.Setenv(expected[0].Name, expected[0].Value)
+	defer os.Unsetenv(expected[0].Name)
+
+	registeredAppliers = ephemeral.ApplierList{}
+	registeredAppliers.Register(ephemeral.OSEnvVar(expected[0].Name))
+	registeredAppliers.Apply(&options)
+
+	c.Assert(options.EnvironmentVariables, DeepEquals, expected)
+}
+
+func (s *EphemeralSuite) TestRegisteringOSEnvVarCoreV1Container(c *C) {
+	expected := []corev1.EnvVar{
+		{
+			Name:  "KANISTER_REGISTERED_OS_ENVVAR",
+			Value: "1",
+		},
+	}
+
+	var options corev1.Container
+
+	// OS environment variable not set
+	var registeredAppliers ephemeral.ApplierList
+	registeredAppliers.Register(ephemeral.OSEnvVar(expected[0].Name))
+	registeredAppliers.Apply(&options)
+
+	c.Assert(options.Env, DeepEquals, []corev1.EnvVar(nil))
+
+	// OS environment variable set
+	os.Setenv(expected[0].Name, expected[0].Value)
+	defer os.Unsetenv(expected[0].Name)
+
+	registeredAppliers = ephemeral.ApplierList{}
+	registeredAppliers.Register(ephemeral.OSEnvVar(expected[0].Name))
+	registeredAppliers.Apply(&options)
+
+	c.Assert(options.Env, DeepEquals, expected)
+}
+
+func (s *EphemeralSuite) TestRegisteringStaticEnvVarKubePodOptions(c *C) {
+	expected := []corev1.EnvVar{
+		{
+			Name:  "KANISTER_REGISTERED_STATIC_ENVVAR",
+			Value: "1",
+		},
+	}
+
+	var options kube.PodOptions
+
+	var registeredAppliers ephemeral.ApplierList
+	registeredAppliers.Register(ephemeral.StaticEnvVar(expected[0].Name, expected[0].Value))
+	registeredAppliers.Apply(&options)
+
+	c.Assert(options.EnvironmentVariables, DeepEquals, expected)
+}
+
+func (s *EphemeralSuite) TestRegisteringStaticEnvVarCoreV1Container(c *C) {
+	expected := []corev1.EnvVar{
+		{
+			Name:  "KANISTER_REGISTERED_STATIC_ENVVAR",
+			Value: "1",
+		},
+	}
+
+	var options corev1.Container
+
+	var registeredAppliers ephemeral.ApplierList
+	registeredAppliers.Register(ephemeral.StaticEnvVar(expected[0].Name, expected[0].Value))
+	registeredAppliers.Apply(&options)
+
+	c.Assert(options.Env, DeepEquals, expected)
+}

--- a/pkg/ephemeral/envvar_test.go
+++ b/pkg/ephemeral/envvar_test.go
@@ -1,3 +1,17 @@
+// Copyright 2024 The Kanister Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package ephemeral_test
 
 import (

--- a/pkg/ephemeral/ephemeral.go
+++ b/pkg/ephemeral/ephemeral.go
@@ -1,8 +1,23 @@
+// Copyright 2024 The Kanister Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package ephemeral
 
 import (
-	"github.com/kanisterio/kanister/pkg/kube"
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/kanisterio/kanister/pkg/kube"
 )
 
 var (
@@ -10,7 +25,7 @@ var (
 	PodOptions ApplierList[kube.PodOptions]
 )
 
-// ApplierSet is a group of Appliers, typically returned by an constructor.
+// ApplierSet is a group of Appliers, typically returned by a constructor.
 type ApplierSet struct {
 	Container  Applier[corev1.Container]
 	PodOptions Applier[kube.PodOptions]
@@ -87,7 +102,7 @@ func (f FiltererFunc[T]) Filter(options *T) bool {
 	return f(options)
 }
 
-// Filter applies the Applier's if the Filterer criterion is met.
+// Filter applies the Appliers if the Filterer criterion is met.
 func Filter[T Constraint](filterer Filterer[T], appliers ...Applier[T]) Applier[T] {
 	return ApplierFunc[T](func(options *T) {
 		if !filterer.Filter(options) {
@@ -100,7 +115,8 @@ func Filter[T Constraint](filterer Filterer[T], appliers ...Applier[T]) Applier[
 	})
 }
 
-// PodOptionsNameFilter is a Filterer that filters based on the PodOptions.Name.
+// PodOptionsNameFilter is a Filterer that filters based on the PodOptions.Name
+// which is the Pod name.
 type PodOptionsNameFilter string
 
 func (n PodOptionsNameFilter) Filter(options *kube.PodOptions) bool {

--- a/pkg/ephemeral/ephemeral.go
+++ b/pkg/ephemeral/ephemeral.go
@@ -1,0 +1,73 @@
+package ephemeral
+
+// Applier is the interface which applies a manipulation to the PodOption to be
+// used to run ephemeral pdos.
+type Applier interface {
+	Apply(any)
+}
+
+// ApplierFunc is a function which implements the Applier interface and can be
+// used to generically manipulate the PodOptions.
+type ApplierFunc func(any)
+
+func (f ApplierFunc) Apply(options any) { f(options) }
+
+var (
+	// Options holds the registered Appliers.
+	Options ApplierList
+)
+
+// ApplierList is an array of registered Appliers which will be applied on
+// a PodOption.
+type ApplierList []Applier
+
+// Apply calls the Applier::Apply method on all registered appliers.
+func (l ApplierList) Apply(options any) {
+	for _, applier := range l {
+		applier.Apply(options)
+	}
+}
+
+// Register adds the applier to the list of Appliers to be used when
+// manipulating the PodOptions.
+func (l *ApplierList) Register(applier Applier) {
+	*l = append(*l, applier)
+}
+
+// Filterer is the interface which filters the use of registered appliers to
+// only those PodOptions that match the filter criteria.
+type Filterer interface {
+	Filter(any) bool
+}
+
+// FiltererFunc is a function which implements the Filterer interface and can be
+// used to generically filter PodOptions to manipulate using the ApplierList.
+type FiltererFunc func(any) bool
+
+func (f FiltererFunc) Filter(options any) bool {
+	return f(options)
+}
+
+// PodNameFilter is a Filterer that filters based on the PodOptions.Name.
+type PodNameFilter string
+
+func (f PodNameFilter) Filter(options any) bool {
+	if v, ok := options.(struct{ Name string }); ok {
+		return string(f) == v.Name
+	}
+
+	return false
+}
+
+// Filter applies the Applier's if the Filterer criterion is met.
+func Filter(filterer Filterer, appliers ...Applier) Applier {
+	return ApplierFunc(func(options any) {
+		if !filterer.Filter(options) {
+			return
+		}
+
+		for _, applier := range appliers {
+			applier.Apply(options)
+		}
+	})
+}

--- a/pkg/ephemeral/ephemeral_test.go
+++ b/pkg/ephemeral/ephemeral_test.go
@@ -1,0 +1,115 @@
+package ephemeral_test
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/kanisterio/kanister/pkg/ephemeral"
+	"github.com/kanisterio/kanister/pkg/kube"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) { TestingT(t) }
+
+type EphemeralSuite struct {
+	OriginalContainer  ephemeral.ApplierList[corev1.Container]
+	OriginalPodOptions ephemeral.ApplierList[kube.PodOptions]
+}
+
+var _ = Suite(&EphemeralSuite{})
+
+func (s *EphemeralSuite) SetUpTest(c *C) {
+	s.OriginalContainer = ephemeral.Container
+	ephemeral.Container = ephemeral.ApplierList[corev1.Container]{}
+
+	s.OriginalPodOptions = ephemeral.PodOptions
+	ephemeral.PodOptions = ephemeral.ApplierList[kube.PodOptions]{}
+}
+
+func (s *EphemeralSuite) TearDownTest(c *C) {
+	ephemeral.Container = s.OriginalContainer
+	ephemeral.PodOptions = s.OriginalPodOptions
+}
+
+type TestContainerApplier struct{}
+
+func (TestContainerApplier) Apply(*corev1.Container) {}
+
+func (s *EphemeralSuite) TestRegisterContainerApplier(c *C) {
+	var applier TestContainerApplier
+
+	c.Assert(len(ephemeral.Container), Equals, 0)
+	ephemeral.Register(applier)
+
+	if c.Check(len(ephemeral.Container), Equals, 1) {
+		c.Check(ephemeral.Container[0], Equals, applier)
+	}
+}
+
+type TestPodOptionsApplier struct{}
+
+func (TestPodOptionsApplier) Apply(*kube.PodOptions) {}
+
+func (s *EphemeralSuite) TestRegisterPodOptionsApplier(c *C) {
+	var applier TestPodOptionsApplier
+
+	c.Assert(len(ephemeral.PodOptions), Equals, 0)
+	ephemeral.Register(applier)
+
+	if c.Check(len(ephemeral.PodOptions), Equals, 1) {
+		c.Check(ephemeral.PodOptions[0], Equals, applier)
+	}
+}
+
+func (s *EphemeralSuite) TestRegisterSet(c *C) {
+	set := ephemeral.ApplierSet{
+		Container:  TestContainerApplier{},
+		PodOptions: TestPodOptionsApplier{},
+	}
+
+	c.Assert(len(ephemeral.Container), Equals, 0)
+	c.Assert(len(ephemeral.PodOptions), Equals, 0)
+	ephemeral.RegisterSet(set)
+
+	if c.Check(len(ephemeral.Container), Equals, 1) {
+		c.Check(ephemeral.Container[0], Equals, set.Container)
+	}
+	if c.Check(len(ephemeral.PodOptions), Equals, 1) {
+		c.Check(ephemeral.PodOptions[0], Equals, set.PodOptions)
+	}
+}
+
+func (s *EphemeralSuite) TestFilter(c *C) {
+	applier := ephemeral.Filter(
+		ephemeral.PodOptionsNameFilter("matches"),
+		ephemeral.ApplierFunc[kube.PodOptions](func(options *kube.PodOptions) {
+			options.Image = "applied-image"
+		}),
+	)
+
+	var options kube.PodOptions
+
+	options.Name = "nomatch"
+	applier.Apply(&options)
+	c.Check(options.Image, Equals, "")
+
+	options.Name = "matches"
+	applier.Apply(&options)
+	c.Check(options.Image, Equals, "applied-image")
+}
+
+func (s *EphemeralSuite) TestContainerNameFilter(c *C) {
+	filter := ephemeral.ContainerNameFilter("matches")
+
+	c.Check(filter.Filter(&corev1.Container{Name: "matches"}), Equals, true)
+	c.Check(filter.Filter(&corev1.Container{Name: "nomatch"}), Equals, false)
+}
+
+func (s *EphemeralSuite) TestPodOptionsNameFilter(c *C) {
+	filter := ephemeral.PodOptionsNameFilter("matches")
+
+	c.Check(filter.Filter(&kube.PodOptions{Name: "matches"}), Equals, true)
+	c.Check(filter.Filter(&kube.PodOptions{Name: "nomatch"}), Equals, false)
+}

--- a/pkg/ephemeral/ephemeral_test.go
+++ b/pkg/ephemeral/ephemeral_test.go
@@ -1,3 +1,17 @@
+// Copyright 2024 The Kanister Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package ephemeral_test
 
 import (

--- a/pkg/function/backup_data_stats.go
+++ b/pkg/function/backup_data_stats.go
@@ -26,6 +26,7 @@ import (
 	kanister "github.com/kanisterio/kanister/pkg"
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	"github.com/kanisterio/kanister/pkg/consts"
+	"github.com/kanisterio/kanister/pkg/ephemeral"
 	"github.com/kanisterio/kanister/pkg/format"
 	"github.com/kanisterio/kanister/pkg/kube"
 	"github.com/kanisterio/kanister/pkg/param"
@@ -75,6 +76,10 @@ func backupDataStats(ctx context.Context, cli kubernetes.Interface, tp param.Tem
 		Command:      []string{"sh", "-c", "tail -f /dev/null"},
 		PodOverride:  podOverride,
 	}
+
+	// Apply the registered ephemeral pod changes.
+	ephemeral.Options.Apply(options)
+
 	pr := kube.NewPodRunner(cli, options)
 	podFunc := backupDataStatsPodFunc(tp, encryptionKey, backupArtifactPrefix, backupID, mode)
 	return pr.Run(ctx, podFunc)

--- a/pkg/function/backup_data_stats.go
+++ b/pkg/function/backup_data_stats.go
@@ -78,7 +78,7 @@ func backupDataStats(ctx context.Context, cli kubernetes.Interface, tp param.Tem
 	}
 
 	// Apply the registered ephemeral pod changes.
-	ephemeral.Options.Apply(options)
+	ephemeral.PodOptions.Apply(options)
 
 	pr := kube.NewPodRunner(cli, options)
 	podFunc := backupDataStatsPodFunc(tp, encryptionKey, backupArtifactPrefix, backupID, mode)

--- a/pkg/function/checkRepository.go
+++ b/pkg/function/checkRepository.go
@@ -61,7 +61,7 @@ func CheckRepository(ctx context.Context, cli kubernetes.Interface, tp param.Tem
 	}
 
 	// Apply the registered ephemeral pod changes.
-	ephemeral.Options.Apply(options)
+	ephemeral.PodOptions.Apply(options)
 
 	pr := kube.NewPodRunner(cli, options)
 	podFunc := CheckRepositoryPodFunc(cli, tp, encryptionKey, targetPaths, insecureTLS)

--- a/pkg/function/checkRepository.go
+++ b/pkg/function/checkRepository.go
@@ -12,6 +12,7 @@ import (
 	kanister "github.com/kanisterio/kanister/pkg"
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	"github.com/kanisterio/kanister/pkg/consts"
+	"github.com/kanisterio/kanister/pkg/ephemeral"
 	"github.com/kanisterio/kanister/pkg/kube"
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/progress"
@@ -58,6 +59,10 @@ func CheckRepository(ctx context.Context, cli kubernetes.Interface, tp param.Tem
 		Command:      []string{"sh", "-c", "tail -f /dev/null"},
 		PodOverride:  podOverride,
 	}
+
+	// Apply the registered ephemeral pod changes.
+	ephemeral.Options.Apply(options)
+
 	pr := kube.NewPodRunner(cli, options)
 	podFunc := CheckRepositoryPodFunc(cli, tp, encryptionKey, targetPaths, insecureTLS)
 	return pr.Run(ctx, podFunc)

--- a/pkg/function/copy_volume_data.go
+++ b/pkg/function/copy_volume_data.go
@@ -102,7 +102,7 @@ func copyVolumeData(
 	}
 
 	// Apply the registered ephemeral pod changes.
-	ephemeral.Options.Apply(options)
+	ephemeral.PodOptions.Apply(options)
 
 	pr := kube.NewPodRunner(cli, options)
 	podFunc := copyVolumeDataPodFunc(cli, tp, mountPoint, targetPath, encryptionKey, insecureTLS)

--- a/pkg/function/copy_volume_data.go
+++ b/pkg/function/copy_volume_data.go
@@ -28,6 +28,7 @@ import (
 	kanister "github.com/kanisterio/kanister/pkg"
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	"github.com/kanisterio/kanister/pkg/consts"
+	"github.com/kanisterio/kanister/pkg/ephemeral"
 	"github.com/kanisterio/kanister/pkg/format"
 	"github.com/kanisterio/kanister/pkg/kube"
 	"github.com/kanisterio/kanister/pkg/log"
@@ -99,6 +100,10 @@ func copyVolumeData(
 		}},
 		PodOverride: podOverride,
 	}
+
+	// Apply the registered ephemeral pod changes.
+	ephemeral.Options.Apply(options)
+
 	pr := kube.NewPodRunner(cli, options)
 	podFunc := copyVolumeDataPodFunc(cli, tp, mountPoint, targetPath, encryptionKey, insecureTLS)
 	return pr.Run(ctx, podFunc)

--- a/pkg/function/delete_data.go
+++ b/pkg/function/delete_data.go
@@ -29,6 +29,7 @@ import (
 	kanister "github.com/kanisterio/kanister/pkg"
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	"github.com/kanisterio/kanister/pkg/consts"
+	"github.com/kanisterio/kanister/pkg/ephemeral"
 	"github.com/kanisterio/kanister/pkg/format"
 	"github.com/kanisterio/kanister/pkg/kube"
 	"github.com/kanisterio/kanister/pkg/param"
@@ -97,6 +98,10 @@ func deleteData(
 		Command:      []string{"sh", "-c", "tail -f /dev/null"},
 		PodOverride:  podOverride,
 	}
+
+	// Apply the registered ephemeral pod changes.
+	ephemeral.Options.Apply(options)
+
 	pr := kube.NewPodRunner(cli, options)
 	podFunc := deleteDataPodFunc(tp, reclaimSpace, encryptionKey, insecureTLS, targetPaths, deleteTags, deleteIdentifiers)
 	return pr.Run(ctx, podFunc)

--- a/pkg/function/delete_data.go
+++ b/pkg/function/delete_data.go
@@ -100,7 +100,7 @@ func deleteData(
 	}
 
 	// Apply the registered ephemeral pod changes.
-	ephemeral.Options.Apply(options)
+	ephemeral.PodOptions.Apply(options)
 
 	pr := kube.NewPodRunner(cli, options)
 	podFunc := deleteDataPodFunc(tp, reclaimSpace, encryptionKey, insecureTLS, targetPaths, deleteTags, deleteIdentifiers)

--- a/pkg/function/delete_data_using_kopia_server.go
+++ b/pkg/function/delete_data_using_kopia_server.go
@@ -161,7 +161,7 @@ func deleteDataFromServer(
 	}
 
 	// Apply the registered ephemeral pod changes.
-	ephemeral.Options.Apply(options)
+	ephemeral.PodOptions.Apply(options)
 
 	pr := kube.NewPodRunner(cli, options)
 	podFunc := deleteDataFromServerPodFunc(

--- a/pkg/function/delete_data_using_kopia_server.go
+++ b/pkg/function/delete_data_using_kopia_server.go
@@ -25,6 +25,7 @@ import (
 
 	kanister "github.com/kanisterio/kanister/pkg"
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
+	"github.com/kanisterio/kanister/pkg/ephemeral"
 	"github.com/kanisterio/kanister/pkg/format"
 	kankopia "github.com/kanisterio/kanister/pkg/kopia"
 	kopiacmd "github.com/kanisterio/kanister/pkg/kopia/command"
@@ -158,6 +159,10 @@ func deleteDataFromServer(
 		Image:        image,
 		Command:      []string{"bash", "-c", "tail -f /dev/null"},
 	}
+
+	// Apply the registered ephemeral pod changes.
+	ephemeral.Options.Apply(options)
+
 	pr := kube.NewPodRunner(cli, options)
 	podFunc := deleteDataFromServerPodFunc(
 		hostname,

--- a/pkg/function/kube_task.go
+++ b/pkg/function/kube_task.go
@@ -69,7 +69,7 @@ func kubeTask(ctx context.Context, cli kubernetes.Interface, namespace, image st
 	}
 
 	// Apply the registered ephemeral pod changes.
-	ephemeral.Options.Apply(options)
+	ephemeral.PodOptions.Apply(options)
 
 	// Mark pod with label having key `kanister.io/JobID`, the value of which is a reference to the origin of the pod.
 	kube.AddLabelsToPodOptionsFromContext(ctx, options, path.Join(consts.LabelPrefix, consts.LabelSuffixJobID))

--- a/pkg/function/kube_task.go
+++ b/pkg/function/kube_task.go
@@ -26,6 +26,7 @@ import (
 	kanister "github.com/kanisterio/kanister/pkg"
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	"github.com/kanisterio/kanister/pkg/consts"
+	"github.com/kanisterio/kanister/pkg/ephemeral"
 	"github.com/kanisterio/kanister/pkg/field"
 	"github.com/kanisterio/kanister/pkg/kube"
 	"github.com/kanisterio/kanister/pkg/output"
@@ -66,6 +67,10 @@ func kubeTask(ctx context.Context, cli kubernetes.Interface, namespace, image st
 		Command:      command,
 		PodOverride:  podOverride,
 	}
+
+	// Apply the registered ephemeral pod changes.
+	ephemeral.Options.Apply(options)
+
 	// Mark pod with label having key `kanister.io/JobID`, the value of which is a reference to the origin of the pod.
 	kube.AddLabelsToPodOptionsFromContext(ctx, options, path.Join(consts.LabelPrefix, consts.LabelSuffixJobID))
 	pr := kube.NewPodRunner(cli, options)

--- a/pkg/function/prepare_data.go
+++ b/pkg/function/prepare_data.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/kanisterio/kanister/pkg/consts"
+	"github.com/kanisterio/kanister/pkg/ephemeral"
 	"github.com/kanisterio/kanister/pkg/field"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -107,6 +108,10 @@ func prepareData(ctx context.Context, cli kubernetes.Interface, namespace, servi
 		ServiceAccountName: serviceAccount,
 		PodOverride:        podOverride,
 	}
+
+	// Apply the registered ephemeral pod changes.
+	ephemeral.Options.Apply(options)
+
 	pr := kube.NewPodRunner(cli, options)
 	podFunc := prepareDataPodFunc(cli)
 	return pr.Run(ctx, podFunc)

--- a/pkg/function/prepare_data.go
+++ b/pkg/function/prepare_data.go
@@ -110,7 +110,7 @@ func prepareData(ctx context.Context, cli kubernetes.Interface, namespace, servi
 	}
 
 	// Apply the registered ephemeral pod changes.
-	ephemeral.Options.Apply(options)
+	ephemeral.PodOptions.Apply(options)
 
 	pr := kube.NewPodRunner(cli, options)
 	podFunc := prepareDataPodFunc(cli)

--- a/pkg/function/restore_data.go
+++ b/pkg/function/restore_data.go
@@ -143,7 +143,7 @@ func restoreData(ctx context.Context, cli kubernetes.Interface, tp param.Templat
 	}
 
 	// Apply the registered ephemeral pod changes.
-	ephemeral.Options.Apply(options)
+	ephemeral.PodOptions.Apply(options)
 
 	pr := kube.NewPodRunner(cli, options)
 	podFunc := restoreDataPodFunc(tp, encryptionKey, backupArtifactPrefix, restorePath, backupTag, backupID, insecureTLS)

--- a/pkg/function/restore_data.go
+++ b/pkg/function/restore_data.go
@@ -25,6 +25,7 @@ import (
 
 	kanister "github.com/kanisterio/kanister/pkg"
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
+	"github.com/kanisterio/kanister/pkg/ephemeral"
 	"github.com/kanisterio/kanister/pkg/format"
 	"github.com/kanisterio/kanister/pkg/kube"
 	"github.com/kanisterio/kanister/pkg/param"
@@ -140,6 +141,10 @@ func restoreData(ctx context.Context, cli kubernetes.Interface, tp param.Templat
 		Volumes:      validatedVols,
 		PodOverride:  podOverride,
 	}
+
+	// Apply the registered ephemeral pod changes.
+	ephemeral.Options.Apply(options)
+
 	pr := kube.NewPodRunner(cli, options)
 	podFunc := restoreDataPodFunc(tp, encryptionKey, backupArtifactPrefix, restorePath, backupTag, backupID, insecureTLS)
 	return pr.Run(ctx, podFunc)

--- a/pkg/function/restore_data_using_kopia_server.go
+++ b/pkg/function/restore_data_using_kopia_server.go
@@ -26,6 +26,7 @@ import (
 
 	kanister "github.com/kanisterio/kanister/pkg"
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
+	"github.com/kanisterio/kanister/pkg/ephemeral"
 	"github.com/kanisterio/kanister/pkg/format"
 	kankopia "github.com/kanisterio/kanister/pkg/kopia"
 	kopiacmd "github.com/kanisterio/kanister/pkg/kopia/command"
@@ -206,6 +207,9 @@ func restoreDataFromServer(
 		Volumes:      validatedVols,
 		PodOverride:  podOverride,
 	}
+
+	// Apply the registered ephemeral pod changes.
+	ephemeral.Options.Apply(options)
 
 	pr := kube.NewPodRunner(cli, options)
 	podFunc := restoreDataFromServerPodFunc(

--- a/pkg/function/restore_data_using_kopia_server.go
+++ b/pkg/function/restore_data_using_kopia_server.go
@@ -209,7 +209,7 @@ func restoreDataFromServer(
 	}
 
 	// Apply the registered ephemeral pod changes.
-	ephemeral.Options.Apply(options)
+	ephemeral.PodOptions.Apply(options)
 
 	pr := kube.NewPodRunner(cli, options)
 	podFunc := restoreDataFromServerPodFunc(


### PR DESCRIPTION
## Change Overview

This PR introduces the ephemeral package meant to handle registering and applying ephemeral pod specific fields.

The first use-case was to introduce FIPS related environment variables that need to be set on all ephemeral pods to ensure the crypto backend (OpenSSL in this case) is started with the FIPS provider enabled and fails otherwise.

The registration mechanism is made to be generic by using an `Applier` interface which is used to register different ways of applying changes to a `*kube.PodOptions` or a `*corev1.Container` .

For now convenience functions related to registering environment variable Applier's are added. The conditional environment variable helper is the OSEnvVar function which looks to see if the environment variable is set on the OS and applies it to the ephemeral pod if so. This usage is the main need for setting the FIPS environment variables since they're already present on the parent pod launching the ephemeral pods.

All places that used the `kube.PodOptions` and `corev1.Container` types have the ephemeral.Options.Apply() function added which adds all registered Appliers (only environment variables at this point) to the pod.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [X] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #2856 

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [X] :zap: Unit test
- [ ] :green_heart: E2E
