### PR TITLE
docs: Rework blueprints to separate DB tools image and kanister-tools image

### DIFF
--- a/examples/elasticsearch/blueprint-v2/elasticsearch-blueprint.yaml
+++ b/examples/elasticsearch/blueprint-v2/elasticsearch-blueprint.yaml
@@ -23,7 +23,7 @@ actions:
         namespace: "{{ .StatefulSet.Namespace }}"
         sharedVolumeMedium: Memory
 
-        initImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        initImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
         initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data"]
 
         backgroundImage: elasticdump/elasticsearch-dump:latest
@@ -41,7 +41,7 @@ actions:
           master_password="{{ index .Phases.backupToStore.Secrets.esMasterCredSecret.Data "password" | toString }}"
           NODE_TLS_REJECT_UNAUTHORIZED=0 elasticdump --bulk=true --input=https://${master_username}:${master_password}@${host_name}:9200 --output=$ > /tmp/data
 
-        ouptutImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        ouptutImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
         outputCommand:
         - bash
         - -o
@@ -69,10 +69,10 @@ actions:
       args:
         namespace: "{{ .StatefulSet.Namespace }}"
 
-        initImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        initImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
         initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data"]
 
-        backgroundImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        backgroundImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
         backgroundCommand:
         - bash
         - -o
@@ -109,7 +109,7 @@ actions:
       name: deleteFromStore
       args:
         namespace: "{{ .Namespace.Name }}"
-        image: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        image: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
         command:
         - bash
         - -o

--- a/examples/elasticsearch/blueprint-v2/elasticsearch-blueprint.yaml
+++ b/examples/elasticsearch/blueprint-v2/elasticsearch-blueprint.yaml
@@ -11,17 +11,23 @@ actions:
         # `kopiaOutput` is the name provided to kando using `--output-name` flag
         kopiaSnapshot: "{{ .Phases.backupToStore.Output.kopiaOutput }}"
     phases:
-    - func: KubeTask
+    - func: MultiContainerRun
       name: backupToStore
       objects:
         esMasterCredSecret:
           kind: Secret
           name: "{{ index .Object.metadata.labels.app }}-credentials"
           namespace: "{{ .StatefulSet.Namespace }}"
+
       args:
         namespace: "{{ .StatefulSet.Namespace }}"
-        image: "ghcr.io/kanisterio/es-sidecar:0.112.0"
-        command:
+        sharedVolumeMedium: Memory
+
+        initImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data"]
+
+        backgroundImage: elasticdump/elasticsearch-dump:latest
+        backgroundCommand:
         - bash
         - -o
         - errexit
@@ -33,25 +39,54 @@ actions:
           backup_file_path='backup.gz'
           master_username="{{ index .Phases.backupToStore.Secrets.esMasterCredSecret.Data "username" | toString }}"
           master_password="{{ index .Phases.backupToStore.Secrets.esMasterCredSecret.Data "password" | toString }}"
-          NODE_TLS_REJECT_UNAUTHORIZED=0 elasticdump --bulk=true --input=https://${master_username}:${master_password}@${host_name}:9200 --output=/backup
-          gzip -c /backup | kando location push --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --output-name "kopiaOutput" -
+          NODE_TLS_REJECT_UNAUTHORIZED=0 elasticdump --bulk=true --input=https://${master_username}:${master_password}@${host_name}:9200 --output=$ > /tmp/data
+
+        ouptutImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        outputCommand:
+        - bash
+        - -o
+        - errexit
+        - -o
+        - pipefail
+        - -c
+        - |
+          cat /tmp/data | gzip -c | kando location push --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --output-name "kopiaOutput" -
+
+
   restore:
     inputArtifactNames:
     # The kopia snapshot info created in backup phase can be used here
     # Use the `--kopia-snapshot` flag in kando to pass in `esBackup.KopiaSnapshot`
     - esBackup
     phases:
-    - func: KubeTask
+    - func: MultiContainerRun
       name: restoreFromObjectStore
       objects:
         esMasterCredSecret:
           kind: Secret
           name: "{{ index .Object.metadata.labels.app }}-credentials"
-          namespace: "{{ .StatefulSet.Namespace }}"      
+          namespace: "{{ .StatefulSet.Namespace }}"
       args:
         namespace: "{{ .StatefulSet.Namespace }}"
-        image: "ghcr.io/kanisterio/es-sidecar:0.112.0"
-        command:
+
+        initImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data"]
+
+        backgroundImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        backgroundCommand:
+        - bash
+        - -o
+        - errexit
+        - -o
+        - pipefail
+        - -c
+        - |
+          backup_file_path='backup.gz'
+          kopia_snap='{{ .ArtifactsIn.esBackup.KopiaSnapshot }}'
+          kando location pull --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --kopia-snapshot "${kopia_snap}" - | gunzip -c > /tmp/data
+
+        ouptutImage: elasticdump/elasticsearch-dump:latest
+        outputCommand:
         - bash
         - -o
         - errexit
@@ -60,11 +95,10 @@ actions:
         - -c
         - |
           host_name="{{ .Object.spec.serviceName }}.{{ .StatefulSet.Namespace }}.svc.cluster.local"
-          backup_file_path='backup.gz'
-          kopia_snap='{{ .ArtifactsIn.esBackup.KopiaSnapshot }}'
           master_username="{{ index .Phases.restoreFromObjectStore.Secrets.esMasterCredSecret.Data "username" | toString }}"
           master_password="{{ index .Phases.restoreFromObjectStore.Secrets.esMasterCredSecret.Data "password" | toString }}"
-          kando location pull --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --kopia-snapshot "${kopia_snap}" - | gunzip -c | NODE_TLS_REJECT_UNAUTHORIZED=0 elasticdump --bulk=true --input=$ --output=https://${master_username}:${master_password}@${host_name}:9200
+          cat /tmp/data | NODE_TLS_REJECT_UNAUTHORIZED=0 elasticdump --bulk=true --input=$ --output=https://${master_username}:${master_password}@${host_name}:9200
+
   delete:
     inputArtifactNames:
     # The kopia snapshot info created in backup phase can be used here
@@ -75,7 +109,7 @@ actions:
       name: deleteFromStore
       args:
         namespace: "{{ .Namespace.Name }}"
-        image: "ghcr.io/kanisterio/es-sidecar:0.112.0"
+        image: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
         command:
         - bash
         - -o

--- a/examples/elasticsearch/blueprint-v2/elasticsearch-blueprint.yaml
+++ b/examples/elasticsearch/blueprint-v2/elasticsearch-blueprint.yaml
@@ -24,7 +24,7 @@ actions:
         sharedVolumeMedium: Memory
 
         initImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
-        initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data"]
+        initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data; chmod 777 /tmp/data"]
 
         backgroundImage: elasticdump/elasticsearch-dump:latest
         backgroundCommand:
@@ -70,7 +70,7 @@ actions:
         namespace: "{{ .StatefulSet.Namespace }}"
 
         initImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
-        initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data"]
+        initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data; chmod 777 /tmp/data"]
 
         backgroundImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
         backgroundCommand:

--- a/examples/elasticsearch/blueprint-v2/elasticsearch-blueprint.yaml
+++ b/examples/elasticsearch/blueprint-v2/elasticsearch-blueprint.yaml
@@ -41,7 +41,7 @@ actions:
           master_password="{{ index .Phases.backupToStore.Secrets.esMasterCredSecret.Data "password" | toString }}"
           NODE_TLS_REJECT_UNAUTHORIZED=0 elasticdump --bulk=true --input=https://${master_username}:${master_password}@${host_name}:9200 --output=$ > /tmp/data
 
-        ouptutImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
+        outputImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
         outputCommand:
         - bash
         - -o
@@ -85,7 +85,7 @@ actions:
           kopia_snap='{{ .ArtifactsIn.esBackup.KopiaSnapshot }}'
           kando location pull --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --kopia-snapshot "${kopia_snap}" - | gunzip -c > /tmp/data
 
-        ouptutImage: elasticdump/elasticsearch-dump:latest
+        outputImage: elasticdump/elasticsearch-dump:latest
         outputCommand:
         - bash
         - -o

--- a/examples/etcd/etcd-in-cluster/k8s/etcd-incluster-blueprint.yaml
+++ b/examples/etcd/etcd-in-cluster/k8s/etcd-incluster-blueprint.yaml
@@ -40,7 +40,7 @@ actions:
         sharedVolumeMedium: Memory
 
         initImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
-        initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data"]
+        initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data; chmod 777 /tmp/data"]
 
         backgroundImage: ghcr.io/kanisterio/kanister-kubectl-1.18:0.112.0
         backgroundCommand:

