### PR TITLE
build: remove duplicate call to push_images.sh

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -127,7 +127,6 @@ jobs:
     - run: docker builder prune -af
     - run: make release-snapshot
     - run: COMMIT_SHA=${{ github.sha }} ./build/push_images.sh
-    - run: ./build/push_images.sh
   image_tags:
     runs-on: ubuntu-latest
     outputs:


### PR DESCRIPTION
## Change Overview

Duplicate call to push_images.sh must be left from conflict resolution

Fixes https://github.com/kanisterio/kanister/actions/runs/9716510282/job/26820564846

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [x] :building_construction: Build

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
