### PR TITLE
build: push dev images with commit sha and short commit sha tags

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -109,4 +109,4 @@ jobs:
     - run: docker image prune -af
     - run: docker builder prune -af
     - run: make release-snapshot
-    - run: ./build/push_images.sh
+    - run: COMMIT_SHA_TAG=${{ github.sha }} ./build/push_images.sh

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -109,4 +109,4 @@ jobs:
     - run: docker image prune -af
     - run: docker builder prune -af
     - run: make release-snapshot
-    - run: COMMIT_SHA_TAG=${{ github.sha }} ./build/push_images.sh
+    - run: COMMIT_SHA=${{ github.sha }} ./build/push_images.sh

--- a/build/push_images.sh
+++ b/build/push_images.sh
@@ -25,6 +25,13 @@ IMAGES=(`cat ${IMAGES_NAME_PATH} | jq -r .images[]`)
 
 TAG=${1:-"v9.99.9-dev"}
 
+COMMIT_SHA_TAG=${COMMIT_SHA_TAG:?"COMMIT_SHA_TAG is required"}
+SHORT_COMMIT_SHA_TAG=${COMMIT_SHA_TAG::12}
+
 for i in ${IMAGES[@]}; do
+   docker tag $IMAGE_REGISTRY/$i:$TAG $IMAGE_REGISTRY/$i:$COMMIT_SHA_TAG
+   docker tag $IMAGE_REGISTRY/$i:$TAG $IMAGE_REGISTRY/$i:$SHORT_COMMIT_SHA_TAG
    docker push $IMAGE_REGISTRY/$i:$TAG
+   docker push $IMAGE_REGISTRY/$i:$COMMIT_SHA_TAG
+   docker push $IMAGE_REGISTRY/$i:$SHORT_COMMIT_SHA_TAG
 done

--- a/build/push_images.sh
+++ b/build/push_images.sh
@@ -25,8 +25,8 @@ IMAGES=(`cat ${IMAGES_NAME_PATH} | jq -r .images[]`)
 
 TAG=${1:-"v9.99.9-dev"}
 
-COMMIT_SHA_TAG=${COMMIT_SHA_TAG:?"COMMIT_SHA_TAG is required"}
-SHORT_COMMIT_SHA_TAG=${COMMIT_SHA_TAG::12}
+COMMIT_SHA_TAG=commit-${COMMIT_SHA:?"COMMIT_SHA is required"}
+SHORT_COMMIT_SHA_TAG=short-commit-${COMMIT_SHA::12}
 
 for i in ${IMAGES[@]}; do
    docker tag $IMAGE_REGISTRY/$i:$TAG $IMAGE_REGISTRY/$i:$COMMIT_SHA_TAG


### PR DESCRIPTION
## Change Overview

In order to improve testing of kanister dev versions, tag dev images using commit sha. 
If a user application is using kanister from a commit instead of released version, but relies on kanister images, it will be able to reference image version with commit tag.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [x] :building_construction: Build

## Test Plan

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
