### PR TITLE
Implement new method `Resolve` of kopia's `fs.Symlink`

### DIFF
--- a/pkg/virtualfs/symlink.go
+++ b/pkg/virtualfs/symlink.go
@@ -32,5 +32,5 @@ func (imsl *inmemorySymlink) Readlink(ctx context.Context) (string, error) {
 }
 
 func (imsl *inmemorySymlink) Resolve(ctx context.Context) (fs.Entry, error) {
-	panic("Resolve for mock implementation is not supported")
+	panic("Resolve not supported")
 }

--- a/pkg/virtualfs/symlink.go
+++ b/pkg/virtualfs/symlink.go
@@ -30,3 +30,7 @@ var _ fs.Symlink = (*inmemorySymlink)(nil)
 func (imsl *inmemorySymlink) Readlink(ctx context.Context) (string, error) {
 	panic("Symlinks not supported")
 }
+
+func (imsl *inmemorySymlink) Resolve(ctx context.Context) (fs.Entry, error) {
+	panic("Resolve for mock implementation is not supported")
+}


### PR DESCRIPTION


## Change Overview

We have a mock type in kanister that implements kopia's `fs.Symlink` interface. Since this interface was recently modified to have a new method the mock type that we have in Kanister started to not implement that.
This commit makes sure that we add a dummy implementation of the type.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :building_construction: Build