--- a/examples/etcd/etcd-in-cluster/k8s/etcd-incluster-blueprint.yaml
+++ b/examples/etcd/etcd-in-cluster/k8s/etcd-incluster-blueprint.yaml
@@ -39,7 +39,7 @@ actions:
       args:
         sharedVolumeMedium: Memory
 
-        initImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        initImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
         initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data"]
 
         backgroundImage: ghcr.io/kanisterio/kanister-kubectl-1.18:0.112.0
@@ -55,7 +55,7 @@ actions:
             gzip -c /tmp/etcd-backup.db > /tmp/data
 
 
-        outputImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        outputImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
         outputCommand:
           - sh
           - -o
@@ -66,7 +66,7 @@ actions:
           - |
             BACKUP_LOCATION=etcd_backups/{{ .Object.metadata.namespace }}/{{ toDate "2006-01-02T15:04:05.999999999Z07:00" .Time | date "2006-01-02T15:04:05Z07:00" }}/etcd-backup.db.gz
 
-            cat /tmp/data > kando location push --profile '{{ toJson .Profile }}' --path $BACKUP_LOCATION -
+            cat /tmp/data | kando location push --profile '{{ toJson .Profile }}' --path $BACKUP_LOCATION -
             kando output backupLocation $BACKUP_LOCATION
 
     - func: KubeTask
@@ -91,7 +91,7 @@ actions:
       name: deleteFromObjectStore
       args:
         namespace: "{{ .Namespace.Name }}"
-        image: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        image: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
         command:
         - bash
         - -o

--- a/examples/etcd/etcd-in-cluster/k8s/etcd-incluster-blueprint.yaml
+++ b/examples/etcd/etcd-in-cluster/k8s/etcd-incluster-blueprint.yaml
@@ -34,11 +34,29 @@ actions:
             kando output etcdPod $ETCD_POD
             kando output etcdNS $ETCDNS
 
-    - func: KubeTask
+    - func: MultiContainerRun
       name: uploadSnapshot
       args:
-        image: ghcr.io/kanisterio/kanister-kubectl-1.18:0.112.0
-        command:
+        sharedVolumeMedium: Memory
+
+        initImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data"]
+
+        backgroundImage: ghcr.io/kanisterio/kanister-kubectl-1.18:0.112.0
+        backgroundCommand:
+          - sh
+          - -o
+          - errexit
+          - -o
+          - pipefail
+          - -c
+          - |
+            kubectl cp {{ .Phases.takeSnapshot.Output.etcdNS }}/{{ .Phases.takeSnapshot.Output.etcdPod }}:/tmp/etcd-backup.db /tmp/etcd-backup.db
+            gzip -c /tmp/etcd-backup.db > /tmp/data
+
+
+        outputImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        outputCommand:
           - sh
           - -o
           - errexit
@@ -47,9 +65,8 @@ actions:
           - -c
           - |
             BACKUP_LOCATION=etcd_backups/{{ .Object.metadata.namespace }}/{{ toDate "2006-01-02T15:04:05.999999999Z07:00" .Time | date "2006-01-02T15:04:05Z07:00" }}/etcd-backup.db.gz
-            kubectl cp {{ .Phases.takeSnapshot.Output.etcdNS }}/{{ .Phases.takeSnapshot.Output.etcdPod }}:/tmp/etcd-backup.db /tmp/etcd-backup.db
-            gzip /tmp/etcd-backup.db
-            kando location push --profile '{{ toJson .Profile }}'  /tmp/etcd-backup.db.gz --path $BACKUP_LOCATION
+
+            cat /tmp/data > kando location push --profile '{{ toJson .Profile }}' --path $BACKUP_LOCATION -
             kando output backupLocation $BACKUP_LOCATION
 
     - func: KubeTask
@@ -74,7 +91,7 @@ actions:
       name: deleteFromObjectStore
       args:
         namespace: "{{ .Namespace.Name }}"
-        image: "ghcr.io/kanisterio/kanister-tools:0.112.0"
+        image: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
         command:
         - bash
         - -o

--- a/examples/etcd/etcd-in-cluster/ocp/blueprint-v2/etcd-incluster-ocp-blueprint.yaml
+++ b/examples/etcd/etcd-in-cluster/ocp/blueprint-v2/etcd-incluster-ocp-blueprint.yaml
@@ -37,7 +37,7 @@ actions:
         sharedVolumeMedium: Memory
 
         initImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
-        initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data"]
+        initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data; chmod 777 /tmp/data"]
 
         backgroundImage: ghcr.io/kanisterio/kanister-kubectl-1.18:0.112.0
         backgroundCommand:

--- a/examples/etcd/etcd-in-cluster/ocp/blueprint-v2/etcd-incluster-ocp-blueprint.yaml
+++ b/examples/etcd/etcd-in-cluster/ocp/blueprint-v2/etcd-incluster-ocp-blueprint.yaml
@@ -31,11 +31,28 @@ actions:
             kando output etcdPod $ETCD_POD
             kando output etcdNS $etcdns
 
-    - func: KubeTask
+    - func: MultiContainerRun
       name: uploadSnapshot
       args:
-        image: ghcr.io/kanisterio/kanister-kubectl-1.18:0.112.0
-        command:
+        sharedVolumeMedium: Memory
+
+        initImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data"]
+
+        backgroundImage: ghcr.io/kanisterio/kanister-kubectl-1.18:0.112.0
+        backgroundCommand:
+          - sh
+          - -o
+          - errexit
+          - -o
+          - pipefail
+          - -c
+          - |
+            kubectl cp -c etcd {{ .Phases.takeSnapshot.Output.etcdNS }}/{{ .Phases.takeSnapshot.Output.etcdPod }}:/tmp/etcd-backup.db /tmp/etcd-backup.db
+            gzip -c /tmp/etcd-backup.db  > /tmp/data
+
+        outputImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        outputCommand:
           - sh
           - -o
           - errexit
@@ -44,8 +61,9 @@ actions:
           - -c
           - |
             BACKUP_LOCATION='etcd-backup.db.gz'
-            kubectl cp -c etcd {{ .Phases.takeSnapshot.Output.etcdNS }}/{{ .Phases.takeSnapshot.Output.etcdPod }}:/tmp/etcd-backup.db /tmp/etcd-backup.db
-            gzip -c /tmp/etcd-backup.db  | kando location push --profile '{{ toJson .Profile }}' --path "${BACKUP_LOCATION}" --output-name "kopiaOutput" -
+
+            cat /tmp/data > | kando location push --profile '{{ toJson .Profile }}' --path "${BACKUP_LOCATION}" --output-name "kopiaOutput" -
+            kando output backupLocation $BACKUP_LOCATION
 
     - func: KubeTask
       name: removeSnapshot
@@ -73,7 +91,7 @@ actions:
     - func: PrepareData
       name: copyFromObjectStore
       args:
-        image: "ghcr.io/kanisterio/kanister-tools:0.112.0"
+        image: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
         namespace: "{{ .Object.metadata.namespace }}"
         podOverride:
           nodeSelector:
@@ -108,7 +126,7 @@ actions:
       name: deleteFromObjectStore
       args:
         namespace: "{{ .Namespace.Name }}"
-        image: "ghcr.io/kanisterio/kanister-tools:0.112.0"
+        image: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
         command:
         - bash
         - -o

--- a/examples/etcd/etcd-in-cluster/ocp/blueprint-v2/etcd-incluster-ocp-blueprint.yaml
+++ b/examples/etcd/etcd-in-cluster/ocp/blueprint-v2/etcd-incluster-ocp-blueprint.yaml
@@ -36,7 +36,7 @@ actions:
       args:
         sharedVolumeMedium: Memory
 
-        initImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        initImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
         initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data"]
 
         backgroundImage: ghcr.io/kanisterio/kanister-kubectl-1.18:0.112.0
@@ -51,7 +51,7 @@ actions:
             kubectl cp -c etcd {{ .Phases.takeSnapshot.Output.etcdNS }}/{{ .Phases.takeSnapshot.Output.etcdPod }}:/tmp/etcd-backup.db /tmp/etcd-backup.db
             gzip -c /tmp/etcd-backup.db  > /tmp/data
 
-        outputImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        outputImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
         outputCommand:
           - sh
           - -o
@@ -62,7 +62,7 @@ actions:
           - |
             BACKUP_LOCATION='etcd-backup.db.gz'
 
-            cat /tmp/data > | kando location push --profile '{{ toJson .Profile }}' --path "${BACKUP_LOCATION}" --output-name "kopiaOutput" -
+            cat /tmp/data | kando location push --profile '{{ toJson .Profile }}' --path "${BACKUP_LOCATION}" --output-name "kopiaOutput" -
             kando output backupLocation $BACKUP_LOCATION
 
     - func: KubeTask
