### PR TITLE
DEVOPS-7803 restore log stream

### DIFF
--- a/pkg/kube/pod.go
+++ b/pkg/kube/pod.go
@@ -330,10 +330,13 @@ func DeletePod(ctx context.Context, cli kubernetes.Interface, pod *corev1.Pod) e
 	return nil
 }
 
-func StreamPodLogs(ctx context.Context, cli kubernetes.Interface, namespace, podName, containerName string) (io.ReadCloser, error) {
+func StreamPodLogs(ctx context.Context, cli kubernetes.Interface, namespace, podName, containerName string, sinceTime *metav1.Time) (io.ReadCloser, error) {
 	plo := &corev1.PodLogOptions{
 		Follow:    true,
 		Container: containerName,
+	}
+	if sinceTime != nil {
+		plo.SinceTime = sinceTime
 	}
 	return cli.CoreV1().Pods(namespace).GetLogs(podName, plo).Stream(ctx)
 }
@@ -354,7 +357,7 @@ func GetPodLogs(ctx context.Context, cli kubernetes.Interface, namespace, podNam
 
 // getErrorFromLogs fetches logs from pod and constructs error containing last ten lines of log and specified error message
 func getErrorFromLogs(ctx context.Context, cli kubernetes.Interface, namespace, podName, containerName string, err error, errorMessage string) error {
-	r, logErr := StreamPodLogs(ctx, cli, namespace, podName, containerName)
+	r, logErr := StreamPodLogs(ctx, cli, namespace, podName, containerName, nil)
 	if logErr != nil {
 		return errkit.Wrap(logErr, "Failed to fetch logs from the pod")
 	}

--- a/pkg/kube/pod_controller.go
+++ b/pkg/kube/pod_controller.go
@@ -234,7 +234,66 @@ func (p *podController) StreamPodLogs(ctx context.Context) (io.ReadCloser, error
 		return nil, ErrPodControllerPodNotStarted
 	}
 
-	return StreamPodLogs(ctx, p.cli, p.pod.Namespace, p.pod.Name, ContainerNameFromPodOptsOrDefault(p.podOptions))
+	return newRestoreLogStreamReader(ctx, p.cli, p.pod.Namespace, p.pod.Name, ContainerNameFromPodOptsOrDefault(p.podOptions))
+}
+
+// newRestoreLogStreamReader creates a new restoreLogStreamReader instance which is used to stream logs from a pod.
+// restoreLogStreamReader will automatically try to establish a new log stream if the current one is closed and the pod is still alive.
+// This wrapper has to exist as there is hardcoded 4h timeout in kubelet for streaming logs.
+func newRestoreLogStreamReader(ctx context.Context, cli kubernetes.Interface, namespace, podName, containerName string) (io.ReadCloser, error) {
+	reader, err := StreamPodLogs(ctx, cli, namespace, podName, containerName, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &restoreLogStreamReader{
+		ctx:           ctx,
+		cli:           cli,
+		namespace:     namespace,
+		podName:       podName,
+		containerName: containerName,
+		reader:        reader,
+	}, nil
+}
+
+type restoreLogStreamReader struct {
+	ctx           context.Context
+	cli           kubernetes.Interface
+	namespace     string
+	podName       string
+	containerName string
+	reader        io.ReadCloser
+	lastReadTime  metav1.Time
+}
+
+func (s *restoreLogStreamReader) Read(p []byte) (n int, err error) {
+	n, err = s.reader.Read(p)
+	defer func() { s.lastReadTime = metav1.Now() }()
+	if err == io.EOF {
+		pod, err := s.cli.CoreV1().Pods(s.namespace).Get(s.ctx, s.podName, metav1.GetOptions{})
+		if err != nil {
+			return 0, err
+		}
+
+		if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
+			return n, io.EOF
+		}
+
+		err = s.reader.Close()
+		if err != nil {
+			return 0, err
+		}
+		s.reader, err = StreamPodLogs(s.ctx, s.cli, s.namespace, s.podName, s.containerName, &s.lastReadTime)
+		if err != nil {
+			return 0, err
+		}
+
+		return s.reader.Read(p)
+	}
+	return n, err
+}
+
+func (s *restoreLogStreamReader) Close() error {
+	return s.reader.Close()
 }
 
 // GetCommandExecutor returns PodCommandExecutor instance which is configured to execute commands within pod controlled


### PR DESCRIPTION
## Change Overview

Unfortunately, there is a hardcoded timeout in the kubelet server. If we want to support long-lasting phases, we need to work around it.

This PR introduces re-establishing the log stream connection while the pod is still running.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #1622 

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

I created a phase executing function `KubeTask`, with a long-lasting command (sleep). I ensured that the logs were read until the end of its execution and that the output was properly gathered.


- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
