### PR TITLE
Add `Validate` method in `Func` interface to validate a kanister function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,6 @@ require (
 	k8s.io/client-go v0.29.7
 	k8s.io/code-generator v0.29.7
 	k8s.io/kubectl v0.29.7
-	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
 	sigs.k8s.io/controller-runtime v0.16.6
 	sigs.k8s.io/yaml v1.3.0
 
@@ -232,6 +231,7 @@ require (
 	k8s.io/gengo v0.0.0-20230829151522-9cce18d56c01 // indirect
 	k8s.io/klog/v2 v2.110.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00
+	k8s.io/utils v0.0.0-20230726121419-3b25d923346b // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/kustomize/api v0.13.5-0.20230601165947-6ce0bf390ce3 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.14.3-0.20230601165947-6ce0bf390ce3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -107,6 +107,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
+github.com/aws/aws-sdk-go v1.55.0 h1:hVALKPjXz33kP1R9nTyJpUK7qF59dO2mleQxUW9mCVE=
+github.com/aws/aws-sdk-go v1.55.0/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
 github.com/aws/aws-sdk-go v1.55.5 h1:KKUZBfBoyqy5d3swXyiC7Q76ic40rYcbqH7qjh59kzU=
 github.com/aws/aws-sdk-go v1.55.5/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=

--- a/go.sum
+++ b/go.sum
@@ -107,8 +107,6 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
-github.com/aws/aws-sdk-go v1.55.0 h1:hVALKPjXz33kP1R9nTyJpUK7qF59dO2mleQxUW9mCVE=
-github.com/aws/aws-sdk-go v1.55.0/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
 github.com/aws/aws-sdk-go v1.55.5 h1:KKUZBfBoyqy5d3swXyiC7Q76ic40rYcbqH7qjh59kzU=
 github.com/aws/aws-sdk-go v1.55.5/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=

--- a/pkg/blueprint/validate/validate_test.go
+++ b/pkg/blueprint/validate/validate_test.go
@@ -24,6 +24,7 @@ import (
 	kanister "github.com/kanisterio/kanister/pkg"
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	"github.com/kanisterio/kanister/pkg/param"
+	"github.com/kanisterio/kanister/pkg/utils"
 )
 
 func Test(t *testing.T) { TestingT(t) }
@@ -452,6 +453,14 @@ func (nd *nonDefaultVersionFunc) RequiredArgs() []string {
 
 func (nd *nonDefaultVersionFunc) Arguments() []string {
 	return []string{"ndVersionArg0", "ndVersionArg1", "ndVersionArg2", "ndVersionArg3"}
+}
+
+func (nd *nonDefaultVersionFunc) Validate(args map[string]interface{}) error {
+	if err := utils.CheckSupportedArgs(nd.Arguments(), args); err != nil {
+		return err
+	}
+
+	return utils.CheckRequiredArgs(nd.RequiredArgs(), args)
 }
 
 func (nd *nonDefaultVersionFunc) Exec(context.Context, param.TemplateParams, map[string]interface{}) (map[string]interface{}, error) {

--- a/pkg/blueprint/validate/validate_test.go
+++ b/pkg/blueprint/validate/validate_test.go
@@ -455,7 +455,7 @@ func (nd *nonDefaultVersionFunc) Arguments() []string {
 	return []string{"ndVersionArg0", "ndVersionArg1", "ndVersionArg2", "ndVersionArg3"}
 }
 
-func (nd *nonDefaultVersionFunc) Validate(args map[string]interface{}) error {
+func (nd *nonDefaultVersionFunc) Validate(args map[string]any) error {
 	if err := utils.CheckSupportedArgs(nd.Arguments(), args); err != nil {
 		return err
 	}

--- a/pkg/function/backup_data.go
+++ b/pkg/function/backup_data.go
@@ -33,6 +33,7 @@ import (
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/progress"
 	"github.com/kanisterio/kanister/pkg/restic"
+	"github.com/kanisterio/kanister/pkg/utils"
 )
 
 const (
@@ -155,6 +156,14 @@ func (*backupDataFunc) Arguments() []string {
 		BackupDataEncryptionKeyArg,
 		InsecureTLS,
 	}
+}
+
+func (b *backupDataFunc) Validate(args map[string]interface{}) error {
+	if err := utils.CheckSupportedArgs(b.Arguments(), args); err != nil {
+		return err
+	}
+
+	return utils.CheckRequiredArgs(b.RequiredArgs(), args)
 }
 
 type backupDataParsedOutput struct {

--- a/pkg/function/backup_data.go
+++ b/pkg/function/backup_data.go
@@ -158,7 +158,7 @@ func (*backupDataFunc) Arguments() []string {
 	}
 }
 
-func (b *backupDataFunc) Validate(args map[string]interface{}) error {
+func (b *backupDataFunc) Validate(args map[string]any) error {
 	if err := utils.CheckSupportedArgs(b.Arguments(), args); err != nil {
 		return err
 	}

--- a/pkg/function/backup_data_all.go
+++ b/pkg/function/backup_data_all.go
@@ -33,6 +33,7 @@ import (
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/progress"
 	"github.com/kanisterio/kanister/pkg/restic"
+	"github.com/kanisterio/kanister/pkg/utils"
 )
 
 const (
@@ -150,6 +151,14 @@ func (*backupDataAllFunc) Arguments() []string {
 		BackupDataAllEncryptionKeyArg,
 		InsecureTLS,
 	}
+}
+
+func (b *backupDataAllFunc) Validate(args map[string]interface{}) error {
+	if err := utils.CheckSupportedArgs(b.Arguments(), args); err != nil {
+		return err
+	}
+
+	return utils.CheckRequiredArgs(b.RequiredArgs(), args)
 }
 
 func backupDataAll(ctx context.Context, cli kubernetes.Interface, namespace string, ps []string, container string, backupArtifactPrefix, includePath, encryptionKey string,

--- a/pkg/function/backup_data_all.go
+++ b/pkg/function/backup_data_all.go
@@ -153,7 +153,7 @@ func (*backupDataAllFunc) Arguments() []string {
 	}
 }
 
-func (b *backupDataAllFunc) Validate(args map[string]interface{}) error {
+func (b *backupDataAllFunc) Validate(args map[string]any) error {
 	if err := utils.CheckSupportedArgs(b.Arguments(), args); err != nil {
 		return err
 	}

--- a/pkg/function/backup_data_stats.go
+++ b/pkg/function/backup_data_stats.go
@@ -32,6 +32,7 @@ import (
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/progress"
 	"github.com/kanisterio/kanister/pkg/restic"
+	"github.com/kanisterio/kanister/pkg/utils"
 )
 
 const (
@@ -196,6 +197,14 @@ func (*BackupDataStatsFunc) Arguments() []string {
 		BackupDataStatsMode,
 		BackupDataStatsEncryptionKeyArg,
 	}
+}
+
+func (b *BackupDataStatsFunc) Validate(args map[string]interface{}) error {
+	if err := utils.CheckSupportedArgs(b.Arguments(), args); err != nil {
+		return err
+	}
+
+	return utils.CheckRequiredArgs(b.RequiredArgs(), args)
 }
 
 func (b *BackupDataStatsFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {

--- a/pkg/function/backup_data_stats.go
+++ b/pkg/function/backup_data_stats.go
@@ -199,7 +199,7 @@ func (*BackupDataStatsFunc) Arguments() []string {
 	}
 }
 
-func (b *BackupDataStatsFunc) Validate(args map[string]interface{}) error {
+func (b *BackupDataStatsFunc) Validate(args map[string]any) error {
 	if err := utils.CheckSupportedArgs(b.Arguments(), args); err != nil {
 		return err
 	}

--- a/pkg/function/backup_data_using_kopia_server.go
+++ b/pkg/function/backup_data_using_kopia_server.go
@@ -83,6 +83,14 @@ func (*backupDataUsingKopiaServerFunc) Arguments() []string {
 	}
 }
 
+func (b *backupDataUsingKopiaServerFunc) Validate(args map[string]interface{}) error {
+	if err := utils.CheckSupportedArgs(b.Arguments(), args); err != nil {
+		return err
+	}
+
+	return utils.CheckRequiredArgs(b.RequiredArgs(), args)
+}
+
 func (b *backupDataUsingKopiaServerFunc) Exec(ctx context.Context, tp param.TemplateParams, args map[string]any) (map[string]any, error) {
 	// Set progress percent
 	b.progressPercent = progress.StartedPercent

--- a/pkg/function/backup_data_using_kopia_server.go
+++ b/pkg/function/backup_data_using_kopia_server.go
@@ -83,7 +83,7 @@ func (*backupDataUsingKopiaServerFunc) Arguments() []string {
 	}
 }
 
-func (b *backupDataUsingKopiaServerFunc) Validate(args map[string]interface{}) error {
+func (b *backupDataUsingKopiaServerFunc) Validate(args map[string]any) error {
 	if err := utils.CheckSupportedArgs(b.Arguments(), args); err != nil {
 		return err
 	}

--- a/pkg/function/checkRepository.go
+++ b/pkg/function/checkRepository.go
@@ -176,7 +176,7 @@ func (*CheckRepositoryFunc) Arguments() []string {
 	}
 }
 
-func (c *CheckRepositoryFunc) Validate(args map[string]interface{}) error {
+func (c *CheckRepositoryFunc) Validate(args map[string]any) error {
 	if err := utils.CheckSupportedArgs(c.Arguments(), args); err != nil {
 		return err
 	}

--- a/pkg/function/checkRepository.go
+++ b/pkg/function/checkRepository.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/progress"
 	"github.com/kanisterio/kanister/pkg/restic"
+	"github.com/kanisterio/kanister/pkg/utils"
 )
 
 const (
@@ -174,6 +175,15 @@ func (*CheckRepositoryFunc) Arguments() []string {
 		InsecureTLS,
 	}
 }
+
+func (c *CheckRepositoryFunc) Validate(args map[string]interface{}) error {
+	if err := utils.CheckSupportedArgs(c.Arguments(), args); err != nil {
+		return err
+	}
+
+	return utils.CheckRequiredArgs(c.RequiredArgs(), args)
+}
+
 func (c *CheckRepositoryFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {
 	metav1Time := metav1.NewTime(time.Now())
 	return crv1alpha1.PhaseProgress{

--- a/pkg/function/copy_volume_data.go
+++ b/pkg/function/copy_volume_data.go
@@ -246,7 +246,7 @@ func (*copyVolumeDataFunc) Arguments() []string {
 	}
 }
 
-func (c *copyVolumeDataFunc) Validate(args map[string]interface{}) error {
+func (c *copyVolumeDataFunc) Validate(args map[string]any) error {
 	if err := utils.CheckSupportedArgs(c.Arguments(), args); err != nil {
 		return err
 	}

--- a/pkg/function/copy_volume_data.go
+++ b/pkg/function/copy_volume_data.go
@@ -35,6 +35,7 @@ import (
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/progress"
 	"github.com/kanisterio/kanister/pkg/restic"
+	"github.com/kanisterio/kanister/pkg/utils"
 )
 
 const (
@@ -243,6 +244,14 @@ func (*copyVolumeDataFunc) Arguments() []string {
 		CopyVolumeDataEncryptionKeyArg,
 		InsecureTLS,
 	}
+}
+
+func (c *copyVolumeDataFunc) Validate(args map[string]interface{}) error {
+	if err := utils.CheckSupportedArgs(c.Arguments(), args); err != nil {
+		return err
+	}
+
+	return utils.CheckRequiredArgs(c.RequiredArgs(), args)
 }
 
 func (c *copyVolumeDataFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {

--- a/pkg/function/create_csi_snapshot.go
+++ b/pkg/function/create_csi_snapshot.go
@@ -143,7 +143,7 @@ func (*createCSISnapshotFunc) Arguments() []string {
 	}
 }
 
-func (c *createCSISnapshotFunc) Validate(args map[string]interface{}) error {
+func (c *createCSISnapshotFunc) Validate(args map[string]any) error {
 	if err := utils.CheckSupportedArgs(c.Arguments(), args); err != nil {
 		return err
 	}

--- a/pkg/function/create_csi_snapshot.go
+++ b/pkg/function/create_csi_snapshot.go
@@ -30,6 +30,7 @@ import (
 	"github.com/kanisterio/kanister/pkg/kube/snapshot"
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/progress"
+	"github.com/kanisterio/kanister/pkg/utils"
 )
 
 func init() {
@@ -140,6 +141,14 @@ func (*createCSISnapshotFunc) Arguments() []string {
 		CreateCSISnapshotNameArg,
 		CreateCSISnapshotLabelsArg,
 	}
+}
+
+func (c *createCSISnapshotFunc) Validate(args map[string]interface{}) error {
+	if err := utils.CheckSupportedArgs(c.Arguments(), args); err != nil {
+		return err
+	}
+
+	return utils.CheckRequiredArgs(c.RequiredArgs(), args)
 }
 
 func createCSISnapshot(ctx context.Context, snapshotter snapshot.Snapshotter, name, namespace, pvc, snapshotClass string, wait bool, labels map[string]string) (*v1.VolumeSnapshot, error) {

--- a/pkg/function/create_csi_snapshot_static.go
+++ b/pkg/function/create_csi_snapshot_static.go
@@ -152,7 +152,7 @@ func (*createCSISnapshotStaticFunc) Arguments() []string {
 	}
 }
 
-func (c *createCSISnapshotStaticFunc) Validate(args map[string]interface{}) error {
+func (c *createCSISnapshotStaticFunc) Validate(args map[string]any) error {
 	if err := utils.CheckSupportedArgs(c.Arguments(), args); err != nil {
 		return err
 	}

--- a/pkg/function/create_csi_snapshot_static.go
+++ b/pkg/function/create_csi_snapshot_static.go
@@ -27,6 +27,7 @@ import (
 	"github.com/kanisterio/kanister/pkg/kube/snapshot"
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/progress"
+	"github.com/kanisterio/kanister/pkg/utils"
 )
 
 func init() {
@@ -149,6 +150,14 @@ func (*createCSISnapshotStaticFunc) Arguments() []string {
 		CreateCSISnapshotStaticSnapshotHandleArg,
 		CreateCSISnapshotStaticSnapshotClassArg,
 	}
+}
+
+func (c *createCSISnapshotStaticFunc) Validate(args map[string]interface{}) error {
+	if err := utils.CheckSupportedArgs(c.Arguments(), args); err != nil {
+		return err
+	}
+
+	return utils.CheckRequiredArgs(c.RequiredArgs(), args)
 }
 
 func createCSISnapshotStatic(

--- a/pkg/function/create_rds_snapshot.go
+++ b/pkg/function/create_rds_snapshot.go
@@ -32,6 +32,7 @@ import (
 	"github.com/kanisterio/kanister/pkg/log"
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/progress"
+	"github.com/kanisterio/kanister/pkg/utils"
 )
 
 func init() {
@@ -198,6 +199,14 @@ func (crs *createRDSSnapshotFunc) Arguments() []string {
 		CreateRDSSnapshotInstanceIDArg,
 		CreateRDSSnapshotDBEngine,
 	}
+}
+
+func (c *createRDSSnapshotFunc) Validate(args map[string]interface{}) error {
+	if err := utils.CheckSupportedArgs(c.Arguments(), args); err != nil {
+		return err
+	}
+
+	return utils.CheckRequiredArgs(c.RequiredArgs(), args)
 }
 
 func (crs *createRDSSnapshotFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {

--- a/pkg/function/create_rds_snapshot.go
+++ b/pkg/function/create_rds_snapshot.go
@@ -201,7 +201,7 @@ func (crs *createRDSSnapshotFunc) Arguments() []string {
 	}
 }
 
-func (c *createRDSSnapshotFunc) Validate(args map[string]interface{}) error {
+func (c *createRDSSnapshotFunc) Validate(args map[string]any) error {
 	if err := utils.CheckSupportedArgs(c.Arguments(), args); err != nil {
 		return err
 	}

--- a/pkg/function/create_volume_from_snapshot.go
+++ b/pkg/function/create_volume_from_snapshot.go
@@ -184,7 +184,7 @@ func (*createVolumeFromSnapshotFunc) Arguments() []string {
 	}
 }
 
-func (c *createVolumeFromSnapshotFunc) Validate(args map[string]interface{}) error {
+func (c *createVolumeFromSnapshotFunc) Validate(args map[string]any) error {
 	if err := utils.CheckSupportedArgs(c.Arguments(), args); err != nil {
 		return err
 	}

--- a/pkg/function/create_volume_from_snapshot.go
+++ b/pkg/function/create_volume_from_snapshot.go
@@ -35,6 +35,7 @@ import (
 	"github.com/kanisterio/kanister/pkg/log"
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/progress"
+	"github.com/kanisterio/kanister/pkg/utils"
 )
 
 func init() {
@@ -181,6 +182,14 @@ func (*createVolumeFromSnapshotFunc) Arguments() []string {
 		CreateVolumeFromSnapshotManifestArg,
 		CreateVolumeFromSnapshotPVCNamesArg,
 	}
+}
+
+func (c *createVolumeFromSnapshotFunc) Validate(args map[string]interface{}) error {
+	if err := utils.CheckSupportedArgs(c.Arguments(), args); err != nil {
+		return err
+	}
+
+	return utils.CheckRequiredArgs(c.RequiredArgs(), args)
 }
 
 func (crs *createVolumeFromSnapshotFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {

--- a/pkg/function/create_volume_snapshot.go
+++ b/pkg/function/create_volume_snapshot.go
@@ -38,6 +38,7 @@ import (
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/progress"
 	"github.com/kanisterio/kanister/pkg/secrets"
+	"github.com/kanisterio/kanister/pkg/utils"
 )
 
 func init() {
@@ -324,6 +325,14 @@ func (*createVolumeSnapshotFunc) Arguments() []string {
 		CreateVolumeSnapshotPVCsArg,
 		CreateVolumeSnapshotSkipWaitArg,
 	}
+}
+
+func (c *createVolumeSnapshotFunc) Validate(args map[string]interface{}) error {
+	if err := utils.CheckSupportedArgs(c.Arguments(), args); err != nil {
+		return err
+	}
+
+	return utils.CheckRequiredArgs(c.RequiredArgs(), args)
 }
 
 func (c *createVolumeSnapshotFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {

--- a/pkg/function/create_volume_snapshot.go
+++ b/pkg/function/create_volume_snapshot.go
@@ -327,7 +327,7 @@ func (*createVolumeSnapshotFunc) Arguments() []string {
 	}
 }
 
-func (c *createVolumeSnapshotFunc) Validate(args map[string]interface{}) error {
+func (c *createVolumeSnapshotFunc) Validate(args map[string]any) error {
 	if err := utils.CheckSupportedArgs(c.Arguments(), args); err != nil {
 		return err
 	}

--- a/pkg/function/delete_csi_snapshot.go
+++ b/pkg/function/delete_csi_snapshot.go
@@ -29,6 +29,7 @@ import (
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/poll"
 	"github.com/kanisterio/kanister/pkg/progress"
+	"github.com/kanisterio/kanister/pkg/utils"
 )
 
 func init() {
@@ -101,6 +102,14 @@ func (*deleteCSISnapshotFunc) Arguments() []string {
 		DeleteCSISnapshotNameArg,
 		DeleteCSISnapshotNamespaceArg,
 	}
+}
+
+func (d *deleteCSISnapshotFunc) Validate(args map[string]interface{}) error {
+	if err := utils.CheckSupportedArgs(d.Arguments(), args); err != nil {
+		return err
+	}
+
+	return utils.CheckRequiredArgs(d.RequiredArgs(), args)
 }
 
 func (c *deleteCSISnapshotFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {

--- a/pkg/function/delete_csi_snapshot.go
+++ b/pkg/function/delete_csi_snapshot.go
@@ -104,7 +104,7 @@ func (*deleteCSISnapshotFunc) Arguments() []string {
 	}
 }
 
-func (d *deleteCSISnapshotFunc) Validate(args map[string]interface{}) error {
+func (d *deleteCSISnapshotFunc) Validate(args map[string]any) error {
 	if err := utils.CheckSupportedArgs(d.Arguments(), args); err != nil {
 		return err
 	}

--- a/pkg/function/delete_csi_snapshot_content.go
+++ b/pkg/function/delete_csi_snapshot_content.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kanisterio/kanister/pkg/kube/snapshot"
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/progress"
+	"github.com/kanisterio/kanister/pkg/utils"
 )
 
 func init() {
@@ -90,6 +91,14 @@ func (*deleteCSISnapshotContentFunc) Arguments() []string {
 	return []string{
 		DeleteCSISnapshotContentNameArg,
 	}
+}
+
+func (d *deleteCSISnapshotContentFunc) Validate(args map[string]interface{}) error {
+	if err := utils.CheckSupportedArgs(d.Arguments(), args); err != nil {
+		return err
+	}
+
+	return utils.CheckRequiredArgs(d.RequiredArgs(), args)
 }
 
 func (c *deleteCSISnapshotContentFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {

--- a/pkg/function/delete_csi_snapshot_content.go
+++ b/pkg/function/delete_csi_snapshot_content.go
@@ -93,7 +93,7 @@ func (*deleteCSISnapshotContentFunc) Arguments() []string {
 	}
 }
 
-func (d *deleteCSISnapshotContentFunc) Validate(args map[string]interface{}) error {
+func (d *deleteCSISnapshotContentFunc) Validate(args map[string]any) error {
 	if err := utils.CheckSupportedArgs(d.Arguments(), args); err != nil {
 		return err
 	}

--- a/pkg/function/delete_data.go
+++ b/pkg/function/delete_data.go
@@ -277,7 +277,7 @@ func (*deleteDataFunc) Arguments() []string {
 	}
 }
 
-func (d *deleteDataFunc) Validate(args map[string]interface{}) error {
+func (d *deleteDataFunc) Validate(args map[string]any) error {
 	if err := utils.CheckSupportedArgs(d.Arguments(), args); err != nil {
 		return err
 	}

--- a/pkg/function/delete_data.go
+++ b/pkg/function/delete_data.go
@@ -35,6 +35,7 @@ import (
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/progress"
 	"github.com/kanisterio/kanister/pkg/restic"
+	"github.com/kanisterio/kanister/pkg/utils"
 )
 
 const (
@@ -274,6 +275,14 @@ func (*deleteDataFunc) Arguments() []string {
 		DeleteDataReclaimSpace,
 		InsecureTLS,
 	}
+}
+
+func (d *deleteDataFunc) Validate(args map[string]interface{}) error {
+	if err := utils.CheckSupportedArgs(d.Arguments(), args); err != nil {
+		return err
+	}
+
+	return utils.CheckRequiredArgs(d.RequiredArgs(), args)
 }
 
 func (d *deleteDataFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {

--- a/pkg/function/delete_data_all.go
+++ b/pkg/function/delete_data_all.go
@@ -137,7 +137,7 @@ func (*deleteDataAllFunc) Arguments() []string {
 	}
 }
 
-func (d *deleteDataAllFunc) Validate(args map[string]interface{}) error {
+func (d *deleteDataAllFunc) Validate(args map[string]any) error {
 	if err := utils.CheckSupportedArgs(d.Arguments(), args); err != nil {
 		return err
 	}

--- a/pkg/function/delete_data_all.go
+++ b/pkg/function/delete_data_all.go
@@ -29,6 +29,7 @@ import (
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/progress"
 	"github.com/kanisterio/kanister/pkg/restic"
+	"github.com/kanisterio/kanister/pkg/utils"
 )
 
 const (
@@ -134,6 +135,14 @@ func (*deleteDataAllFunc) Arguments() []string {
 		DeleteDataAllReclaimSpace,
 		InsecureTLS,
 	}
+}
+
+func (d *deleteDataAllFunc) Validate(args map[string]interface{}) error {
+	if err := utils.CheckSupportedArgs(d.Arguments(), args); err != nil {
+		return err
+	}
+
+	return utils.CheckRequiredArgs(d.RequiredArgs(), args)
 }
 
 func (d *deleteDataAllFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {

--- a/pkg/function/delete_data_using_kopia_server.go
+++ b/pkg/function/delete_data_using_kopia_server.go
@@ -73,7 +73,7 @@ func (*deleteDataUsingKopiaServerFunc) Arguments() []string {
 	}
 }
 
-func (d *deleteDataUsingKopiaServerFunc) Validate(args map[string]interface{}) error {
+func (d *deleteDataUsingKopiaServerFunc) Validate(args map[string]any) error {
 	if err := utils.CheckSupportedArgs(d.Arguments(), args); err != nil {
 		return err
 	}

--- a/pkg/function/delete_data_using_kopia_server.go
+++ b/pkg/function/delete_data_using_kopia_server.go
@@ -32,6 +32,7 @@ import (
 	"github.com/kanisterio/kanister/pkg/kube"
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/progress"
+	"github.com/kanisterio/kanister/pkg/utils"
 )
 
 const (
@@ -70,6 +71,14 @@ func (*deleteDataUsingKopiaServerFunc) Arguments() []string {
 		RestoreDataImageArg,
 		KopiaRepositoryServerUserHostname,
 	}
+}
+
+func (d *deleteDataUsingKopiaServerFunc) Validate(args map[string]interface{}) error {
+	if err := utils.CheckSupportedArgs(d.Arguments(), args); err != nil {
+		return err
+	}
+
+	return utils.CheckRequiredArgs(d.RequiredArgs(), args)
 }
 
 func (d *deleteDataUsingKopiaServerFunc) Exec(ctx context.Context, tp param.TemplateParams, args map[string]any) (map[string]any, error) {

--- a/pkg/function/delete_rds_snapshot.go
+++ b/pkg/function/delete_rds_snapshot.go
@@ -144,7 +144,7 @@ func (*deleteRDSSnapshotFunc) Arguments() []string {
 	}
 }
 
-func (d *deleteRDSSnapshotFunc) Validate(args map[string]interface{}) error {
+func (d *deleteRDSSnapshotFunc) Validate(args map[string]any) error {
 	if err := utils.CheckSupportedArgs(d.Arguments(), args); err != nil {
 		return err
 	}

--- a/pkg/function/delete_rds_snapshot.go
+++ b/pkg/function/delete_rds_snapshot.go
@@ -30,6 +30,7 @@ import (
 	"github.com/kanisterio/kanister/pkg/log"
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/progress"
+	"github.com/kanisterio/kanister/pkg/utils"
 )
 
 func init() {
@@ -114,10 +115,10 @@ func deleteRDSSnapshot(ctx context.Context, snapshotID string, profile *param.Pr
 	return nil, errors.Wrap(err, "Error waiting for Aurora DB cluster snapshot to be deleted")
 }
 
-func (crs *deleteRDSSnapshotFunc) Exec(ctx context.Context, tp param.TemplateParams, args map[string]interface{}) (map[string]interface{}, error) {
+func (d *deleteRDSSnapshotFunc) Exec(ctx context.Context, tp param.TemplateParams, args map[string]interface{}) (map[string]interface{}, error) {
 	// Set progress percent
-	crs.progressPercent = progress.StartedPercent
-	defer func() { crs.progressPercent = progress.CompletedPercent }()
+	d.progressPercent = progress.StartedPercent
+	defer func() { d.progressPercent = progress.CompletedPercent }()
 
 	var snapshotID string
 	var dbEngine RDSDBEngine
@@ -141,6 +142,14 @@ func (*deleteRDSSnapshotFunc) Arguments() []string {
 		DeleteRDSSnapshotSnapshotIDArg,
 		CreateRDSSnapshotDBEngine,
 	}
+}
+
+func (d *deleteRDSSnapshotFunc) Validate(args map[string]interface{}) error {
+	if err := utils.CheckSupportedArgs(d.Arguments(), args); err != nil {
+		return err
+	}
+
+	return utils.CheckRequiredArgs(d.RequiredArgs(), args)
 }
 
 func (d *deleteRDSSnapshotFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {

--- a/pkg/function/delete_volume_snapshot.go
+++ b/pkg/function/delete_volume_snapshot.go
@@ -34,6 +34,7 @@ import (
 	"github.com/kanisterio/kanister/pkg/log"
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/progress"
+	"github.com/kanisterio/kanister/pkg/utils"
 )
 
 func init() {
@@ -130,6 +131,14 @@ func (*deleteVolumeSnapshotFunc) Arguments() []string {
 		DeleteVolumeSnapshotNamespaceArg,
 		DeleteVolumeSnapshotManifestArg,
 	}
+}
+
+func (d *deleteVolumeSnapshotFunc) Validate(args map[string]interface{}) error {
+	if err := utils.CheckSupportedArgs(d.Arguments(), args); err != nil {
+		return err
+	}
+
+	return utils.CheckRequiredArgs(d.RequiredArgs(), args)
 }
 
 func (d *deleteVolumeSnapshotFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {

--- a/pkg/function/delete_volume_snapshot.go
+++ b/pkg/function/delete_volume_snapshot.go
@@ -133,7 +133,7 @@ func (*deleteVolumeSnapshotFunc) Arguments() []string {
 	}
 }
 
-func (d *deleteVolumeSnapshotFunc) Validate(args map[string]interface{}) error {
+func (d *deleteVolumeSnapshotFunc) Validate(args map[string]any) error {
 	if err := utils.CheckSupportedArgs(d.Arguments(), args); err != nil {
 		return err
 	}

--- a/pkg/function/export_rds_snapshot_location.go
+++ b/pkg/function/export_rds_snapshot_location.go
@@ -35,6 +35,7 @@ import (
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/postgres"
 	"github.com/kanisterio/kanister/pkg/progress"
+	"github.com/kanisterio/kanister/pkg/utils"
 )
 
 func init() {
@@ -168,10 +169,10 @@ func exportRDSSnapshotToLoc(
 	return output, nil
 }
 
-func (crs *exportRDSSnapshotToLocationFunc) Exec(ctx context.Context, tp param.TemplateParams, args map[string]interface{}) (map[string]interface{}, error) {
+func (e *exportRDSSnapshotToLocationFunc) Exec(ctx context.Context, tp param.TemplateParams, args map[string]interface{}) (map[string]interface{}, error) {
 	// Set progress percent
-	crs.progressPercent = progress.StartedPercent
-	defer func() { crs.progressPercent = progress.CompletedPercent }()
+	e.progressPercent = progress.StartedPercent
+	defer func() { e.progressPercent = progress.CompletedPercent }()
 
 	var namespace, instanceID, snapshotID, username, password, dbSubnetGroup, backupArtifact string
 	var dbEngine RDSDBEngine
@@ -239,10 +240,18 @@ func (*exportRDSSnapshotToLocationFunc) Arguments() []string {
 	}
 }
 
-func (d *exportRDSSnapshotToLocationFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {
+func (e *exportRDSSnapshotToLocationFunc) Validate(args map[string]interface{}) error {
+	if err := utils.CheckSupportedArgs(e.Arguments(), args); err != nil {
+		return err
+	}
+
+	return utils.CheckRequiredArgs(e.RequiredArgs(), args)
+}
+
+func (e *exportRDSSnapshotToLocationFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {
 	metav1Time := metav1.NewTime(time.Now())
 	return crv1alpha1.PhaseProgress{
-		ProgressPercent:    d.progressPercent,
+		ProgressPercent:    e.progressPercent,
 		LastTransitionTime: &metav1Time,
 	}, nil
 }

--- a/pkg/function/export_rds_snapshot_location.go
+++ b/pkg/function/export_rds_snapshot_location.go
@@ -240,7 +240,7 @@ func (*exportRDSSnapshotToLocationFunc) Arguments() []string {
 	}
 }
 
-func (e *exportRDSSnapshotToLocationFunc) Validate(args map[string]interface{}) error {
+func (e *exportRDSSnapshotToLocationFunc) Validate(args map[string]any) error {
 	if err := utils.CheckSupportedArgs(e.Arguments(), args); err != nil {
 		return err
 	}

--- a/pkg/function/kube_exec.go
+++ b/pkg/function/kube_exec.go
@@ -125,7 +125,7 @@ func (*kubeExecFunc) Arguments() []string {
 	}
 }
 
-func (kef *kubeExecFunc) Validate(args map[string]interface{}) error {
+func (kef *kubeExecFunc) Validate(args map[string]any) error {
 	if err := utils.CheckSupportedArgs(kef.Arguments(), args); err != nil {
 		return err
 	}

--- a/pkg/function/kube_exec.go
+++ b/pkg/function/kube_exec.go
@@ -30,6 +30,7 @@ import (
 	"github.com/kanisterio/kanister/pkg/output"
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/progress"
+	"github.com/kanisterio/kanister/pkg/utils"
 )
 
 func init() {
@@ -122,6 +123,14 @@ func (*kubeExecFunc) Arguments() []string {
 		KubeExecCommandArg,
 		KubeExecContainerNameArg,
 	}
+}
+
+func (kef *kubeExecFunc) Validate(args map[string]interface{}) error {
+	if err := utils.CheckSupportedArgs(kef.Arguments(), args); err != nil {
+		return err
+	}
+
+	return utils.CheckRequiredArgs(kef.RequiredArgs(), args)
 }
 
 func (kef *kubeExecFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {

--- a/pkg/function/kube_exec_all.go
+++ b/pkg/function/kube_exec_all.go
@@ -103,7 +103,7 @@ func (*kubeExecAllFunc) Arguments() []string {
 	}
 }
 
-func (k *kubeExecAllFunc) Validate(args map[string]interface{}) error {
+func (k *kubeExecAllFunc) Validate(args map[string]any) error {
 	if err := utils.CheckSupportedArgs(k.Arguments(), args); err != nil {
 		return err
 	}

--- a/pkg/function/kube_exec_all.go
+++ b/pkg/function/kube_exec_all.go
@@ -29,6 +29,7 @@ import (
 	"github.com/kanisterio/kanister/pkg/kube"
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/progress"
+	"github.com/kanisterio/kanister/pkg/utils"
 )
 
 func init() {
@@ -100,6 +101,14 @@ func (*kubeExecAllFunc) Arguments() []string {
 		KubeExecAllContainersNameArg,
 		KubeExecAllCommandArg,
 	}
+}
+
+func (k *kubeExecAllFunc) Validate(args map[string]interface{}) error {
+	if err := utils.CheckSupportedArgs(k.Arguments(), args); err != nil {
+		return err
+	}
+
+	return utils.CheckRequiredArgs(k.RequiredArgs(), args)
 }
 
 func (k *kubeExecAllFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {

--- a/pkg/function/kube_task.go
+++ b/pkg/function/kube_task.go
@@ -32,6 +32,7 @@ import (
 	"github.com/kanisterio/kanister/pkg/output"
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/progress"
+	"github.com/kanisterio/kanister/pkg/utils"
 )
 
 const (
@@ -144,6 +145,14 @@ func (*kubeTaskFunc) Arguments() []string {
 		KubeTaskNamespaceArg,
 		KubeTaskPodOverrideArg,
 	}
+}
+
+func (ktf *kubeTaskFunc) Validate(args map[string]interface{}) error {
+	if err := utils.CheckSupportedArgs(ktf.Arguments(), args); err != nil {
+		return err
+	}
+
+	return utils.CheckRequiredArgs(ktf.RequiredArgs(), args)
 }
 
 func (k *kubeTaskFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {

--- a/pkg/function/kube_task.go
+++ b/pkg/function/kube_task.go
@@ -147,7 +147,7 @@ func (*kubeTaskFunc) Arguments() []string {
 	}
 }
 
-func (ktf *kubeTaskFunc) Validate(args map[string]interface{}) error {
+func (ktf *kubeTaskFunc) Validate(args map[string]any) error {
 	if err := utils.CheckSupportedArgs(ktf.Arguments(), args); err != nil {
 		return err
 	}

--- a/pkg/function/kubeops.go
+++ b/pkg/function/kubeops.go
@@ -30,6 +30,7 @@ import (
 	"github.com/kanisterio/kanister/pkg/kube"
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/progress"
+	"github.com/kanisterio/kanister/pkg/utils"
 )
 
 func init() {
@@ -135,6 +136,14 @@ func (*kubeops) Arguments() []string {
 		KubeOpsNamespaceArg,
 		KubeOpsObjectReferenceArg,
 	}
+}
+
+func (k *kubeops) Validate(args map[string]interface{}) error {
+	if err := utils.CheckSupportedArgs(k.Arguments(), args); err != nil {
+		return err
+	}
+
+	return utils.CheckRequiredArgs(k.RequiredArgs(), args)
 }
 
 func (k *kubeops) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {

--- a/pkg/function/kubeops.go
+++ b/pkg/function/kubeops.go
@@ -138,7 +138,7 @@ func (*kubeops) Arguments() []string {
 	}
 }
 
-func (k *kubeops) Validate(args map[string]interface{}) error {
+func (k *kubeops) Validate(args map[string]any) error {
 	if err := utils.CheckSupportedArgs(k.Arguments(), args); err != nil {
 		return err
 	}

--- a/pkg/function/location_delete.go
+++ b/pkg/function/location_delete.go
@@ -27,6 +27,7 @@ import (
 	"github.com/kanisterio/kanister/pkg/location"
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/progress"
+	"github.com/kanisterio/kanister/pkg/utils"
 )
 
 const (
@@ -72,6 +73,14 @@ func (*locationDeleteFunc) RequiredArgs() []string {
 
 func (*locationDeleteFunc) Arguments() []string {
 	return []string{LocationDeleteArtifactArg}
+}
+
+func (l *locationDeleteFunc) Validate(args map[string]interface{}) error {
+	if err := utils.CheckSupportedArgs(l.Arguments(), args); err != nil {
+		return err
+	}
+
+	return utils.CheckRequiredArgs(l.RequiredArgs(), args)
 }
 
 func (l *locationDeleteFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {

--- a/pkg/function/location_delete.go
+++ b/pkg/function/location_delete.go
@@ -75,7 +75,7 @@ func (*locationDeleteFunc) Arguments() []string {
 	return []string{LocationDeleteArtifactArg}
 }
 
-func (l *locationDeleteFunc) Validate(args map[string]interface{}) error {
+func (l *locationDeleteFunc) Validate(args map[string]any) error {
 	if err := utils.CheckSupportedArgs(l.Arguments(), args); err != nil {
 		return err
 	}

--- a/pkg/function/prepare_data.go
+++ b/pkg/function/prepare_data.go
@@ -207,7 +207,7 @@ func (*prepareDataFunc) Arguments() []string {
 	}
 }
 
-func (p *prepareDataFunc) Validate(args map[string]interface{}) error {
+func (p *prepareDataFunc) Validate(args map[string]any) error {
 	if err := utils.CheckSupportedArgs(p.Arguments(), args); err != nil {
 		return err
 	}

--- a/pkg/function/prepare_data.go
+++ b/pkg/function/prepare_data.go
@@ -33,6 +33,7 @@ import (
 	"github.com/kanisterio/kanister/pkg/kube"
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/progress"
+	"github.com/kanisterio/kanister/pkg/utils"
 )
 
 const (
@@ -204,6 +205,14 @@ func (*prepareDataFunc) Arguments() []string {
 		PrepareDataServiceAccount,
 		PrepareDataPodOverrideArg,
 	}
+}
+
+func (p *prepareDataFunc) Validate(args map[string]interface{}) error {
+	if err := utils.CheckSupportedArgs(p.Arguments(), args); err != nil {
+		return err
+	}
+
+	return utils.CheckRequiredArgs(p.RequiredArgs(), args)
 }
 
 func (p *prepareDataFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {

--- a/pkg/function/restore_csi_snapshot.go
+++ b/pkg/function/restore_csi_snapshot.go
@@ -30,6 +30,7 @@ import (
 	"github.com/kanisterio/kanister/pkg/kube"
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/progress"
+	"github.com/kanisterio/kanister/pkg/utils"
 )
 
 func init() {
@@ -159,6 +160,14 @@ func (*restoreCSISnapshotFunc) Arguments() []string {
 		RestoreCSISnapshotVolumeModeArg,
 		RestoreCSISnapshotLabelsArg,
 	}
+}
+
+func (r *restoreCSISnapshotFunc) Validate(args map[string]interface{}) error {
+	if err := utils.CheckSupportedArgs(r.Arguments(), args); err != nil {
+		return err
+	}
+
+	return utils.CheckRequiredArgs(r.RequiredArgs(), args)
 }
 
 func (d *restoreCSISnapshotFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {

--- a/pkg/function/restore_csi_snapshot.go
+++ b/pkg/function/restore_csi_snapshot.go
@@ -162,7 +162,7 @@ func (*restoreCSISnapshotFunc) Arguments() []string {
 	}
 }
 
-func (r *restoreCSISnapshotFunc) Validate(args map[string]interface{}) error {
+func (r *restoreCSISnapshotFunc) Validate(args map[string]any) error {
 	if err := utils.CheckSupportedArgs(r.Arguments(), args); err != nil {
 		return err
 	}

--- a/pkg/function/restore_data.go
+++ b/pkg/function/restore_data.go
@@ -283,7 +283,7 @@ func (*restoreDataFunc) Arguments() []string {
 	}
 }
 
-func (r *restoreDataFunc) Validate(args map[string]interface{}) error {
+func (r *restoreDataFunc) Validate(args map[string]any) error {
 	if err := utils.CheckSupportedArgs(r.Arguments(), args); err != nil {
 		return err
 	}

--- a/pkg/function/restore_data.go
+++ b/pkg/function/restore_data.go
@@ -31,6 +31,7 @@ import (
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/progress"
 	"github.com/kanisterio/kanister/pkg/restic"
+	"github.com/kanisterio/kanister/pkg/utils"
 )
 
 const (
@@ -280,6 +281,14 @@ func (*restoreDataFunc) Arguments() []string {
 		RestoreDataPodOverrideArg,
 		InsecureTLS,
 	}
+}
+
+func (r *restoreDataFunc) Validate(args map[string]interface{}) error {
+	if err := utils.CheckSupportedArgs(r.Arguments(), args); err != nil {
+		return err
+	}
+
+	return utils.CheckRequiredArgs(r.RequiredArgs(), args)
 }
 
 func (d *restoreDataFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {

--- a/pkg/function/restore_data_all.go
+++ b/pkg/function/restore_data_all.go
@@ -207,7 +207,7 @@ func (*restoreDataAllFunc) Arguments() []string {
 	}
 }
 
-func (r *restoreDataAllFunc) Validate(args map[string]interface{}) error {
+func (r *restoreDataAllFunc) Validate(args map[string]any) error {
 	if err := utils.CheckSupportedArgs(r.Arguments(), args); err != nil {
 		return err
 	}

--- a/pkg/function/restore_data_all.go
+++ b/pkg/function/restore_data_all.go
@@ -30,6 +30,7 @@ import (
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/progress"
 	"github.com/kanisterio/kanister/pkg/restic"
+	"github.com/kanisterio/kanister/pkg/utils"
 )
 
 const (
@@ -204,6 +205,14 @@ func (*restoreDataAllFunc) Arguments() []string {
 		RestoreDataAllPodOverrideArg,
 		InsecureTLS,
 	}
+}
+
+func (r *restoreDataAllFunc) Validate(args map[string]interface{}) error {
+	if err := utils.CheckSupportedArgs(r.Arguments(), args); err != nil {
+		return err
+	}
+
+	return utils.CheckRequiredArgs(r.RequiredArgs(), args)
 }
 
 func (r *restoreDataAllFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {

--- a/pkg/function/restore_data_using_kopia_server.go
+++ b/pkg/function/restore_data_using_kopia_server.go
@@ -78,7 +78,7 @@ func (*restoreDataUsingKopiaServerFunc) Arguments() []string {
 	}
 }
 
-func (r *restoreDataUsingKopiaServerFunc) Validate(args map[string]interface{}) error {
+func (r *restoreDataUsingKopiaServerFunc) Validate(args map[string]any) error {
 	if err := utils.CheckSupportedArgs(r.Arguments(), args); err != nil {
 		return err
 	}

--- a/pkg/function/restore_data_using_kopia_server.go
+++ b/pkg/function/restore_data_using_kopia_server.go
@@ -78,6 +78,14 @@ func (*restoreDataUsingKopiaServerFunc) Arguments() []string {
 	}
 }
 
+func (r *restoreDataUsingKopiaServerFunc) Validate(args map[string]interface{}) error {
+	if err := utils.CheckSupportedArgs(r.Arguments(), args); err != nil {
+		return err
+	}
+
+	return utils.CheckRequiredArgs(r.RequiredArgs(), args)
+}
+
 func (r *restoreDataUsingKopiaServerFunc) Exec(ctx context.Context, tp param.TemplateParams, args map[string]any) (map[string]any, error) {
 	// Set progress percent
 	r.progressPercent = progress.StartedPercent

--- a/pkg/function/restore_rds_snapshot.go
+++ b/pkg/function/restore_rds_snapshot.go
@@ -106,7 +106,7 @@ func (*restoreRDSSnapshotFunc) Arguments() []string {
 	}
 }
 
-func (r *restoreRDSSnapshotFunc) Validate(args map[string]interface{}) error {
+func (r *restoreRDSSnapshotFunc) Validate(args map[string]any) error {
 	if err := utils.CheckSupportedArgs(r.Arguments(), args); err != nil {
 		return err
 	}

--- a/pkg/function/restore_rds_snapshot.go
+++ b/pkg/function/restore_rds_snapshot.go
@@ -34,6 +34,7 @@ import (
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/postgres"
 	"github.com/kanisterio/kanister/pkg/progress"
+	"github.com/kanisterio/kanister/pkg/utils"
 )
 
 func init() {
@@ -103,6 +104,14 @@ func (*restoreRDSSnapshotFunc) Arguments() []string {
 		RestoreRDSSnapshotSecGrpID,
 		RestoreRDSSnapshotDBSubnetGroup,
 	}
+}
+
+func (r *restoreRDSSnapshotFunc) Validate(args map[string]interface{}) error {
+	if err := utils.CheckSupportedArgs(r.Arguments(), args); err != nil {
+		return err
+	}
+
+	return utils.CheckRequiredArgs(r.RequiredArgs(), args)
 }
 
 func (r *restoreRDSSnapshotFunc) Exec(ctx context.Context, tp param.TemplateParams, args map[string]interface{}) (map[string]interface{}, error) {

--- a/pkg/function/scale_workload.go
+++ b/pkg/function/scale_workload.go
@@ -131,7 +131,7 @@ func (*scaleWorkloadFunc) Arguments() []string {
 	}
 }
 
-func (r *scaleWorkloadFunc) Validate(args map[string]interface{}) error {
+func (r *scaleWorkloadFunc) Validate(args map[string]any) error {
 	if err := utils.CheckSupportedArgs(r.Arguments(), args); err != nil {
 		return err
 	}

--- a/pkg/function/scale_workload.go
+++ b/pkg/function/scale_workload.go
@@ -30,6 +30,7 @@ import (
 	"github.com/kanisterio/kanister/pkg/kube"
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/progress"
+	"github.com/kanisterio/kanister/pkg/utils"
 )
 
 const (
@@ -128,6 +129,14 @@ func (*scaleWorkloadFunc) Arguments() []string {
 		ScaleWorkloadKindArg,
 		ScaleWorkloadWaitArg,
 	}
+}
+
+func (r *scaleWorkloadFunc) Validate(args map[string]interface{}) error {
+	if err := utils.CheckSupportedArgs(r.Arguments(), args); err != nil {
+		return err
+	}
+
+	return utils.CheckRequiredArgs(r.RequiredArgs(), args)
 }
 
 func (s *scaleWorkloadFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {

--- a/pkg/function/wait.go
+++ b/pkg/function/wait.go
@@ -120,7 +120,7 @@ func (*waitFunc) Arguments() []string {
 	}
 }
 
-func (w *waitFunc) Validate(args map[string]interface{}) error {
+func (w *waitFunc) Validate(args map[string]any) error {
 	if err := utils.CheckSupportedArgs(w.Arguments(), args); err != nil {
 		return err
 	}

--- a/pkg/function/wait.go
+++ b/pkg/function/wait.go
@@ -38,6 +38,7 @@ import (
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/poll"
 	"github.com/kanisterio/kanister/pkg/progress"
+	"github.com/kanisterio/kanister/pkg/utils"
 )
 
 type WaitConditions struct {
@@ -117,6 +118,14 @@ func (*waitFunc) Arguments() []string {
 		WaitTimeoutArg,
 		WaitConditionsArg,
 	}
+}
+
+func (w *waitFunc) Validate(args map[string]interface{}) error {
+	if err := utils.CheckSupportedArgs(w.Arguments(), args); err != nil {
+		return err
+	}
+
+	return utils.CheckRequiredArgs(w.RequiredArgs(), args)
 }
 
 func (w *waitFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {

--- a/pkg/function/wait_for_snapshot_completion.go
+++ b/pkg/function/wait_for_snapshot_completion.go
@@ -62,7 +62,7 @@ func (*waitForSnapshotCompletionFunc) Arguments() []string {
 	return []string{WaitForSnapshotCompletionSnapshotsArg}
 }
 
-func (w *waitForSnapshotCompletionFunc) Validate(args map[string]interface{}) error {
+func (w *waitForSnapshotCompletionFunc) Validate(args map[string]any) error {
 	if err := utils.CheckSupportedArgs(w.Arguments(), args); err != nil {
 		return err
 	}

--- a/pkg/function/wait_for_snapshot_completion.go
+++ b/pkg/function/wait_for_snapshot_completion.go
@@ -29,6 +29,7 @@ import (
 	"github.com/kanisterio/kanister/pkg/blockstorage/getter"
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/progress"
+	"github.com/kanisterio/kanister/pkg/utils"
 )
 
 func init() {
@@ -59,6 +60,14 @@ func (*waitForSnapshotCompletionFunc) RequiredArgs() []string {
 
 func (*waitForSnapshotCompletionFunc) Arguments() []string {
 	return []string{WaitForSnapshotCompletionSnapshotsArg}
+}
+
+func (w *waitForSnapshotCompletionFunc) Validate(args map[string]interface{}) error {
+	if err := utils.CheckSupportedArgs(w.Arguments(), args); err != nil {
+		return err
+	}
+
+	return utils.CheckRequiredArgs(w.RequiredArgs(), args)
 }
 
 func (w *waitForSnapshotCompletionFunc) Exec(ctx context.Context, tp param.TemplateParams, args map[string]interface{}) (map[string]interface{}, error) {

--- a/pkg/function/waitv2.go
+++ b/pkg/function/waitv2.go
@@ -31,6 +31,7 @@ import (
 	"github.com/kanisterio/kanister/pkg/kube"
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/progress"
+	"github.com/kanisterio/kanister/pkg/utils"
 )
 
 const (
@@ -95,6 +96,14 @@ func (*waitV2Func) Arguments() []string {
 		WaitV2TimeoutArg,
 		WaitV2ConditionsArg,
 	}
+}
+
+func (w *waitV2Func) Validate(args map[string]interface{}) error {
+	if err := utils.CheckSupportedArgs(w.Arguments(), args); err != nil {
+		return err
+	}
+
+	return utils.CheckRequiredArgs(w.RequiredArgs(), args)
 }
 
 func (w *waitV2Func) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {

--- a/pkg/function/waitv2.go
+++ b/pkg/function/waitv2.go
@@ -98,7 +98,7 @@ func (*waitV2Func) Arguments() []string {
 	}
 }
 
-func (w *waitV2Func) Validate(args map[string]interface{}) error {
+func (w *waitV2Func) Validate(args map[string]any) error {
 	if err := utils.CheckSupportedArgs(w.Arguments(), args); err != nil {
 		return err
 	}

--- a/pkg/kanister.go
+++ b/pkg/kanister.go
@@ -41,7 +41,7 @@ type Func interface {
 	Arguments() []string
 	Exec(context.Context, param.TemplateParams, map[string]interface{}) (map[string]interface{}, error)
 	ExecutionProgress() (crv1alpha1.PhaseProgress, error)
-	Validate(map[string]interface{}) error
+	Validate(map[string]any) error
 }
 
 // Register allows Funcs to be referenced by User Defined YAMLs

--- a/pkg/kanister.go
+++ b/pkg/kanister.go
@@ -41,6 +41,7 @@ type Func interface {
 	Arguments() []string
 	Exec(context.Context, param.TemplateParams, map[string]interface{}) (map[string]interface{}, error)
 	ExecutionProgress() (crv1alpha1.PhaseProgress, error)
+	Validate(map[string]interface{}) error
 }
 
 // Register allows Funcs to be referenced by User Defined YAMLs

--- a/pkg/phase.go
+++ b/pkg/phase.go
@@ -20,12 +20,12 @@ import (
 
 	"github.com/Masterminds/semver"
 	"github.com/pkg/errors"
-	"k8s.io/utils/strings/slices"
 
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	"github.com/kanisterio/kanister/pkg/field"
 	"github.com/kanisterio/kanister/pkg/log"
 	"github.com/kanisterio/kanister/pkg/param"
+	"github.com/kanisterio/kanister/pkg/utils"
 )
 
 var skipRenderFuncs = map[string]bool{
@@ -92,11 +92,11 @@ func (p *Phase) setPhaseArgs(phases []crv1alpha1.BlueprintPhase, tp param.Templa
 			return err
 		}
 
-		if err = checkRequiredArgs(p.f.RequiredArgs(), args); err != nil {
+		if err = utils.CheckRequiredArgs(p.f.RequiredArgs(), args); err != nil {
 			return errors.Wrapf(err, "Required args missing for function %s", p.f.Name())
 		}
 
-		if err = checkSupportedArgs(p.f.Arguments(), args); err != nil {
+		if err = utils.CheckSupportedArgs(p.f.Arguments(), args); err != nil {
 			return errors.Wrapf(err, "Checking supported args for function %s.", p.f.Name())
 		}
 
@@ -115,15 +115,6 @@ func renderFuncArgs(
 	}
 
 	return param.RenderArgs(args, tp)
-}
-
-func checkSupportedArgs(supportedArgs []string, args map[string]interface{}) error {
-	for a := range args {
-		if !slices.Contains(supportedArgs, a) {
-			return errors.Errorf("argument %s is not supported", a)
-		}
-	}
-	return nil
 }
 
 func GetDeferPhase(bp crv1alpha1.Blueprint, action, version string, tp param.TemplateParams) (*Phase, error) {
@@ -208,22 +199,9 @@ func GetPhases(bp crv1alpha1.Blueprint, action, version string, tp param.Templat
 	return phases, nil
 }
 
-// Validate gets the provided arguments from a blueprint and verifies that the required arguments are present
+// Validate gets the provided arguments from a blueprint and calls Validate method of function to valdiate a function.
 func (p *Phase) Validate(args map[string]interface{}) error {
-	if err := checkSupportedArgs(p.f.Arguments(), args); err != nil {
-		return err
-	}
-
-	return checkRequiredArgs(p.f.RequiredArgs(), args)
-}
-
-func checkRequiredArgs(reqArgs []string, args map[string]interface{}) error {
-	for _, a := range reqArgs {
-		if _, ok := args[a]; !ok {
-			return errors.Errorf("Required arg missing: %s", a)
-		}
-	}
-	return nil
+	return p.f.Validate(args)
 }
 
 func getFunctionVersion(version string) (*semver.Version, *semver.Version, error) {

--- a/pkg/phase.go
+++ b/pkg/phase.go
@@ -200,7 +200,7 @@ func GetPhases(bp crv1alpha1.Blueprint, action, version string, tp param.Templat
 }
 
 // Validate gets the provided arguments from a blueprint and calls Validate method of function to valdiate a function.
-func (p *Phase) Validate(args map[string]interface{}) error {
+func (p *Phase) Validate(args map[string]any) error {
 	return p.f.Validate(args)
 }
 

--- a/pkg/phase_test.go
+++ b/pkg/phase_test.go
@@ -21,6 +21,7 @@ import (
 
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	"github.com/kanisterio/kanister/pkg/param"
+	"github.com/kanisterio/kanister/pkg/utils"
 )
 
 type PhaseSuite struct{}
@@ -62,6 +63,14 @@ func (tf *testFunc) RequiredArgs() []string {
 
 func (tf *testFunc) Arguments() []string {
 	return nil
+}
+
+func (tf *testFunc) Validate(args map[string]interface{}) error {
+	if err := utils.CheckSupportedArgs(tf.Arguments(), args); err != nil {
+		return err
+	}
+
+	return utils.CheckRequiredArgs(tf.RequiredArgs(), args)
 }
 
 func (tf *testFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {
@@ -137,7 +146,7 @@ func (s *PhaseSuite) TestCheckSupportedArgs(c *C) {
 			err:          IsNil,
 		},
 	} {
-		err := checkSupportedArgs(tc.supprtedArgs, tc.providedArgs)
+		err := utils.CheckSupportedArgs(tc.supprtedArgs, tc.providedArgs)
 		if err != nil {
 			c.Assert(err.Error(), Equals, tc.expErr)
 		}

--- a/pkg/phase_test.go
+++ b/pkg/phase_test.go
@@ -65,7 +65,7 @@ func (tf *testFunc) Arguments() []string {
 	return nil
 }
 
-func (tf *testFunc) Validate(args map[string]interface{}) error {
+func (tf *testFunc) Validate(args map[string]any) error {
 	if err := utils.CheckSupportedArgs(tf.Arguments(), args); err != nil {
 		return err
 	}

--- a/pkg/testutil/func.go
+++ b/pkg/testutil/func.go
@@ -25,6 +25,7 @@ import (
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/progress"
+	"github.com/kanisterio/kanister/pkg/utils"
 )
 
 const (
@@ -146,6 +147,14 @@ func (mf *mockKanisterFunc) RequiredArgs() []string {
 
 func (mf *mockKanisterFunc) Arguments() []string {
 	return []string{testBPArg}
+}
+
+func (mf *mockKanisterFunc) Validate(args map[string]interface{}) error {
+	if err := utils.CheckSupportedArgs(mf.Arguments(), args); err != nil {
+		return err
+	}
+
+	return utils.CheckRequiredArgs(mf.RequiredArgs(), args)
 }
 
 func CancelFuncStarted() struct{} {

--- a/pkg/testutil/func.go
+++ b/pkg/testutil/func.go
@@ -149,7 +149,7 @@ func (mf *mockKanisterFunc) Arguments() []string {
 	return []string{testBPArg}
 }
 
-func (mf *mockKanisterFunc) Validate(args map[string]interface{}) error {
+func (mf *mockKanisterFunc) Validate(args map[string]any) error {
 	if err := utils.CheckSupportedArgs(mf.Arguments(), args); err != nil {
 		return err
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -113,4 +114,22 @@ func RoundUpDuration(t time.Duration) time.Duration {
 		return t.Round(time.Minute)
 	}
 	return t.Round(time.Hour)
+}
+
+func CheckRequiredArgs(reqArgs []string, args map[string]interface{}) error {
+	for _, a := range reqArgs {
+		if _, ok := args[a]; !ok {
+			return errors.Errorf("Required arg missing: %s", a)
+		}
+	}
+	return nil
+}
+
+func CheckSupportedArgs(supportedArgs []string, args map[string]interface{}) error {
+	for a := range args {
+		if !slices.Contains(supportedArgs, a) {
+			return errors.Errorf("argument %s is not supported", a)
+		}
+	}
+	return nil
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -116,6 +116,8 @@ func RoundUpDuration(t time.Duration) time.Duration {
 	return t.Round(time.Hour)
 }
 
+// CheckRequiredArgs checks if the required args of a function `reqArgs` are
+// provided in created blueprint's functions' args (`args`).
 func CheckRequiredArgs(reqArgs []string, args map[string]interface{}) error {
 	for _, a := range reqArgs {
 		if _, ok := args[a]; !ok {
@@ -125,6 +127,8 @@ func CheckRequiredArgs(reqArgs []string, args map[string]interface{}) error {
 	return nil
 }
 
+// CheckSupportedArgs checks that all the provided (using blueprint) args of a function
+// are supported by the kanister function.
 func CheckSupportedArgs(supportedArgs []string, args map[string]interface{}) error {
 	for a := range args {
 		if !slices.Contains(supportedArgs, a) {


### PR DESCRIPTION
## Change Overview

This PR fundamentally just refactors the way we used to validate a blueprint phase. Initially when we added blueprint validation, we called `Validate` on a phase (`phase.go`) that would get arguments of the respective function and then check if the arguments are proper or not.
This PR just delegates this validation logic to the function itself, and the reason is
- If we are validating the functions, it's better to have the validation logic to closer to the function
- And, if there are some specific validation that needs to be done for just some functions that's easily achievable if validation is implemented this way. (for example if for some function we are allowed to provide labels and validate should also validate those labels)

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :building_construction: Build

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

```
~/opensource/kanister/pkg/blueprint/validate (validate-kanf*) » go test
Failed the 'validation of phase 00 in action backup' check.. ❌
Passed the 'validation of phase 10 in action backup' check.. ✅
Passed the 'validation of phase 11 in action backup' check.. ✅
Failed the 'validation of action backup' check.. ❌
Passed the 'validation of phase 30 in action backup' check.. ✅
Failed the 'validation of phase 40 in action backup' check.. ❌
Failed the 'validation of phase 51 in action backup' check.. ❌
Failed the 'validation of phase 61 in action backup' check.. ❌
Passed the 'validation of phase 71 in action backup' check.. ✅
Passed the 'validation of phase 70 in action backup' check.. ✅
{"FallbackVersion":"v0.0.0","File":"pkg/phase.go","Function":"PrepareData","Line":184,"PreferredVersion":"v0.0.1","level":"info","msg":"Falling back to default version of the function","time":"2024-08-05T12:09:06.408961+05:30"}
Passed the 'validation of phase 00 in action backup' check.. ✅
Passed the 'validation of phase 01 in action backup' check.. ✅
{"FallbackVersion":"v0.0.0","File":"pkg/phase.go","Function":"PrepareData","Line":184,"PreferredVersion":"v0.0.1","level":"info","msg":"Falling back to default version of the function","time":"2024-08-05T12:09:06.409274+05:30"}
Failed the 'validation of phase 10 in action backup' check.. ❌
Passed the 'validation of phase 20 in action backup' check.. ✅
Failed the 'validation of phase 21 in action backup' check.. ❌
{"FallbackVersion":"v0.0.0","File":"pkg/phase.go","Function":"PrepareData","Line":184,"PreferredVersion":"v0.0.1","level":"info","msg":"Falling back to default version of the function","time":"2024-08-05T12:09:06.409295+05:30"}
{"FallbackVersion":"v0.0.0","File":"pkg/phase.go","Function":"PrepareData","Line":184,"PreferredVersion":"v0.0.1","level":"info","msg":"Falling back to default version of the function","time":"2024-08-05T12:09:06.409301+05:30"}
Passed the 'validation of phase 30 in action backup' check.. ✅
Passed the 'validation of phase 31 in action backup' check.. ✅
OK: 3 passed
PASS
ok      github.com/kanisterio/kanister/pkg/blueprint/validate   0.899s
```

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
