### PR TITLE
Run `E2ESuite` as part of `make integration-test`

### DIFF
--- a/build/integration-test.sh
+++ b/build/integration-test.sh
@@ -113,6 +113,9 @@ case "${1}" in
         ;;
 esac
 
+# add e2e suite in test apps
+TEST_APPS="${TEST_APPS}|^E2ESuite$"
+
 check_dependencies
 echo "Running integration tests:"
 pushd ${INTEGRATION_TEST_DIR}

--- a/pkg/testing/e2e_test.go
+++ b/pkg/testing/e2e_test.go
@@ -292,4 +292,6 @@ func (s *E2ESuite) TestKubeTask(c *C) {
 		return false, nil
 	})
 	c.Assert(err, IsNil)
+
+	c.Assert(1, Equals, 2)
 }

--- a/pkg/testing/e2e_test.go
+++ b/pkg/testing/e2e_test.go
@@ -292,6 +292,4 @@ func (s *E2ESuite) TestKubeTask(c *C) {
 		return false, nil
 	})
 	c.Assert(err, IsNil)
-
-	c.Assert(1, Equals, 2)
 }


### PR DESCRIPTION

## Change Overview

E2ESuite was supposed to be run (because it has `integration` tag set) as part of integration test script `make integration-test` but because of a bug it was not being run.
This PR fixes that makes sure that the E2ESuite is run as part of integration test.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :building_construction: Build

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [x] :green_heart: E2E

Run `make integration-test` and make sure the E2E test is run.