### PR TITLE
style: Make proper imports ordering

### DIFF
--- a/pkg/app/bp.go
+++ b/pkg/app/bp.go
@@ -19,11 +19,12 @@ import (
 	"strings"
 	"time"
 
+	"k8s.io/apimachinery/pkg/util/rand"
+
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	bp "github.com/kanisterio/kanister/pkg/blueprint"
 	"github.com/kanisterio/kanister/pkg/field"
 	"github.com/kanisterio/kanister/pkg/log"
-	"k8s.io/apimachinery/pkg/util/rand"
 )
 
 const (

--- a/pkg/app/utils.go
+++ b/pkg/app/utils.go
@@ -19,13 +19,14 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/kanisterio/kanister/pkg/aws/ec2"
-	"github.com/kanisterio/kanister/pkg/aws/rds"
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
+
+	"github.com/kanisterio/kanister/pkg/aws/ec2"
+	"github.com/kanisterio/kanister/pkg/aws/rds"
 )
 
 const (

--- a/pkg/aws/rds/rds.go
+++ b/pkg/aws/rds/rds.go
@@ -23,8 +23,9 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/rds"
-	"github.com/kanisterio/kanister/pkg/poll"
 	"github.com/pkg/errors"
+
+	"github.com/kanisterio/kanister/pkg/poll"
 )
 
 const (

--- a/pkg/blockstorage/zone/zone_test.go
+++ b/pkg/blockstorage/zone/zone_test.go
@@ -21,12 +21,13 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/kanisterio/kanister/pkg/kube"
 	. "gopkg.in/check.v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/kanisterio/kanister/pkg/kube"
 )
 
 // Hook up gocheck into the "go test" runner.

