### PR TITLE
Add readonly and htpasswd configuration flags

### DIFF
--- a/pkg/kopia/command/const.go
+++ b/pkg/kopia/command/const.go
@@ -77,6 +77,7 @@ const (
 	userPasswordFlag          = "--user-password"
 	enablePprof               = "--enable-pprof"
 	metricsListerAddress      = "--metrics-listen-addr"
+	htpasswdFilePath          = "--htpasswd-file"
 
 	// Repository specific
 	repositorySubCommand      = "repository"
@@ -121,4 +122,7 @@ const (
 
 	// DefaultLogDirectory is the directory where kopia log file is created
 	DefaultLogDirectory = "/tmp/kopia-log"
+
+	// DefaultHtpasswdFilePath is the path to the generated htpasswd file
+	DefaultHtpasswdFilePath = "/tmp/kopia-htpasswd"
 )

--- a/pkg/kopia/command/server.go
+++ b/pkg/kopia/command/server.go
@@ -21,6 +21,8 @@ type ServerStartCommandArgs struct {
 	TLSKeyFile           string
 	ServerUsername       string
 	ServerPassword       string
+	HtpasswdFilePath     string
+	ReadOnly             bool
 	AutoGenerateCert     bool
 	Background           bool
 	EnablePprof          bool
@@ -39,11 +41,20 @@ func ServerStart(cmdArgs ServerStartCommandArgs) []string {
 	args = args.AppendLoggableKV(addressFlag, cmdArgs.ServerAddress)
 	args = args.AppendLoggableKV(tlsCertFilePath, cmdArgs.TLSCertFile)
 	args = args.AppendLoggableKV(tlsKeyFilePath, cmdArgs.TLSKeyFile)
+
+	if cmdArgs.HtpasswdFilePath != "" {
+		args = args.AppendLoggableKV(htpasswdFilePath, cmdArgs.HtpasswdFilePath)
+	}
+
 	args = args.AppendLoggableKV(serverUsernameFlag, cmdArgs.ServerUsername)
 	args = args.AppendRedactedKV(serverPasswordFlag, cmdArgs.ServerPassword)
 
 	args = args.AppendLoggableKV(serverControlUsernameFlag, cmdArgs.ServerUsername)
 	args = args.AppendRedactedKV(serverControlPasswordFlag, cmdArgs.ServerPassword)
+
+	if cmdArgs.ReadOnly {
+		args = args.AppendLoggable(readOnlyFlag)
+	}
 
 	if cmdArgs.EnablePprof {
 		args = args.AppendLoggable(enablePprof)

--- a/pkg/kopia/command/server_test.go
+++ b/pkg/kopia/command/server_test.go
@@ -103,6 +103,24 @@ func (kServer *KopiaServerTestSuite) TestServerCommands(c *C) {
 		},
 		{
 			f: func() []string {
+				args := ServerStartCommandArgs{
+					CommandArgs:      commandArgs,
+					ServerAddress:    "a-server-address",
+					TLSCertFile:      "/path/to/cert/tls.crt",
+					TLSKeyFile:       "/path/to/key/tls.key",
+					ServerUsername:   "a-username@a-hostname",
+					ServerPassword:   "a-user-password",
+					AutoGenerateCert: false,
+					Background:       true,
+					ReadOnly:         true,
+					HtpasswdFilePath: "/path/htpasswd",
+				}
+				return ServerStart(args)
+			},
+			expectedLog: "bash -o errexit -c kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log server start --address=a-server-address --tls-cert-file=/path/to/cert/tls.crt --tls-key-file=/path/to/key/tls.key --htpasswd-file=/path/htpasswd --server-username=a-username@a-hostname --server-password=a-user-password --server-control-username=a-username@a-hostname --server-control-password=a-user-password --readonly > /dev/null 2>&1 &",
+		},
+		{
+			f: func() []string {
 				args := ServerStatusCommandArgs{
 					CommandArgs:    commandArgs,
 					ServerAddress:  "a-server-address",


### PR DESCRIPTION
## Change Overview

This PR introduces 2 new flags to enhance Kopia's server mode.

- Added a new boolean flag `ReadOnly` to `ServerStartCommandArgs` struct. When enabled, this flag ensures that the Kopia server operates in a read-only mode by preventing write operations to the repository. 
- Added a new string argument `HtpasswdFilePath` to `ServerStartCommandArgs` struct. This allows Kopia to authenticate users using [HTTP authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication). 

The new fields in the `ServerStartCommandArgs` struct have default zero values (`false` for `ReadOnly` and `""` for `HtpasswdFilePath`) and should not affect existing code.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [x] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
