### PR TITLE
fix: Make sure all storage providers return similar error if snapshot doesn't exist

### DIFF
--- a/pkg/blockstorage/awsebs/awsebs.go
+++ b/pkg/blockstorage/awsebs/awsebs.go
@@ -536,7 +536,7 @@ func getSnapshots(ctx context.Context, ec2Cli *EC2, snapIDs []*string) ([]*ec2.S
 	if len(dso.Snapshots) != len(snapIDs) {
 		log.Error().Print("Did not find all requested snapshots", field.M{"snapshots_requested": snapIDs, "snapshots_found": dso.Snapshots})
 		// TODO: Move mapping to HTTP error to the caller
-		return nil, errors.New("Object not found")
+		return nil, errors.New(blockstorage.SnapshotDoesNotExistError)
 	}
 	return dso.Snapshots, nil
 }
@@ -615,7 +615,7 @@ func waitOnSnapshotID(ctx context.Context, ec2Cli *EC2, snapID string) error {
 			return false, errors.Wrapf(err, "Failed to describe snapshot, snapshot_id: %s", snapID)
 		}
 		if len(dso.Snapshots) != 1 {
-			return false, errors.New("Object not found")
+			return false, errors.New(blockstorage.SnapshotDoesNotExistError)
 		}
 		s := dso.Snapshots[0]
 		if *s.State == ec2.SnapshotStateError {

--- a/pkg/blockstorage/blockstorage.go
+++ b/pkg/blockstorage/blockstorage.go
@@ -50,3 +50,5 @@ type RestoreTargeter interface {
 	// If not globally restorable, returns a map of the regions and zones to which snapshot can be restored.
 	SnapshotRestoreTargets(context.Context, *Snapshot) (global bool, regionsAndZones map[string][]string, err error)
 }
+
+const SnapshotDoesNotExistError = "Snapshot does not exist"

--- a/pkg/blockstorage/blockstorage_test.go
+++ b/pkg/blockstorage/blockstorage_test.go
@@ -141,6 +141,9 @@ func (s *BlockStorageProviderSuite) TestCreateSnapshot(c *C) {
 		err = s.provider.SnapshotDelete(context.Background(), snapshot)
 		c.Assert(err, IsNil)
 		s.snapshots = nil
+		_, err = s.provider.SnapshotGet(context.Background(), snapshot.ID)
+		c.Assert(err, NotNil)
+		c.Assert(err.Error(), Matches, blockstorage.SnapshotDoesNotExistError)
 	}
 }
 

--- a/pkg/blockstorage/gcepd/gcepd.go
+++ b/pkg/blockstorage/gcepd/gcepd.go
@@ -259,6 +259,9 @@ func (s *GpdStorage) SnapshotDelete(ctx context.Context, snapshot *blockstorage.
 func (s *GpdStorage) SnapshotGet(ctx context.Context, id string) (*blockstorage.Snapshot, error) {
 	snap, err := s.service.Snapshots.Get(s.project, id).Context(ctx).Do()
 	if err != nil {
+		if isNotFoundError(err) {
+			return nil, errors.Wrap(err, blockstorage.SnapshotDoesNotExistError)
+		}
 		return nil, err
 	}
 	return s.snapshotParse(ctx, snap), nil

--- a/pkg/function/delete_volume_snapshot.go
+++ b/pkg/function/delete_volume_snapshot.go
@@ -49,7 +49,6 @@ const (
 	DeleteVolumeSnapshotFuncName     = "DeleteVolumeSnapshot"
 	DeleteVolumeSnapshotNamespaceArg = "namespace"
 	DeleteVolumeSnapshotManifestArg  = "snapshots"
-	SnapshotDoesNotExistError        = "does not exist"
 )
 
 type deleteVolumeSnapshotFunc struct {
@@ -84,7 +83,7 @@ func deleteVolumeSnapshot(ctx context.Context, cli kubernetes.Interface, namespa
 		}
 		snapshot, err := provider.SnapshotGet(ctx, pvcInfo.SnapshotID)
 		if err != nil {
-			if strings.Contains(err.Error(), SnapshotDoesNotExistError) {
+			if strings.Contains(err.Error(), blockstorage.SnapshotDoesNotExistError) {
 				log.WithContext(ctx).Print("Snapshot already deleted", field.M{"SnapshotID": pvcInfo.SnapshotID})
 			} else {
 				return nil, errors.Wrapf(err, "Failed to get Snapshot from Provider")


### PR DESCRIPTION
## Change Overview

`DeleteVolumeSnapshot` function matches error returned from SnapshotGet with a 'does not exist' string.

This PR makes it so all providers wrap their errors with "Snapshot does not exist" message if they detect that snapshot does not exist in SnapshotGet

**NOTE:** technically SnapshotDelete should be idempotent, but it seems like `DeleteVolumeSnapshot` adds an extra check for logging purposes. Also we could have done some better error matching then just comparing strings. Although long term goal is to remove storage providers and move to CSI interfaces, hence it doesn't make sense to spend too much time on providers.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :building_construction: Build

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

- We need to make sure we run `blockstorage_test.go` for azure, aws and gcp.
- @mdsoysa can you please provide a test scenario to reproduce the original issue?

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [x] :green_heart: E2E
