### PR TITLE
Fix publish_charts job in the release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -112,7 +112,7 @@ jobs:
       release_tag: ${{ needs.run_if.outputs.release_tag }}
 
   publish_charts:
-    runs-on: [run_if, release_packages]
+    needs: [run_if, release_packages]
     env:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
       RELEASE_TAG: ${{ needs.run_if.outputs.release_tag }}


### PR DESCRIPTION
## Change Overview

The job is supposed to run only on release and it seemed to be failing for every commit on master.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :building_construction: Build

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
