### PR TITLE
build: bump golangci-lint version in build image

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -77,6 +77,9 @@ linters-settings:
     skip-generated: true
   stylecheck:
     checks: [ "all", "-ST1001", "-ST1005", "-ST1016", "-ST1023", "-ST1000"]
+  errcheck:
+    exclude-functions:
+      - fmt.Fprintln
 
 exclude-dirs:
   - pkg/client/applyconfiguration/cr/v1alpha1 # generated from code-gen

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -19,7 +19,7 @@ COPY --from=goreleaser/goreleaser:v1.26.2 /usr/bin/goreleaser /usr/local/bin/
 
 COPY --from=alpine/helm:3.12.2 /usr/bin/helm /usr/local/bin/
 
-COPY --from=golangci/golangci-lint:v1.57.2 /usr/bin/golangci-lint /usr/local/bin/
+COPY --from=golangci/golangci-lint:v1.60.1 /usr/bin/golangci-lint /usr/local/bin/
 
 RUN wget -O /usr/local/bin/kind \
       https://github.com/kubernetes-sigs/kind/releases/download/v0.18.0/kind-$(echo $TARGETPLATFORM | tr / -) \

--- a/pkg/function/create_volume_snapshot.go
+++ b/pkg/function/create_volume_snapshot.go
@@ -134,7 +134,7 @@ func createVolumeSnapshot(ctx context.Context, tp param.TemplateParams, cli kube
 	}
 	wg.Wait()
 
-	err := fmt.Errorf(strings.Join(errstrings, "\n"))
+	err := fmt.Errorf("%s", strings.Join(errstrings, "\n"))
 	if len(err.Error()) > 0 {
 		return nil, errkit.Wrap(err, "Failed to snapshot one of the volumes")
 	}

--- a/pkg/function/create_volume_snapshot.go
+++ b/pkg/function/create_volume_snapshot.go
@@ -134,7 +134,7 @@ func createVolumeSnapshot(ctx context.Context, tp param.TemplateParams, cli kube
 	}
 	wg.Wait()
 
-	err := fmt.Errorf("%s", strings.Join(errstrings, "\n"))
+	err := errkit.New(strings.Join(errstrings, "\n"))
 	if len(err.Error()) > 0 {
 		return nil, errkit.Wrap(err, "Failed to snapshot one of the volumes")
 	}

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -60,7 +60,7 @@ func (*healthCheckHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	w.WriteHeader(http.StatusOK)
 	w.Header().Set("Content-Type", "application/json")
-	_, _ = io.WriteString(w, string(js))
+	_, _ = io.Writer.Write(w, js)
 }
 
 // RunWebhookServer starts the validating webhook resources for blueprint kanister resources

--- a/pkg/kube/pod.go
+++ b/pkg/kube/pod.go
@@ -167,7 +167,7 @@ func GetPodObjectFromPodOptions(ctx context.Context, cli kubernetes.Interface, o
 		ServiceAccountName: sa,
 	}
 
-	if opts.EnvironmentVariables != nil && len(opts.EnvironmentVariables) > 0 {
+	if len(opts.EnvironmentVariables) > 0 {
 		defaultSpecs.Containers[0].Env = opts.EnvironmentVariables
 	}
 

--- a/pkg/kube/pod_test.go
+++ b/pkg/kube/pod_test.go
@@ -252,7 +252,7 @@ func (s *PodSuite) TestPod(c *check.C) {
 			c.Assert(pod.Spec.RestartPolicy, check.Equals, po.RestartPolicy)
 		}
 
-		if po.EnvironmentVariables != nil && len(po.EnvironmentVariables) > 0 {
+		if len(po.EnvironmentVariables) > 0 {
 			c.Assert(pod.Spec.Containers[0].Env, check.DeepEquals, po.EnvironmentVariables)
 		}
 


### PR DESCRIPTION
## Change Overview

Old version of golangci-lint has a memory leak causing it to crash with oom in recent go versions.
Updated golangci-lint version in build image.
Fixed lint errors.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [x] :building_construction: Build

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
