### PR TITLE
feat: support `image` argument in ExportRDSSnapshotToLocation and RestoreRDSSnapshot

### DIFF
--- a/docs/functions.rst
+++ b/docs/functions.rst
@@ -990,6 +990,7 @@ Arguments:
    `databases`, No, `[]string`, list of databases to take backup of
    `securityGroupID`, No, `[]string`, list of ``securityGroupID`` to be passed to temporary RDS instance. ()
    `dbSubnetGroup`, No, `string`, DB Subnet Group to be passed to temporary RDS instance
+   `image`, No, `string`, kanister-tools image to be used for running export job
 
 .. note::
    - If ``databases`` argument is not set, backup of all the databases will be taken.
@@ -1080,6 +1081,7 @@ Arguments:
    `namespace`, No, `string`, namespace in which to execute. Required if ``snapshotID`` is nil
    `dbEngine`, No, `string`, one of the RDS db engines. Supported engines: ``PostgreSQL`` ``aurora`` ``aurora-mysql`` and ``aurora-postgresql``. Required if ``snapshotID`` is nil or Aurora is run in RDS instance
    `dbSubnetGroup`, No, `string`, DB Subnet Group to be passed to restored RDS instance
+   `image`, No, `string`, kanister-tools image to be used for running restore. Only relevant when restoring from data dump (if `snapshotID` is empty)
 
 .. note::
    - If ``snapshotID`` is not set, restore will be done from data dump. In that case ``backupID`` `arg` is required.

--- a/docs_new/functions.md
+++ b/docs_new/functions.md
@@ -859,6 +859,7 @@ Arguments:
   | databases            | No       | []string   | list of databases to take backup of |
   | securityGroupID      | No       | []string   | list of `securityGroupID` to be passed to temporary RDS instance |
   | dbSubnetGroup        | No       | string     | DB Subnet Group to be passed to temporary RDS instance |
+  | image                | No       | string     | kanister-tools image to be used for running export job |
 
 ::: tip NOTE
 
@@ -954,6 +955,7 @@ Arguments:
   | namespace            | No       | string     | namespace in which to execute. Required if `snapshotID` is nil |
   | dbEngine             | No       | string     | one of the RDS db engines. Supported engines: `PostgreSQL`, `aurora`, `aurora-mysql` and `aurora-postgresql`. Required if `snapshotID` is nil or Aurora is run in RDS instance |
   | dbSubnetGroup        | No       | string     | DB Subnet Group to be passed to restored RDS instance |
+  | image                | No       | string     |  kanister-tools image to be used for running restore, only relevant when restoring from data dump (if `snapshotID` is empty) |
 
 ::: tip NOTE
 

--- a/pkg/function/rds_functions_test.go
+++ b/pkg/function/rds_functions_test.go
@@ -128,7 +128,7 @@ func (s *RDSFunctionsTest) TestPrepareCommand(c *C) {
 	}
 
 	for _, tc := range testCases {
-		outCommand, _, err := prepareCommand(context.Background(), tc.dbEngine, tc.action, tc.dbEndpoint, tc.username, tc.password, tc.dbList, tc.backupPrefix, tc.backupID, tc.tp.Profile, tc.dbEngineVersion)
+		outCommand, err := prepareCommand(context.Background(), tc.dbEngine, tc.action, tc.dbEndpoint, tc.username, tc.password, tc.dbList, tc.backupPrefix, tc.backupID, tc.tp.Profile, tc.dbEngineVersion)
 
 		c.Check(err, tc.errChecker, Commentf("Case %s failed", tc.name))
 		c.Assert(outCommand, DeepEquals, tc.command)

--- a/releasenotes/notes/postgress-tools-image-override-4882c70780e8a496.yaml
+++ b/releasenotes/notes/postgress-tools-image-override-4882c70780e8a496.yaml
@@ -1,0 +1,2 @@
+---
+features: Support ``image`` argument for ``ExportRDSSnapshotToLocation`` and ``RestoreRDSSnapshot`` functions to override default postgres-kanister-tools image.


### PR DESCRIPTION
## Change Overview

Added an optional `image` argument with default set to `ghcr.io/kanisterio/postgres-kanister-tools:<current verison>`

The goal is to allow bluprints and actions to override default postgres-kanister-tools image similar to other functions.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [x] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :building_construction: Build

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [x] :green_heart: E2E
