### PR TITLE
Improve progress tracking

### DIFF
--- a/pkg/apis/cr/v1alpha1/types.go
+++ b/pkg/apis/cr/v1alpha1/types.go
@@ -202,7 +202,7 @@ type PhaseProgress struct {
 	// EstimatedUploadSizeB represents the total estimated size of data in Bytes
 	// that will be uploaded during the phase execution.
 	// This field will be empty for phases which do not involve data movement.
-	EstimatedUploadSizeB int64 `json:"estinatedUploadSizeB,omitempty"`
+	EstimatedUploadSizeB int64 `json:"estimatedUploadSizeB,omitempty"`
 	// EstimatedTimeSeconds is the estimated time required in seconds to upload the
 	// remaining data estimated with EstimatedUploadSizeB.
 	// This field will be empty for phases which do not involve data movement.

--- a/pkg/apis/cr/v1alpha1/types.go
+++ b/pkg/apis/cr/v1alpha1/types.go
@@ -155,6 +155,20 @@ type ActionProgress struct {
 	// PercentCompleted is computed by assessing the number of completed phases
 	// against the total number of phases.
 	PercentCompleted string `json:"percentCompleted,omitempty"`
+	// SizeDownloadedB represents the size of data downloaded in Bytes at a given time during action execution.
+	// This field will be empty for actions which do not involve data movement.
+	SizeDownloadedB int64 `json:"sizeDownloadedB,omitempty"`
+	// SizeUploadedB represents the size of data uploaded in Bytes at a given time during action execution.
+	// This field will be empty for actions which do not involve data movement.
+	SizeUploadedB int64 `json:"sizeUploadedB,omitempty"`
+	// EstimatedDownloadSizeB represents the total estimated size of data in Bytes
+	// that will be downloaded during the action execution.
+	// This field will be empty for actions which do not involve data movement.
+	EstimatedDownloadSizeB int64 `json:"estimatedDownloadSizeB,omitempty"`
+	// EstimatedUploadSizeB represents the total estimated size of data in Bytes
+	// that will be uploaded during the phase execution.
+	// This field will be empty for phases which do not involve data movement.
+	EstimatedUploadSizeB int64 `json:"estimatedUploadSizeB,omitempty"`
 	// LastTransitionTime represents the last date time when the progress status
 	// was received.
 	LastTransitionTime *metav1.Time `json:"lastTransitionTime,omitempty"`
@@ -196,15 +210,22 @@ type Phase struct {
 type PhaseProgress struct {
 	// ProgressPercent represents the execution progress in percentage.
 	ProgressPercent string `json:"progressPercent,omitempty"`
+	// SizeDownloadedB represents the size of data downloaded in Bytes at a given time during phase execution.
+	// This field will be empty for phases which do not involve data movement.
+	SizeDownloadedB int64 `json:"sizeDownloadedB,omitempty"`
 	// SizeUploadedB represents the size of data uploaded in Bytes at a given time during phase execution.
 	// This field will be empty for phases which do not involve data movement.
 	SizeUploadedB int64 `json:"sizeUploadedB,omitempty"`
+	// EstimatedDownloadSizeB represents the total estimated size of data in Bytes
+	// that will be downloaded during the phase execution.
+	// This field will be empty for phases which do not involve data movement.
+	EstimatedDownloadSizeB int64 `json:"estimatedDownloadSizeB,omitempty"`
 	// EstimatedUploadSizeB represents the total estimated size of data in Bytes
 	// that will be uploaded during the phase execution.
 	// This field will be empty for phases which do not involve data movement.
 	EstimatedUploadSizeB int64 `json:"estimatedUploadSizeB,omitempty"`
-	// EstimatedTimeSeconds is the estimated time required in seconds to upload the
-	// remaining data estimated with EstimatedUploadSizeB.
+	// EstimatedTimeSeconds is the estimated time required in seconds to transfer the
+	// remaining data estimated with EstimatedUploadSizeB / EstimatedDownloadSizeB.
 	// This field will be empty for phases which do not involve data movement.
 	EstimatedTimeSeconds int64 `json:"estinatedTimeSeconds,omitempty"`
 	// LastTransitionTime represents the last date time when the progress status

--- a/pkg/apis/cr/v1alpha1/types.go
+++ b/pkg/apis/cr/v1alpha1/types.go
@@ -153,7 +153,7 @@ type ActionProgress struct {
 	// RunningPhase represents which phase of the action is being run
 	RunningPhase string `json:"runningPhase,omitempty"`
 	// PercentCompleted is computed by assessing the number of completed phases
-	// against the the total number of phases.
+	// against the total number of phases.
 	PercentCompleted string `json:"percentCompleted,omitempty"`
 	// LastTransitionTime represents the last date time when the progress status
 	// was received.

--- a/pkg/customresource/actionset.yaml
+++ b/pkg/customresource/actionset.yaml
@@ -207,6 +207,14 @@ spec:
                       type: string
                     percentCompleted:
                       type: string
+                    sizeDownloadedB:
+                      type: integer
+                    sizeUploadedB:
+                      type: integer
+                    estimatedDownloadSizeB:
+                      type: integer
+                    estimatedUploadSizeB:
+                      type: integer
                     lastTransitionTime:
                       type: string
                       format: date-time
@@ -271,9 +279,13 @@ spec:
                             properties:
                               progressPercent:
                                 type: string
+                              sizeDownloadedB:
+                                type: integer
                               sizeUploadedB:
                                 type: integer
                               estimatedTimeSeconds:
+                                type: integer
+                              estimatedDownloadSizeB:
                                 type: integer
                               estimatedUploadSizeB:
                                 type: integer
@@ -297,9 +309,13 @@ spec:
                               properties:
                                 progressPercent:
                                   type: string
+                                sizeDownloadedB:
+                                  type: integer
                                 sizeUploadedB:
                                   type: integer
                                 estimatedTimeSeconds:
+                                  type: integer
+                                estimatedDownloadSizeB:
                                   type: integer
                                 estimatedUploadSizeB:
                                   type: integer
@@ -325,6 +341,22 @@ spec:
           type: string
           description: Progress of completion in percentage
           jsonPath: .status.progress.percentCompleted
+        - name: SizeDownloadedB
+          type: integer
+          description: Amount of data downloaded during action execution
+          jsonPath: .status.progress.sizeDownloadedB
+        - name: SizeUploadedB
+          type: integer
+          description: Amount of data uploaded during action execution
+          jsonPath: .status.progress.sizeUploadedB
+        - name: EstimatedDownloadSizeB
+          type: integer
+          description: Estimated amount of data to be downloaded during action execution
+          jsonPath: .status.progress.estimatedDownloadSizeB
+        - name: EstimatedUploadSizeB
+          type: integer
+          description: Estimated amount of data to be uploaded during action execution
+          jsonPath: .status.progress.estimatedUploadSizeB
         - name: Running Phase
           type: string
           description: The phase that is being run. If the actionset is completed, it is set to ""

--- a/pkg/progress/action.go
+++ b/pkg/progress/action.go
@@ -144,6 +144,26 @@ func completedOrFailed(aIDX int, actionSet *crv1alpha1.ActionSet, phaseName stri
 	return false
 }
 
+func isPhaseProgressDiffer(a, b crv1alpha1.PhaseProgress) bool {
+	if a.ProgressPercent != b.ProgressPercent {
+		return true
+	}
+
+	if a.SizeDownloadedB != b.SizeDownloadedB || a.SizeUploadedB != b.SizeUploadedB {
+		return true
+	}
+
+	if a.EstimatedDownloadSizeB != b.EstimatedDownloadSizeB || a.EstimatedUploadSizeB != b.EstimatedUploadSizeB {
+		return true
+	}
+
+	if a.EstimatedTimeSeconds != b.EstimatedTimeSeconds {
+		return true
+	}
+
+	return false
+}
+
 func setActionSetPhaseProgress(actionSet *crv1alpha1.ActionSet, phaseName string, phaseProgress crv1alpha1.PhaseProgress) error {
 	// Update or create phase status in ActionSet status
 	// Update phase progress if there is a change
@@ -156,7 +176,7 @@ func setActionSetPhaseProgress(actionSet *crv1alpha1.ActionSet, phaseName string
 				actionSet.Status.Actions[i].Phases[j].State == crv1alpha1.StateFailed {
 				continue
 			}
-			if actionSet.Status.Actions[i].Phases[j].Progress.ProgressPercent != phaseProgress.ProgressPercent {
+			if isPhaseProgressDiffer(actionSet.Status.Actions[i].Phases[j].Progress, phaseProgress) {
 				actionSet.Status.Actions[i].Phases[j].Progress = phaseProgress
 				if err := SetActionSetPercentCompleted(actionSet); err != nil {
 					return err
@@ -170,30 +190,43 @@ func setActionSetPhaseProgress(actionSet *crv1alpha1.ActionSet, phaseName string
 // SetActionSetPercentCompleted calculate and set percent completion of the action. The action completion percentage
 // is calculated by taking an average of all the involved phases.
 func SetActionSetPercentCompleted(actionSet *crv1alpha1.ActionSet) error {
-	actionProgress := 0
-	totalPhases := 0
+	var actionProgress, totalPhases int
+	var sizeUploadedB, sizeDownloadedB, estimatedUploadSizeB, estimatedDownloadSizeB int64
 	for _, actions := range actionSet.Status.Actions {
 		for _, phase := range actions.Phases {
+			sizeUploadedB += phase.Progress.SizeUploadedB
+			sizeDownloadedB += phase.Progress.SizeDownloadedB
+			estimatedUploadSizeB += phase.Progress.EstimatedUploadSizeB
+			estimatedDownloadSizeB += phase.Progress.EstimatedDownloadSizeB
+			totalPhases++
+
 			if phase.Progress.ProgressPercent == "" {
-				totalPhases++
 				continue
 			}
+
 			pp, err := strconv.Atoi(phase.Progress.ProgressPercent)
 			if err != nil {
 				return errors.Wrap(err, "Invalid phase progress percent")
 			}
 			actionProgress += pp
-			totalPhases++
 		}
 	}
 	actionProgress /= totalPhases
 
-	// Update LastTransitionTime only if there is a change in action PercentCompleted
-	if strconv.Itoa(actionProgress) == actionSet.Status.Progress.PercentCompleted {
+	// Update LastTransitionTime only if there is a change in action progress
+	if strconv.Itoa(actionProgress) == actionSet.Status.Progress.PercentCompleted &&
+		actionSet.Status.Progress.SizeDownloadedB == sizeDownloadedB &&
+		actionSet.Status.Progress.SizeUploadedB == sizeUploadedB &&
+		actionSet.Status.Progress.EstimatedDownloadSizeB == estimatedDownloadSizeB &&
+		actionSet.Status.Progress.EstimatedUploadSizeB == estimatedUploadSizeB {
 		return nil
 	}
 	metav1Time := metav1.NewTime(time.Now())
 	actionSet.Status.Progress.LastTransitionTime = &metav1Time
 	actionSet.Status.Progress.PercentCompleted = strconv.Itoa(actionProgress)
+	actionSet.Status.Progress.SizeDownloadedB = sizeDownloadedB
+	actionSet.Status.Progress.SizeUploadedB = sizeUploadedB
+	actionSet.Status.Progress.EstimatedDownloadSizeB = estimatedDownloadSizeB
+	actionSet.Status.Progress.EstimatedUploadSizeB = estimatedUploadSizeB
 	return nil
 }


### PR DESCRIPTION
## Change Overview

Currently we are tracking only amounts of data uploaded during action or phase. This PR brings new counters which allows us to track both, uploaded and downloaded data. 

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
