### PR TITLE
Add runs-on to the publish_chart job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -112,6 +112,7 @@ jobs:
       release_tag: ${{ needs.run_if.outputs.release_tag }}
 
   publish_charts:
+    runs-on: ubuntu-latest
     needs: [run_if, release_packages]
     env:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
## Change Overview

Missed adding `runs-on` when fixing the bug in #3187 

```
[Invalid workflow file: .github/workflows/release.yaml#L115](https://github.com/kanisterio/kanister/actions/runs/11411652685/workflow)
The workflow is not valid. .github/workflows/release.yaml (Line: 115, Col: 5): Required property is missing: runs-on
```

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :building_construction: Build

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

The workflow got triggered when releasing a new version and failed. Once we merge this, I will re-trigger the failed workflow.
Not testing this separately on a branch due to time constraints.

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
