### PR TITLE
docs: Document using actionset labels to extend logs

### DIFF
--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -7,5 +7,6 @@ Tasks
 
    tasks/argo.rst
    tasks/logs_level.rst
+   tasks/logs_labels.rst
    tasks/logs.rst
    tasks/scaleworkload.rst

--- a/docs/tasks/logs_labels.rst
+++ b/docs/tasks/logs_labels.rst
@@ -1,0 +1,27 @@
+Configuring logs for specific ActionSets
+----------------------------------------
+
+Kanister uses structured logging to ensure that its logs can be easily
+categorized, indexed and searched by downstream log aggregation software.
+
+Extra fields can be added to the logs related to a specific ActionSet by adding
+a label in the ActionSet with ``kanister.io`` prefix.
+
+For example:
+
+.. code-block:: yaml
+  :linenos:
+
+  apiVersion: cr.kanister.io/v1alpha1
+  kind: ActionSet
+  metadata:
+    namespace: kanister
+    name: myActionSet
+    labels:
+        kanister.io/myFieldName: myFieldValue
+
+All logs concerning this ActionSet execution will have
+``myFieldName`` field with ``myFieldValue`` value.
+
+
+

--- a/docs_new/.vitepress/config.mts
+++ b/docs_new/.vitepress/config.mts
@@ -39,6 +39,7 @@ export default defineConfig({
             link: "/tasks/logs",
           },
           { text: "Modifying Kanister Log Level", link: "/tasks/logs_level" },
+          { text: "Configuring logs for specific ActionSets", link: "/tasks/logs_labels" },
           {
             text: "Using ScaleWorkload function with output artifact",
             link: "/tasks/scaleworkload",

--- a/docs_new/generatedSidebar.js
+++ b/docs_new/generatedSidebar.js
@@ -13,6 +13,7 @@ module.exports = [
       { text: "Argo.md", link: "/tasks/argo" },
       { text: "Logs.md", link: "/tasks/logs" },
       { text: "Logs_level.md", link: "/tasks/logs_level" },
+      { text: "logs_labels.md", link: "/tasks/logs_labels" },
       { text: "Scaleworkload.md", link: "/tasks/scaleworkload" },
     ],
   },

--- a/docs_new/tasks/logs_labels.md
+++ b/docs_new/tasks/logs_labels.md
@@ -1,0 +1,23 @@
+# Configuring logs for specific ActionSets
+
+Kanister uses structured logging to ensure that its logs can be easily
+categorized, indexed and searched by downstream log aggregation software.
+
+Extra fields can be added to the logs related to a specific ActionSet by adding
+a label in the ActionSet with `kanister.io` prefix.
+
+For example:
+
+``` yaml
+  apiVersion: cr.kanister.io/v1alpha1
+  kind: ActionSet
+  metadata:
+    namespace: kanister
+    name: myActionSet
+    labels:
+        kanister.io/myFieldName: myFieldValue
+
+```
+
+All logs concerning this ActionSet execution will have
+`myFieldName` field with `myFieldValue` value.


### PR DESCRIPTION
## Change Overview

Add missing documentation about using `kanister.io/` prefixed labels to extend actionset logs.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [x] :world_map: Documentation
- [ ] :robot: Test
- [ ] :building_construction: Build

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #2873 

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
