### PR TITLE
Install gcloud auth plugin in kanister build image

### DIFF
--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -13,6 +13,7 @@ RUN curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /
 RUN apt update && apt install -y docker-ce docker-ce-cli containerd.io \
     && apt-get clean
 
+RUN apt-get install apt-transport-https ca-certificates gnupg
 RUN apt-get install -y google-cloud-sdk-gke-gcloud-auth-plugin
 
 COPY --from=bitnami/kubectl:1.26 /opt/bitnami/kubectl/bin/kubectl /usr/local/bin/

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -13,6 +13,8 @@ RUN curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /
 RUN apt update && apt install -y docker-ce docker-ce-cli containerd.io \
     && apt-get clean
 
+RUN apt-get install -y google-cloud-sdk-gke-gcloud-auth-plugin
+
 COPY --from=bitnami/kubectl:1.26 /opt/bitnami/kubectl/bin/kubectl /usr/local/bin/
 
 COPY --from=goreleaser/goreleaser:v1.26.2 /usr/bin/goreleaser /usr/local/bin/

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -13,8 +13,12 @@ RUN curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /
 RUN apt update && apt install -y docker-ce docker-ce-cli containerd.io \
     && apt-get clean
 
-RUN apt-get install apt-transport-https ca-certificates gnupg
-RUN apt-get install -y google-cloud-sdk-gke-gcloud-auth-plugin
+RUN apt-get install apt-transport-https ca-certificates
+# Add the gcloud CLI distribution URI as a package source and install plugin
+RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg \
+  && echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
+  && apt-get update \
+  && apt-get install -y google-cloud-sdk-gke-gcloud-auth-plugin
 
 COPY --from=bitnami/kubectl:1.26 /opt/bitnami/kubectl/bin/kubectl /usr/local/bin/
 


### PR DESCRIPTION
## Change Overview

When running the integration test using `make integration-test` we are asked to install minio using `make install-minio` but if our k8s cluster is gke and in the kuebconfig gcloud auth plugin is used, `make install-minio` fails with below error

```
Unable to connect to the server: getting credentials: exec: executable gke-gcloud-auth-plugin not found

It looks like you are trying to use a client-go credential plugin that is not installed.

To learn more about this feature, consult the documentation available at:
      https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins

Install gke-gcloud-auth-plugin for use with kubectl by following https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl#install_plugin
```
And this seems to be happening because our build image doesn't have gcloud auth plugin installed. This PR installs that.


## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :building_construction: Build

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
