### PR TITLE
Log kanx child out/err to parent stdout/err

### DIFF
--- a/pkg/kanx/logger.go
+++ b/pkg/kanx/logger.go
@@ -1,0 +1,41 @@
+package kanx
+
+import (
+	"io"
+	"sync"
+
+	"github.com/kanisterio/kanister/pkg/field"
+	"github.com/kanisterio/kanister/pkg/log"
+)
+
+var _ io.Writer = (*logWriter)(nil)
+
+type logWriter struct {
+	logger log.Logger
+	writer io.Writer
+	fields field.M
+	mutex  *sync.Mutex
+}
+
+func newLogWriter(l log.Logger, w io.Writer) *logWriter {
+	return &logWriter{
+		logger: l,
+		writer: w,
+		fields: nil,
+		mutex:  &sync.Mutex{},
+	}
+}
+
+func (lw *logWriter) SetFields(m field.M) {
+	lw.mutex.Lock()
+	defer lw.mutex.Unlock()
+	lw.fields = m
+}
+
+func (lw *logWriter) Write(buf []byte) (int, error) {
+	lw.mutex.Lock()
+	f := lw.fields
+	lw.mutex.Unlock()
+	lw.logger.PrintTo(lw.writer, string(buf), f)
+	return len(buf), nil
+}

--- a/pkg/kanx/logger_test.go
+++ b/pkg/kanx/logger_test.go
@@ -6,12 +6,12 @@ import (
 
 	"github.com/kanisterio/kanister/pkg/field"
 	"github.com/kanisterio/kanister/pkg/log"
-	. "gopkg.in/check.v1"
+	"gopkg.in/check.v1"
 )
 
 type LoggerSuite struct{}
 