@@ -84,14 +84,14 @@ actions:
     # having label `etcd-restore`. The pod is used to download the backup file from the
     # object store and copy it to the /mnt/data location of the PV mapped to PVC `pvc-etcd`.
     # The PV's mount path is /mnt/data on leader node where the cluster-ocp-restore.sh
-    # script would be executed. 
+    # script would be executed.
     inputArtifactNames:
     - etcdBackup
     phases:
     - func: PrepareData
       name: copyFromObjectStore
       args:
-        image: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        image: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
         namespace: "{{ .Object.metadata.namespace }}"
         podOverride:
           nodeSelector:
@@ -102,7 +102,7 @@ actions:
             effect: "NoSchedule"
           containers:
           - name: container
-            securityContext:    
+            securityContext:
               privileged: true
         volumes:
           pvc-etcd: "/mnt/data"
@@ -126,7 +126,7 @@ actions:
       name: deleteFromObjectStore
       args:
         namespace: "{{ .Namespace.Name }}"
-        image: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        image: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
         command:
         - bash
         - -o

--- a/examples/mongodb-deploymentconfig/blueprint-v2/mongo-dep-config-blueprint.yaml
+++ b/examples/mongodb-deploymentconfig/blueprint-v2/mongo-dep-config-blueprint.yaml
@@ -11,7 +11,7 @@ actions:
         # `kopiaOutput` is the name provided to kando using `--output-name` flag
         kopiaSnapshot: "{{ .Phases.mongoDump.Output.kopiaOutput }}"
     phases:
-    - func: KubeTask
+    - func: MultiContainerRun
       name: mongoDump
       objects:
         mongosecret:
@@ -20,8 +20,13 @@ actions:
           namespace: "{{ .DeploymentConfig.Namespace }}"
       args:
         namespace: "{{ .DeploymentConfig.Namespace }}"
-        image: ghcr.io/kanisterio/mongodb:0.112.0
-        command:
+        sharedVolumeMedium: Memory
+
+        initImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data"]
+
+        backgroundImage: bitnami/mongodb:7.0-debian-12
+        backgroundCommand:
           - bash
           - -o
           - errexit
@@ -33,15 +38,26 @@ actions:
             dbPassword='{{ index .Phases.mongoDump.Secrets.mongosecret.Data "database-admin-password" | toString }}'
             dump_cmd="mongodump --gzip --archive --host ${host} -u admin -p ${dbPassword}"
             echo $dump_cmd
+            ${dump_cmd} > /tmp/data
+
+        outputImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        outputCommand:
+          - bash
+          - -o
+          - errexit
+          - -o
+          - pipefail
+          - -c
+          - |
             backup_file_path='rs_backup.gz'
-            ${dump_cmd} | kando location push --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --output-name "kopiaOutput" -
+            cat /tmp/data | kando location push --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --output-name "kopiaOutput" -
   restore:
     inputArtifactNames:
     # The kopia snapshot info created in backup phase can be used here
     # Use the `--kopia-snapshot` flag in kando to pass in `mongoBackup.KopiaSnapshot`
       - mongoBackup
     phases:
-    - func: KubeTask
+    - func: MultiContainerRun
       name: pullFromStore
       objects:
         mongosecret:
@@ -50,8 +66,26 @@ actions:
           namespace: "{{ .DeploymentConfig.Namespace }}"
       args:
         namespace: "{{ .DeploymentConfig.Namespace }}"
-        image: ghcr.io/kanisterio/mongodb:0.112.0
-        command:
+        sharedVolumeMedium: Memory
+
+        initImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data"]
+
+        backgroundImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        backgroundCommand:
+          - bash
+          - -o
+          - errexit
+          - -o
+          - pipefail
+          - -c
+          - |
+            backup_file_path='rs_backup.gz'
+            kopia_snap='{{ .ArtifactsIn.mongoBackup.KopiaSnapshot }}'
+            kando location pull --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --kopia-snapshot "${kopia_snap}" - > /tmp/data
+
+        outputImage: bitnami/mongodb:7.0-debian-12
+        outputCommand:
           - bash
           - -o
           - errexit
@@ -62,9 +96,7 @@ actions:
             host="{{ .DeploymentConfig.Name }}.{{ .DeploymentConfig.Namespace }}.svc.cluster.local"
             dbPassword='{{ index .Phases.pullFromStore.Secrets.mongosecret.Data "database-admin-password" | toString }}'
             restore_cmd="mongorestore --gzip --archive --drop --host ${host} -u admin -p ${dbPassword}"
-            backup_file_path='rs_backup.gz'
-            kopia_snap='{{ .ArtifactsIn.mongoBackup.KopiaSnapshot }}'
-            kando location pull --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --kopia-snapshot "${kopia_snap}" - | ${restore_cmd}
+            cat /tmp/data | ${restore_cmd}
   delete:
     inputArtifactNames:
     # The kopia snapshot info created in backup phase can be used here
@@ -75,7 +107,7 @@ actions:
       name: deleteFromStore
       args:
         namespace: "{{ .Namespace.Name }}"
-        image: ghcr.io/kanisterio/mongodb:0.112.0
+        image: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
         command:
           - bash
           - -o

--- a/examples/mongodb-deploymentconfig/blueprint-v2/mongo-dep-config-blueprint.yaml
+++ b/examples/mongodb-deploymentconfig/blueprint-v2/mongo-dep-config-blueprint.yaml
@@ -23,7 +23,7 @@ actions:
         sharedVolumeMedium: Memory
 
         initImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
-        initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data"]
+        initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data; chmod 777 /tmp/data"]
 
         backgroundImage: bitnami/mongodb:7.0-debian-12
         backgroundCommand:
@@ -69,7 +69,7 @@ actions:
         sharedVolumeMedium: Memory
 
         initImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
-        initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data"]
+        initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data; chmod 777 /tmp/data"]
 
         backgroundImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
         backgroundCommand:

--- a/examples/mongodb-deploymentconfig/blueprint-v2/mongo-dep-config-blueprint.yaml
+++ b/examples/mongodb-deploymentconfig/blueprint-v2/mongo-dep-config-blueprint.yaml
@@ -22,7 +22,7 @@ actions:
         namespace: "{{ .DeploymentConfig.Namespace }}"
         sharedVolumeMedium: Memory
 
-        initImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        initImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
         initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data"]
 
         backgroundImage: bitnami/mongodb:7.0-debian-12
@@ -40,7 +40,7 @@ actions:
             echo $dump_cmd
             ${dump_cmd} > /tmp/data
 
-        outputImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        outputImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
         outputCommand:
           - bash
           - -o
@@ -68,10 +68,10 @@ actions:
         namespace: "{{ .DeploymentConfig.Namespace }}"
         sharedVolumeMedium: Memory
 
-        initImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        initImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
         initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data"]
 
-        backgroundImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        backgroundImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
         backgroundCommand:
           - bash
           - -o
@@ -107,7 +107,7 @@ actions:
       name: deleteFromStore
       args:
         namespace: "{{ .Namespace.Name }}"
-        image: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        image: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
         command:
           - bash
           - -o

--- a/examples/mongodb/blueprint-v2/mongo-blueprint.yaml
+++ b/examples/mongodb/blueprint-v2/mongo-blueprint.yaml
@@ -23,7 +23,7 @@ actions:
         sharedVolumeMedium: Memory
 
         initImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
-        initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data"]
+        initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data; chmod 777 /tmp/data"]
 
         backgroundImage: bitnami/mongodb:7.0-debian-12
         backgroundCommand:
@@ -69,7 +69,7 @@ actions:
         sharedVolumeMedium: Memory
 
         initImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
-        initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data"]
+        initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data; chmod 777 /tmp/data"]
 
         backgroundImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
         backgroundCommand:

--- a/examples/mongodb/blueprint-v2/mongo-blueprint.yaml
+++ b/examples/mongodb/blueprint-v2/mongo-blueprint.yaml
@@ -22,7 +22,7 @@ actions:
         namespace: "{{ .StatefulSet.Namespace }}"
         sharedVolumeMedium: Memory
 
-        initImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        initImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
         initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data"]
 
         backgroundImage: bitnami/mongodb:7.0-debian-12
@@ -39,7 +39,7 @@ actions:
             dump_cmd="mongodump --oplog --gzip --archive --host ${host} -u root -p ${dbPassword}"
             ${dump_cmd} > /tmp/data
 
-        outputImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        outputImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
         outputCommand:
           - bash
           - -o
@@ -68,10 +68,10 @@ actions:
         namespace: "{{ .StatefulSet.Namespace }}"
         sharedVolumeMedium: Memory
 
-        initImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        initImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
         initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data"]
 
