### PR TITLE
docs: Display release version number on new docs website

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -131,7 +131,9 @@ jobs:
         run: pnpm install
         working-directory: ./docs_new
       - name: Build with VitePress
-        run: pnpm docs:build
+        run: |
+          echo "{\"version\":\"${RELEASE_TAG}\"}" > ./.vitepress/version.json
+          pnpm docs:build
         working-directory: ./docs_new
       - name: download helm index
         uses: actions/download-artifact@v4

--- a/docs_new/.vitepress/config.mts
+++ b/docs_new/.vitepress/config.mts
@@ -1,4 +1,5 @@
 import { defineConfig } from "vitepress";
+import version from "./version.json"
 
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
@@ -17,6 +18,7 @@ export default defineConfig({
     footer: {
       copyright: "© Copyright 2017-2024, Kanister",
     },
+    nav: [{text: version.version, link: ""}],
 
     sidebar: [
       { text: "Overview", link: "/overview" },

--- a/docs_new/.vitepress/version.json
+++ b/docs_new/.vitepress/version.json
@@ -1,0 +1,1 @@
+{"version":"dev"}


### PR DESCRIPTION
## Change Overview

Version is taken from a JSON file which is updated on docs release build

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [x] :building_construction: Build

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

Test dev version:

- Build and run the docs:
```
cd docs_new
echo "{\"version\":\"my_version\"}" > ./.vitepress/version.json
pnpm run docs:build
pnpm run docs:preview
```
- Check `my_version` version on the website

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
