### PR TITLE
Fix AWSEBSSuite.TestGetRegions issue caused by check.v1 refactor

### DIFF
--- a/pkg/blockstorage/awsebs/awsebs_test.go
+++ b/pkg/blockstorage/awsebs/awsebs_test.go
@@ -107,5 +107,5 @@ func (s AWSEBSSuite) TestGetRegions(c *check.C) {
 
 	regions, err := ebsp.GetRegions(ctx)
 	c.Assert(err, check.IsNil)
-	c.Assert(regions, check.IsNil)
+	c.Assert(regions, check.NotNil)
 }


### PR DESCRIPTION
## Change Overview

The check.v1 refactor PR introduced a test bug by changing the expected result [here](https://github.com/kanisterio/kanister/pull/3137/files#diff-6308bb49b562ea685d456c02f84de0c391ec6da2c88d19b07fe9f161f322c62cL110).

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :building_construction: Build

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
