### PR TITLE
Find a UID match for pods with multiple ownerReferences

### DIFF
--- a/pkg/kube/utils.go
+++ b/pkg/kube/utils.go
@@ -20,6 +20,8 @@ import (
 	"github.com/kanisterio/errkit"
 	osversioned "github.com/openshift/client-go/apps/clientset/versioned"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/kanisterio/kanister/pkg/field"
@@ -194,4 +196,15 @@ func AddLabelsToPodOptionsFromContext(
 			return
 		}
 	}
+}
+
+// uidInOwnerRefs returns true if one of the ownerReferences of an object matches the
+// provided UID.
+func uidInOwnerRefs(ownerReferences []metav1.OwnerReference, uid types.UID) bool {
+	for _, ownerRef := range ownerReferences {
+		if ownerRef.UID == uid {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/kube/workload.go
+++ b/pkg/kube/workload.go
@@ -344,8 +344,14 @@ func FetchPods(cli kubernetes.Interface, namespace string, uid types.UID) (runni
 		return nil, nil, errkit.Wrap(err, "Could not list Pods")
 	}
 	for _, pod := range pods.Items {
-		if len(pod.OwnerReferences) != 1 ||
-			pod.OwnerReferences[0].UID != uid {
+		ownerUIDMatches := false
+		for _, ownerRef := range pod.OwnerReferences {
+			if ownerRef.UID == uid {
+				ownerUIDMatches = true
+				break
+			}
+		}
+		if !ownerUIDMatches {
 			continue
 		}
 		if pod.Status.Phase != corev1.PodRunning {


### PR DESCRIPTION
## Change Overview

Currently, Kanister does not see any pods that have more than one item in their `ownerReferences` field as healthy. This PR aims to fix that.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :building_construction: Build

## Issues

- fixes #3208 

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->
I am not a go developer (unfortunately), but I tried my best. I think the basics are there and should work as expected, though I understand the static strings for `Kind` may be less than desirable.

Test/verify:

1. Create a Deployment/StatefulSet/etc.
2. Edit the pod(s) from the deployment, and add an item to ownerReferences
3. Create an `ActionSet` targeting this deployment
4. It should proceed without issues

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E