-        backgroundImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        backgroundImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
         backgroundCommand:
            - bash
           - -o
@@ -107,7 +107,7 @@ actions:
       name: deleteFromStore
       args:
         namespace: "{{ .Namespace.Name }}"
-        image: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        image: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
         command:
           - bash
           - -o

--- a/examples/mongodb/blueprint-v2/mongo-blueprint.yaml
+++ b/examples/mongodb/blueprint-v2/mongo-blueprint.yaml
@@ -73,7 +73,7 @@ actions:
 
         backgroundImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
         backgroundCommand:
-           - bash
+          - bash
           - -o
           - errexit
           - -o

--- a/examples/mongodb/blueprint-v2/mongo-blueprint.yaml
+++ b/examples/mongodb/blueprint-v2/mongo-blueprint.yaml
@@ -11,7 +11,7 @@ actions:
         # `kopiaOutput` is the name provided to kando using `--output-name` flag
         kopiaSnapshot: "{{ .Phases.takeConsistentBackup.Output.kopiaOutput }}"
     phases:
-    - func: KubeTask
+    - func: MultiContainerRun
       name: takeConsistentBackup
       objects:
         mongosecret:
@@ -20,8 +20,13 @@ actions:
           namespace: "{{ .StatefulSet.Namespace }}"
       args:
         namespace: "{{ .StatefulSet.Namespace }}"
-        image: ghcr.io/kanisterio/mongodb:0.112.0
-        command:
+        sharedVolumeMedium: Memory
+
+        initImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data"]
+
+        backgroundImage: bitnami/mongodb:7.0-debian-12
+        backgroundCommand:
           - bash
           - -o
           - errexit
@@ -32,15 +37,27 @@ actions:
             host='{{ .StatefulSet.Name }}-0.{{ .StatefulSet.Name }}-headless.{{ .StatefulSet.Namespace }}.svc.cluster.local'
             dbPassword='{{ index .Phases.takeConsistentBackup.Secrets.mongosecret.Data "mongodb-root-password" | toString }}'
             dump_cmd="mongodump --oplog --gzip --archive --host ${host} -u root -p ${dbPassword}"
+            ${dump_cmd} > /tmp/data
+
+        outputImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        outputCommand:
+          - bash
+          - -o
+          - errexit
+          - -o
+          - pipefail
+          - -c
+          - |
             backup_file_path='rs_backup.gz'
-            ${dump_cmd} | kando location push --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --output-name "kopiaOutput" -
+            cat /tmp/data | kando location push --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --output-name "kopiaOutput" -
+
   restore:
     inputArtifactNames:
     # The kopia snapshot info created in backup phase can be used here
     # Use the `--kopia-snapshot` flag in kando to pass in `mongoBackup.KopiaSnapshot`
       - mongoBackup
     phases:
-    - func: KubeTask
+    - func: MultiContainerRun
       name: pullFromStore
       objects:
         mongosecret:
@@ -49,8 +66,26 @@ actions:
           namespace: "{{ .StatefulSet.Namespace }}"
       args:
         namespace: "{{ .StatefulSet.Namespace }}"
-        image: ghcr.io/kanisterio/mongodb:0.112.0
-        command:
+        sharedVolumeMedium: Memory
+
+        initImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data"]
+
+        backgroundImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        backgroundCommand:
+           - bash
+          - -o
+          - errexit
+          - -o
+          - pipefail
+          - -c
+          - |
+            backup_file_path='rs_backup.gz'
+            kopia_snap='{{ .ArtifactsIn.mongoBackup.KopiaSnapshot }}'
+            kando location pull --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --kopia-snapshot "${kopia_snap}" - > /tmp/data
+
+        outputImage: bitnami/mongodb:7.0-debian-12
+        outputCommand:
           - bash
           - -o
           - errexit
@@ -61,9 +96,7 @@ actions:
             host='{{ .StatefulSet.Name }}-0.{{ .StatefulSet.Name }}-headless.{{ .StatefulSet.Namespace }}.svc.cluster.local'
             dbPassword='{{ index .Phases.pullFromStore.Secrets.mongosecret.Data "mongodb-root-password" | toString }}'
             restore_cmd="mongorestore --gzip --archive --oplogReplay --drop --host ${host} -u root -p ${dbPassword}"
-            backup_file_path='rs_backup.gz'
-            kopia_snap='{{ .ArtifactsIn.mongoBackup.KopiaSnapshot }}'
-            kando location pull --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --kopia-snapshot "${kopia_snap}" - | ${restore_cmd}
+            cat /tmp/data | ${restore_cmd}
   delete:
     inputArtifactNames:
     # The kopia snapshot info created in backup phase can be used here
@@ -74,7 +107,7 @@ actions:
       name: deleteFromStore
       args:
         namespace: "{{ .Namespace.Name }}"
-        image: ghcr.io/kanisterio/mongodb:0.112.0
+        image: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
         command:
           - bash
           - -o

--- a/examples/mssql/blueprint-v2/mssql-blueprint.yaml
+++ b/examples/mssql/blueprint-v2/mssql-blueprint.yaml
@@ -8,7 +8,7 @@ actions:
       mssqlCloudDump:
         kopiaSnapshot: "{{ .Phases.dumpToObjectStore.Output.kopiaOutput }}"
     phases:
-      - func: KubeTask
+      - func: MultiContainerRun
         name: dumpToObjectStore
         objects:
           mssql:
@@ -16,8 +16,32 @@ actions:
             name: '{{ index .Object.metadata.labels "app" }}'
             namespace: '{{ .Deployment.Namespace }}'
         args:
-          image: ghcr.io/kanisterio/mssql-tools:0.112.0
-          command:
+          sharedVolumeMedium: Memory
+
+          initImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+          initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data"]
+
+          backgroundImage: ghcr.io/kanisterio/mssql-tools:0.112.0
+          backgroundCommand:
+            - bash
+            - -o
+            - errexit
+            - -o
+            - pipefail
+            - -c
+            - |
+              root_password="{{ index .Phases.dumpToObjectStore.Secrets.mssql.Data "SA_PASSWORD" | toString }}"
+              root_uname="sa"
+              mssql_pod="{{ index .Deployment.Namespace }}/{{ index .Deployment.Pods 0 }}"
+              server_name="{{ index .Deployment.Name }}.{{index .Deployment.Namespace}}.svc.cluster.local"
+              databases=$(/opt/mssql-tools/bin/sqlcmd -S ${server_name} -U ${root_uname} -P ${root_password} -Q "SET NOCOUNT ON; SELECT name FROM sys.databases WHERE name NOT IN ('master','model','msdb','tempdb')" -b -s "," -h -1)
+              for database in $databases; do /opt/mssql-tools/bin/sqlcmd -S ${server_name} -U ${root_uname} -P ${root_password} -Q "backup database $database to disk = '/tmp/backup/$database.bak' with format;"; done
+              kubectl cp ${mssql_pod}:/tmp/backup /tmp/backup
+              tar zcvf - -C /tmp/ backup > /tmp/data
+              kubectl exec -it {{ index .Deployment.Pods 0 }} -n {{ index .Deployment.Namespace }} -- rm -r /tmp/backup
+
+          outputImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+          outputCommand:
             - bash
             - -o
             - errexit
@@ -26,20 +50,13 @@ actions:
             - -c
             - |
               kopiaPath="backup.tar.gz"
-              root_password="{{ index .Phases.dumpToObjectStore.Secrets.mssql.Data "SA_PASSWORD" | toString }}"
-              root_uname="sa"
-              mssql_pod="{{ index .Deployment.Namespace }}/{{ index .Deployment.Pods 0 }}"
-              server_name="{{ index .Deployment.Name }}.{{index .Deployment.Namespace}}.svc.cluster.local"
-              databases=$(/opt/mssql-tools/bin/sqlcmd -S ${server_name} -U ${root_uname} -P ${root_password} -Q "SET NOCOUNT ON; SELECT name FROM sys.databases WHERE name NOT IN ('master','model','msdb','tempdb')" -b -s "," -h -1)
-              for database in $databases; do /opt/mssql-tools/bin/sqlcmd -S ${server_name} -U ${root_uname} -P ${root_password} -Q "backup database $database to disk = '/tmp/backup/$database.bak' with format;"; done
-              kubectl cp ${mssql_pod}:/tmp/backup /tmp/backup
-              tar zcvf - -C /tmp/ backup | kando location push --profile '{{ toJson .Profile }}' --path "${kopiaPath}" --output-name "kopiaOutput" -
-              kubectl exec -it {{ index .Deployment.Pods 0 }} -n {{ index .Deployment.Namespace }} -- rm -r /tmp/backup
+              cat /tmp/data > kando location push --profile '{{ toJson .Profile }}' --path "${kopiaPath}" --output-name "kopiaOutput" -
+
   restore:
     inputArtifactNames:
       - mssqlCloudDump
     phases:
