### PR TITLE
docs: Rework OCP blueprints to separate DB tools image and kanister-tools image

### DIFF
--- a/examples/etcd/etcd-in-cluster/ocp/blueprint-v2/etcd-incluster-ocp-blueprint.yaml
+++ b/examples/etcd/etcd-in-cluster/ocp/blueprint-v2/etcd-incluster-ocp-blueprint.yaml
@@ -31,11 +31,28 @@ actions:
             kando output etcdPod $ETCD_POD
             kando output etcdNS $etcdns
 
-    - func: KubeTask
+    - func: MultiContainerRun
       name: uploadSnapshot
       args:
-        image: ghcr.io/kanisterio/kanister-kubectl-1.18:0.113.0
-        command:
+        sharedVolumeMedium: Memory
+
+        initImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.113.0 {{- end}}'
+        initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data; chmod 666 /tmp/data"]
+
+        backgroundImage: ghcr.io/kanisterio/kanister-kubectl-1.18:0.113.0
+        backgroundCommand:
+          - sh
+          - -o
+          - errexit
+          - -o
+          - pipefail
+          - -c
+          - |
+            kubectl cp -c etcd {{ .Phases.takeSnapshot.Output.etcdNS }}/{{ .Phases.takeSnapshot.Output.etcdPod }}:/tmp/etcd-backup.db /tmp/etcd-backup.db
+            gzip -c /tmp/etcd-backup.db  > /tmp/data
+
+        outputImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.113.0 {{- end}}'
+        outputCommand:
           - sh
           - -o
           - errexit
@@ -44,8 +61,8 @@ actions:
           - -c
           - |
             BACKUP_LOCATION='etcd-backup.db.gz'
-            kubectl cp -c etcd {{ .Phases.takeSnapshot.Output.etcdNS }}/{{ .Phases.takeSnapshot.Output.etcdPod }}:/tmp/etcd-backup.db /tmp/etcd-backup.db
-            gzip -c /tmp/etcd-backup.db  | kando location push --profile '{{ toJson .Profile }}' --path "${BACKUP_LOCATION}" --output-name "kopiaOutput" -
+
+            cat /tmp/data | kando location push --profile '{{ toJson .Profile }}' --path "${BACKUP_LOCATION}" --output-name "kopiaOutput" -
 
     - func: KubeTask
       name: removeSnapshot
@@ -66,14 +83,14 @@ actions:
     # having label `etcd-restore`. The pod is used to download the backup file from the
     # object store and copy it to the /mnt/data location of the PV mapped to PVC `pvc-etcd`.
     # The PV's mount path is /mnt/data on leader node where the cluster-ocp-restore.sh
-    # script would be executed. 
+    # script would be executed.
     inputArtifactNames:
     - etcdBackup
     phases:
     - func: PrepareData
       name: copyFromObjectStore
       args:
-        image: "ghcr.io/kanisterio/kanister-tools:0.113.0"
+        image: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.113.0 {{- end}}'
         namespace: "{{ .Object.metadata.namespace }}"
         podOverride:
           nodeSelector:
@@ -84,7 +101,7 @@ actions:
             effect: "NoSchedule"
           containers:
           - name: container
-            securityContext:    
+            securityContext:
               privileged: true
         volumes:
           pvc-etcd: "/mnt/data"
@@ -108,7 +125,7 @@ actions:
       name: deleteFromObjectStore
       args:
         namespace: "{{ .Namespace.Name }}"
-        image: "ghcr.io/kanisterio/kanister-tools:0.113.0"
+        image: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.113.0 {{- end}}'
         command:
         - bash
         - -o

--- a/examples/mongodb-deploymentconfig/blueprint-v2/mongo-dep-config-blueprint.yaml
+++ b/examples/mongodb-deploymentconfig/blueprint-v2/mongo-dep-config-blueprint.yaml
@@ -11,7 +11,7 @@ actions:
         # `kopiaOutput` is the name provided to kando using `--output-name` flag
         kopiaSnapshot: "{{ .Phases.mongoDump.Output.kopiaOutput }}"
     phases:
-    - func: KubeTask
+    - func: MultiContainerRun
       name: mongoDump
       objects:
         mongosecret:
@@ -20,8 +20,13 @@ actions:
           namespace: "{{ .DeploymentConfig.Namespace }}"
       args:
         namespace: "{{ .DeploymentConfig.Namespace }}"
-        image: ghcr.io/kanisterio/mongodb:0.113.0
-        command:
+        sharedVolumeMedium: Memory
+
+        initImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.113.0 {{- end}}'
+        initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data; chmod 666 /tmp/data"]
+
+        backgroundImage: bitnami/mongodb:7.0-debian-12
+        backgroundCommand:
           - bash
           - -o
           - errexit
