### PR TITLE
Add `AddLabels` and `AddAnnotations` method to `PodOptions` type

### DIFF
--- a/pkg/kube/pod.go
+++ b/pkg/kube/pod.go
@@ -84,6 +84,34 @@ type PodOptions struct {
 	Lifecycle                *corev1.Lifecycle
 }
 
+func (po *PodOptions) AddLabels(labels map[string]string) {
+	if po == nil {
+		return
+	}
+
+	if po.Labels == nil {
+		po.Labels = make(map[string]string)
+	}
+
+	for k, v := range labels {
+		po.Labels[k] = v
+	}
+}
+
+func (po *PodOptions) AddAnnotations(annotations map[string]string) {
+	if po == nil {
+		return
+	}
+
+	if po.Annotations == nil {
+		po.Annotations = make(map[string]string)
+	}
+
+	for k, v := range annotations {
+		po.Annotations[k] = v
+	}
+}
+
 func GetPodObjectFromPodOptions(ctx context.Context, cli kubernetes.Interface, opts *PodOptions) (*corev1.Pod, error) {
 	// If Namespace is not specified, use the controller Namespace.
 	cns, err := GetControllerNamespace()

--- a/pkg/kube/pod_test.go
+++ b/pkg/kube/pod_test.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"time"
 
+	"gopkg.in/check.v1"
 	. "gopkg.in/check.v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -1077,4 +1078,168 @@ func (s *PodControllerTestSuite) TestContainerNameFromPodOptsOrDefault(c *C) {
 
 	name = ContainerNameFromPodOptsOrDefault(nil)
 	c.Assert(name, Equals, DefaultContainerName)
+}
+
+func (s *PodSuite) TestAddLabels(c *check.C) {
+	for _, tc := range []struct {
+		podOptions         *PodOptions
+		labels             map[string]string
+		expectedPodOptions *PodOptions
+	}{
+		{
+			podOptions: &PodOptions{},
+			labels: map[string]string{
+				"keyOne": "valOne",
+			},
+			expectedPodOptions: &PodOptions{
+				Labels: map[string]string{
+					"keyOne": "valOne",
+				},
+			},
+		},
+		{
+			podOptions: nil,
+			labels: map[string]string{
+				"keyOne": "valOne",
+			},
+			expectedPodOptions: nil,
+		},
+		{
+			podOptions: &PodOptions{
+				Labels: map[string]string{
+					"key": "val",
+				},
+			},
+			labels: map[string]string{
+				"keyOne": "valOne",
+			},
+			expectedPodOptions: &PodOptions{
+				Labels: map[string]string{
+					"key":    "val",
+					"keyOne": "valOne",
+				},
+			},
+		},
+		{
+			podOptions: &PodOptions{
+				Labels: map[string]string{
+					"key":     "val",
+					"keyZero": "valZero",
+				},
+			},
+			labels: map[string]string{
+				"keyOne": "valOne",
+				"keyTwo": "valTwo",
+			},
+			expectedPodOptions: &PodOptions{
+				Labels: map[string]string{
+					"key":     "val",
+					"keyZero": "valZero",
+					"keyOne":  "valOne",
+					"keyTwo":  "valTwo",
+				},
+			},
+		},
+		{
+			podOptions: &PodOptions{
+				Labels: map[string]string{
+					"key":     "val",
+					"keyZero": "valZero",
+				},
+			},
+			labels: nil,
+			expectedPodOptions: &PodOptions{
+				Labels: map[string]string{
+					"key":     "val",
+					"keyZero": "valZero",
+				},
+			},
+		},
+	} {
+		tc.podOptions.AddLabels(tc.labels)
+		// AddLabelsToPodOptions(tc.podOptions, tc.labels)
+		c.Assert(tc.podOptions, check.DeepEquals, tc.expectedPodOptions)
+	}
+}
+
+func (s *PodSuite) TestAddAnnotations(c *check.C) {
+	for _, tc := range []struct {
+		podOptions         *PodOptions
+		annotations        map[string]string
+		expectedPodOptions *PodOptions
+	}{
+		{
+			podOptions: &PodOptions{},
+			annotations: map[string]string{
+				"keyOne": "valOne",
+			},
+			expectedPodOptions: &PodOptions{
+				Annotations: map[string]string{
+					"keyOne": "valOne",
+				},
+			},
+		},
+		{
+			podOptions: nil,
+			annotations: map[string]string{
+				"keyOne": "valOne",
+			},
+			expectedPodOptions: nil,
+		},
+		{
+			podOptions: &PodOptions{
+				Annotations: map[string]string{
+					"key": "val",
+				},
+			},
+			annotations: map[string]string{
+				"keyOne": "valOne",
+			},
+			expectedPodOptions: &PodOptions{
+				Annotations: map[string]string{
+					"key":    "val",
+					"keyOne": "valOne",
+				},
+			},
+		},
+		{
+			podOptions: &PodOptions{
+				Annotations: map[string]string{
+					"key":     "val",
+					"keyZero": "valZero",
+				},
+			},
+			annotations: map[string]string{
+				"keyOne": "valOne",
+				"keyTwo": "valTwo",
+			},
+			expectedPodOptions: &PodOptions{
+				Annotations: map[string]string{
+					"key":     "val",
+					"keyZero": "valZero",
+					"keyOne":  "valOne",
+					"keyTwo":  "valTwo",
+				},
+			},
+		},
+		{
+			podOptions: &PodOptions{
+				Annotations: map[string]string{
+					"key":     "val",
+					"keyZero": "valZero",
+				},
+			},
+			annotations: nil,
+			expectedPodOptions: &PodOptions{
+				Annotations: map[string]string{
+					"key":     "val",
+					"keyZero": "valZero",
+				},
+			},
+		},
+	} {
+		tc.podOptions.AddAnnotations(tc.annotations)
+		// AddAnnotationsToPodOptions(tc.podOptions, tc.annotations)
+		c.Assert(tc.podOptions, check.DeepEquals, tc.expectedPodOptions)
+	}
 }