-      - func: KubeTask
+      - func: MultiContainerRun
         name: restoreFromObjectStore
         objects:
           mssql:
@@ -47,8 +64,13 @@ actions:
             name: '{{ index .Object.metadata.labels "app" }}'
             namespace: '{{ .Deployment.Namespace }}'
         args:
-          image: ghcr.io/kanisterio/mssql-tools:0.112.0
-          command:
+          sharedVolumeMedium: Memory
+
+          initImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+          initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data"]
+
+          backgroundImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+          backgroundCommand:
             - bash
             - -o
             - errexit
@@ -58,15 +80,27 @@ actions:
             - |
               kopiaPath="backup.tar.gz"
               kopia_snap='{{ .ArtifactsIn.mssqlCloudDump.KopiaSnapshot }}'
+              kando location pull --profile '{{ toJson .Profile }}' --path "${kopiaPath}" --kopia-snapshot ${kopia_snap} - > /tmp/data
+
+          outputImage: ghcr.io/kanisterio/mssql-tools:0.112.0
+          outputCommand:
+            - bash
+            - -o
+            - errexit
+            - -o
+            - pipefail
+            - -c
+            - |
               root_password="{{ index .Phases.restoreFromObjectStore.Secrets.mssql.Data "SA_PASSWORD" | toString }}"
               root_uname="sa"
               mssql_pod="{{ index .Deployment.Namespace }}/{{ index .Deployment.Pods 0 }}"
               server_name="{{ index .Deployment.Name }}.{{ index .Deployment.Namespace }}.svc.cluster.local"
-              kando location pull --profile '{{ toJson .Profile }}' --path "${kopiaPath}" --kopia-snapshot ${kopia_snap} - | tar zxvf - -C /tmp/
+              cat /tmp/data > tar zxvf - -C /tmp/
               kubectl cp /tmp/backup ${mssql_pod}:/tmp/backup
               backup_files=$(ls /tmp/backup)
               for script in $backup_files; do database="$(cut -d'.' -f1 <<<"$script")"; /opt/mssql-tools/bin/sqlcmd -S ${server_name} -U ${root_uname} -P ${root_password} -Q "restore database $database from disk = '/tmp/backup/$script' with replace"; done
               kubectl exec -it {{ index .Deployment.Pods 0 }} -n {{ index .Deployment.Namespace }} -- rm -r /tmp/backup
+
   delete:
     inputArtifactNames:
       - mssqlCloudDump
@@ -74,7 +108,7 @@ actions:
       - func: KubeTask
         name: deleteFromBlobStore
         args:
-          image: ghcr.io/kanisterio/mssql-tools:0.112.0
+          image: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
           command:
             - bash
             - -o

--- a/examples/mssql/blueprint-v2/mssql-blueprint.yaml
+++ b/examples/mssql/blueprint-v2/mssql-blueprint.yaml
@@ -18,7 +18,7 @@ actions:
         args:
           sharedVolumeMedium: Memory
 
-          initImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+          initImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
           initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data"]
 
           backgroundImage: ghcr.io/kanisterio/mssql-tools:0.112.0
@@ -40,7 +40,7 @@ actions:
               tar zcvf - -C /tmp/ backup > /tmp/data
               kubectl exec -it {{ index .Deployment.Pods 0 }} -n {{ index .Deployment.Namespace }} -- rm -r /tmp/backup
 
-          outputImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+          outputImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
           outputCommand:
             - bash
             - -o
@@ -50,7 +50,7 @@ actions:
             - -c
             - |
               kopiaPath="backup.tar.gz"
-              cat /tmp/data > kando location push --profile '{{ toJson .Profile }}' --path "${kopiaPath}" --output-name "kopiaOutput" -
+              cat /tmp/data | kando location push --profile '{{ toJson .Profile }}' --path "${kopiaPath}" --output-name "kopiaOutput" -
 
   restore:
     inputArtifactNames:
@@ -66,10 +66,10 @@ actions:
         args:
           sharedVolumeMedium: Memory
 
-          initImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+          initImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
           initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data"]
 
-          backgroundImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+          backgroundImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
           backgroundCommand:
             - bash
             - -o
@@ -95,7 +95,7 @@ actions:
               root_uname="sa"
               mssql_pod="{{ index .Deployment.Namespace }}/{{ index .Deployment.Pods 0 }}"
               server_name="{{ index .Deployment.Name }}.{{ index .Deployment.Namespace }}.svc.cluster.local"
-              cat /tmp/data > tar zxvf - -C /tmp/
+              cat /tmp/data | tar zxvf - -C /tmp/
               kubectl cp /tmp/backup ${mssql_pod}:/tmp/backup
               backup_files=$(ls /tmp/backup)
               for script in $backup_files; do database="$(cut -d'.' -f1 <<<"$script")"; /opt/mssql-tools/bin/sqlcmd -S ${server_name} -U ${root_uname} -P ${root_password} -Q "restore database $database from disk = '/tmp/backup/$script' with replace"; done
@@ -108,7 +108,7 @@ actions:
       - func: KubeTask
         name: deleteFromBlobStore
         args:
-          image: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+          image: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
           command:
             - bash
             - -o

--- a/examples/mssql/blueprint-v2/mssql-blueprint.yaml
+++ b/examples/mssql/blueprint-v2/mssql-blueprint.yaml
@@ -19,7 +19,7 @@ actions:
           sharedVolumeMedium: Memory
 
           initImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
-          initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data"]
+          initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data; chmod 777 /tmp/data"]
 
           backgroundImage: ghcr.io/kanisterio/mssql-tools:0.112.0
           backgroundCommand:
@@ -67,7 +67,7 @@ actions:
           sharedVolumeMedium: Memory
 
           initImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
-          initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data"]
+          initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data; chmod 777 /tmp/data"]
 
           backgroundImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
           backgroundCommand:

--- a/examples/mysql-deploymentconfig/blueprint-v2/mysql-dep-config-blueprint.yaml
+++ b/examples/mysql-deploymentconfig/blueprint-v2/mysql-dep-config-blueprint.yaml
@@ -21,8 +21,7 @@ actions:
       args:
         namespace: "{{ .DeploymentConfig.Namespace }}"
         sharedVolumeMedium: Memory
-
-        initImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        initImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
         initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data"]
 
         ## FIXME: do we want to use mysql 9?
@@ -39,7 +38,7 @@ actions:
           dump_cmd="mysqldump --column-statistics=0 -u root --password=${root_password} -h {{ .DeploymentConfig.Name }} --single-transaction --all-databases"
           ${dump_cmd} > /tmp/data
 
-        outputImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        outputImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
         outputCommand:
         - bash
         - -o
@@ -68,11 +67,11 @@ actions:
         namespace: "{{ .DeploymentConfig.Namespace }}"
         sharedVolumeMedium: Memory
 
-        initImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        initImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
         initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data"]
 
 
-        backgroundImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        backgroundImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
         backgroundCommand:
         - bash
         - -o
@@ -108,7 +107,7 @@ actions:
     - func: KubeTask
       name: deleteFromStore
       args:
-        image: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        image: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
         namespace: "{{ .Namespace.Name }}"
         command:
         - bash

--- a/examples/mysql-deploymentconfig/blueprint-v2/mysql-dep-config-blueprint.yaml
+++ b/examples/mysql-deploymentconfig/blueprint-v2/mysql-dep-config-blueprint.yaml
@@ -22,7 +22,7 @@ actions:
         namespace: "{{ .DeploymentConfig.Namespace }}"
         sharedVolumeMedium: Memory
         initImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
-        initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data"]
+        initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data; chmod 777 /tmp/data"]
 
         ## FIXME: do we want to use mysql 9?
         backgroundImage: mysql:8
@@ -68,7 +68,7 @@ actions:
         sharedVolumeMedium: Memory
 
         initImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
-        initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data"]
+        initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data; chmod 777 /tmp/data"]
 
 
         backgroundImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'

--- a/examples/mysql-deploymentconfig/blueprint-v2/mysql-dep-config-blueprint.yaml
+++ b/examples/mysql-deploymentconfig/blueprint-v2/mysql-dep-config-blueprint.yaml
@@ -11,7 +11,7 @@ actions:
         # `kopiaOutput` is the name provided to kando using `--output-name` flag
         kopiaSnapshot: "{{ .Phases.dumpToStore.Output.kopiaOutput }}"
     phases:
-    - func: KubeTask
+    - func: MultiContainerRun
       name: dumpToStore
       objects:
         mysqlsecret:
