### PR TITLE
Pin postgres image tag version to 16

### DIFF
--- a/pkg/app/postgresql.go
+++ b/pkg/app/postgresql.go
@@ -65,7 +65,7 @@ func NewPostgresDB(name string, subPath string) App {
 				// Update manually whenever a new version is release.
 				// TODO: Automate the update process for the image tag.
 				"image.repository": "postgres",
-				"image.tag": "16-bullseye",
+				"image.tag":        "16-bullseye",
 			},
 		},
 	}

--- a/pkg/app/postgresql.go
+++ b/pkg/app/postgresql.go
@@ -41,7 +41,7 @@ type PostgresDB struct {
 }
 
 // NewPostgresDB initialises an instance of Postgres DB
-// Last tested chart version "10.12.3". Also, we are using postgres version 13.4
+// Last tested chart version "15.5.38". Also, we are using postgres version 16
 func NewPostgresDB(name string, subPath string) App {
 	return &PostgresDB{
 		name: name,
@@ -62,6 +62,9 @@ func NewPostgresDB(name string, subPath string) App {
 				"primary.containerSecurityContext.capabilities.add[1]":    "FOWNER",
 				"primary.containerSecurityContext.capabilities.add[2]":    "DAC_OVERRIDE",
 				"primary.containerSecurityContext.readOnlyRootFilesystem": "false",
+				// Update manually whenever a new version is release.
+				// TODO: Automate the update process for the image tag.
+				"image.tag": "16-bullseye",
 			},
 		},
 	}

--- a/pkg/app/postgresql.go
+++ b/pkg/app/postgresql.go
@@ -64,6 +64,7 @@ func NewPostgresDB(name string, subPath string) App {
 				"primary.containerSecurityContext.readOnlyRootFilesystem": "false",
 				// Update manually whenever a new version is release.
 				// TODO: Automate the update process for the image tag.
+				"image.repository": "postgres",
 				"image.tag": "16-bullseye",
 			},
 		},


### PR DESCRIPTION
## Change Overview

- Whenever a new version of the bitnami chart is released with breaking changes, our tests start failing with client-server version mismatch. Pinning the image tag will allow us to manually update whenever a new version is released.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :building_construction: Build

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [x] :green_heart: E2E
