### PR TITLE
build(ci): treat postgres-kanister-tools and mysql-sidecar images as "officially supported"

### DIFF
--- a/.github/workflows/build_example_images.yaml
+++ b/.github/workflows/build_example_images.yaml
@@ -40,21 +40,6 @@ jobs:
         org.opencontainers.image.title=kanister cassandra
         org.opencontainers.image.description=Image for kanister cassandra example blueprints
 
-  build_mysql_sidecar:
-    permissions:
-      packages: write
-    uses: ./.github/workflows/build_docker.yaml
-    with:
-      image_file: docker/kanister-mysql/image/Dockerfile
-      image_name: kanisterio/mysql-sidecar
-      image_tag: ${{ inputs.image_tag }}
-      ref:  ${{ inputs.ref }}
-      build-args: |
-        TOOLS_IMAGE=ghcr.io/kanisterio/kanister-tools:${{ inputs.image_tag }}
-      labels: |
-        org.opencontainers.image.title=kanister mysql sidecar
-        org.opencontainers.image.description=Image for kanister maysql example blueprints
-
   build_kafka-adobe-s3-sink-connector:
     permissions:
       packages: write
@@ -84,21 +69,6 @@ jobs:
       labels: |
         org.opencontainers.image.title=kanister kafka source connector
         org.opencontainers.image.description=Image for kanister kafka example blueprints
-
-  build_postgres-kanister-tools:
-    permissions:
-      packages: write
-    uses: ./.github/workflows/build_docker.yaml
-    with:
-      image_file: docker/postgres-kanister-tools/Dockerfile
-      image_name: kanisterio/postgres-kanister-tools
-      image_tag: ${{ inputs.image_tag }}
-      ref:  ${{ inputs.ref }}
-      build-args: |
-        TOOLS_IMAGE=ghcr.io/kanisterio/kanister-tools:${{ inputs.image_tag }}
-      labels: |
-        org.opencontainers.image.title=kanister tools for postgresql
-        org.opencontainers.image.description=Image for kanister postgresql example blueprints
 
   build_postgresql:
     permissions:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -83,6 +83,16 @@ dockers:
   dockerfile: 'docker/kanister-kubectl/Dockerfile'
   build_flag_templates:
   - "--build-arg=TOOLS_IMAGE=ghcr.io/kanisterio/kanister-tools:{{ .Tag }}"
+- image_templates:
+  - 'ghcr.io/kanisterio/postgres-kanister-tools:{{ .Tag }}'
+  dockerfile: 'docker/postgres-kanister-tools/Dockerfile'
+  build_flag_templates:
+  - "--build-arg=TOOLS_IMAGE=ghcr.io/kanisterio/kanister-tools:{{ .Tag }}"
+- image_templates:
+  - 'ghcr.io/kanisterio/mysql-sidecar:{{ .Tag }}'
+  dockerfile: 'docker/kanister-mysql/image/Dockerfile'
+  build_flag_templates:
+  - "--build-arg=TOOLS_IMAGE=ghcr.io/kanisterio/kanister-tools:{{ .Tag }}"
 snapshot:
   name_template: '{{ .Tag }}'
 checksum:

--- a/build/example_images.json
+++ b/build/example_images.json
@@ -1,9 +1,7 @@
 {
     "image_registry": "ghcr.io/kanisterio",
     "images": [
-        "mysql-sidecar",
         "kafka-adobe-s3-sink-connector",
-        "postgres-kanister-tools",
         "postgresql",
         "cassandra",
         "mongodb",

--- a/build/published_images.json
+++ b/build/published_images.json
@@ -4,7 +4,9 @@
         "kanister-kubectl-1.18",
         "controller",
         "kanister-tools",
-        "repo-server-controller"
+        "repo-server-controller",
+        "postgres-kanister-tools",
+        "mysql-sidecar"
     ],
     "tag": "v9.99.9-dev"
 }


### PR DESCRIPTION
## Change Overview

Move `mysql-sidecar` and `postgres-kanister-tools` into "published images" group and build them in the main release steps.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [x] :building_construction: Build

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

Make sure images are built after merge to master.

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