@@ -19,9 +19,28 @@ actions:
           name: "{{ .DeploymentConfig.Name }}"
           namespace: "{{ .DeploymentConfig.Namespace }}"
       args:
-        image: ghcr.io/kanisterio/mysql-sidecar:0.112.0
         namespace: "{{ .DeploymentConfig.Namespace }}"
-        command:
+        sharedVolumeMedium: Memory
+
+        initImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data"]
+
+        ## FIXME: do we want to use mysql 9?
+        backgroundImage: mysql:8
+        backgroundCommand:
+        - bash
+        - -o
+        - errexit
+        - -o
+        - pipefail
+        - -c
+        - |
+          root_password="{{ index .Phases.dumpToStore.Secrets.mysqlsecret.Data "database-root-password" | toString }}"
+          dump_cmd="mysqldump --column-statistics=0 -u root --password=${root_password} -h {{ .DeploymentConfig.Name }} --single-transaction --all-databases"
+          ${dump_cmd} > /tmp/data
+
+        outputImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        outputCommand:
         - bash
         - -o
         - errexit
@@ -30,16 +49,15 @@ actions:
         - -c
         - |
           backup_file_path="dump.sql"
-          root_password="{{ index .Phases.dumpToStore.Secrets.mysqlsecret.Data "database-root-password" | toString }}"
-          dump_cmd="mysqldump --column-statistics=0 -u root --password=${root_password} -h {{ .DeploymentConfig.Name }} --single-transaction --all-databases"
-          ${dump_cmd} | kando location push --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --output-name "kopiaOutput" -
+          cat /tmp/data | kando location push --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --output-name "kopiaOutput" -
+
   restore:
     inputArtifactNames:
     # The kopia snapshot info created in backup phase can be used here
     # Use the `--kopia-snapshot` flag in kando to pass in `mysqlBackup.KopiaSnapshot`
     - mysqlBackup
     phases:
-    - func: KubeTask
+    - func: MultiContainerRun
       name: restoreFromStore
       objects:
         mysqlsecret:
@@ -47,9 +65,15 @@ actions:
           name: "{{ .DeploymentConfig.Name }}"
           namespace: "{{ .DeploymentConfig.Namespace }}"
       args:
-        image: ghcr.io/kanisterio/mysql-sidecar:0.112.0
         namespace: "{{ .DeploymentConfig.Namespace }}"
-        command:
+        sharedVolumeMedium: Memory
+
+        initImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data"]
+
+
+        backgroundImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        backgroundCommand:
         - bash
         - -o
         - errexit
@@ -59,9 +83,22 @@ actions:
         - |
           backup_file_path="dump.sql"
           kopia_snap='{{ .ArtifactsIn.mysqlBackup.KopiaSnapshot }}'
+          kando location pull --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --kopia-snapshot "${kopia_snap}" - > /tmp/data
+
+        ## FIXME: do we want to use mysql 9?
+        outputImage: mysql:8
+        outputCommand:
+        - bash
+        - -o
+        - errexit
+        - -o
+        - pipefail
+        - -c
+        - |
           root_password="{{ index .Phases.restoreFromStore.Secrets.mysqlsecret.Data "database-root-password" | toString }}"
           restore_cmd="mysql -u root --password=${root_password} -h {{ .DeploymentConfig.Name }}"
-          kando location pull --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --kopia-snapshot "${kopia_snap}" - | ${restore_cmd}
+          cat /tmp/data | ${restore_cmd}
+
   delete:
     inputArtifactNames:
     # The kopia snapshot info created in backup phase can be used here
@@ -71,7 +108,7 @@ actions:
     - func: KubeTask
       name: deleteFromStore
       args:
-        image: ghcr.io/kanisterio/mysql-sidecar:0.112.0
+        image: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
         namespace: "{{ .Namespace.Name }}"
         command:
         - bash

--- a/examples/mysql/blueprint-v2/mysql-blueprint.yaml
+++ b/examples/mysql/blueprint-v2/mysql-blueprint.yaml
@@ -23,7 +23,7 @@ actions:
         sharedVolumeMedium: Memory
 
         initImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
-        initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data"]
+        initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data; chmod 777 /tmp/data"]
 
         backgroundImage: mysql:8
         backgroundCommand:
@@ -68,7 +68,7 @@ actions:
         sharedVolumeMedium: Memory
 
         initImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
-        initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data"]
+        initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data; chmod 777 /tmp/data"]
 
         backgroundImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
         backgroundCommand:

--- a/examples/mysql/blueprint-v2/mysql-blueprint.yaml
+++ b/examples/mysql/blueprint-v2/mysql-blueprint.yaml
@@ -11,7 +11,7 @@ actions:
         # `kopiaOutput` is the name provided to kando using `--output-name` flag
         kopiaSnapshot: "{{ .Phases.dumpToStore.Output.kopiaOutput }}"
     phases:
-    - func: KubeTask
+    - func: MultiContainerRun
       name: dumpToStore
       objects:
         mysqlSecret:
@@ -19,9 +19,27 @@ actions:
           name: '{{ index .Object.metadata.labels "app.kubernetes.io/instance" }}'
           namespace: '{{ .StatefulSet.Namespace }}'
       args:
-        image: ghcr.io/kanisterio/mysql-sidecar:0.112.0
         namespace: "{{ .StatefulSet.Namespace }}"
-        command:
+        sharedVolumeMedium: Memory
+
+        initImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
+        initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data"]
+
+        backgroundImage: mysql:8
+        backgroundCommand:
+        - bash
+        - -o
+        - errexit
+        - -o
+        - pipefail
+        - -c
+        - |
+          root_password="{{ index .Phases.dumpToStore.Secrets.mysqlSecret.Data "mysql-root-password" | toString }}"
+          dump_cmd="mysqldump --column-statistics=0 -u root --password=${root_password} -h {{ index .Object.metadata.labels "app.kubernetes.io/instance" }} --single-transaction --all-databases"
+          ${dump_cmd} > /tmp/data
+
+        outputImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
+        outputCommand:
         - bash
         - -o
         - errexit
@@ -30,16 +48,15 @@ actions:
         - -c
         - |
           backup_file_path="dump.sql"
-          root_password="{{ index .Phases.dumpToStore.Secrets.mysqlSecret.Data "mysql-root-password" | toString }}"
-          dump_cmd="mysqldump --column-statistics=0 -u root --password=${root_password} -h {{ index .Object.metadata.labels "app.kubernetes.io/instance" }} --single-transaction --all-databases"
-          ${dump_cmd} | kando location push --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --output-name "kopiaOutput" -
+          cat /tmp/data | kando location push --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --output-name "kopiaOutput" -
+
   restore:
     inputArtifactNames:
     # The kopia snapshot info created in backup phase can be used here
     # Use the `--kopia-snapshot` flag in kando to pass in `mysqlBackup.KopiaSnapshot`
     - mysqlBackup
     phases:
-    - func: KubeTask
+    - func: MultiContainerRun
       name: restoreFromStore
       objects:
         mysqlSecret:
@@ -47,9 +64,14 @@ actions:
           name: '{{ index .Object.metadata.labels "app.kubernetes.io/instance" }}'
           namespace: '{{ .StatefulSet.Namespace }}'
       args:
-        image: ghcr.io/kanisterio/mysql-sidecar:0.112.0
         namespace: "{{ .StatefulSet.Namespace }}"
-        command:
+        sharedVolumeMedium: Memory
+
+        initImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
+        initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data"]
+
+        backgroundImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
+        backgroundCommand:
         - bash
         - -o
         - errexit
@@ -59,9 +81,20 @@ actions:
         - |
           backup_file_path="dump.sql"
           kopia_snap='{{ .ArtifactsIn.mysqlBackup.KopiaSnapshot }}'
+          kando location pull --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --kopia-snapshot "${kopia_snap}" - > /tmp/data
+
+        outputImage: mysql:8
+        outputCommand:
+        - bash
+        - -o
+        - errexit
+        - -o
+        - pipefail
+        - -c
+        - |
           root_password="{{ index .Phases.restoreFromStore.Secrets.mysqlSecret.Data "mysql-root-password" | toString }}"
-          restore_cmd="mysql -u root --password=${root_password} -h {{ index .Object.metadata.labels "app.kubernetes.io/instance" }}"
-          kando location pull --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --kopia-snapshot "${kopia_snap}" - | ${restore_cmd}
+          cat /tmp/data | mysql -u root --password=${root_password} -h {{ index .Object.metadata.labels "app.kubernetes.io/instance" }}
+
   delete:
     inputArtifactNames:
     # The kopia snapshot info created in backup phase can be used here
@@ -71,7 +104,7 @@ actions:
     - func: KubeTask
       name: deleteFromStore
       args:
