### PR TITLE
build: Rework docs and helm chart index publishing in release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -98,72 +98,19 @@ jobs:
         GHCR_LOGIN_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GHCR_LOGIN_USER: ${{ github.actor }}
         GORELEASE_PARAMS: ${{ env.DRAFT_RELEASE == 'true' && '--draft' || '' }}
-    ## Upload to use in docs publishing
-    - uses: actions/upload-artifact@v4
-      with:
-        name: helm-index
-        path: helm_package/index.yaml
     - id: output_release
       run: echo "release_url=https://github.com/kanisterio/kanister/releases/tag/${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
 
   build_docs:
     runs-on: ubuntu-latest
     needs: [run_if, release_packages]
-    env:
-      RELEASE_TAG: ${{ needs.run_if.outputs.release_tag }}
-    steps:
-      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
-        with:
-          ref: ${{ env.RELEASE_TAG }}
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          run_install: false
-          package_json_file: docs_new/package.json
-          version: 8
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-      - name: Install dependencies
-        run: pnpm install
-        working-directory: ./docs_new
-      - name: Build with VitePress
-        run: |
-          echo "{\"version\":\"${RELEASE_TAG}\"}" > ./.vitepress/version.json
-          pnpm docs:build
-        working-directory: ./docs_new
-      - name: download helm index
-        uses: actions/download-artifact@v4
-        with:
-          name: helm-index
-          path: docs_new/.vitepress/dist/helm_charts/
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: docs_new/.vitepress/dist
-
-  publish_docs_and_charts:
-    needs: build_docs
-
-    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
     permissions:
+      contents: read
       pages: write      # to deploy to Pages
       id-token: write   # to verify the deployment originates from an appropriate source
-
-    # Deploy to the github-pages environment
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
-    # Specify runner + deployment step
-    runs-on: ubuntu-latest
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4 # or specific "vX.X.X" version tag for this action
+    uses: ./.github/workflows/publish_docs.yaml
+    with:
+      release_tag: ${{ needs.run_if.outputs.release_tag }}
 
   ## TODO: using https://github.com/slackapi/slack-github-action/blob/main/README.md#technique-3-slack-incoming-webhook
   ## we need to set up incoming webhook

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,6 +6,8 @@ release:
   prerelease: auto
   extra_files:
   - glob: 'helm_package/kanister-operator-*.tgz'
+  - glob: 'helm_package/index.yaml'
+    name_template: helm_index.yaml
 builds:
 - id: kanctl
   binary: kanctl


### PR DESCRIPTION
## Change Overview

Publish helm chart index in the release artifacts. Publish docs via workflow_call to publish_docs workflow.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [x] :building_construction: Build

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