--- a/pkg/kube/pod_test.go
+++ b/pkg/kube/pod_test.go
@@ -25,7 +25,6 @@ import (
 	"strings"
 	"time"
 
-	"gopkg.in/check.v1"
 	. "gopkg.in/check.v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -1080,7 +1079,7 @@ func (s *PodControllerTestSuite) TestContainerNameFromPodOptsOrDefault(c *C) {
 	c.Assert(name, Equals, DefaultContainerName)
 }
 
-func (s *PodSuite) TestAddLabels(c *check.C) {
+func (s *PodSuite) TestAddLabels(c *C) {
 	for _, tc := range []struct {
 		podOptions         *PodOptions
 		labels             map[string]string
@@ -1157,11 +1156,11 @@ func (s *PodSuite) TestAddLabels(c *check.C) {
 		},
 	} {
 		tc.podOptions.AddLabels(tc.labels)
-		c.Assert(tc.podOptions, check.DeepEquals, tc.expectedPodOptions)
+		c.Assert(tc.podOptions, DeepEquals, tc.expectedPodOptions)
 	}
 }
 
-func (s *PodSuite) TestAddAnnotations(c *check.C) {
+func (s *PodSuite) TestAddAnnotations(c *C) {
 	for _, tc := range []struct {
 		podOptions         *PodOptions
 		annotations        map[string]string
@@ -1238,6 +1237,6 @@ func (s *PodSuite) TestAddAnnotations(c *check.C) {
 		},
 	} {
 		tc.podOptions.AddAnnotations(tc.annotations)
-		c.Assert(tc.podOptions, check.DeepEquals, tc.expectedPodOptions)
+		c.Assert(tc.podOptions, DeepEquals, tc.expectedPodOptions)
 	}
 }

--- a/pkg/kube/pod_test.go
+++ b/pkg/kube/pod_test.go
@@ -1157,7 +1157,6 @@ func (s *PodSuite) TestAddLabels(c *check.C) {
 		},
 	} {
 		tc.podOptions.AddLabels(tc.labels)
-		// AddLabelsToPodOptions(tc.podOptions, tc.labels)
 		c.Assert(tc.podOptions, check.DeepEquals, tc.expectedPodOptions)
 	}
 }
@@ -1239,7 +1238,6 @@ func (s *PodSuite) TestAddAnnotations(c *check.C) {
 		},
 	} {
 		tc.podOptions.AddAnnotations(tc.annotations)
-		// AddAnnotationsToPodOptions(tc.podOptions, tc.annotations)
 		c.Assert(tc.podOptions, check.DeepEquals, tc.expectedPodOptions)
 	}
 }


### PR DESCRIPTION
## Change Overview

This PR just adds two methods to the `PodOptions` type that can be used to add labels and annotations to the `labels` and `annotations` fields of the type.
These `labels` and `annotations` are used as labels and annotations of the pod that gets created eventually with this podoption.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :building_construction: Build

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E

```
kind-kind
~/work/opensource/kanister/pkg/kube (master*) » go test -check.f "PodSuite.TestAddLabels"
OK: 1 passed
PASS
ok      github.com/kanisterio/kanister/pkg/kube 0.540s

kind-kind
~/work/opensource/kanister/pkg/kube (master*) » go test -check.f "PodSuite.TestAddAnnotations"
OK: 1 passed
PASS
ok      github.com/kanisterio/kanister/pkg/kube 0.570s
```