### PR TITLE
deps: Bump kopia and restic versions in kanister-tools image

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -73,8 +73,6 @@ dockers:
   build_flag_templates:
   - "--pull"
   - "--build-arg=kan_tools_version={{ .Tag }}"
-# Refers to https://github.com/kopia/kopia/commit/951f126b3c5e7ed4b266db2b597ebb018eb11088
-  - "--build-arg=kopia_build_commit=951f126"
   - "--build-arg=kopia_repo_org=kopia"
   extra_files:
   - 'LICENSE'

--- a/docker/tools/Dockerfile
+++ b/docker/tools/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.22-bullseye AS builder
 
 ARG kopia_build_commit=master
 ARG kopia_repo_org=kopia
-ARG restic_vsn=v0.16.4
+ARG restic_vsn=v0.16.5
 ARG gosu_vsn=1.17
 ENV CGO_ENABLED=1 GOEXPERIMENT=boringcrypto GO_EXTLINK_ENABLED=0
 RUN apt-get install git


### PR DESCRIPTION
## Change Overview

Update restic to `v0.16.5`

Unpin kopia version (use master branch)

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [x] :building_construction: Build

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [x] :green_heart: E2E
