### PR TITLE
deps(docker): bump restic version for kanister-tools image to v0.16.5

### DIFF
--- a/docker/tools/Dockerfile
+++ b/docker/tools/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.22-bullseye AS builder
 
 ARG kopia_build_commit=master
 ARG kopia_repo_org=kopia
-ARG restic_vsn=v0.16.4
+ARG restic_vsn=v0.16.5
 ARG gosu_vsn=1.17
 ENV CGO_ENABLED=1 GOEXPERIMENT=boringcrypto GO_EXTLINK_ENABLED=0
 RUN apt-get install git


### PR DESCRIPTION
## Change Overview

Updated restic version to 0.16.5 to pick up dependencies updates and security fixes.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [x] :building_construction: Build

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [x] :green_heart: E2E