-        image: ghcr.io/kanisterio/mysql-sidecar:0.112.0
+        image: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
         namespace: "{{ .Namespace.Name }}"
         command:
         - bash

--- a/examples/postgresql-deploymentconfig/blueprint-v2/postgres-dep-config-blueprint.yaml
+++ b/examples/postgresql-deploymentconfig/blueprint-v2/postgres-dep-config-blueprint.yaml
@@ -12,7 +12,7 @@ actions:
         # `kopiaOutput` is the name provided to kando using `--output-name` flag
         kopiaSnapshot: "{{ .Phases.pgDump.Output.kopiaOutput }}"
     phases:
-    - func: KubeTask
+    - func: MultiContainerRun
       name: pgDump
       objects:
         pgSecret:
@@ -20,9 +20,14 @@ actions:
           name: '{{ .DeploymentConfig.Name }}-{{ .DeploymentConfig.Namespace }}'
           namespace: '{{ .DeploymentConfig.Namespace }}'
       args:
-        image: ghcr.io/kanisterio/postgres-kanister-tools:0.112.0
         namespace: '{{ .DeploymentConfig.Namespace }}'
-        command:
+        sharedVolumeMedium: Memory
+
+        initImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data"]
+
+        backgroundImage: postgres:17-bullseye
+        backgroundCommand:
         - bash
         - -o
         - errexit
@@ -33,8 +38,20 @@ actions:
           export PGHOST='{{ .DeploymentConfig.Name }}.{{ .DeploymentConfig.Namespace }}.svc.cluster.local'
           export PGUSER='postgres'
           export PGPASSWORD='{{ index .Phases.pgDump.Secrets.pgSecret.Data "postgresql_admin_password" | toString }}'
-          backup_file_path="backup.sql"
-          pg_dumpall --clean -U $PGUSER | kando location push --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --output-name "kopiaOutput" -
+          pg_dumpall --clean -U $PGUSER > /tmp/data
+
+        outputImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        outputCommand:
+          - bash
+          - -o
+          - errexit
+          - -o
+          - pipefail
+          - -c
+          - |
+            backup_file_path="backup.sql"
+            cat /tmp/data | kando location push --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --output-name "kopiaOutput" -
+
   restore:
     kind: DeploymentConfig
     inputArtifactNames:
@@ -42,7 +59,7 @@ actions:
     # Use the `--kopia-snapshot` flag in kando to pass in `pgBackup.KopiaSnapshot`
     - pgBackup
     phases:
-    - func: KubeTask
+    - func: MultiContainerRun
       name: pgRestore
       objects:
         pgSecret:
@@ -50,9 +67,27 @@ actions:
           name: '{{ .DeploymentConfig.Name }}-{{ .DeploymentConfig.Namespace }}'
           namespace: '{{ .DeploymentConfig.Namespace }}'
       args:
-        image: ghcr.io/kanisterio/postgres-kanister-tools:0.112.0
         namespace: '{{ .DeploymentConfig.Namespace }}'
-        command:
+        sharedVolumeMedium: Memory
+
+        initImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data"]
+
+        backgroundImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        backgroundCommand:
+        - bash
+        - -o
+        - errexit
+        - -o
+        - pipefail
+        - -c
+        - |
+          backup_file_path="backup.sql"
+          kopia_snap='{{ .ArtifactsIn.pgBackup.KopiaSnapshot }}'
+          kando location pull --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --kopia-snapshot "${kopia_snap}" - > /tmp/data
+
+        outputImage: postgres:17-bullseye
+        outputCommand:
         - bash
         - -o
         - errexit
@@ -63,9 +98,8 @@ actions:
           export PGHOST='{{ .DeploymentConfig.Name }}.{{ .DeploymentConfig.Namespace }}.svc.cluster.local'
           export PGUSER='postgres'
           export PGPASSWORD='{{ index .Phases.pgRestore.Secrets.pgSecret.Data "postgresql_admin_password" | toString }}'
-          backup_file_path="backup.sql"
-          kopia_snap='{{ .ArtifactsIn.pgBackup.KopiaSnapshot }}'
-          kando location pull --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --kopia-snapshot "${kopia_snap}" - | psql -q -U "${PGUSER}"
+          cat /tmp/data | psql -q -U "${PGUSER}"
+
   delete:
     inputArtifactNames:
     # The kopia snapshot info created in backup phase can be used here
@@ -75,7 +109,7 @@ actions:
     - func: KubeTask
       name: deleteDump
       args:
-        image: ghcr.io/kanisterio/postgres-kanister-tools:0.112.0
+        image: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
         namespace: "{{ .Namespace.Name }}"
         command:
           - bash

--- a/examples/postgresql-deploymentconfig/blueprint-v2/postgres-dep-config-blueprint.yaml
+++ b/examples/postgresql-deploymentconfig/blueprint-v2/postgres-dep-config-blueprint.yaml
@@ -24,7 +24,7 @@ actions:
         sharedVolumeMedium: Memory
 
         initImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
-        initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data"]
+        initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data; chmod 777 /tmp/data"]
 
         backgroundImage: postgres:17-bullseye
         backgroundCommand:
@@ -71,7 +71,7 @@ actions:
         sharedVolumeMedium: Memory
 
         initImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
-        initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data"]
+        initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data; chmod 777 /tmp/data"]
 
         backgroundImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
         backgroundCommand:

--- a/examples/postgresql-deploymentconfig/blueprint-v2/postgres-dep-config-blueprint.yaml
+++ b/examples/postgresql-deploymentconfig/blueprint-v2/postgres-dep-config-blueprint.yaml
@@ -23,7 +23,7 @@ actions:
         namespace: '{{ .DeploymentConfig.Namespace }}'
         sharedVolumeMedium: Memory
 
-        initImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        initImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
         initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data"]
 
         backgroundImage: postgres:17-bullseye
@@ -40,7 +40,7 @@ actions:
           export PGPASSWORD='{{ index .Phases.pgDump.Secrets.pgSecret.Data "postgresql_admin_password" | toString }}'
           pg_dumpall --clean -U $PGUSER > /tmp/data
 
-        outputImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        outputImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
         outputCommand:
           - bash
           - -o
@@ -70,10 +70,10 @@ actions:
         namespace: '{{ .DeploymentConfig.Namespace }}'
         sharedVolumeMedium: Memory
 
-        initImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        initImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
         initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data"]
 
-        backgroundImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        backgroundImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
         backgroundCommand:
         - bash
         - -o
@@ -109,7 +109,7 @@ actions:
     - func: KubeTask
       name: deleteDump
       args:
-        image: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        image: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
         namespace: "{{ .Namespace.Name }}"
         command:
           - bash

--- a/examples/postgresql-ha/hook-blueprint/postgres-ha-hook.yaml
+++ b/examples/postgresql-ha/hook-blueprint/postgres-ha-hook.yaml
@@ -26,7 +26,7 @@ actions:
           namespace: '{{ .StatefulSet.Namespace }}'
       args:
         namespace: '{{ .StatefulSet.Namespace }}'
-        image: ghcr.io/kanisterio/postgres-kanister-tools:0.112.0
+        image: {{if .Options.psqlImage }} {{.Options.psqlImage}} {{else}} postgres:17-bullseye {{end}}
         command:
         - bash
         - -o

--- a/examples/postgresql-ha/hook-blueprint/postgres-ha-hook.yaml
+++ b/examples/postgresql-ha/hook-blueprint/postgres-ha-hook.yaml
@@ -26,7 +26,7 @@ actions:
           namespace: '{{ .StatefulSet.Namespace }}'
       args:
         namespace: '{{ .StatefulSet.Namespace }}'
-        image: {{if .Options.psqlImage }} {{.Options.psqlImage}} {{else}} postgres:17-bullseye {{end}}
+        image: '{{if index .Options "psqlImage" }} {{- .Options.psqlImage -}} {{else -}} bitnami/postgresql-repmgr {{- end}}'
         command:
         - bash
         - -o
@@ -41,7 +41,7 @@ actions:
           postgresMaster=$(psql -U postgres -h $PGHOST -d repmgr  -t -c "select node_name from repmgr.nodes where type='primary'")
           postgresStandby=$(psql -U postgres -h $PGHOST -d repmgr  -t -c "select node_name from repmgr.nodes where type='standby'")
           primaryHost=''${postgresMaster}'.{{ .StatefulSet.Name }}-headless.{{ .StatefulSet.Namespace }}.svc.cluster.local'
