### PR TITLE
fix: Quote profile json when passing to kando in go code

### DIFF
--- a/pkg/function/export_rds_snapshot_location.go
+++ b/pkg/function/export_rds_snapshot_location.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -435,6 +436,8 @@ func postgresBackupCommand(dbEndpoint, username, password string, dbList []strin
 		return nil, errkit.New("No database found to backup")
 	}
 
+	profileQuoted := strconv.Quote(string(profile))
+
 	command := []string{
 		"bash",
 		"-o",
@@ -452,9 +455,9 @@ func postgresBackupCommand(dbEndpoint, username, password string, dbList []strin
 			for db in "${dblist[@]}";
 			  do echo "backing up $db db" && pg_dump $db -C --inserts > /backup/$db.sql;
 			done
-			tar -zc backup | kando location push --profile '%s' --path "${BACKUP_PREFIX}/${BACKUP_ID}" -
+			tar -zc backup | kando location push --profile %s --path "${BACKUP_PREFIX}/${BACKUP_ID}" -
 			kando output %s ${BACKUP_ID}`,
-			dbEndpoint, backupPrefix, backupID, strings.Join(dbList, " "), profile, ExportRDSSnapshotToLocBackupID),
+			dbEndpoint, backupPrefix, backupID, strings.Join(dbList, " "), profileQuoted, ExportRDSSnapshotToLocBackupID),
 	}
 	return command, nil
 }

--- a/pkg/function/restore_rds_snapshot.go
+++ b/pkg/function/restore_rds_snapshot.go
@@ -17,6 +17,7 @@ package function
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -335,6 +336,8 @@ func postgresRestoreCommand(pgHost, username, password string, backupArtifactPre
 		replaceCommand = ` sed 's/"LOCALE"/"LC_COLLATE"/' |`
 	}
 
+	profileQuoted := strconv.Quote(string(profile))
+
 	return []string{
 		"bash",
 		"-o",
@@ -344,8 +347,8 @@ func postgresRestoreCommand(pgHost, username, password string, backupArtifactPre
 		"-c",
 		fmt.Sprintf(`
 		export PGHOST=%s
-		kando location pull --profile '%s' --path "%s" - | gunzip -c -f |%s psql -q -U "${PGUSER}" %s
-		`, pgHost, profile, fmt.Sprintf("%s/%s", backupArtifactPrefix, backupID), replaceCommand, postgres.DefaultConnectDatabase),
+		kando location pull --profile %s --path "%s" - | gunzip -c -f |%s psql -q -U "${PGUSER}" %s
+		`, pgHost, profileQuoted, fmt.Sprintf("%s/%s", backupArtifactPrefix, backupID), replaceCommand, postgres.DefaultConnectDatabase),
 	}, nil
 }
 


### PR DESCRIPTION
## Change Overview

Add quoting when building kando command with profile in go code.
Add unit test case for non-null profile.

Fixes https://github.com/kanisterio/kanister/security/code-scanning/198 and https://github.com/kanisterio/kanister/security/code-scanning/199

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :building_construction: Build

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