--- a/pkg/blueprint/validate/validate.go
+++ b/pkg/blueprint/validate/validate.go
@@ -17,12 +17,13 @@ package validate
 import (
 	"fmt"
 
+	"github.com/pkg/errors"
+
 	kanister "github.com/kanisterio/kanister/pkg"
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	_ "github.com/kanisterio/kanister/pkg/function"
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/utils"
-	"github.com/pkg/errors"
 )
 
 const (

--- a/pkg/chronicle/chronicle_pull.go
+++ b/pkg/chronicle/chronicle_pull.go
@@ -19,9 +19,10 @@ import (
 	"context"
 	"io"
 
+	"github.com/pkg/errors"
+
 	"github.com/kanisterio/kanister/pkg/location"
 	"github.com/kanisterio/kanister/pkg/param"
-	"github.com/pkg/errors"
 )
 
 func Pull(ctx context.Context, target io.Writer, p param.Profile, manifest string) error {

--- a/pkg/client/clientset/versioned/clientset.go
+++ b/pkg/client/clientset/versioned/clientset.go
@@ -22,10 +22,11 @@ import (
 	"fmt"
 	"net/http"
 
-	crv1alpha1 "github.com/kanisterio/kanister/pkg/client/clientset/versioned/typed/cr/v1alpha1"
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
+
+	crv1alpha1 "github.com/kanisterio/kanister/pkg/client/clientset/versioned/typed/cr/v1alpha1"
 )
 
 type Interface interface {

--- a/pkg/client/clientset/versioned/fake/clientset_generated.go
+++ b/pkg/client/clientset/versioned/fake/clientset_generated.go
@@ -19,14 +19,15 @@ limitations under the License.
 package fake
 
 import (
-	clientset "github.com/kanisterio/kanister/pkg/client/clientset/versioned"
-	crv1alpha1 "github.com/kanisterio/kanister/pkg/client/clientset/versioned/typed/cr/v1alpha1"
-	fakecrv1alpha1 "github.com/kanisterio/kanister/pkg/client/clientset/versioned/typed/cr/v1alpha1/fake"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/discovery"
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	"k8s.io/client-go/testing"
+
+	clientset "github.com/kanisterio/kanister/pkg/client/clientset/versioned"
+	crv1alpha1 "github.com/kanisterio/kanister/pkg/client/clientset/versioned/typed/cr/v1alpha1"
+	fakecrv1alpha1 "github.com/kanisterio/kanister/pkg/client/clientset/versioned/typed/cr/v1alpha1/fake"
 )
 
 // NewSimpleClientset returns a clientset that will respond with the provided objects.

--- a/pkg/client/clientset/versioned/fake/register.go
+++ b/pkg/client/clientset/versioned/fake/register.go
@@ -19,12 +19,13 @@ limitations under the License.
 package fake
 
 import (
-	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
+	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 )
 
 var scheme = runtime.NewScheme()

--- a/pkg/client/clientset/versioned/scheme/register.go
+++ b/pkg/client/clientset/versioned/scheme/register.go
@@ -19,12 +19,13 @@ limitations under the License.
 package scheme
 
 import (
-	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
+	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 )
 
 var Scheme = runtime.NewScheme()

--- a/pkg/client/clientset/versioned/typed/cr/v1alpha1/actionset.go
+++ b/pkg/client/clientset/versioned/typed/cr/v1alpha1/actionset.go
@@ -22,12 +22,13 @@ import (
 	"context"
 	"time"
 
-	v1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
-	scheme "github.com/kanisterio/kanister/pkg/client/clientset/versioned/scheme"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
+
+	v1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
+	scheme "github.com/kanisterio/kanister/pkg/client/clientset/versioned/scheme"
 )
 
 // ActionSetsGetter has a method to return a ActionSetInterface.

--- a/pkg/client/clientset/versioned/typed/cr/v1alpha1/blueprint.go
+++ b/pkg/client/clientset/versioned/typed/cr/v1alpha1/blueprint.go
@@ -22,12 +22,13 @@ import (
 	"context"
 	"time"
 
-	v1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
-	scheme "github.com/kanisterio/kanister/pkg/client/clientset/versioned/scheme"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
+
+	v1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
+	scheme "github.com/kanisterio/kanister/pkg/client/clientset/versioned/scheme"
 )
 
 // BlueprintsGetter has a method to return a BlueprintInterface.

--- a/pkg/client/clientset/versioned/typed/cr/v1alpha1/cr_client.go
+++ b/pkg/client/clientset/versioned/typed/cr/v1alpha1/cr_client.go
@@ -21,9 +21,10 @@ package v1alpha1
 import (
 	"net/http"
 
+	rest "k8s.io/client-go/rest"
+
 	v1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	"github.com/kanisterio/kanister/pkg/client/clientset/versioned/scheme"
-	rest "k8s.io/client-go/rest"
 )
 
 type CrV1alpha1Interface interface {

--- a/pkg/client/clientset/versioned/typed/cr/v1alpha1/fake/fake_actionset.go
+++ b/pkg/client/clientset/versioned/typed/cr/v1alpha1/fake/fake_actionset.go
@@ -21,13 +21,14 @@ package fake
 import (
 	"context"
 
-	v1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
+
+	v1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 )
 
 // FakeActionSets implements ActionSetInterface

--- a/pkg/client/clientset/versioned/typed/cr/v1alpha1/fake/fake_blueprint.go
+++ b/pkg/client/clientset/versioned/typed/cr/v1alpha1/fake/fake_blueprint.go
@@ -21,13 +21,14 @@ package fake
 import (
 	"context"
 
-	v1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
+
+	v1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 )
 
 // FakeBlueprints implements BlueprintInterface

--- a/pkg/client/clientset/versioned/typed/cr/v1alpha1/fake/fake_cr_client.go
+++ b/pkg/client/clientset/versioned/typed/cr/v1alpha1/fake/fake_cr_client.go
@@ -19,9 +19,10 @@ limitations under the License.
 package fake
 
 import (
-	v1alpha1 "github.com/kanisterio/kanister/pkg/client/clientset/versioned/typed/cr/v1alpha1"
 	rest "k8s.io/client-go/rest"
 	testing "k8s.io/client-go/testing"
+
+	v1alpha1 "github.com/kanisterio/kanister/pkg/client/clientset/versioned/typed/cr/v1alpha1"
 )
 
 type FakeCrV1alpha1 struct {

--- a/pkg/client/clientset/versioned/typed/cr/v1alpha1/fake/fake_profile.go
+++ b/pkg/client/clientset/versioned/typed/cr/v1alpha1/fake/fake_profile.go
@@ -21,13 +21,14 @@ package fake
 import (
 	"context"
 
-	v1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
+
+	v1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 )
 
 // FakeProfiles implements ProfileInterface

--- a/pkg/client/clientset/versioned/typed/cr/v1alpha1/fake/fake_repositoryserver.go
+++ b/pkg/client/clientset/versioned/typed/cr/v1alpha1/fake/fake_repositoryserver.go
@@ -21,13 +21,14 @@ package fake
 import (
 	"context"
 
-	v1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
+
+	v1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 )
 
 // FakeRepositoryServers implements RepositoryServerInterface

--- a/pkg/client/clientset/versioned/typed/cr/v1alpha1/profile.go
+++ b/pkg/client/clientset/versioned/typed/cr/v1alpha1/profile.go
@@ -22,12 +22,13 @@ import (
 	"context"
 	"time"
 
-	v1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
-	scheme "github.com/kanisterio/kanister/pkg/client/clientset/versioned/scheme"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
+
+	v1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
+	scheme "github.com/kanisterio/kanister/pkg/client/clientset/versioned/scheme"
 )
 
 // ProfilesGetter has a method to return a ProfileInterface.

--- a/pkg/client/clientset/versioned/typed/cr/v1alpha1/repositoryserver.go
+++ b/pkg/client/clientset/versioned/typed/cr/v1alpha1/repositoryserver.go
@@ -22,12 +22,13 @@ import (
 	"context"
 	"time"
 
-	v1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
-	scheme "github.com/kanisterio/kanister/pkg/client/clientset/versioned/scheme"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
+
+	v1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
+	scheme "github.com/kanisterio/kanister/pkg/client/clientset/versioned/scheme"
 )
 
 // RepositoryServersGetter has a method to return a RepositoryServerInterface.

--- a/pkg/client/informers/externalversions/cr/v1alpha1/actionset.go
+++ b/pkg/client/informers/externalversions/cr/v1alpha1/actionset.go
@@ -22,14 +22,15 @@ import (
 	"context"
 	time "time"
 
-	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
-	versioned "github.com/kanisterio/kanister/pkg/client/clientset/versioned"
-	internalinterfaces "github.com/kanisterio/kanister/pkg/client/informers/externalversions/internalinterfaces"
-	v1alpha1 "github.com/kanisterio/kanister/pkg/client/listers/cr/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"
 	cache "k8s.io/client-go/tools/cache"
+
+	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
+	versioned "github.com/kanisterio/kanister/pkg/client/clientset/versioned"
+	internalinterfaces "github.com/kanisterio/kanister/pkg/client/informers/externalversions/internalinterfaces"
+	v1alpha1 "github.com/kanisterio/kanister/pkg/client/listers/cr/v1alpha1"
 )
 
 // ActionSetInformer provides access to a shared informer and lister for

--- a/pkg/client/informers/externalversions/cr/v1alpha1/blueprint.go
+++ b/pkg/client/informers/externalversions/cr/v1alpha1/blueprint.go
@@ -22,14 +22,15 @@ import (
 	"context"
 	time "time"
 
-	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
-	versioned "github.com/kanisterio/kanister/pkg/client/clientset/versioned"
-	internalinterfaces "github.com/kanisterio/kanister/pkg/client/informers/externalversions/internalinterfaces"
-	v1alpha1 "github.com/kanisterio/kanister/pkg/client/listers/cr/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"
 	cache "k8s.io/client-go/tools/cache"
+
+	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
+	versioned "github.com/kanisterio/kanister/pkg/client/clientset/versioned"
+	internalinterfaces "github.com/kanisterio/kanister/pkg/client/informers/externalversions/internalinterfaces"
+	v1alpha1 "github.com/kanisterio/kanister/pkg/client/listers/cr/v1alpha1"
 )
 
 // BlueprintInformer provides access to a shared informer and lister for

--- a/pkg/client/informers/externalversions/cr/v1alpha1/profile.go
+++ b/pkg/client/informers/externalversions/cr/v1alpha1/profile.go
@@ -22,14 +22,15 @@ import (
 	"context"
 	time "time"
 
-	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
-	versioned "github.com/kanisterio/kanister/pkg/client/clientset/versioned"
-	internalinterfaces "github.com/kanisterio/kanister/pkg/client/informers/externalversions/internalinterfaces"
-	v1alpha1 "github.com/kanisterio/kanister/pkg/client/listers/cr/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"
 	cache "k8s.io/client-go/tools/cache"
+
+	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
+	versioned "github.com/kanisterio/kanister/pkg/client/clientset/versioned"
+	internalinterfaces "github.com/kanisterio/kanister/pkg/client/informers/externalversions/internalinterfaces"
+	v1alpha1 "github.com/kanisterio/kanister/pkg/client/listers/cr/v1alpha1"
 )
 
 // ProfileInformer provides access to a shared informer and lister for

--- a/pkg/client/informers/externalversions/cr/v1alpha1/repositoryserver.go
+++ b/pkg/client/informers/externalversions/cr/v1alpha1/repositoryserver.go
@@ -22,14 +22,15 @@ import (
 	"context"
 	time "time"
 
-	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
-	versioned "github.com/kanisterio/kanister/pkg/client/clientset/versioned"
-	internalinterfaces "github.com/kanisterio/kanister/pkg/client/informers/externalversions/internalinterfaces"
-	v1alpha1 "github.com/kanisterio/kanister/pkg/client/listers/cr/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"
 	cache "k8s.io/client-go/tools/cache"
+
+	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
+	versioned "github.com/kanisterio/kanister/pkg/client/clientset/versioned"
+	internalinterfaces "github.com/kanisterio/kanister/pkg/client/informers/externalversions/internalinterfaces"
+	v1alpha1 "github.com/kanisterio/kanister/pkg/client/listers/cr/v1alpha1"
 )
 
 // RepositoryServerInformer provides access to a shared informer and lister for

--- a/pkg/client/informers/externalversions/factory.go
+++ b/pkg/client/informers/externalversions/factory.go
@@ -23,13 +23,14 @@ import (
 	sync "sync"
 	time "time"
 
-	versioned "github.com/kanisterio/kanister/pkg/client/clientset/versioned"
-	cr "github.com/kanisterio/kanister/pkg/client/informers/externalversions/cr"
-	internalinterfaces "github.com/kanisterio/kanister/pkg/client/informers/externalversions/internalinterfaces"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	cache "k8s.io/client-go/tools/cache"
+
+	versioned "github.com/kanisterio/kanister/pkg/client/clientset/versioned"
+	cr "github.com/kanisterio/kanister/pkg/client/informers/externalversions/cr"
+	internalinterfaces "github.com/kanisterio/kanister/pkg/client/informers/externalversions/internalinterfaces"
 )
 
 // SharedInformerOption defines the functional option type for SharedInformerFactory.

--- a/pkg/client/informers/externalversions/generic.go
+++ b/pkg/client/informers/externalversions/generic.go
@@ -21,9 +21,10 @@ package externalversions
 import (
 	"fmt"
 
-	v1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	cache "k8s.io/client-go/tools/cache"
+
+	v1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 )
 
 // GenericInformer is type of SharedIndexInformer which will locate and delegate to other

--- a/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -21,10 +21,11 @@ package internalinterfaces
 import (
 	time "time"
 
-	versioned "github.com/kanisterio/kanister/pkg/client/clientset/versioned"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	cache "k8s.io/client-go/tools/cache"
+
+	versioned "github.com/kanisterio/kanister/pkg/client/clientset/versioned"
 )
 
 // NewInformerFunc takes versioned.Interface and time.Duration to return a SharedIndexInformer.

--- a/pkg/client/listers/cr/v1alpha1/actionset.go
+++ b/pkg/client/listers/cr/v1alpha1/actionset.go
@@ -19,10 +19,11 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
+
+	v1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 )
 
 // ActionSetLister helps list ActionSets.

--- a/pkg/client/listers/cr/v1alpha1/blueprint.go
+++ b/pkg/client/listers/cr/v1alpha1/blueprint.go
@@ -19,10 +19,11 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
+
+	v1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 )
 
 // BlueprintLister helps list Blueprints.

--- a/pkg/client/listers/cr/v1alpha1/profile.go
+++ b/pkg/client/listers/cr/v1alpha1/profile.go
@@ -19,10 +19,11 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
+
+	v1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 )
 
 // ProfileLister helps list Profiles.

--- a/pkg/client/listers/cr/v1alpha1/repositoryserver.go
+++ b/pkg/client/listers/cr/v1alpha1/repositoryserver.go
@@ -19,10 +19,11 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
+
+	v1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 )
 
 // RepositoryServerLister helps list RepositoryServers.

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -27,7 +27,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/kanisterio/kanister/pkg/customresource"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"gopkg.in/tomb.v2"
@@ -41,11 +40,14 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/tools/reference"
 
+	osversioned "github.com/openshift/client-go/apps/clientset/versioned"
+
 	kanister "github.com/kanisterio/kanister/pkg"
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	"github.com/kanisterio/kanister/pkg/client/clientset/versioned"
 	"github.com/kanisterio/kanister/pkg/client/clientset/versioned/scheme"
 	"github.com/kanisterio/kanister/pkg/consts"
+	"github.com/kanisterio/kanister/pkg/customresource"
 	"github.com/kanisterio/kanister/pkg/eventer"
 	"github.com/kanisterio/kanister/pkg/field"
 	"github.com/kanisterio/kanister/pkg/log"
@@ -54,7 +56,6 @@ import (
 	"github.com/kanisterio/kanister/pkg/progress"
 	"github.com/kanisterio/kanister/pkg/reconcile"
 	"github.com/kanisterio/kanister/pkg/validate"
-	osversioned "github.com/openshift/client-go/apps/clientset/versioned"
 )
 
 // Controller represents a controller object for kanister custom resources

--- a/pkg/controllers/repositoryserver/handler.go
+++ b/pkg/controllers/repositoryserver/handler.go
@@ -22,8 +22,6 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/jpillora/backoff"
-	"github.com/kanisterio/kanister/pkg/consts"
-	"github.com/kanisterio/kanister/pkg/kopia/command/storage"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -33,6 +31,9 @@ import (
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/kanisterio/kanister/pkg/consts"
+	"github.com/kanisterio/kanister/pkg/kopia/command/storage"
 
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	"github.com/kanisterio/kanister/pkg/kube"

--- a/pkg/controllers/repositoryserver/repository_test.go
+++ b/pkg/controllers/repositoryserver/repository_test.go
@@ -15,11 +15,12 @@
 package repositoryserver
 
 import (
+	. "gopkg.in/check.v1"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	"github.com/kanisterio/kanister/pkg/kopia/command"
 	"github.com/kanisterio/kanister/pkg/testutil"
-	. "gopkg.in/check.v1"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 func (s *RepoServerControllerSuite) TestCacheSizeConfiguration(c *C) {

--- a/pkg/controllers/repositoryserver/secrets_manager_test.go
+++ b/pkg/controllers/repositoryserver/secrets_manager_test.go
@@ -17,9 +17,10 @@ package repositoryserver
 import (
 	"context"
 
-	"github.com/kanisterio/kanister/pkg/testutil"
 	. "gopkg.in/check.v1"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/kanisterio/kanister/pkg/testutil"
 )
 
 func (s *RepoServerControllerSuite) TestFetchSecretsForRepositoryServer(c *C) {

--- a/pkg/controllers/repositoryserver/server.go
+++ b/pkg/controllers/repositoryserver/server.go
@@ -21,14 +21,15 @@ import (
 	"os"
 	"time"
 
+	"github.com/pkg/errors"
+	"k8s.io/kube-openapi/pkg/util/sets"
+
 	"github.com/kanisterio/kanister/pkg/format"
 	"github.com/kanisterio/kanister/pkg/kopia"
 	"github.com/kanisterio/kanister/pkg/kopia/command"
 	"github.com/kanisterio/kanister/pkg/kopia/maintenance"
 	"github.com/kanisterio/kanister/pkg/kube"
 	reposerver "github.com/kanisterio/kanister/pkg/secrets/repositoryserver"
-	"github.com/pkg/errors"
-	"k8s.io/kube-openapi/pkg/util/sets"
 )
 
 const (

--- a/pkg/discovery/crd.go
+++ b/pkg/discovery/crd.go
@@ -17,11 +17,12 @@ package discovery
 import (
 	"context"
 
-	"github.com/kanisterio/kanister/pkg/filter"
 	"github.com/pkg/errors"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	crdclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kanisterio/kanister/pkg/filter"
 )
 
 // CRDMatcher returns a ResourceTypeMatcher that matches all CRs in this cluster.

--- a/pkg/discovery/crd_test.go
+++ b/pkg/discovery/crd_test.go
@@ -17,10 +17,11 @@ package discovery
 import (
 	"context"
 
-	"github.com/kanisterio/kanister/pkg/filter"
-	"github.com/kanisterio/kanister/pkg/kube"
 	. "gopkg.in/check.v1"
 	crdclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+
+	"github.com/kanisterio/kanister/pkg/filter"
+	"github.com/kanisterio/kanister/pkg/kube"
 )
 
 type CRDSuite struct{}

--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -17,11 +17,12 @@ package discovery
 import (
 	"context"
 
-	"github.com/kanisterio/kanister/pkg/filter"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
+
+	"github.com/kanisterio/kanister/pkg/filter"
 )
 
 func AllGVRs(ctx context.Context, cli discovery.DiscoveryInterface) ([]schema.GroupVersionResource, error) {

--- a/pkg/format/format_test.go
+++ b/pkg/format/format_test.go
@@ -6,8 +6,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/kanisterio/kanister/pkg/output"
 	. "gopkg.in/check.v1"
+
+	"github.com/kanisterio/kanister/pkg/output"
 )
 
 func Test(t *testing.T) { TestingT(t) }

--- a/pkg/function/data_test.go
+++ b/pkg/function/data_test.go
@@ -27,6 +27,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	k8sscheme "k8s.io/client-go/kubernetes/scheme"
 
+	osversioned "github.com/openshift/client-go/apps/clientset/versioned"
+
 	kanister "github.com/kanisterio/kanister/pkg"
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	"github.com/kanisterio/kanister/pkg/client/clientset/versioned"
@@ -36,7 +38,6 @@ import (
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/resource"
 	"github.com/kanisterio/kanister/pkg/testutil"
-	osversioned "github.com/openshift/client-go/apps/clientset/versioned"
 )
 
 type DataSuite struct {

--- a/pkg/function/delete_csi_snapshot_content.go
+++ b/pkg/function/delete_csi_snapshot_content.go
@@ -18,13 +18,14 @@ import (
 	"context"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	kanister "github.com/kanisterio/kanister/pkg"
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	"github.com/kanisterio/kanister/pkg/kube"
 	"github.com/kanisterio/kanister/pkg/kube/snapshot"
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/progress"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func init() {

--- a/pkg/function/e2e_volume_snapshot_test.go
+++ b/pkg/function/e2e_volume_snapshot_test.go
@@ -30,6 +30,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	k8sscheme "k8s.io/client-go/kubernetes/scheme"
 
+	osversioned "github.com/openshift/client-go/apps/clientset/versioned"
+
 	kanister "github.com/kanisterio/kanister/pkg"
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	awsconfig "github.com/kanisterio/kanister/pkg/aws"
@@ -39,7 +41,6 @@ import (
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/resource"
 	"github.com/kanisterio/kanister/pkg/testutil"
-	osversioned "github.com/openshift/client-go/apps/clientset/versioned"
 )
 
 const (

--- a/pkg/function/kube_exec.go
+++ b/pkg/function/kube_exec.go
@@ -22,13 +22,14 @@ import (
 	"strings"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	kanister "github.com/kanisterio/kanister/pkg"
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	"github.com/kanisterio/kanister/pkg/kube"
 	"github.com/kanisterio/kanister/pkg/output"
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/progress"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func init() {

--- a/pkg/function/kube_exec_all_test.go
+++ b/pkg/function/kube_exec_all_test.go
@@ -25,6 +25,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	k8sscheme "k8s.io/client-go/kubernetes/scheme"
 
+	osversioned "github.com/openshift/client-go/apps/clientset/versioned"
+
 	kanister "github.com/kanisterio/kanister/pkg"
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	"github.com/kanisterio/kanister/pkg/client/clientset/versioned"
@@ -32,7 +34,6 @@ import (
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/resource"
 	"github.com/kanisterio/kanister/pkg/testutil"
-	osversioned "github.com/openshift/client-go/apps/clientset/versioned"
 )
 
 type KubeExecAllTest struct {

--- a/pkg/function/kube_exec_test.go
+++ b/pkg/function/kube_exec_test.go
@@ -26,6 +26,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	k8sscheme "k8s.io/client-go/kubernetes/scheme"
 
+	osversioned "github.com/openshift/client-go/apps/clientset/versioned"
+
 	kanister "github.com/kanisterio/kanister/pkg"
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	"github.com/kanisterio/kanister/pkg/client/clientset/versioned"
@@ -33,7 +35,6 @@ import (
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/resource"
 	"github.com/kanisterio/kanister/pkg/testutil"
-	osversioned "github.com/openshift/client-go/apps/clientset/versioned"
 )
 
 type KubeExecTest struct {

--- a/pkg/function/prepare_data.go
+++ b/pkg/function/prepare_data.go
@@ -20,15 +20,15 @@ import (
 	"io"
 	"time"
 
-	"github.com/kanisterio/kanister/pkg/consts"
-	"github.com/kanisterio/kanister/pkg/ephemeral"
-	"github.com/kanisterio/kanister/pkg/field"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
 	kanister "github.com/kanisterio/kanister/pkg"
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
+	"github.com/kanisterio/kanister/pkg/consts"
+	"github.com/kanisterio/kanister/pkg/ephemeral"
+	"github.com/kanisterio/kanister/pkg/field"
 	"github.com/kanisterio/kanister/pkg/format"
 	"github.com/kanisterio/kanister/pkg/kube"
 	"github.com/kanisterio/kanister/pkg/param"

--- a/pkg/function/rds_functions_test.go
+++ b/pkg/function/rds_functions_test.go
@@ -19,9 +19,10 @@ import (
 	"fmt"
 	"strings"
 
+	. "gopkg.in/check.v1"
+
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/postgres"
-	. "gopkg.in/check.v1"
 )
 
 type RDSFunctionsTest struct{}

--- a/pkg/function/scale_test.go
+++ b/pkg/function/scale_test.go
@@ -25,6 +25,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	k8sscheme "k8s.io/client-go/kubernetes/scheme"
 
+	osversioned "github.com/openshift/client-go/apps/clientset/versioned"
+
 	kanister "github.com/kanisterio/kanister/pkg"
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	"github.com/kanisterio/kanister/pkg/client/clientset/versioned"
@@ -32,7 +34,6 @@ import (
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/resource"
 	"github.com/kanisterio/kanister/pkg/testutil"
-	osversioned "github.com/openshift/client-go/apps/clientset/versioned"
 )
 
 type ScaleSuite struct {

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -27,10 +27,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	"github.com/kanisterio/kanister/pkg/validatingwebhook"
-	"github.com/kanisterio/kanister/pkg/version"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"github.com/kanisterio/kanister/pkg/validatingwebhook"
+	"github.com/kanisterio/kanister/pkg/version"
 )
 
 const (

--- a/pkg/kanctl/actionset.go
+++ b/pkg/kanctl/actionset.go
@@ -31,12 +31,13 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/yaml"
 
+	osversioned "github.com/openshift/client-go/apps/clientset/versioned"
+
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	"github.com/kanisterio/kanister/pkg/client/clientset/versioned"
 	"github.com/kanisterio/kanister/pkg/kube"
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/poll"
-	osversioned "github.com/openshift/client-go/apps/clientset/versioned"
 )
 
 const (

--- a/pkg/kanctl/profile_test.go
+++ b/pkg/kanctl/profile_test.go
@@ -1,11 +1,12 @@
 package kanctl
 
 import (
-	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
-	"github.com/kanisterio/kanister/pkg/secrets"
 	check "gopkg.in/check.v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
+	"github.com/kanisterio/kanister/pkg/secrets"
 )
 
 func (k *KanctlTestSuite) TestConstructProfile(c *check.C) {

--- a/pkg/kanctl/validate.go
+++ b/pkg/kanctl/validate.go
@@ -15,9 +15,10 @@
 package kanctl
 
 import (
-	kanister "github.com/kanisterio/kanister/pkg"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+
+	kanister "github.com/kanisterio/kanister/pkg"
 )
 
 type validateParams struct {

--- a/pkg/kando/chronicle_push.go
+++ b/pkg/kando/chronicle_push.go
@@ -17,8 +17,9 @@ package kando
 import (
 	"time"
 
-	"github.com/kanisterio/kanister/pkg/chronicle"
 	"github.com/spf13/cobra"
+
+	"github.com/kanisterio/kanister/pkg/chronicle"
 )
 
 const (

--- a/pkg/kube/exec.go
+++ b/pkg/kube/exec.go
@@ -23,12 +23,13 @@ import (
 	"strings"
 
 	"github.com/kanisterio/errkit"
-	"github.com/kanisterio/kanister/pkg/format"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
+
+	"github.com/kanisterio/kanister/pkg/format"
 )
 
 // ExecError is an error returned by kube.Exec, kube.ExecOutput and kube.ExecWithOptions.

--- a/pkg/kube/snapshot/mocks/mock_snapshotter.go
+++ b/pkg/kube/snapshot/mocks/mock_snapshotter.go
@@ -9,9 +9,10 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	snapshot "github.com/kanisterio/kanister/pkg/kube/snapshot"
 	v1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
+
+	snapshot "github.com/kanisterio/kanister/pkg/kube/snapshot"
 )
 
 // MockSnapshotter is a mock of Snapshotter interface.

--- a/pkg/kube/snapshot/snapshot_stable.go
+++ b/pkg/kube/snapshot/snapshot_stable.go
@@ -18,7 +18,6 @@ import (
 	"context"
 
 	"github.com/kanisterio/errkit"
-	"github.com/kanisterio/kanister/pkg/blockstorage"
 	v1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -26,6 +25,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+
+	"github.com/kanisterio/kanister/pkg/blockstorage"
 )
 
 const (

--- a/pkg/kube/workload.go
+++ b/pkg/kube/workload.go
@@ -30,9 +30,10 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 
-	"github.com/kanisterio/kanister/pkg/poll"
 	osAppsv1 "github.com/openshift/api/apps/v1"
 	osversioned "github.com/openshift/client-go/apps/clientset/versioned"
+
+	"github.com/kanisterio/kanister/pkg/poll"
 )
 
 const (

--- a/pkg/kube/workload_ready_test.go
+++ b/pkg/kube/workload_ready_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/kanisterio/kanister/pkg/errorchecker"
 	. "gopkg.in/check.v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -13,6 +12,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/kanisterio/kanister/pkg/errorchecker"
 )
 
 type WorkloadReadySuite struct{}

--- a/pkg/objectstore/aws.go
+++ b/pkg/objectstore/aws.go
@@ -23,8 +23,9 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/s3"
-	kaws "github.com/kanisterio/kanister/pkg/aws"
 	"github.com/pkg/errors"
+
+	kaws "github.com/kanisterio/kanister/pkg/aws"
 )
 
 const (

--- a/pkg/output/stream_test.go
+++ b/pkg/output/stream_test.go
@@ -20,9 +20,10 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/kanisterio/kanister/pkg/output"
 	. "gopkg.in/check.v1"
 	apirand "k8s.io/apimachinery/pkg/util/rand"
+
+	"github.com/kanisterio/kanister/pkg/output"
 )
 
 type EndlinePolicy int

--- a/pkg/param/param_test.go
+++ b/pkg/param/param_test.go
@@ -35,13 +35,14 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 
+	osapps "github.com/openshift/api/apps/v1"
+	osversioned "github.com/openshift/client-go/apps/clientset/versioned"
+	osfake "github.com/openshift/client-go/apps/clientset/versioned/fake"
+
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	crfake "github.com/kanisterio/kanister/pkg/client/clientset/versioned/fake"
 	"github.com/kanisterio/kanister/pkg/ksprig"
 	"github.com/kanisterio/kanister/pkg/kube"
-	osapps "github.com/openshift/api/apps/v1"
-	osversioned "github.com/openshift/client-go/apps/clientset/versioned"
-	osfake "github.com/openshift/client-go/apps/clientset/versioned/fake"
 )
 
 // Hook up gocheck into the "go test" runner.

--- a/pkg/progress/action_multi_actions_test.go
+++ b/pkg/progress/action_multi_actions_test.go
@@ -3,11 +3,11 @@ package progress
 import (
 	"context"
 
-	"github.com/kanisterio/kanister/pkg/client/clientset/versioned/fake"
 	. "gopkg.in/check.v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"github.com/kanisterio/kanister/pkg/client/clientset/versioned/fake"
 )
 
 type TestSuiteMultiActions struct {

--- a/pkg/progress/action_multi_phases_test.go
+++ b/pkg/progress/action_multi_phases_test.go
@@ -3,11 +3,11 @@ package progress
 import (
 	"context"
 
-	"github.com/kanisterio/kanister/pkg/client/clientset/versioned/fake"
 	. "gopkg.in/check.v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"github.com/kanisterio/kanister/pkg/client/clientset/versioned/fake"
 )
 
 type TestSuiteMultiPhases struct {

--- a/pkg/progress/action_single_phase_test.go
+++ b/pkg/progress/action_single_phase_test.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/kanisterio/kanister/pkg/client/clientset/versioned"
-	"github.com/kanisterio/kanister/pkg/client/clientset/versioned/fake"
 	. "gopkg.in/check.v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"github.com/kanisterio/kanister/pkg/client/clientset/versioned"
+	"github.com/kanisterio/kanister/pkg/client/clientset/versioned/fake"
 )
 
 const (

--- a/pkg/secrets/azure_test.go
+++ b/pkg/secrets/azure_test.go
@@ -15,9 +15,10 @@
 package secrets
 
 import (
-	"github.com/kanisterio/kanister/pkg/objectstore"
 	. "gopkg.in/check.v1"
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/kanisterio/kanister/pkg/objectstore"
 )
 
 type AzureSecretSuite struct{}

--- a/pkg/secrets/gcp_test.go
+++ b/pkg/secrets/gcp_test.go
@@ -17,11 +17,12 @@ package secrets
 import (
 	"encoding/base64"
 
-	secerrors "github.com/kanisterio/kanister/pkg/secrets/errors"
 	"github.com/pkg/errors"
 	. "gopkg.in/check.v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	secerrors "github.com/kanisterio/kanister/pkg/secrets/errors"
 )
 
 type GCPSecretSuite struct{}


### PR DESCRIPTION
## Change Overview

Since we are trying to keep imports ordered consistently, this PR contains reordering of wrongly grouped imports.
`find . -type f -name '*.go' -exec goimports -w -d -local github.com/kanisterio/kanister {} \;` command was used

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :building_construction: Build

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