-          secondaryHost=''${postgresStandby}'.{{ .StatefulSet.Name }}-headless.{{ .StatefulSet.Namespace }}.svc.cluster.local' 
+          secondaryHost=''${postgresStandby}'.{{ .StatefulSet.Name }}-headless.{{ .StatefulSet.Namespace }}.svc.cluster.local'
           export conn_info_primary='user=repmgr password='${PGREPL}' host='${primaryHost}' dbname=repmgr port=5432 connect_timeout=5'
           export conn_info_standby='user=repmgr password='${PGREPL}' host='${secondaryHost}' dbname=repmgr port=5432 connect_timeout=5'
           psql -U postgres -h $PGHOST -d repmgr -c "update repmgr.nodes set conninfo='${conn_info_primary}' where type='primary'"

--- a/examples/postgresql/blueprint-v2/postgres-blueprint.yaml
+++ b/examples/postgresql/blueprint-v2/postgres-blueprint.yaml
@@ -23,7 +23,7 @@ actions:
         namespace: '{{ .StatefulSet.Namespace }}'
         sharedVolumeMedium: Memory
 
-        initImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        initImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
         initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data"]
 
         backgroundImage: postgres:17-bullseye
@@ -40,7 +40,7 @@ actions:
           export PGPASSWORD='{{ index .Phases.pgDump.Secrets.pgSecret.Data "postgres-password" | toString }}'
           pg_dumpall --clean -U $PGUSER > /tmp/data
 
-        outputImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        outputImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
         outputCommand:
         - bash
         - -o
@@ -70,10 +70,10 @@ actions:
         namespace: '{{ .StatefulSet.Namespace }}'
         sharedVolumeMedium: Memory
 
-        initImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        initImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
         initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data"]
 
-        backgroundImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        backgroundImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
         backgroundCommand:
         - bash
         - -o
@@ -98,7 +98,7 @@ actions:
           export PGHOST='{{ index .Object.metadata.labels "app.kubernetes.io/instance" }}-postgresql.{{ .StatefulSet.Namespace }}.svc.cluster.local'
           export PGUSER='postgres'
           export PGPASSWORD='{{ index .Phases.pgRestore.Secrets.pgSecret.Data "postgres-password" | toString }}'
-          cat /tmp/data > psql -q -U "${PGUSER}"
+          cat /tmp/data | psql -q -U "${PGUSER}"
 
   delete:
     inputArtifactNames:
@@ -109,7 +109,7 @@ actions:
     - func: KubeTask
       name: deleteDump
       args:
-        image: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        image: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
         namespace: "{{ .Namespace.Name }}"
         command:
           - bash

--- a/examples/postgresql/blueprint-v2/postgres-blueprint.yaml
+++ b/examples/postgresql/blueprint-v2/postgres-blueprint.yaml
@@ -12,7 +12,7 @@ actions:
         # `kopiaOutput` is the name provided to kando using `--output-name` flag
         kopiaSnapshot: "{{ .Phases.pgDump.Output.kopiaOutput }}"
     phases:
-    - func: KubeTask
+    - func: MultiContainerRun
       name: pgDump
       objects:
         pgSecret:
@@ -20,9 +20,14 @@ actions:
           name: '{{ index .Object.metadata.labels "app.kubernetes.io/instance" }}-postgresql'
           namespace: '{{ .StatefulSet.Namespace }}'
       args:
-        image: ghcr.io/kanisterio/postgres-kanister-tools:0.112.0
         namespace: '{{ .StatefulSet.Namespace }}'
-        command:
+        sharedVolumeMedium: Memory
+
+        initImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data"]
+
+        backgroundImage: postgres:17-bullseye
+        backgroundCommand:
         - bash
         - -o
         - errexit
@@ -33,8 +38,20 @@ actions:
           export PGHOST='{{ index .Object.metadata.labels "app.kubernetes.io/instance" }}-postgresql.{{ .StatefulSet.Namespace }}.svc.cluster.local'
           export PGUSER='postgres'
           export PGPASSWORD='{{ index .Phases.pgDump.Secrets.pgSecret.Data "postgres-password" | toString }}'
+          pg_dumpall --clean -U $PGUSER > /tmp/data
+
+        outputImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        outputCommand:
+        - bash
+        - -o
+        - errexit
+        - -o
+        - pipefail
+        - -c
+        - |
           backup_file_path="backup.sql"
-          pg_dumpall --clean -U $PGUSER | kando location push --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --output-name "kopiaOutput" -
+          cat /tmp/data | kando location push --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --output-name "kopiaOutput" -
+
   restore:
     kind: StatefulSet
     inputArtifactNames:
@@ -42,7 +59,7 @@ actions:
     # Use the `--kopia-snapshot` flag in kando to pass in `pgBackup.KopiaSnapshot`
     - pgBackup
     phases:
-    - func: KubeTask
+    - func: MultiContainerRun
       name: pgRestore
       objects:
         pgSecret:
@@ -50,9 +67,27 @@ actions:
           name: '{{ index .Object.metadata.labels "app.kubernetes.io/instance" }}-postgresql'
           namespace: '{{ .StatefulSet.Namespace }}'
       args:
-        image: ghcr.io/kanisterio/postgres-kanister-tools:0.112.0
         namespace: '{{ .StatefulSet.Namespace }}'
-        command:
+        sharedVolumeMedium: Memory
+
+        initImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data"]
+
+        backgroundImage: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
+        backgroundCommand:
+        - bash
+        - -o
+        - errexit
+        - -o
+        - pipefail
+        - -c
+        - |
+          backup_file_path="backup.sql"
+          kopia_snap='{{ .ArtifactsIn.pgBackup.KopiaSnapshot }}'
+          kando location pull --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --kopia-snapshot "${kopia_snap}" - > /tmp/data
+
+        outputImage: postgres:17-bullseye
+        outputCommand:
         - bash
         - -o
         - errexit
@@ -63,9 +98,8 @@ actions:
           export PGHOST='{{ index .Object.metadata.labels "app.kubernetes.io/instance" }}-postgresql.{{ .StatefulSet.Namespace }}.svc.cluster.local'
           export PGUSER='postgres'
           export PGPASSWORD='{{ index .Phases.pgRestore.Secrets.pgSecret.Data "postgres-password" | toString }}'
-          backup_file_path="backup.sql"
-          kopia_snap='{{ .ArtifactsIn.pgBackup.KopiaSnapshot }}'
-          kando location pull --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --kopia-snapshot "${kopia_snap}" - | psql -q -U "${PGUSER}"
+          cat /tmp/data > psql -q -U "${PGUSER}"
+
   delete:
     inputArtifactNames:
     # The kopia snapshot info created in backup phase can be used here
@@ -75,7 +109,7 @@ actions:
     - func: KubeTask
       name: deleteDump
       args:
-        image: ghcr.io/kanisterio/postgres-kanister-tools:0.112.0
+        image: {{if .Options.kanisterImage }} {{.Options.kanisterImage}} {{else}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{end}}
         namespace: "{{ .Namespace.Name }}"
         command:
           - bash

--- a/examples/postgresql/blueprint-v2/postgres-blueprint.yaml
+++ b/examples/postgresql/blueprint-v2/postgres-blueprint.yaml
@@ -24,7 +24,7 @@ actions:
         sharedVolumeMedium: Memory
 
         initImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
-        initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data"]
+        initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data; chmod 777 /tmp/data"]
 
         backgroundImage: postgres:17-bullseye
         backgroundCommand:
@@ -71,7 +71,7 @@ actions:
         sharedVolumeMedium: Memory
 
         initImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
-        initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data"]
+        initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data; chmod 777 /tmp/data"]
 
         backgroundImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.112.0 {{- end}}'
         backgroundCommand:

--- a/pkg/function/multi_container_run.go
+++ b/pkg/function/multi_container_run.go
@@ -242,9 +242,19 @@ func (ktpf *multiContainerRunFunc) Exec(ctx context.Context, tp param.TemplatePa
 	if err = OptArg(args, MultiContainerRunInitCommandArg, &ktpf.initCommand, nil); err != nil {
 		return nil, err
 	}
+
 	if err = OptArg(args, MultiContainerRunNamespaceArg, &ktpf.namespace, ""); err != nil {
 		return nil, err
 	}
+
+	if ktpf.namespace == "" {
+		controllerNamespace, err := kube.GetControllerNamespace()
+		if err != nil {
+			return nil, errkit.Wrap(err, "Failed to get controller namespace")
+		}
+		ktpf.namespace = controllerNamespace
+	}
+
 	if err = OptArg(args, MultiContainerRunVolumeMediumArg, &ktpf.storageMedium, ""); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Change Overview

Separation of images allows kanister maintainters to build less images in kanister release process and allows the users of those blueprints to always use up to data databse images.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [x] :world_map: Documentation
- [ ] :robot: Test
- [ ] :building_construction: Build

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

**TODO:** All updated blueprints need to be tested

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
