### PR TITLE
Another nil check fix in BlockStorageProviderSuite

### DIFF
--- a/pkg/blockstorage/blockstorage_test.go
+++ b/pkg/blockstorage/blockstorage_test.go
@@ -142,7 +142,7 @@ func (s *BlockStorageProviderSuite) TestCreateSnapshot(c *check.C) {
 		c.Assert(err, check.IsNil)
 		s.snapshots = nil
 		_, err = s.provider.SnapshotGet(context.Background(), snapshot.ID)
-		c.Assert(err, check.IsNil)
+		c.Assert(err, check.NotNil)
 		c.Assert(strings.Contains(err.Error(), blockstorage.SnapshotDoesNotExistError), check.Equals, true)
 	}
 }


### PR DESCRIPTION
## Change Overview

The check.v1 refactor PR introduced a test bug by changing the expected result [here](https://github.com/kanisterio/kanister/pull/3137/files#diff-9e204f8cdb7839d57a13afc414f135f77be6348efa5dda9f37b014177afe18b8L145).
Similar to #3159 

I explored the entire PR. This is the last one that requires a fix but I could be wrong.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :building_construction: Build

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
