### PR TITLE
Change `pinned` to `bookmarked` for zoom link

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ vulnerabilities.
 
 The Kanister community meetings happen once every two weeks on Thursday, 16:00
 UTC, where we discuss ongoing interesting features, issues, and pull requests.
-Come join us! Everyone is welcome! 🙌 (Zoom link is pinned on Slack)
+Come join us! Everyone is welcome! 🙌 (Zoom link is bookmarked on Slack.)
 
 If you are currently using Kanister, we would love to hear about it! Feel free
 to add your organization to the [`ADOPTERS.md`](ADOPTERS.md) by submitting a


### PR DESCRIPTION


## Change Overview

Community call link is actually bookmarked on the slack workspace not pinned. By reading pinned someone might just look into the pinned tab and not find the link.
This comiit correct that.

## Pull request type

Please check the type of change your PR introduces:
- [x] :hamster: Trivial/Minor
- [x] :world_map: Documentation
