### PR TITLE
Add E2E test for custom labels/annotations to function pods

### DIFF
--- a/pkg/testing/e2e_test.go
+++ b/pkg/testing/e2e_test.go
@@ -467,6 +467,8 @@ func (s *E2ESuite) TestPodLabelsAndAnnotations(c *C) {
 
 	err = s.waitForActionSetComplete(asCreatedFour.Name)
 	c.Assert(err, IsNil)
+
+	c.Assert(1, Equals, 2)
 }
 
 func (s *E2ESuite) waitForActionSetComplete(asName string) error {

--- a/pkg/testing/e2e_test.go
+++ b/pkg/testing/e2e_test.go
@@ -467,8 +467,6 @@ func (s *E2ESuite) TestPodLabelsAndAnnotations(c *C) {
 
 	err = s.waitForActionSetComplete(asCreatedFour.Name)
 	c.Assert(err, IsNil)
-
-	c.Assert(1, Equals, 2)
 }
 
 func (s *E2ESuite) waitForActionSetComplete(asName string) error {

--- a/pkg/testing/e2e_test.go
+++ b/pkg/testing/e2e_test.go
@@ -170,6 +170,7 @@ func (s *E2ESuite) TestKubeExec(c *C) {
 		return false, nil
 	})
 	c.Assert(err, IsNil)
+	c.Logf("Completed E2E TestKubeExec")
 }
 
 func (s *E2ESuite) TestKubeTask(c *C) {
@@ -293,6 +294,7 @@ func (s *E2ESuite) TestKubeTask(c *C) {
 		return false, nil
 	})
 	c.Assert(err, IsNil)
+	c.Log("Completed E2E TestKubeTask")
 }
 
 func (s *E2ESuite) TestPodLabelsAndAnnotations(c *C) {
@@ -467,6 +469,7 @@ func (s *E2ESuite) TestPodLabelsAndAnnotations(c *C) {
 
 	err = s.waitForActionSetComplete(asCreatedFour.Name)
 	c.Assert(err, IsNil)
+	c.Log("Completed E2E TestPodLabelsAndAnnotations")
 }
 
 func (s *E2ESuite) waitForActionSetComplete(asName string) error {

--- a/pkg/testing/e2e_test.go
+++ b/pkg/testing/e2e_test.go
@@ -530,6 +530,9 @@ func (s *E2ESuite) waitForActionSetComplete(asName string) error {
 	})
 }
 
+// waitForFunctionPodReady waits for the pod created by a Kanister function. The pods
+// that get created by Kanister function have the label `createdBy=kanister`, that's
+// why we are checking that label in the pods to make sure one pod is created.
 func (s *E2ESuite) waitForFunctionPodReady() error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()


### PR DESCRIPTION
## Change Overview

This PR adds e2e test to verify that the labels and annotations configured via the actionset and blueprint are properly added to the pod that is created via the kanister functions run by an actionset.


## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [x] :robot: Test
- [ ] :building_construction: Build

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [x] :green_heart: E2E

```
make test
ller).onUpdateActionSet","Line":256,"hostname":"orbstack","level":"info","msg":"Updated ActionSet 'actionset-lkznq' Status-\u003ecomplete","time":"2024-08-22T14:22:06.417586158Z"}
PASS: e2e_test.go:300: E2ESuite.TestPodLabelsAndAnnotations     95.080s
OK: 1 passed
--- PASS: Test (96.73s)
PASS
ok      github.com/kanisterio/kanister/pkg/testing      96.885s
=== RUN   Test
OK: 0 passed
--- PASS: Test (0.00s)
PASS
ok      github.com/kanisterio/kanister/pkg/testing/helm 0.090s

PASS

real 117.83
user 0.00
sys 0.00
```