### PR TITLE
DEVOPS-7803 restore log stream

### DIFF
--- a/pkg/kube/pod.go
+++ b/pkg/kube/pod.go
@@ -295,10 +295,16 @@ func DeletePod(ctx context.Context, cli kubernetes.Interface, pod *corev1.Pod) e
 	return nil
 }
 
-func StreamPodLogs(ctx context.Context, cli kubernetes.Interface, namespace, podName, containerName string) (io.ReadCloser, error) {
+func StreamPodLogs(ctx context.Context, cli kubernetes.Interface, namespace, podName, containerName string, sinceNow bool) (io.ReadCloser, error) {
 	plo := &corev1.PodLogOptions{
 		Follow:    true,
 		Container: containerName,
+	}
+	if sinceNow {
+		plo.SinceTime = func() *metav1.Time {
+			now := metav1.Now()
+			return &now
+		}()
 	}
 	return cli.CoreV1().Pods(namespace).GetLogs(podName, plo).Stream(ctx)
 }
@@ -319,7 +325,7 @@ func GetPodLogs(ctx context.Context, cli kubernetes.Interface, namespace, podNam
 
 // getErrorFromLogs fetches logs from pod and constructs error containing last ten lines of log and specified error message
 func getErrorFromLogs(ctx context.Context, cli kubernetes.Interface, namespace, podName, containerName string, err error, errorMessage string) error {
-	r, logErr := StreamPodLogs(ctx, cli, namespace, podName, containerName)
+	r, logErr := StreamPodLogs(ctx, cli, namespace, podName, containerName, false)
 	if logErr != nil {
 		return errors.Wrapf(logErr, "Failed to fetch logs from the pod")
 	}


### PR DESCRIPTION
## Change Overview

Unfortunately, there is a hardcoded timeout in the kubelet server. If we want to support long-lasting phases, we need to work around it.

This PR introduces re-establishing the log stream connection while the pod is still running.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #1622 

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

I created a phase executing function `KubeTask`, with a long-lasting command (sleep). I ensured that the logs were read until the end of its execution and that the output was properly gathered.


- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
