### PR TITLE
test: add faster test target go-test which does not run go vet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ push-name:
 version:
 	@echo $(VERSION)
 
-.PHONY: deploy test codegen build-dirs run clean container-clean bin-clean docs start-kind tiller stop-kind release-snapshot go-mod-download
+.PHONY: deploy format-vet go-test test codegen build-dirs run clean container-clean bin-clean docs start-kind tiller stop-kind release-snapshot go-mod-download
 
 deploy: release-controller .deploy-$(DOTFILE_IMAGE)
 .deploy-$(DOTFILE_IMAGE):
@@ -158,8 +158,13 @@ deploy: release-controller .deploy-$(DOTFILE_IMAGE)
 		bundle.yaml.in > .deploy-$(DOTFILE_IMAGE)
 	@kubectl apply -f .deploy-$(DOTFILE_IMAGE)
 
-test: build-dirs
+format-vet: build-dirs
+	@$(MAKE) run CMD="./build/format-vet.sh $(SRC_DIRS)"
+
+go-test: build-dirs
 	@$(MAKE) run CMD="TEST_FILTER=$(TEST_FILTER) ./build/test.sh $(SRC_DIRS)"
+
+test: format-vet go-test
 
 helm-test: build-dirs
 	@$(MAKE) run CMD="./build/helm-test.sh $(SRC_DIRS)"

--- a/build/format-vet.sh
+++ b/build/format-vet.sh
@@ -37,13 +37,5 @@ echo "PASS"
 echo
 
 echo -n "Checking go vet: "
-ERRS=$(go vet ${TARGETS} 2>&1 || true)
-if [ -n "${ERRS}" ]; then
-    echo "FAIL"
-    echo "${ERRS}"
-    echo
-    # TODO: Renable govet. Currently generated code fails to pass go vet. report,
-    # but don't exit on failures.
-    exit 1
-fi
-echo
+go vet ${TARGETS}
+echo "PASS"

--- a/build/format-vet.sh
+++ b/build/format-vet.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Copyright 2024 The Kanister Authors.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+
+export CGO_ENABLED=0
+export GO111MODULE=on
+
+TARGETS=$(for d in "$@"; do echo ./$d/...; done)
+
+echo -n "Checking gofmt: "
+ERRS=$(find "$@" -type f -name \*.go | xargs gofmt -l 2>&1 || true)
+if [ -n "${ERRS}" ]; then
+    echo "FAIL - the following files need to be gofmt'ed:"
+    for e in ${ERRS}; do
+        echo "    $e"
+    done
+    echo
+    exit 1
+fi
+echo "PASS"
+echo
+
+echo -n "Checking go vet: "
+ERRS=$(go vet ${TARGETS} 2>&1 || true)
+if [ -n "${ERRS}" ]; then
+    echo "FAIL"
+    echo "${ERRS}"
+    echo
+    # TODO: Renable govet. Currently generated code fails to pass go vet. report,
+    # but don't exit on failures.
+    exit 1
+fi
+echo

--- a/build/test.sh
+++ b/build/test.sh
@@ -33,31 +33,6 @@ fi
 
 TARGETS=$(for d in "$@"; do echo ./$d/...; done)
 
-echo -n "Checking gofmt: "
-ERRS=$(find "$@" -type f -name \*.go | xargs gofmt -l 2>&1 || true)
-if [ -n "${ERRS}" ]; then
-    echo "FAIL - the following files need to be gofmt'ed:"
-    for e in ${ERRS}; do
-        echo "    $e"
-    done
-    echo
-    exit 1
-fi
-echo "PASS"
-echo
-
-echo -n "Checking go vet: "
-ERRS=$(go vet ${TARGETS} 2>&1 || true)
-if [ -n "${ERRS}" ]; then
-    echo "FAIL"
-    echo "${ERRS}"
-    echo
-    # TODO: Renable govet. Currently generated code fails to pass go vet. report,
-    # but don't exit on failures.
-    #exit 1
-fi
-echo
-
 check_dependencies() {
     # Check if minio is already deployed. We suppress only `stdout` and not `stderr` to make sure we catch errors if `helm status` fails
     if helm status minio -n minio 1> /dev/null ; then


### PR DESCRIPTION
## Change Overview

Currently `make test` runs `go vet` before `go test`. This would take some extra time and makes quick test iterations (e.g. using TEST_FILTER) longer.

This change separates `go vet` into a separate `format-vet` target and adds `go-test` target to only run tests. `make test` will still run both.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [x] :robot: Test
- [ ] :building_construction: Build

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
