### PR TITLE
Fix a bug in the code where we merge actionset and bp labels/annotations

### DIFF
--- a/pkg/function/backup_data_stats.go
+++ b/pkg/function/backup_data_stats.go
@@ -191,7 +191,8 @@ func (b *BackupDataStatsFunc) Exec(ctx context.Context, tp param.TemplateParams,
 		return nil, err
 	}
 
-	var labels, annotations map[string]string
+	annotations := bpAnnotations
+	labels := bpLabels
 	if tp.PodAnnotations != nil {
 		// merge the actionset annotations with blueprint annotations
 		var actionSetAnn ActionSetAnnotations = tp.PodAnnotations

--- a/pkg/function/checkRepository.go
+++ b/pkg/function/checkRepository.go
@@ -171,7 +171,8 @@ func (c *CheckRepositoryFunc) Exec(ctx context.Context, tp param.TemplateParams,
 		return nil, err
 	}
 
-	var labels, annotations map[string]string
+	annotations := bpAnnotations
+	labels := bpLabels
 	if tp.PodAnnotations != nil {
 		// merge the actionset annotations with blueprint annotations
 		var actionSetAnn ActionSetAnnotations = tp.PodAnnotations

--- a/pkg/function/copy_volume_data.go
+++ b/pkg/function/copy_volume_data.go
@@ -226,7 +226,8 @@ func (c *copyVolumeDataFunc) Exec(ctx context.Context, tp param.TemplateParams, 
 		return nil, err
 	}
 
-	var labels, annotations map[string]string
+	annotations := bpAnnotations
+	labels := bpLabels
 	if tp.PodAnnotations != nil {
 		// merge the actionset annotations with blueprint annotations
 		var actionSetAnn ActionSetAnnotations = tp.PodAnnotations

--- a/pkg/function/delete_data.go
+++ b/pkg/function/delete_data.go
@@ -257,7 +257,8 @@ func (d *deleteDataFunc) Exec(ctx context.Context, tp param.TemplateParams, args
 		return nil, err
 	}
 
-	var labels, annotations map[string]string
+	annotations := bpAnnotations
+	labels := bpLabels
 	if tp.PodAnnotations != nil {
 		// merge the actionset annotations with blueprint annotations
 		var actionSetAnn ActionSetAnnotations = tp.PodAnnotations

--- a/pkg/function/delete_data_all.go
+++ b/pkg/function/delete_data_all.go
@@ -103,7 +103,8 @@ func (d *deleteDataAllFunc) Exec(ctx context.Context, tp param.TemplateParams, a
 		return nil, err
 	}
 
-	var labels, annotations map[string]string
+	annotations := bpAnnotations
+	labels := bpLabels
 	if tp.PodAnnotations != nil {
 		// merge the actionset annotations with blueprint annotations
 		var actionSetAnn ActionSetAnnotations = tp.PodAnnotations

--- a/pkg/function/delete_data_using_kopia_server.go
+++ b/pkg/function/delete_data_using_kopia_server.go
@@ -120,7 +120,8 @@ func (d *deleteDataUsingKopiaServerFunc) Exec(ctx context.Context, tp param.Temp
 		return nil, err
 	}
 
-	var labels, annotations map[string]string
+	annotations := bpAnnotations
+	labels := bpLabels
 	if tp.PodAnnotations != nil {
 		// merge the actionset annotations with blueprint annotations
 		var actionSetAnn ActionSetAnnotations = tp.PodAnnotations

--- a/pkg/function/export_rds_snapshot_location.go
+++ b/pkg/function/export_rds_snapshot_location.go
@@ -232,7 +232,8 @@ func (e *exportRDSSnapshotToLocationFunc) Exec(ctx context.Context, tp param.Tem
 		return nil, err
 	}
 
-	var labels, annotations map[string]string
+	annotations := bpAnnotations
+	labels := bpLabels
 	if tp.PodAnnotations != nil {
 		// merge the actionset annotations with blueprint annotations
 		var actionSetAnn ActionSetAnnotations = tp.PodAnnotations

--- a/pkg/function/kube_task.go
+++ b/pkg/function/kube_task.go
@@ -143,7 +143,8 @@ func (ktf *kubeTaskFunc) Exec(ctx context.Context, tp param.TemplateParams, args
 		return nil, err
 	}
 
-	var labels, annotations map[string]string
+	annotations := bpAnnotations
+	labels := bpLabels
 	if tp.PodAnnotations != nil {
 		// merge the actionset annotations with blueprint annotations
 		var actionSetAnn ActionSetAnnotations = tp.PodAnnotations

--- a/pkg/function/prepare_data.go
+++ b/pkg/function/prepare_data.go
@@ -196,7 +196,8 @@ func (p *prepareDataFunc) Exec(ctx context.Context, tp param.TemplateParams, arg
 		return nil, err
 	}
 
-	var labels, annotations map[string]string
+	annotations := bpAnnotations
+	labels := bpLabels
 	if tp.PodAnnotations != nil {
 		// merge the actionset annotations with blueprint annotations
 		var actionSetAnn ActionSetAnnotations = tp.PodAnnotations

--- a/pkg/function/restore_data.go
+++ b/pkg/function/restore_data.go
@@ -246,7 +246,8 @@ func (r *restoreDataFunc) Exec(ctx context.Context, tp param.TemplateParams, arg
 		return nil, err
 	}
 
-	var labels, annotations map[string]string
+	annotations := bpAnnotations
+	labels := bpLabels
 	if tp.PodAnnotations != nil {
 		// merge the actionset annotations with blueprint annotations
 		var actionSetAnn ActionSetAnnotations = tp.PodAnnotations

--- a/pkg/function/restore_data_all.go
+++ b/pkg/function/restore_data_all.go
@@ -137,7 +137,8 @@ func (r *restoreDataAllFunc) Exec(ctx context.Context, tp param.TemplateParams, 
 		return nil, err
 	}
 
-	var labels, annotations map[string]string
+	annotations := bpAnnotations
+	labels := bpLabels
 	if tp.PodAnnotations != nil {
 		// merge the actionset annotations with blueprint annotations
 		var actionSetAnn ActionSetAnnotations = tp.PodAnnotations

--- a/pkg/function/restore_data_using_kopia_server.go
+++ b/pkg/function/restore_data_using_kopia_server.go
@@ -129,7 +129,8 @@ func (r *restoreDataUsingKopiaServerFunc) Exec(ctx context.Context, tp param.Tem
 		return nil, err
 	}
 
-	var labels, annotations map[string]string
+	annotations := bpAnnotations
+	labels := bpLabels
 	if tp.PodAnnotations != nil {
 		// merge the actionset annotations with blueprint annotations
 		var actionSetAnn ActionSetAnnotations = tp.PodAnnotations

--- a/pkg/function/restore_rds_snapshot.go
+++ b/pkg/function/restore_rds_snapshot.go
@@ -155,7 +155,8 @@ func (r *restoreRDSSnapshotFunc) Exec(ctx context.Context, tp param.TemplatePara
 		return nil, err
 	}
 
-	var labels, annotations map[string]string
+	annotations := bpAnnotations
+	labels := bpLabels
 	if tp.PodAnnotations != nil {
 		// merge the actionset annotations with blueprint annotations
 		var actionSetAnn ActionSetAnnotations = tp.PodAnnotations

--- a/pkg/testing/e2e_test.go
+++ b/pkg/testing/e2e_test.go
@@ -411,7 +411,7 @@ func (s *E2ESuite) TestPodLabelsAndAnnotations(c *C) {
 	c.Assert(err, IsNil)
 
 	// 4. scenario where labels/annotations are only provided via blueprint
-	asThree := backupActionsetWihtPodLabelsAndAnnotations(s.namespace, bp.Name, map[string]string{}, map[string]string{})
+	asThree := backupActionsetWihtPodLabelsAndAnnotations(s.namespace, bp.Name, nil, nil)
 	asCreatedThree, err := s.crCli.ActionSets(s.namespace).Create(context.Background(), asThree, metav1.CreateOptions{})
 	c.Assert(err, IsNil)
 


### PR DESCRIPTION
## Change Overview

In the code where we are merging the labels/annotations passed via actionset with the labels/annotations configured inthe blueprint we checked if tp.Annotations is nil and then merged both the annotations. While doing this we introduced a bug, where if the actionset labels and annotations are nil, and even though blueprint annotations are proivided the kanister function created pod would not have the correct labels/annotations.

Even though this might not be a problem if the actionset is created by the kanctl command it would be a problem if the pod labels and annotations set to nil by creating the actionset resource yaml manually.

This PR fixes that.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :building_construction: Build

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [x] :green_heart: E2E

```
make integration-test
...
2024/09/09 11:21:05 Completed E2E TestPodLabelsAndAnnotations
OK: 3 passed
--- PASS: Test (140.91s)
PASS
ok      github.com/kanisterio/kanister/pkg/testing      141.056s
/go/src/github.com/kanisterio/kanister
real 144.24
user 0.01
sys 0.01
```