-var _ = Suite(&LoggerSuite{})
+var _ = check.Suite(&LoggerSuite{})
 
 type Log struct {
 	File     *string `json:"File,omitempty"`
@@ -23,43 +23,43 @@ type Log struct {
 	Boo      *string `json:"boo,omitempty"`
 }
 
-func (s *LoggerSuite) TestLogger(c *C) {
+func (s *LoggerSuite) TestLogger(c *check.C) {
 	buf := bytes.NewBuffer(nil)
 	msg := []byte("hello!")
 
 	lw := newLogWriter(log.Info(), buf)
 
 	n, err := lw.Write(msg)
-	c.Assert(err, IsNil)
-	c.Assert(n, Equals, len(msg))
+	c.Assert(err, check.IsNil)
+	c.Assert(n, check.Equals, len(msg))
 
 	l := Log{}
 	err = json.Unmarshal(buf.Bytes(), &l)
-	c.Assert(err, IsNil)
+	c.Assert(err, check.IsNil)
 
-	c.Assert(l.File, NotNil)
-	c.Assert(l.Function, NotNil)
-	c.Assert(l.Line, Not(Equals), 0)
-	c.Assert(l.Level, NotNil)
-	c.Assert(*l.Msg, Equals, string(msg))
-	c.Assert(l.Time, NotNil)
-	c.Assert(l.Boo, IsNil)
+	c.Assert(l.File, check.NotNil)
+	c.Assert(l.Function, check.NotNil)
+	c.Assert(l.Line, check.Not(check.Equals), 0)
+	c.Assert(l.Level, check.NotNil)
+	c.Assert(*l.Msg, check.Equals, string(msg))
+	c.Assert(l.Time, check.NotNil)
+	c.Assert(l.Boo, check.IsNil)
 
 	buf.Reset()
 	lw.SetFields(field.M{"boo": "far"})
 	n, err = lw.Write(msg)
-	c.Assert(err, IsNil)
-	c.Assert(n, Equals, len(msg))
+	c.Assert(err, check.IsNil)
+	c.Assert(n, check.Equals, len(msg))
 
 	l = Log{}
 	err = json.Unmarshal(buf.Bytes(), &l)
-	c.Assert(err, IsNil)
+	c.Assert(err, check.IsNil)
 
-	c.Assert(l.File, NotNil)
-	c.Assert(l.Function, NotNil)
-	c.Assert(l.Line, Not(Equals), 0)
-	c.Assert(l.Level, NotNil)
-	c.Assert(*l.Msg, Equals, string(msg))
-	c.Assert(l.Time, NotNil)
-	c.Assert(*l.Boo, Equals, "far")
+	c.Assert(l.File, check.NotNil)
+	c.Assert(l.Function, check.NotNil)
+	c.Assert(l.Line, check.Not(check.Equals), 0)
+	c.Assert(l.Level, check.NotNil)
+	c.Assert(*l.Msg, check.Equals, string(msg))
+	c.Assert(l.Time, check.NotNil)
+	c.Assert(*l.Boo, check.Equals, "far")
 }

--- a/pkg/kanx/logger_test.go
+++ b/pkg/kanx/logger_test.go
@@ -1,0 +1,65 @@
+package kanx
+
+import (
+	"bytes"
+	"encoding/json"
+
+	"github.com/kanisterio/kanister/pkg/field"
+	"github.com/kanisterio/kanister/pkg/log"
+	. "gopkg.in/check.v1"
+)
+
+type LoggerSuite struct{}
+
+var _ = Suite(&LoggerSuite{})
+
+type Log struct {
+	File     *string `json:"File,omitempty"`
+	Function *string `json:"Function,omitempty"`
+	Line     *int    `json:"Line,omitempty"`
+	Level    *string `json:"level,omitempty"`
+	Msg      *string `json:"msg,omitempty"`
+	Time     *string `json:"time,omitempty"`
+	Boo      *string `json:"boo,omitempty"`
+}
+
+func (s *LoggerSuite) TestLogger(c *C) {
+	buf := bytes.NewBuffer(nil)
+	msg := []byte("hello!")
+
+	lw := newLogWriter(log.Info(), buf)
+
+	n, err := lw.Write(msg)
+	c.Assert(err, IsNil)
+	c.Assert(n, Equals, len(msg))
+
+	l := Log{}
+	err = json.Unmarshal(buf.Bytes(), &l)
+	c.Assert(err, IsNil)
+
+	c.Assert(l.File, NotNil)
+	c.Assert(l.Function, NotNil)
+	c.Assert(l.Line, Not(Equals), 0)
+	c.Assert(l.Level, NotNil)
+	c.Assert(*l.Msg, Equals, string(msg))
+	c.Assert(l.Time, NotNil)
+	c.Assert(l.Boo, IsNil)
+
+	buf.Reset()
+	lw.SetFields(field.M{"boo": "far"})
+	n, err = lw.Write(msg)
+	c.Assert(err, IsNil)
+	c.Assert(n, Equals, len(msg))
+
+	l = Log{}
+	err = json.Unmarshal(buf.Bytes(), &l)
+	c.Assert(err, IsNil)
+
+	c.Assert(l.File, NotNil)
+	c.Assert(l.Function, NotNil)
+	c.Assert(l.Line, Not(Equals), 0)
+	c.Assert(l.Level, NotNil)
+	c.Assert(*l.Msg, Equals, string(msg))
+	c.Assert(l.Time, NotNil)
+	c.Assert(*l.Boo, Equals, "far")
+}

--- a/pkg/kanx/logger_test.go
+++ b/pkg/kanx/logger_test.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"encoding/json"
 
+	"gopkg.in/check.v1"
+
 	"github.com/kanisterio/kanister/pkg/field"
 	"github.com/kanisterio/kanister/pkg/log"
-	"gopkg.in/check.v1"
 )
 
 type LoggerSuite struct{}


### PR DESCRIPTION
## Change Overview

<!-- Insert PR description-->

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :building_construction: Build

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

### Test Failed Command
Client Command (tmp.txt doesn't exist)
```
$ ./kando process client create -- tail -f tmp.txt
Created process: pid:60118 state:PROCESS_STATE_RUNNING
```
Server Log
```
{"File":"pkg/kanx/kanx_grpc.pb.go","Function":"github.com/kanisterio/kanister/pkg/kanx._ProcessService_CreateProcesses_Handler","Line":190,"level":"info","msg":"pid:60118 state:PROCESS_STATE_RUNNING","pid":60118,"stderr":"/var/folders/bf/c6ydxpp17p76y97j_yy_6n_m0000gp/T/kando.3769706635.stderr","stdout":"/var/folders/bf/c6ydxpp17p76y97j_yy_6n_m0000gp/T/kando.4170696951.stdout","time":"2024-10-12T22:03:41.640206-07:00"}
{"File":"/opt/homebrew/Cellar/go/1.23.1/libexec/src/io/multi.go","Function":"io.(*multiWriter).Write","Line":85,"level":"info","msg":"tail: tmp.txt: No such file or directory\n","pid":60118,"stderr":"/var/folders/bf/c6ydxpp17p76y97j_yy_6n_m0000gp/T/kando.3769706635.stderr","stdout":"/var/folders/bf/c6ydxpp17p76y97j_yy_6n_m0000gp/T/kando.4170696951.stdout","time":"2024-10-12T22:03:41.641381-07:00"}
{"File":"/opt/homebrew/Cellar/go/1.23.1/libexec/src/runtime/asm_arm64.s","Function":"runtime.goexit","Line":1223,"level":"info","msg":"pid:60118 state:PROCESS_STATE_FAILED exitCode:1 exitErr:\"exit status 1\"","time":"2024-10-12T22:03:41.641514-07:00"}
```
### Test Successful Command
Start Client Command
```
$ touch tmp.txt
$ ./kando process client create -- tail -f tmp.txt
Created process: pid:84873 state:PROCESS_STATE_RUNNING
```
Server Log
```
{"File":"pkg/kanx/kanx_grpc.pb.go","Function":"github.com/kanisterio/kanister/pkg/kanx._ProcessService_CreateProcesses_Handler","Line":190,"level":"info","msg":"pid:84873 state:PROCESS_STATE_RUNNING","pid":84873,"stderr":"/var/folders/bf/c6ydxpp17p76y97j_yy_6n_m0000gp/T/kando.1128989870.stderr","stdout":"/var/folders/bf/c6ydxpp17p76y97j_yy_6n_m0000gp/T/kando.620268834.stdout","time":"2024-10-12T22:05:10.992173-07:00"}
```
Update file
```
$ echo hello > tmp.txt
```
Server Log
```
{"File":"/opt/homebrew/Cellar/go/1.23.1/libexec/src/io/multi.go","Function":"io.(*multiWriter).Write","Line":85,"level":"info","msg":"hello\n","pid":84873,"stderr":"/var/folders/bf/c6ydxpp17p76y97j_yy_6n_m0000gp/T/kando.1128989870.stderr","stdout":"/var/folders/bf/c6ydxpp17p76y97j_yy_6n_m0000gp/T/kando.620268834.stdout","time":"2024-10-12T22:05:22.990652-07:00"}
```


- [x] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