@@ -33,15 +38,26 @@ actions:
             dbPassword='{{ index .Phases.mongoDump.Secrets.mongosecret.Data "database-admin-password" | toString }}'
             dump_cmd="mongodump --gzip --archive --host ${host} -u admin -p ${dbPassword}"
             echo $dump_cmd
+            ${dump_cmd} > /tmp/data
+
+        outputImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.113.0 {{- end}}'
+        outputCommand:
+          - bash
+          - -o
+          - errexit
+          - -o
+          - pipefail
+          - -c
+          - |
             backup_file_path='rs_backup.gz'
-            ${dump_cmd} | kando location push --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --output-name "kopiaOutput" -
+            cat /tmp/data | kando location push --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --output-name "kopiaOutput" -
   restore:
     inputArtifactNames:
     # The kopia snapshot info created in backup phase can be used here
     # Use the `--kopia-snapshot` flag in kando to pass in `mongoBackup.KopiaSnapshot`
       - mongoBackup
     phases:
-    - func: KubeTask
+    - func: MultiContainerRun
       name: pullFromStore
       objects:
         mongosecret:
@@ -50,8 +66,26 @@ actions:
           namespace: "{{ .DeploymentConfig.Namespace }}"
       args:
         namespace: "{{ .DeploymentConfig.Namespace }}"
-        image: ghcr.io/kanisterio/mongodb:0.113.0
-        command:
+        sharedVolumeMedium: Memory
+
+        initImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.113.0 {{- end}}'
+        initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data; chmod 666 /tmp/data"]
+
+        backgroundImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.113.0 {{- end}}'
+        backgroundCommand:
+          - bash
+          - -o
+          - errexit
+          - -o
+          - pipefail
+          - -c
+          - |
+            backup_file_path='rs_backup.gz'
+            kopia_snap='{{ .ArtifactsIn.mongoBackup.KopiaSnapshot }}'
+            kando location pull --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --kopia-snapshot "${kopia_snap}" - > /tmp/data
+
+        outputImage: bitnami/mongodb:7.0-debian-12
+        outputCommand:
           - bash
           - -o
           - errexit
@@ -62,9 +96,7 @@ actions:
             host="{{ .DeploymentConfig.Name }}.{{ .DeploymentConfig.Namespace }}.svc.cluster.local"
             dbPassword='{{ index .Phases.pullFromStore.Secrets.mongosecret.Data "database-admin-password" | toString }}'
             restore_cmd="mongorestore --gzip --archive --drop --host ${host} -u admin -p ${dbPassword}"
-            backup_file_path='rs_backup.gz'
-            kopia_snap='{{ .ArtifactsIn.mongoBackup.KopiaSnapshot }}'
-            kando location pull --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --kopia-snapshot "${kopia_snap}" - | ${restore_cmd}
+            cat /tmp/data | ${restore_cmd}
   delete:
     inputArtifactNames:
     # The kopia snapshot info created in backup phase can be used here
@@ -75,7 +107,7 @@ actions:
       name: deleteFromStore
       args:
         namespace: "{{ .Namespace.Name }}"
-        image: ghcr.io/kanisterio/mongodb:0.113.0
+        image: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.113.0 {{- end}}'
         command:
           - bash
           - -o

--- a/examples/mysql-deploymentconfig/blueprint-v2/mysql-dep-config-blueprint.yaml
+++ b/examples/mysql-deploymentconfig/blueprint-v2/mysql-dep-config-blueprint.yaml
@@ -11,7 +11,7 @@ actions:
         # `kopiaOutput` is the name provided to kando using `--output-name` flag
         kopiaSnapshot: "{{ .Phases.dumpToStore.Output.kopiaOutput }}"
     phases:
-    - func: KubeTask
+    - func: MultiContainerRun
       name: dumpToStore
       objects:
         mysqlsecret:
@@ -19,9 +19,27 @@ actions:
           name: "{{ .DeploymentConfig.Name }}"
           namespace: "{{ .DeploymentConfig.Namespace }}"
       args:
-        image: ghcr.io/kanisterio/mysql-sidecar:0.113.0
         namespace: "{{ .DeploymentConfig.Namespace }}"
