### PR TITLE
Add capability to only run E2E test using `make integration-test`

### DIFF
--- a/build/integration-test.sh
+++ b/build/integration-test.sh
@@ -114,7 +114,12 @@ case "${1}" in
 esac
 
 # add e2e suite in test apps
-TEST_APPS="${TEST_APPS}|^E2ESuite$"
+if [ "${TEST_APPS}" = "" ] ; then
+    TEST_APPS="^E2ESuite$"
+else
+    TEST_APPS="${TEST_APPS}|^E2ESuite$"
+fi
+
 
 check_dependencies
 echo "Running integration tests:"


### PR DESCRIPTION
## Change Overview

To run just the E2E tests locally if we removed all the apps from `SHORT_APPS`, all the integrations apps were included in addition to E2E tests and were being run.
This PR fixes that to make sure that if all the apps are removed from `SHORT_APPS`, only E2E test is run.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :building_construction: Build

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [x] :green_heart: E2E

```
make integration-test
...
2024/09/09 11:57:50 Completed E2E TestPodLabelsAndAnnotations
OK: 3 passed
--- PASS: Test (141.21s)
PASS
ok      github.com/kanisterio/kanister/pkg/testing      141.352s
/go/src/github.com/kanisterio/kanister
real 152.75
user 0.01
sys 0.01
```