-        command:
+        sharedVolumeMedium: Memory
+        initImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.113.0 {{- end}}'
+        initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data; chmod 666 /tmp/data"]
+
+        ## FIXME: do we want to use mysql 9?
+        backgroundImage: mysql:8
+        backgroundCommand:
+        - bash
+        - -o
+        - errexit
+        - -o
+        - pipefail
+        - -c
+        - |
+          root_password="{{ index .Phases.dumpToStore.Secrets.mysqlsecret.Data "database-root-password" | toString }}"
+          dump_cmd="mysqldump --column-statistics=0 -u root --password=${root_password} -h {{ .DeploymentConfig.Name }} --single-transaction --all-databases"
+          ${dump_cmd} > /tmp/data
+
+        outputImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.113.0 {{- end}}'
+        outputCommand:
         - bash
         - -o
         - errexit
@@ -30,16 +48,15 @@ actions:
         - -c
         - |
           backup_file_path="dump.sql"
-          root_password="{{ index .Phases.dumpToStore.Secrets.mysqlsecret.Data "database-root-password" | toString }}"
-          dump_cmd="mysqldump --column-statistics=0 -u root --password=${root_password} -h {{ .DeploymentConfig.Name }} --single-transaction --all-databases"
-          ${dump_cmd} | kando location push --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --output-name "kopiaOutput" -
+          cat /tmp/data | kando location push --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --output-name "kopiaOutput" -
+
   restore:
     inputArtifactNames:
     # The kopia snapshot info created in backup phase can be used here
     # Use the `--kopia-snapshot` flag in kando to pass in `mysqlBackup.KopiaSnapshot`
     - mysqlBackup
     phases:
-    - func: KubeTask
+    - func: MultiContainerRun
       name: restoreFromStore
       objects:
         mysqlsecret:
@@ -47,9 +64,15 @@ actions:
           name: "{{ .DeploymentConfig.Name }}"
           namespace: "{{ .DeploymentConfig.Namespace }}"
       args:
-        image: ghcr.io/kanisterio/mysql-sidecar:0.113.0
         namespace: "{{ .DeploymentConfig.Namespace }}"
-        command:
+        sharedVolumeMedium: Memory
+
+        initImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.113.0 {{- end}}'
+        initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data; chmod 666 /tmp/data"]
+
+
+        backgroundImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.113.0 {{- end}}'
+        backgroundCommand:
         - bash
         - -o
         - errexit
@@ -59,9 +82,22 @@ actions:
         - |
           backup_file_path="dump.sql"
           kopia_snap='{{ .ArtifactsIn.mysqlBackup.KopiaSnapshot }}'
+          kando location pull --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --kopia-snapshot "${kopia_snap}" - > /tmp/data
+
+        ## FIXME: do we want to use mysql 9?
+        outputImage: mysql:8
+        outputCommand:
+        - bash
+        - -o
+        - errexit
+        - -o
+        - pipefail
+        - -c
+        - |
           root_password="{{ index .Phases.restoreFromStore.Secrets.mysqlsecret.Data "database-root-password" | toString }}"
           restore_cmd="mysql -u root --password=${root_password} -h {{ .DeploymentConfig.Name }}"
-          kando location pull --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --kopia-snapshot "${kopia_snap}" - | ${restore_cmd}
+          cat /tmp/data | ${restore_cmd}
+
   delete:
     inputArtifactNames:
     # The kopia snapshot info created in backup phase can be used here
@@ -71,7 +107,7 @@ actions:
     - func: KubeTask
       name: deleteFromStore
       args:
-        image: ghcr.io/kanisterio/mysql-sidecar:0.113.0
+        image: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.113.0 {{- end}}'
         namespace: "{{ .Namespace.Name }}"
         command:
         - bash

--- a/examples/postgresql-deploymentconfig/blueprint-v2/postgres-dep-config-blueprint.yaml
+++ b/examples/postgresql-deploymentconfig/blueprint-v2/postgres-dep-config-blueprint.yaml
@@ -12,7 +12,7 @@ actions:
         # `kopiaOutput` is the name provided to kando using `--output-name` flag
         kopiaSnapshot: "{{ .Phases.pgDump.Output.kopiaOutput }}"
     phases:
-    - func: KubeTask
+    - func: MultiContainerRun
       name: pgDump
       objects:
         pgSecret:
@@ -20,9 +20,14 @@ actions:
           name: '{{ .DeploymentConfig.Name }}-{{ .DeploymentConfig.Namespace }}'
           namespace: '{{ .DeploymentConfig.Namespace }}'
       args:
-        image: ghcr.io/kanisterio/postgres-kanister-tools:0.113.0
         namespace: '{{ .DeploymentConfig.Namespace }}'
-        command:
+        sharedVolumeMedium: Memory
+
+        initImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.113.0 {{- end}}'
+        initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data; chmod 666 /tmp/data"]
+
+        backgroundImage: postgres:15-bullseye
+        backgroundCommand:
         - bash
         - -o
         - errexit
@@ -33,8 +38,20 @@ actions:
           export PGHOST='{{ .DeploymentConfig.Name }}.{{ .DeploymentConfig.Namespace }}.svc.cluster.local'
           export PGUSER='postgres'
           export PGPASSWORD='{{ index .Phases.pgDump.Secrets.pgSecret.Data "postgresql_admin_password" | toString }}'
-          backup_file_path="backup.sql"
-          pg_dumpall --clean -U $PGUSER | kando location push --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --output-name "kopiaOutput" -
+          pg_dumpall --clean -U $PGUSER > /tmp/data
+
+        outputImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.113.0 {{- end}}'
+        outputCommand:
+          - bash
+          - -o
+          - errexit
+          - -o
+          - pipefail
+          - -c
+          - |
+            backup_file_path="backup.sql"
+            cat /tmp/data | kando location push --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --output-name "kopiaOutput" -
+
   restore:
     kind: DeploymentConfig
     inputArtifactNames:
@@ -42,7 +59,7 @@ actions:
     # Use the `--kopia-snapshot` flag in kando to pass in `pgBackup.KopiaSnapshot`
     - pgBackup
     phases:
-    - func: KubeTask
+    - func: MultiContainerRun
       name: pgRestore
       objects:
         pgSecret:
@@ -50,9 +67,27 @@ actions:
           name: '{{ .DeploymentConfig.Name }}-{{ .DeploymentConfig.Namespace }}'
           namespace: '{{ .DeploymentConfig.Namespace }}'
       args:
-        image: ghcr.io/kanisterio/postgres-kanister-tools:0.113.0
         namespace: '{{ .DeploymentConfig.Namespace }}'
-        command:
+        sharedVolumeMedium: Memory
+
+        initImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.113.0 {{- end}}'
+        initCommand: ["bash", "-o", "errexit", "-o", "pipefail", "-c", "mkfifo /tmp/data; chmod 666 /tmp/data"]
+
+        backgroundImage: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.113.0 {{- end}}'
+        backgroundCommand:
+        - bash
+        - -o
+        - errexit
+        - -o
+        - pipefail
+        - -c
+        - |
+          backup_file_path="backup.sql"
+          kopia_snap='{{ .ArtifactsIn.pgBackup.KopiaSnapshot }}'
+          kando location pull --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --kopia-snapshot "${kopia_snap}" - > /tmp/data
+
+        outputImage: postgres:17-bullseye
+        outputCommand:
         - bash
         - -o
         - errexit
@@ -63,9 +98,8 @@ actions:
           export PGHOST='{{ .DeploymentConfig.Name }}.{{ .DeploymentConfig.Namespace }}.svc.cluster.local'
           export PGUSER='postgres'
           export PGPASSWORD='{{ index .Phases.pgRestore.Secrets.pgSecret.Data "postgresql_admin_password" | toString }}'
-          backup_file_path="backup.sql"
-          kopia_snap='{{ .ArtifactsIn.pgBackup.KopiaSnapshot }}'
-          kando location pull --profile '{{ toJson .Profile }}' --path "${backup_file_path}" --kopia-snapshot "${kopia_snap}" - | psql -q -U "${PGUSER}"
+          cat /tmp/data | psql -q -U "${PGUSER}"
+
   delete:
     inputArtifactNames:
     # The kopia snapshot info created in backup phase can be used here
@@ -75,7 +109,7 @@ actions:
     - func: KubeTask
       name: deleteDump
       args:
-        image: ghcr.io/kanisterio/postgres-kanister-tools:0.113.0
+        image: '{{if index .Options "kanisterImage" }} {{- .Options.kanisterImage -}} {{else -}} ghcr.io/kanisterio/kanister-tools:0.113.0 {{- end}}'
         namespace: "{{ .Namespace.Name }}"
         command:
           - bash

--- a/pkg/app/postgresql-deploymentconfig.go
+++ b/pkg/app/postgresql-deploymentconfig.go
@@ -60,7 +60,7 @@ func NewPostgreSQLDepConfig(name string, templateVersion DBTemplate, storageType
 			"POSTGRESQL_ADMIN_PASSWORD": "secretpassword",
 		},
 		params: map[string]string{
-			"POSTGRESQL_VERSION":  "13-el8",
+			"POSTGRESQL_VERSION":  "15-el8",
 			"POSTGRESQL_DATABASE": "postgres",
 		},
 		storageType:       storageType,


### PR DESCRIPTION
## Change Overview

Follow up to #3284

This is a part of split up of #3267

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [x] :world_map: Documentation
- [ ] :robot: Test
- [ ] :building_construction: Build

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
