### PR TITLE
feat: Per phase pod override API

### DIFF
--- a/pkg/apis/cr/v1alpha1/types.go
+++ b/pkg/apis/cr/v1alpha1/types.go
@@ -106,7 +106,13 @@ type ActionSpec struct {
 	RepositoryServer *ObjectReference `json:"repositoryServer,omitempty"`
 	// PodOverride is used to specify pod specs that will override the
 	// default pod specs
+	// DEPRECATED! please use PhasePodOverrides instead to specify overrides per phase
+	// If PhasePodOverrides is defined for a phase, it will replace this value
 	PodOverride JSONMap `json:"podOverride,omitempty"`
+	// PhasePodOverrides is used to specify pod specs that will override default
+	// specs for phases in the action.
+	// Keys should be phase names and values should be pod specs
+	PhasePodOverrides map[string]JSONMap `json:"phasePodOverrides,omitempty"`
 	// Options will be used to specify additional values
 	// to be used in the Blueprint.
 	Options map[string]string `json:"options,omitempty"`

--- a/pkg/client/applyconfiguration/cr/v1alpha1/actionprogress.go
+++ b/pkg/client/applyconfiguration/cr/v1alpha1/actionprogress.go
@@ -21,7 +21,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// ActionProgressApplyConfiguration represents an declarative configuration of the ActionProgress type for use
+// ActionProgressApplyConfiguration represents a declarative configuration of the ActionProgress type for use
 // with apply.
 type ActionProgressApplyConfiguration struct {
 	RunningPhase           *string  `json:"runningPhase,omitempty"`
@@ -33,7 +33,7 @@ type ActionProgressApplyConfiguration struct {
 	LastTransitionTime     *v1.Time `json:"lastTransitionTime,omitempty"`
 }
 
-// ActionProgressApplyConfiguration constructs an declarative configuration of the ActionProgress type for use with
+// ActionProgressApplyConfiguration constructs a declarative configuration of the ActionProgress type for use with
 // apply.
 func ActionProgress() *ActionProgressApplyConfiguration {
 	return &ActionProgressApplyConfiguration{}

--- a/pkg/client/applyconfiguration/cr/v1alpha1/actionset.go
+++ b/pkg/client/applyconfiguration/cr/v1alpha1/actionset.go
@@ -23,7 +23,7 @@ import (
 	v1 "k8s.io/client-go/applyconfigurations/meta/v1"
 )
 
-// ActionSetApplyConfiguration represents an declarative configuration of the ActionSet type for use
+// ActionSetApplyConfiguration represents a declarative configuration of the ActionSet type for use
 // with apply.
 type ActionSetApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration    `json:",inline"`
@@ -32,7 +32,7 @@ type ActionSetApplyConfiguration struct {
 	Status                           *ActionSetStatusApplyConfiguration `json:"status,omitempty"`
 }
 
-// ActionSet constructs an declarative configuration of the ActionSet type for use with
+// ActionSet constructs a declarative configuration of the ActionSet type for use with
 // apply.
 func ActionSet(name, namespace string) *ActionSetApplyConfiguration {
 	b := &ActionSetApplyConfiguration{}
@@ -215,4 +215,10 @@ func (b *ActionSetApplyConfiguration) WithSpec(value *ActionSetSpecApplyConfigur
 func (b *ActionSetApplyConfiguration) WithStatus(value *ActionSetStatusApplyConfiguration) *ActionSetApplyConfiguration {
 	b.Status = value
 	return b
+}
+
+// GetName retrieves the value of the Name field in the declarative configuration.
+func (b *ActionSetApplyConfiguration) GetName() *string {
+	b.ensureObjectMetaApplyConfigurationExists()
+	return b.Name
 }

--- a/pkg/client/applyconfiguration/cr/v1alpha1/actionsetspec.go
+++ b/pkg/client/applyconfiguration/cr/v1alpha1/actionsetspec.go
@@ -17,13 +17,13 @@ limitations under the License.
 
 package v1alpha1
 
-// ActionSetSpecApplyConfiguration represents an declarative configuration of the ActionSetSpec type for use
+// ActionSetSpecApplyConfiguration represents a declarative configuration of the ActionSetSpec type for use
 // with apply.
 type ActionSetSpecApplyConfiguration struct {
 	Actions []ActionSpecApplyConfiguration `json:"actions,omitempty"`
 }
 
-// ActionSetSpecApplyConfiguration constructs an declarative configuration of the ActionSetSpec type for use with
+// ActionSetSpecApplyConfiguration constructs a declarative configuration of the ActionSetSpec type for use with
 // apply.
 func ActionSetSpec() *ActionSetSpecApplyConfiguration {
 	return &ActionSetSpecApplyConfiguration{}

--- a/pkg/client/applyconfiguration/cr/v1alpha1/actionsetstatus.go
+++ b/pkg/client/applyconfiguration/cr/v1alpha1/actionsetstatus.go
@@ -21,7 +21,7 @@ import (
 	v1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 )
 
-// ActionSetStatusApplyConfiguration represents an declarative configuration of the ActionSetStatus type for use
+// ActionSetStatusApplyConfiguration represents a declarative configuration of the ActionSetStatus type for use
 // with apply.
 type ActionSetStatusApplyConfiguration struct {
 	State    *v1alpha1.State                   `json:"state,omitempty"`
@@ -30,7 +30,7 @@ type ActionSetStatusApplyConfiguration struct {
 	Progress *ActionProgressApplyConfiguration `json:"progress,omitempty"`
 }
 
-// ActionSetStatusApplyConfiguration constructs an declarative configuration of the ActionSetStatus type for use with
+// ActionSetStatusApplyConfiguration constructs a declarative configuration of the ActionSetStatus type for use with
 // apply.
 func ActionSetStatus() *ActionSetStatusApplyConfiguration {
 	return &ActionSetStatusApplyConfiguration{}

--- a/pkg/client/applyconfiguration/cr/v1alpha1/actionspec.go
+++ b/pkg/client/applyconfiguration/cr/v1alpha1/actionspec.go
@@ -21,25 +21,26 @@ import (
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 )
 
-// ActionSpecApplyConfiguration represents an declarative configuration of the ActionSpec type for use
+// ActionSpecApplyConfiguration represents a declarative configuration of the ActionSpec type for use
 // with apply.
 type ActionSpecApplyConfiguration struct {
-	Name             *string                                      `json:"name,omitempty"`
-	Object           *ObjectReferenceApplyConfiguration           `json:"object,omitempty"`
-	Blueprint        *string                                      `json:"blueprint,omitempty"`
-	Artifacts        map[string]ArtifactApplyConfiguration        `json:"artifacts,omitempty"`
-	ConfigMaps       map[string]ObjectReferenceApplyConfiguration `json:"configMaps,omitempty"`
-	Secrets          map[string]ObjectReferenceApplyConfiguration `json:"secrets,omitempty"`
-	Profile          *ObjectReferenceApplyConfiguration           `json:"profile,omitempty"`
-	RepositoryServer *ObjectReferenceApplyConfiguration           `json:"repositoryServer,omitempty"`
-	PodOverride      *crv1alpha1.JSONMap                          `json:"podOverride,omitempty"`
-	Options          map[string]string                            `json:"options,omitempty"`
-	PreferredVersion *string                                      `json:"preferredVersion,omitempty"`
-	PodLabels        map[string]string                            `json:"podLabels,omitempty"`
-	PodAnnotations   map[string]string                            `json:"podAnnotations,omitempty"`
+	Name              *string                                      `json:"name,omitempty"`
+	Object            *ObjectReferenceApplyConfiguration           `json:"object,omitempty"`
+	Blueprint         *string                                      `json:"blueprint,omitempty"`
+	Artifacts         map[string]ArtifactApplyConfiguration        `json:"artifacts,omitempty"`
+	ConfigMaps        map[string]ObjectReferenceApplyConfiguration `json:"configMaps,omitempty"`
+	Secrets           map[string]ObjectReferenceApplyConfiguration `json:"secrets,omitempty"`
+	Profile           *ObjectReferenceApplyConfiguration           `json:"profile,omitempty"`
+	RepositoryServer  *ObjectReferenceApplyConfiguration           `json:"repositoryServer,omitempty"`
+	PodOverride       *crv1alpha1.JSONMap                          `json:"podOverride,omitempty"`
+	PhasePodOverrides map[string]crv1alpha1.JSONMap                `json:"phasePodOverrides,omitempty"`
+	Options           map[string]string                            `json:"options,omitempty"`
+	PreferredVersion  *string                                      `json:"preferredVersion,omitempty"`
+	PodLabels         map[string]string                            `json:"podLabels,omitempty"`
+	PodAnnotations    map[string]string                            `json:"podAnnotations,omitempty"`
 }
 
-// ActionSpecApplyConfiguration constructs an declarative configuration of the ActionSpec type for use with
+// ActionSpecApplyConfiguration constructs a declarative configuration of the ActionSpec type for use with
 // apply.
 func ActionSpec() *ActionSpecApplyConfiguration {
 	return &ActionSpecApplyConfiguration{}
@@ -132,6 +133,20 @@ func (b *ActionSpecApplyConfiguration) WithRepositoryServer(value *ObjectReferen
 // If called multiple times, the PodOverride field is set to the value of the last call.
 func (b *ActionSpecApplyConfiguration) WithPodOverride(value crv1alpha1.JSONMap) *ActionSpecApplyConfiguration {
 	b.PodOverride = &value
+	return b
+}
+
+// WithPhasePodOverrides puts the entries into the PhasePodOverrides field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the entries provided by each call will be put on the PhasePodOverrides field,
+// overwriting an existing map entries in PhasePodOverrides field with the same key.
+func (b *ActionSpecApplyConfiguration) WithPhasePodOverrides(entries map[string]crv1alpha1.JSONMap) *ActionSpecApplyConfiguration {
+	if b.PhasePodOverrides == nil && len(entries) > 0 {
+		b.PhasePodOverrides = make(map[string]crv1alpha1.JSONMap, len(entries))
+	}
+	for k, v := range entries {
+		b.PhasePodOverrides[k] = v
+	}
 	return b
 }
 

--- a/pkg/client/applyconfiguration/cr/v1alpha1/actionstatus.go
+++ b/pkg/client/applyconfiguration/cr/v1alpha1/actionstatus.go
@@ -17,7 +17,7 @@ limitations under the License.
 
 package v1alpha1
 
-// ActionStatusApplyConfiguration represents an declarative configuration of the ActionStatus type for use
+// ActionStatusApplyConfiguration represents a declarative configuration of the ActionStatus type for use
 // with apply.
 type ActionStatusApplyConfiguration struct {
 	Name       *string                               `json:"name,omitempty"`
@@ -28,7 +28,7 @@ type ActionStatusApplyConfiguration struct {
 	DeferPhase *PhaseApplyConfiguration              `json:"deferPhase,omitempty"`
 }
 
-// ActionStatusApplyConfiguration constructs an declarative configuration of the ActionStatus type for use with
+// ActionStatusApplyConfiguration constructs a declarative configuration of the ActionStatus type for use with
 // apply.
 func ActionStatus() *ActionStatusApplyConfiguration {
 	return &ActionStatusApplyConfiguration{}

--- a/pkg/client/applyconfiguration/cr/v1alpha1/artifact.go
+++ b/pkg/client/applyconfiguration/cr/v1alpha1/artifact.go
@@ -17,14 +17,14 @@ limitations under the License.
 
 package v1alpha1
 
-// ArtifactApplyConfiguration represents an declarative configuration of the Artifact type for use
+// ArtifactApplyConfiguration represents a declarative configuration of the Artifact type for use
 // with apply.
 type ArtifactApplyConfiguration struct {
 	KeyValue      map[string]string `json:"keyValue,omitempty"`
 	KopiaSnapshot *string           `json:"kopiaSnapshot,omitempty"`
 }
 
-// ArtifactApplyConfiguration constructs an declarative configuration of the Artifact type for use with
+// ArtifactApplyConfiguration constructs a declarative configuration of the Artifact type for use with
 // apply.
 func Artifact() *ArtifactApplyConfiguration {
 	return &ArtifactApplyConfiguration{}

--- a/pkg/client/applyconfiguration/cr/v1alpha1/blueprint.go
+++ b/pkg/client/applyconfiguration/cr/v1alpha1/blueprint.go
@@ -24,7 +24,7 @@ import (
 	v1 "k8s.io/client-go/applyconfigurations/meta/v1"
 )
 
-// BlueprintApplyConfiguration represents an declarative configuration of the Blueprint type for use
+// BlueprintApplyConfiguration represents a declarative configuration of the Blueprint type for use
 // with apply.
 type BlueprintApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration    `json:",inline"`
@@ -32,7 +32,7 @@ type BlueprintApplyConfiguration struct {
 	Actions                          map[string]*v1alpha1.BlueprintAction `json:"actions,omitempty"`
 }
 
-// Blueprint constructs an declarative configuration of the Blueprint type for use with
+// Blueprint constructs a declarative configuration of the Blueprint type for use with
 // apply.
 func Blueprint(name, namespace string) *BlueprintApplyConfiguration {
 	b := &BlueprintApplyConfiguration{}
@@ -213,4 +213,10 @@ func (b *BlueprintApplyConfiguration) WithActions(entries map[string]*v1alpha1.B
 		b.Actions[k] = v
 	}
 	return b
+}
+
+// GetName retrieves the value of the Name field in the declarative configuration.
+func (b *BlueprintApplyConfiguration) GetName() *string {
+	b.ensureObjectMetaApplyConfigurationExists()
+	return b.Name
 }

--- a/pkg/client/applyconfiguration/cr/v1alpha1/blueprintaction.go
+++ b/pkg/client/applyconfiguration/cr/v1alpha1/blueprintaction.go
@@ -17,7 +17,7 @@ limitations under the License.
 
 package v1alpha1
 
-// BlueprintActionApplyConfiguration represents an declarative configuration of the BlueprintAction type for use
+// BlueprintActionApplyConfiguration represents a declarative configuration of the BlueprintAction type for use
 // with apply.
 type BlueprintActionApplyConfiguration struct {
 	Name               *string                               `json:"name,omitempty"`
@@ -30,7 +30,7 @@ type BlueprintActionApplyConfiguration struct {
 	DeferPhase         *BlueprintPhaseApplyConfiguration     `json:"deferPhase,omitempty"`
 }
 
-// BlueprintActionApplyConfiguration constructs an declarative configuration of the BlueprintAction type for use with
+// BlueprintActionApplyConfiguration constructs a declarative configuration of the BlueprintAction type for use with
 // apply.
 func BlueprintAction() *BlueprintActionApplyConfiguration {
 	return &BlueprintActionApplyConfiguration{}

--- a/pkg/client/applyconfiguration/cr/v1alpha1/blueprintphase.go
+++ b/pkg/client/applyconfiguration/cr/v1alpha1/blueprintphase.go
@@ -17,7 +17,7 @@ limitations under the License.
 
 package v1alpha1
 
-// BlueprintPhaseApplyConfiguration represents an declarative configuration of the BlueprintPhase type for use
+// BlueprintPhaseApplyConfiguration represents a declarative configuration of the BlueprintPhase type for use
 // with apply.
 type BlueprintPhaseApplyConfiguration struct {
 	Func       *string                                      `json:"func,omitempty"`
@@ -26,7 +26,7 @@ type BlueprintPhaseApplyConfiguration struct {
 	Args       map[string]interface{}                       `json:"args,omitempty"`
 }
 
-// BlueprintPhaseApplyConfiguration constructs an declarative configuration of the BlueprintPhase type for use with
+// BlueprintPhaseApplyConfiguration constructs a declarative configuration of the BlueprintPhase type for use with
 // apply.
 func BlueprintPhase() *BlueprintPhaseApplyConfiguration {
 	return &BlueprintPhaseApplyConfiguration{}

--- a/pkg/client/applyconfiguration/cr/v1alpha1/cachesizesettings.go
+++ b/pkg/client/applyconfiguration/cr/v1alpha1/cachesizesettings.go
@@ -17,14 +17,14 @@ limitations under the License.
 
 package v1alpha1
 
-// CacheSizeSettingsApplyConfiguration represents an declarative configuration of the CacheSizeSettings type for use
+// CacheSizeSettingsApplyConfiguration represents a declarative configuration of the CacheSizeSettings type for use
 // with apply.
 type CacheSizeSettingsApplyConfiguration struct {
 	Metadata *int `json:"metadata,omitempty"`
 	Content  *int `json:"content,omitempty"`
 }
 
-// CacheSizeSettingsApplyConfiguration constructs an declarative configuration of the CacheSizeSettings type for use with
+// CacheSizeSettingsApplyConfiguration constructs a declarative configuration of the CacheSizeSettings type for use with
 // apply.
 func CacheSizeSettings() *CacheSizeSettingsApplyConfiguration {
 	return &CacheSizeSettingsApplyConfiguration{}

--- a/pkg/client/applyconfiguration/cr/v1alpha1/configuration.go
+++ b/pkg/client/applyconfiguration/cr/v1alpha1/configuration.go
@@ -17,7 +17,7 @@ limitations under the License.
 
 package v1alpha1
 
-// ConfigurationApplyConfiguration represents an declarative configuration of the Configuration type for use
+// ConfigurationApplyConfiguration represents a declarative configuration of the Configuration type for use
 // with apply.
 type ConfigurationApplyConfiguration struct {
 	CacheDirectory *string `json:"cacheDirectory,omitempty"`
@@ -25,7 +25,7 @@ type ConfigurationApplyConfiguration struct {
 	ConfigFilePath *string `json:"configFilePath,omitempty"`
 }
 
-// ConfigurationApplyConfiguration constructs an declarative configuration of the Configuration type for use with
+// ConfigurationApplyConfiguration constructs a declarative configuration of the Configuration type for use with
 // apply.
 func Configuration() *ConfigurationApplyConfiguration {
 	return &ConfigurationApplyConfiguration{}

--- a/pkg/client/applyconfiguration/cr/v1alpha1/credential.go
+++ b/pkg/client/applyconfiguration/cr/v1alpha1/credential.go
@@ -21,7 +21,7 @@ import (
 	v1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 )
 
-// CredentialApplyConfiguration represents an declarative configuration of the Credential type for use
+// CredentialApplyConfiguration represents a declarative configuration of the Credential type for use
 // with apply.
 type CredentialApplyConfiguration struct {
 	Type              *v1alpha1.CredentialType             `json:"type,omitempty"`
@@ -30,7 +30,7 @@ type CredentialApplyConfiguration struct {
 	KopiaServerSecret *KopiaServerSecretApplyConfiguration `json:"kopiaServerSecret,omitempty"`
 }
 
-// CredentialApplyConfiguration constructs an declarative configuration of the Credential type for use with
+// CredentialApplyConfiguration constructs a declarative configuration of the Credential type for use with
 // apply.
 func Credential() *CredentialApplyConfiguration {
 	return &CredentialApplyConfiguration{}

--- a/pkg/client/applyconfiguration/cr/v1alpha1/error.go
+++ b/pkg/client/applyconfiguration/cr/v1alpha1/error.go
@@ -17,13 +17,13 @@ limitations under the License.
 
 package v1alpha1
 
-// ErrorApplyConfiguration represents an declarative configuration of the Error type for use
+// ErrorApplyConfiguration represents a declarative configuration of the Error type for use
 // with apply.
 type ErrorApplyConfiguration struct {
 	Message *string `json:"message,omitempty"`
 }
 
-// ErrorApplyConfiguration constructs an declarative configuration of the Error type for use with
+// ErrorApplyConfiguration constructs a declarative configuration of the Error type for use with
 // apply.
 func Error() *ErrorApplyConfiguration {
 	return &ErrorApplyConfiguration{}

--- a/pkg/client/applyconfiguration/cr/v1alpha1/keypair.go
+++ b/pkg/client/applyconfiguration/cr/v1alpha1/keypair.go
@@ -17,7 +17,7 @@ limitations under the License.
 
 package v1alpha1
 
-// KeyPairApplyConfiguration represents an declarative configuration of the KeyPair type for use
+// KeyPairApplyConfiguration represents a declarative configuration of the KeyPair type for use
 // with apply.
 type KeyPairApplyConfiguration struct {
 	IDField     *string                            `json:"idField,omitempty"`
@@ -25,7 +25,7 @@ type KeyPairApplyConfiguration struct {
 	Secret      *ObjectReferenceApplyConfiguration `json:"secret,omitempty"`
 }
 
-// KeyPairApplyConfiguration constructs an declarative configuration of the KeyPair type for use with
+// KeyPairApplyConfiguration constructs a declarative configuration of the KeyPair type for use with
 // apply.
 func KeyPair() *KeyPairApplyConfiguration {
 	return &KeyPairApplyConfiguration{}

--- a/pkg/client/applyconfiguration/cr/v1alpha1/kopiaserversecret.go
+++ b/pkg/client/applyconfiguration/cr/v1alpha1/kopiaserversecret.go
@@ -17,7 +17,7 @@ limitations under the License.
 
 package v1alpha1
 
-// KopiaServerSecretApplyConfiguration represents an declarative configuration of the KopiaServerSecret type for use
+// KopiaServerSecretApplyConfiguration represents a declarative configuration of the KopiaServerSecret type for use
 // with apply.
 type KopiaServerSecretApplyConfiguration struct {
 	Username       *string                                 `json:"username,omitempty"`
@@ -27,7 +27,7 @@ type KopiaServerSecretApplyConfiguration struct {
 	ConnectOptions map[string]int                          `json:"connectOptions,omitempty"`
 }
 
-// KopiaServerSecretApplyConfiguration constructs an declarative configuration of the KopiaServerSecret type for use with
+// KopiaServerSecretApplyConfiguration constructs a declarative configuration of the KopiaServerSecret type for use with
 // apply.
 func KopiaServerSecret() *KopiaServerSecretApplyConfiguration {
 	return &KopiaServerSecretApplyConfiguration{}

--- a/pkg/client/applyconfiguration/cr/v1alpha1/kopiaserversecretref.go
+++ b/pkg/client/applyconfiguration/cr/v1alpha1/kopiaserversecretref.go
@@ -17,14 +17,14 @@ limitations under the License.
 
 package v1alpha1
 
-// KopiaServerSecretRefApplyConfiguration represents an declarative configuration of the KopiaServerSecretRef type for use
+// KopiaServerSecretRefApplyConfiguration represents a declarative configuration of the KopiaServerSecretRef type for use
 // with apply.
 type KopiaServerSecretRefApplyConfiguration struct {
 	Key    *string                            `json:"key,omitempty"`
 	Secret *ObjectReferenceApplyConfiguration `json:"secret,omitempty"`
 }
 
-// KopiaServerSecretRefApplyConfiguration constructs an declarative configuration of the KopiaServerSecretRef type for use with
+// KopiaServerSecretRefApplyConfiguration constructs a declarative configuration of the KopiaServerSecretRef type for use with
 // apply.
 func KopiaServerSecretRef() *KopiaServerSecretRefApplyConfiguration {
 	return &KopiaServerSecretRefApplyConfiguration{}

--- a/pkg/client/applyconfiguration/cr/v1alpha1/location.go
+++ b/pkg/client/applyconfiguration/cr/v1alpha1/location.go
@@ -21,7 +21,7 @@ import (
 	v1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 )
 
-// LocationApplyConfiguration represents an declarative configuration of the Location type for use
+// LocationApplyConfiguration represents a declarative configuration of the Location type for use
 // with apply.
 type LocationApplyConfiguration struct {
 	Type     *v1alpha1.LocationType `json:"type,omitempty"`
@@ -31,7 +31,7 @@ type LocationApplyConfiguration struct {
 	Region   *string                `json:"region,omitempty"`
 }
 
-// LocationApplyConfiguration constructs an declarative configuration of the Location type for use with
+// LocationApplyConfiguration constructs a declarative configuration of the Location type for use with
 // apply.
 func Location() *LocationApplyConfiguration {
 	return &LocationApplyConfiguration{}

--- a/pkg/client/applyconfiguration/cr/v1alpha1/objectreference.go
+++ b/pkg/client/applyconfiguration/cr/v1alpha1/objectreference.go
@@ -17,7 +17,7 @@ limitations under the License.
 
 package v1alpha1
 
-// ObjectReferenceApplyConfiguration represents an declarative configuration of the ObjectReference type for use
+// ObjectReferenceApplyConfiguration represents a declarative configuration of the ObjectReference type for use
 // with apply.
 type ObjectReferenceApplyConfiguration struct {
 	APIVersion *string `json:"apiVersion,omitempty"`
@@ -28,7 +28,7 @@ type ObjectReferenceApplyConfiguration struct {
 	Namespace  *string `json:"namespace,omitempty"`
 }
 
-// ObjectReferenceApplyConfiguration constructs an declarative configuration of the ObjectReference type for use with
+// ObjectReferenceApplyConfiguration constructs a declarative configuration of the ObjectReference type for use with
 // apply.
 func ObjectReference() *ObjectReferenceApplyConfiguration {
 	return &ObjectReferenceApplyConfiguration{}

--- a/pkg/client/applyconfiguration/cr/v1alpha1/phase.go
+++ b/pkg/client/applyconfiguration/cr/v1alpha1/phase.go
@@ -21,7 +21,7 @@ import (
 	v1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 )
 
-// PhaseApplyConfiguration represents an declarative configuration of the Phase type for use
+// PhaseApplyConfiguration represents a declarative configuration of the Phase type for use
 // with apply.
 type PhaseApplyConfiguration struct {
 	Name     *string                          `json:"name,omitempty"`
@@ -30,7 +30,7 @@ type PhaseApplyConfiguration struct {
 	Progress *PhaseProgressApplyConfiguration `json:"progress,omitempty"`
 }
 
-// PhaseApplyConfiguration constructs an declarative configuration of the Phase type for use with
+// PhaseApplyConfiguration constructs a declarative configuration of the Phase type for use with
 // apply.
 func Phase() *PhaseApplyConfiguration {
 	return &PhaseApplyConfiguration{}

--- a/pkg/client/applyconfiguration/cr/v1alpha1/phaseprogress.go
+++ b/pkg/client/applyconfiguration/cr/v1alpha1/phaseprogress.go
@@ -21,7 +21,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// PhaseProgressApplyConfiguration represents an declarative configuration of the PhaseProgress type for use
+// PhaseProgressApplyConfiguration represents a declarative configuration of the PhaseProgress type for use
 // with apply.
 type PhaseProgressApplyConfiguration struct {
 	ProgressPercent        *string  `json:"progressPercent,omitempty"`
@@ -33,7 +33,7 @@ type PhaseProgressApplyConfiguration struct {
 	LastTransitionTime     *v1.Time `json:"lastTransitionTime,omitempty"`
 }
 
-// PhaseProgressApplyConfiguration constructs an declarative configuration of the PhaseProgress type for use with
+// PhaseProgressApplyConfiguration constructs a declarative configuration of the PhaseProgress type for use with
 // apply.
 func PhaseProgress() *PhaseProgressApplyConfiguration {
 	return &PhaseProgressApplyConfiguration{}

--- a/pkg/client/applyconfiguration/cr/v1alpha1/profile.go
+++ b/pkg/client/applyconfiguration/cr/v1alpha1/profile.go
@@ -23,7 +23,7 @@ import (
 	v1 "k8s.io/client-go/applyconfigurations/meta/v1"
 )
 
-// ProfileApplyConfiguration represents an declarative configuration of the Profile type for use
+// ProfileApplyConfiguration represents a declarative configuration of the Profile type for use
 // with apply.
 type ProfileApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration    `json:",inline"`
@@ -33,7 +33,7 @@ type ProfileApplyConfiguration struct {
 	SkipSSLVerify                    *bool                         `json:"skipSSLVerify,omitempty"`
 }
 
-// Profile constructs an declarative configuration of the Profile type for use with
+// Profile constructs a declarative configuration of the Profile type for use with
 // apply.
 func Profile(name, namespace string) *ProfileApplyConfiguration {
 	b := &ProfileApplyConfiguration{}
@@ -224,4 +224,10 @@ func (b *ProfileApplyConfiguration) WithCredential(value *CredentialApplyConfigu
 func (b *ProfileApplyConfiguration) WithSkipSSLVerify(value bool) *ProfileApplyConfiguration {
 	b.SkipSSLVerify = &value
 	return b
+}
+
+// GetName retrieves the value of the Name field in the declarative configuration.
+func (b *ProfileApplyConfiguration) GetName() *string {
+	b.ensureObjectMetaApplyConfigurationExists()
+	return b.Name
 }

--- a/pkg/client/applyconfiguration/cr/v1alpha1/repository.go
+++ b/pkg/client/applyconfiguration/cr/v1alpha1/repository.go
@@ -21,7 +21,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-// RepositoryApplyConfiguration represents an declarative configuration of the Repository type for use
+// RepositoryApplyConfiguration represents a declarative configuration of the Repository type for use
 // with apply.
 type RepositoryApplyConfiguration struct {
 	RootPath          *string                              `json:"rootPath,omitempty"`
@@ -32,7 +32,7 @@ type RepositoryApplyConfiguration struct {
 	Configuration     *ConfigurationApplyConfiguration     `json:"configuration,omitempty"`
 }
 
-// RepositoryApplyConfiguration constructs an declarative configuration of the Repository type for use with
+// RepositoryApplyConfiguration constructs a declarative configuration of the Repository type for use with
 // apply.
 func Repository() *RepositoryApplyConfiguration {
 	return &RepositoryApplyConfiguration{}

--- a/pkg/client/applyconfiguration/cr/v1alpha1/repositoryserver.go
+++ b/pkg/client/applyconfiguration/cr/v1alpha1/repositoryserver.go
@@ -23,7 +23,7 @@ import (
 	v1 "k8s.io/client-go/applyconfigurations/meta/v1"
 )
 
-// RepositoryServerApplyConfiguration represents an declarative configuration of the RepositoryServer type for use
+// RepositoryServerApplyConfiguration represents a declarative configuration of the RepositoryServer type for use
 // with apply.
 type RepositoryServerApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration    `json:",inline"`
@@ -32,7 +32,7 @@ type RepositoryServerApplyConfiguration struct {
 	Status                           *RepositoryServerStatusApplyConfiguration `json:"status,omitempty"`
 }
 
-// RepositoryServer constructs an declarative configuration of the RepositoryServer type for use with
+// RepositoryServer constructs a declarative configuration of the RepositoryServer type for use with
 // apply.
 func RepositoryServer(name, namespace string) *RepositoryServerApplyConfiguration {
 	b := &RepositoryServerApplyConfiguration{}
@@ -215,4 +215,10 @@ func (b *RepositoryServerApplyConfiguration) WithSpec(value *RepositoryServerSpe
 func (b *RepositoryServerApplyConfiguration) WithStatus(value *RepositoryServerStatusApplyConfiguration) *RepositoryServerApplyConfiguration {
 	b.Status = value
 	return b
+}
+
+// GetName retrieves the value of the Name field in the declarative configuration.
+func (b *RepositoryServerApplyConfiguration) GetName() *string {
+	b.ensureObjectMetaApplyConfigurationExists()
+	return b.Name
 }

--- a/pkg/client/applyconfiguration/cr/v1alpha1/repositoryserverspec.go
+++ b/pkg/client/applyconfiguration/cr/v1alpha1/repositoryserverspec.go
@@ -17,7 +17,7 @@ limitations under the License.
 
 package v1alpha1
 
-// RepositoryServerSpecApplyConfiguration represents an declarative configuration of the RepositoryServerSpec type for use
+// RepositoryServerSpecApplyConfiguration represents a declarative configuration of the RepositoryServerSpec type for use
 // with apply.
 type RepositoryServerSpecApplyConfiguration struct {
 	Storage    *StorageApplyConfiguration    `json:"storage,omitempty"`
@@ -25,7 +25,7 @@ type RepositoryServerSpecApplyConfiguration struct {
 	Server     *ServerApplyConfiguration     `json:"server,omitempty"`
 }
 
-// RepositoryServerSpecApplyConfiguration constructs an declarative configuration of the RepositoryServerSpec type for use with
+// RepositoryServerSpecApplyConfiguration constructs a declarative configuration of the RepositoryServerSpec type for use with
 // apply.
 func RepositoryServerSpec() *RepositoryServerSpecApplyConfiguration {
 	return &RepositoryServerSpecApplyConfiguration{}

--- a/pkg/client/applyconfiguration/cr/v1alpha1/repositoryserverstatus.go
+++ b/pkg/client/applyconfiguration/cr/v1alpha1/repositoryserverstatus.go
@@ -22,7 +22,7 @@ import (
 	v1 "k8s.io/client-go/applyconfigurations/meta/v1"
 )
 
-// RepositoryServerStatusApplyConfiguration represents an declarative configuration of the RepositoryServerStatus type for use
+// RepositoryServerStatusApplyConfiguration represents a declarative configuration of the RepositoryServerStatus type for use
 // with apply.
 type RepositoryServerStatusApplyConfiguration struct {
 	Conditions []v1.ConditionApplyConfiguration     `json:"conditions,omitempty"`
@@ -30,7 +30,7 @@ type RepositoryServerStatusApplyConfiguration struct {
 	Progress   *crv1alpha1.RepositoryServerProgress `json:"progress,omitempty"`
 }
 
-// RepositoryServerStatusApplyConfiguration constructs an declarative configuration of the RepositoryServerStatus type for use with
+// RepositoryServerStatusApplyConfiguration constructs a declarative configuration of the RepositoryServerStatus type for use with
 // apply.
 func RepositoryServerStatus() *RepositoryServerStatusApplyConfiguration {
 	return &RepositoryServerStatusApplyConfiguration{}

--- a/pkg/client/applyconfiguration/cr/v1alpha1/server.go
+++ b/pkg/client/applyconfiguration/cr/v1alpha1/server.go
@@ -21,7 +21,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-// ServerApplyConfiguration represents an declarative configuration of the Server type for use
+// ServerApplyConfiguration represents a declarative configuration of the Server type for use
 // with apply.
 type ServerApplyConfiguration struct {
 	UserAccess     *UserAccessApplyConfiguration `json:"userAccess,omitempty"`
@@ -29,7 +29,7 @@ type ServerApplyConfiguration struct {
 	TLSSecretRef   *v1.SecretReference           `json:"tlsSecretRef,omitempty"`
 }
 
-// ServerApplyConfiguration constructs an declarative configuration of the Server type for use with
+// ServerApplyConfiguration constructs a declarative configuration of the Server type for use with
 // apply.
 func Server() *ServerApplyConfiguration {
 	return &ServerApplyConfiguration{}

--- a/pkg/client/applyconfiguration/cr/v1alpha1/serverinfo.go
+++ b/pkg/client/applyconfiguration/cr/v1alpha1/serverinfo.go
@@ -17,14 +17,14 @@ limitations under the License.
 
 package v1alpha1
 
-// ServerInfoApplyConfiguration represents an declarative configuration of the ServerInfo type for use
+// ServerInfoApplyConfiguration represents a declarative configuration of the ServerInfo type for use
 // with apply.
 type ServerInfoApplyConfiguration struct {
 	PodName     *string `json:"podName,omitempty"`
 	ServiceName *string `json:"serviceName,omitempty"`
 }
 
-// ServerInfoApplyConfiguration constructs an declarative configuration of the ServerInfo type for use with
+// ServerInfoApplyConfiguration constructs a declarative configuration of the ServerInfo type for use with
 // apply.
 func ServerInfo() *ServerInfoApplyConfiguration {
 	return &ServerInfoApplyConfiguration{}

--- a/pkg/client/applyconfiguration/cr/v1alpha1/storage.go
+++ b/pkg/client/applyconfiguration/cr/v1alpha1/storage.go
@@ -21,14 +21,14 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-// StorageApplyConfiguration represents an declarative configuration of the Storage type for use
+// StorageApplyConfiguration represents a declarative configuration of the Storage type for use
 // with apply.
 type StorageApplyConfiguration struct {
 	SecretRef           *v1.SecretReference `json:"secretRef,omitempty"`
 	CredentialSecretRef *v1.SecretReference `json:"credentialSecretRef,omitempty"`
 }
 
-// StorageApplyConfiguration constructs an declarative configuration of the Storage type for use with
+// StorageApplyConfiguration constructs a declarative configuration of the Storage type for use with
 // apply.
 func Storage() *StorageApplyConfiguration {
 	return &StorageApplyConfiguration{}

--- a/pkg/client/applyconfiguration/cr/v1alpha1/useraccess.go
+++ b/pkg/client/applyconfiguration/cr/v1alpha1/useraccess.go
@@ -21,14 +21,14 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-// UserAccessApplyConfiguration represents an declarative configuration of the UserAccess type for use
+// UserAccessApplyConfiguration represents a declarative configuration of the UserAccess type for use
 // with apply.
 type UserAccessApplyConfiguration struct {
 	UserAccessSecretRef *v1.SecretReference `json:"userAccessSecretRef,omitempty"`
 	Username            *string             `json:"username,omitempty"`
 }
 
-// UserAccessApplyConfiguration constructs an declarative configuration of the UserAccess type for use with
+// UserAccessApplyConfiguration constructs a declarative configuration of the UserAccess type for use with
 // apply.
 func UserAccess() *UserAccessApplyConfiguration {
 	return &UserAccessApplyConfiguration{}

--- a/pkg/client/applyconfiguration/utils.go
+++ b/pkg/client/applyconfiguration/utils.go
@@ -20,7 +20,10 @@ package applyconfiguration
 import (
 	v1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/client/applyconfiguration/cr/v1alpha1"
+	internal "github.com/kanisterio/kanister/pkg/client/applyconfiguration/internal"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
+	testing "k8s.io/client-go/testing"
 )
 
 // ForKind returns an apply configuration type for the given GroupVersionKind, or nil if no
@@ -91,4 +94,8 @@ func ForKind(kind schema.GroupVersionKind) interface{} {
 
 	}
 	return nil
+}
+
+func NewTypeConverter(scheme *runtime.Scheme) *testing.TypeConverter {
+	return &testing.TypeConverter{Scheme: scheme, TypeResolver: internal.Parser()}
 }

--- a/pkg/client/clientset/versioned/fake/clientset_generated.go
+++ b/pkg/client/clientset/versioned/fake/clientset_generated.go
@@ -18,6 +18,7 @@ limitations under the License.
 package fake
 
 import (
+	applyconfiguration "github.com/kanisterio/kanister/pkg/client/applyconfiguration"
 	clientset "github.com/kanisterio/kanister/pkg/client/clientset/versioned"
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/client/clientset/versioned/typed/cr/v1alpha1"
 	fakecrv1alpha1 "github.com/kanisterio/kanister/pkg/client/clientset/versioned/typed/cr/v1alpha1/fake"
@@ -30,8 +31,12 @@ import (
 
 // NewSimpleClientset returns a clientset that will respond with the provided objects.
 // It's backed by a very simple object tracker that processes creates, updates and deletions as-is,
-// without applying any validations and/or defaults. It shouldn't be considered a replacement
+// without applying any field management, validations and/or defaults. It shouldn't be considered a replacement
 // for a real clientset and is mostly useful in simple unit tests.
+//
+// DEPRECATED: NewClientset replaces this with support for field management, which significantly improves
+// server side apply testing. NewClientset is only available when apply configurations are generated (e.g.
+// via --with-applyconfig).
 func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 	o := testing.NewObjectTracker(scheme, codecs.UniversalDecoder())
 	for _, obj := range objects {
@@ -71,6 +76,38 @@ func (c *Clientset) Discovery() discovery.DiscoveryInterface {
 
 func (c *Clientset) Tracker() testing.ObjectTracker {
 	return c.tracker
+}
+
+// NewClientset returns a clientset that will respond with the provided objects.
+// It's backed by a very simple object tracker that processes creates, updates and deletions as-is,
+// without applying any validations and/or defaults. It shouldn't be considered a replacement
+// for a real clientset and is mostly useful in simple unit tests.
+func NewClientset(objects ...runtime.Object) *Clientset {
+	o := testing.NewFieldManagedObjectTracker(
+		scheme,
+		codecs.UniversalDecoder(),
+		applyconfiguration.NewTypeConverter(scheme),
+	)
+	for _, obj := range objects {
+		if err := o.Add(obj); err != nil {
+			panic(err)
+		}
+	}
+
+	cs := &Clientset{tracker: o}
+	cs.discovery = &fakediscovery.FakeDiscovery{Fake: &cs.Fake}
+	cs.AddReactor("*", "*", testing.ObjectReaction(o))
+	cs.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
+		gvr := action.GetResource()
+		ns := action.GetNamespace()
+		watch, err := o.Watch(gvr, ns)
+		if err != nil {
+			return false, nil, err
+		}
+		return true, watch, nil
+	})
+
+	return cs
 }
 
 var (

--- a/pkg/client/clientset/versioned/typed/cr/v1alpha1/actionset.go
+++ b/pkg/client/clientset/versioned/typed/cr/v1alpha1/actionset.go
@@ -19,9 +19,6 @@ package v1alpha1
 
 import (
 	"context"
-	json "encoding/json"
-	"fmt"
-	"time"
 
 	v1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/client/applyconfiguration/cr/v1alpha1"
@@ -29,7 +26,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
-	rest "k8s.io/client-go/rest"
+	gentype "k8s.io/client-go/gentype"
 )
 
 // ActionSetsGetter has a method to return a ActionSetInterface.
@@ -54,154 +51,18 @@ type ActionSetInterface interface {
 
 // actionSets implements ActionSetInterface
 type actionSets struct {
-	client rest.Interface
-	ns     string
+	*gentype.ClientWithListAndApply[*v1alpha1.ActionSet, *v1alpha1.ActionSetList, *crv1alpha1.ActionSetApplyConfiguration]
 }
 
 // newActionSets returns a ActionSets
 func newActionSets(c *CrV1alpha1Client, namespace string) *actionSets {
 	return &actionSets{
-		client: c.RESTClient(),
-		ns:     namespace,
+		gentype.NewClientWithListAndApply[*v1alpha1.ActionSet, *v1alpha1.ActionSetList, *crv1alpha1.ActionSetApplyConfiguration](
+			"actionsets",
+			c.RESTClient(),
+			scheme.ParameterCodec,
+			namespace,
+			func() *v1alpha1.ActionSet { return &v1alpha1.ActionSet{} },
+			func() *v1alpha1.ActionSetList { return &v1alpha1.ActionSetList{} }),
 	}
-}
-
-// Get takes name of the actionSet, and returns the corresponding actionSet object, and an error if there is any.
-func (c *actionSets) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.ActionSet, err error) {
-	result = &v1alpha1.ActionSet{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("actionsets").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do(ctx).
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of ActionSets that match those selectors.
-func (c *actionSets) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.ActionSetList, err error) {
-	var timeout time.Duration
-	if opts.TimeoutSeconds != nil {
-		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
-	}
-	result = &v1alpha1.ActionSetList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("actionsets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do(ctx).
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested actionSets.
-func (c *actionSets) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
-	var timeout time.Duration
-	if opts.TimeoutSeconds != nil {
-		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
-	}
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("actionsets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch(ctx)
-}
-
-// Create takes the representation of a actionSet and creates it.  Returns the server's representation of the actionSet, and an error, if there is any.
-func (c *actionSets) Create(ctx context.Context, actionSet *v1alpha1.ActionSet, opts v1.CreateOptions) (result *v1alpha1.ActionSet, err error) {
-	result = &v1alpha1.ActionSet{}
-	err = c.client.Post().
-		Namespace(c.ns).
-		Resource("actionsets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Body(actionSet).
-		Do(ctx).
-		Into(result)
-	return
-}
-
-// Update takes the representation of a actionSet and updates it. Returns the server's representation of the actionSet, and an error, if there is any.
-func (c *actionSets) Update(ctx context.Context, actionSet *v1alpha1.ActionSet, opts v1.UpdateOptions) (result *v1alpha1.ActionSet, err error) {
-	result = &v1alpha1.ActionSet{}
-	err = c.client.Put().
-		Namespace(c.ns).
-		Resource("actionsets").
-		Name(actionSet.Name).
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Body(actionSet).
-		Do(ctx).
-		Into(result)
-	return
-}
-
-// Delete takes name of the actionSet and deletes it. Returns an error if one occurs.
-func (c *actionSets) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
-	return c.client.Delete().
-		Namespace(c.ns).
-		Resource("actionsets").
-		Name(name).
-		Body(&opts).
-		Do(ctx).
-		Error()
-}
-
-// DeleteCollection deletes a collection of objects.
-func (c *actionSets) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	var timeout time.Duration
-	if listOpts.TimeoutSeconds != nil {
-		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
-	}
-	return c.client.Delete().
-		Namespace(c.ns).
-		Resource("actionsets").
-		VersionedParams(&listOpts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Body(&opts).
-		Do(ctx).
-		Error()
-}
-
-// Patch applies the patch and returns the patched actionSet.
-func (c *actionSets) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.ActionSet, err error) {
-	result = &v1alpha1.ActionSet{}
-	err = c.client.Patch(pt).
-		Namespace(c.ns).
-		Resource("actionsets").
-		Name(name).
-		SubResource(subresources...).
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Body(data).
-		Do(ctx).
-		Into(result)
-	return
-}
-
-// Apply takes the given apply declarative configuration, applies it and returns the applied actionSet.
-func (c *actionSets) Apply(ctx context.Context, actionSet *crv1alpha1.ActionSetApplyConfiguration, opts v1.ApplyOptions) (result *v1alpha1.ActionSet, err error) {
-	if actionSet == nil {
-		return nil, fmt.Errorf("actionSet provided to Apply must not be nil")
-	}
-	patchOpts := opts.ToPatchOptions()
-	data, err := json.Marshal(actionSet)
-	if err != nil {
-		return nil, err
-	}
-	name := actionSet.Name
-	if name == nil {
-		return nil, fmt.Errorf("actionSet.Name must be provided to Apply")
-	}
-	result = &v1alpha1.ActionSet{}
-	err = c.client.Patch(types.ApplyPatchType).
-		Namespace(c.ns).
-		Resource("actionsets").
-		Name(*name).
-		VersionedParams(&patchOpts, scheme.ParameterCodec).
-		Body(data).
-		Do(ctx).
-		Into(result)
-	return
 }

--- a/pkg/client/clientset/versioned/typed/cr/v1alpha1/blueprint.go
+++ b/pkg/client/clientset/versioned/typed/cr/v1alpha1/blueprint.go
@@ -19,9 +19,6 @@ package v1alpha1
 
 import (
 	"context"
-	json "encoding/json"
-	"fmt"
-	"time"
 
 	v1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/client/applyconfiguration/cr/v1alpha1"
@@ -29,7 +26,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
-	rest "k8s.io/client-go/rest"
+	gentype "k8s.io/client-go/gentype"
 )
 
 // BlueprintsGetter has a method to return a BlueprintInterface.
@@ -54,154 +51,18 @@ type BlueprintInterface interface {
 
 // blueprints implements BlueprintInterface
 type blueprints struct {
-	client rest.Interface
-	ns     string
+	*gentype.ClientWithListAndApply[*v1alpha1.Blueprint, *v1alpha1.BlueprintList, *crv1alpha1.BlueprintApplyConfiguration]
 }
 
 // newBlueprints returns a Blueprints
 func newBlueprints(c *CrV1alpha1Client, namespace string) *blueprints {
 	return &blueprints{
-		client: c.RESTClient(),
-		ns:     namespace,
+		gentype.NewClientWithListAndApply[*v1alpha1.Blueprint, *v1alpha1.BlueprintList, *crv1alpha1.BlueprintApplyConfiguration](
+			"blueprints",
+			c.RESTClient(),
+			scheme.ParameterCodec,
+			namespace,
+			func() *v1alpha1.Blueprint { return &v1alpha1.Blueprint{} },
+			func() *v1alpha1.BlueprintList { return &v1alpha1.BlueprintList{} }),
 	}
-}
-
-// Get takes name of the blueprint, and returns the corresponding blueprint object, and an error if there is any.
-func (c *blueprints) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.Blueprint, err error) {
-	result = &v1alpha1.Blueprint{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("blueprints").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do(ctx).
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of Blueprints that match those selectors.
-func (c *blueprints) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.BlueprintList, err error) {
-	var timeout time.Duration
-	if opts.TimeoutSeconds != nil {
-		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
-	}
-	result = &v1alpha1.BlueprintList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("blueprints").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do(ctx).
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested blueprints.
-func (c *blueprints) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
-	var timeout time.Duration
-	if opts.TimeoutSeconds != nil {
-		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
-	}
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("blueprints").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch(ctx)
-}
-
-// Create takes the representation of a blueprint and creates it.  Returns the server's representation of the blueprint, and an error, if there is any.
-func (c *blueprints) Create(ctx context.Context, blueprint *v1alpha1.Blueprint, opts v1.CreateOptions) (result *v1alpha1.Blueprint, err error) {
-	result = &v1alpha1.Blueprint{}
-	err = c.client.Post().
-		Namespace(c.ns).
-		Resource("blueprints").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Body(blueprint).
-		Do(ctx).
-		Into(result)
-	return
-}
-
-// Update takes the representation of a blueprint and updates it. Returns the server's representation of the blueprint, and an error, if there is any.
-func (c *blueprints) Update(ctx context.Context, blueprint *v1alpha1.Blueprint, opts v1.UpdateOptions) (result *v1alpha1.Blueprint, err error) {
-	result = &v1alpha1.Blueprint{}
-	err = c.client.Put().
-		Namespace(c.ns).
-		Resource("blueprints").
-		Name(blueprint.Name).
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Body(blueprint).
-		Do(ctx).
-		Into(result)
-	return
-}
-
-// Delete takes name of the blueprint and deletes it. Returns an error if one occurs.
-func (c *blueprints) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
-	return c.client.Delete().
-		Namespace(c.ns).
-		Resource("blueprints").
-		Name(name).
-		Body(&opts).
-		Do(ctx).
-		Error()
-}
-
-// DeleteCollection deletes a collection of objects.
-func (c *blueprints) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	var timeout time.Duration
-	if listOpts.TimeoutSeconds != nil {
-		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
-	}
-	return c.client.Delete().
-		Namespace(c.ns).
-		Resource("blueprints").
-		VersionedParams(&listOpts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Body(&opts).
-		Do(ctx).
-		Error()
-}
-
-// Patch applies the patch and returns the patched blueprint.
-func (c *blueprints) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.Blueprint, err error) {
-	result = &v1alpha1.Blueprint{}
-	err = c.client.Patch(pt).
-		Namespace(c.ns).
-		Resource("blueprints").
-		Name(name).
-		SubResource(subresources...).
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Body(data).
-		Do(ctx).
-		Into(result)
-	return
-}
-
-// Apply takes the given apply declarative configuration, applies it and returns the applied blueprint.
-func (c *blueprints) Apply(ctx context.Context, blueprint *crv1alpha1.BlueprintApplyConfiguration, opts v1.ApplyOptions) (result *v1alpha1.Blueprint, err error) {
-	if blueprint == nil {
-		return nil, fmt.Errorf("blueprint provided to Apply must not be nil")
-	}
-	patchOpts := opts.ToPatchOptions()
-	data, err := json.Marshal(blueprint)
-	if err != nil {
-		return nil, err
-	}
-	name := blueprint.Name
-	if name == nil {
-		return nil, fmt.Errorf("blueprint.Name must be provided to Apply")
-	}
-	result = &v1alpha1.Blueprint{}
-	err = c.client.Patch(types.ApplyPatchType).
-		Namespace(c.ns).
-		Resource("blueprints").
-		Name(*name).
-		VersionedParams(&patchOpts, scheme.ParameterCodec).
-		Body(data).
-		Do(ctx).
-		Into(result)
-	return
 }

--- a/pkg/client/clientset/versioned/typed/cr/v1alpha1/fake/fake_actionset.go
+++ b/pkg/client/clientset/versioned/typed/cr/v1alpha1/fake/fake_actionset.go
@@ -43,22 +43,24 @@ var actionsetsKind = v1alpha1.SchemeGroupVersion.WithKind("ActionSet")
 
 // Get takes name of the actionSet, and returns the corresponding actionSet object, and an error if there is any.
 func (c *FakeActionSets) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.ActionSet, err error) {
+	emptyResult := &v1alpha1.ActionSet{}
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(actionsetsResource, c.ns, name), &v1alpha1.ActionSet{})
+		Invokes(testing.NewGetActionWithOptions(actionsetsResource, c.ns, name, options), emptyResult)
 
 	if obj == nil {
-		return nil, err
+		return emptyResult, err
 	}
 	return obj.(*v1alpha1.ActionSet), err
 }
 
 // List takes label and field selectors, and returns the list of ActionSets that match those selectors.
 func (c *FakeActionSets) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.ActionSetList, err error) {
+	emptyResult := &v1alpha1.ActionSetList{}
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(actionsetsResource, actionsetsKind, c.ns, opts), &v1alpha1.ActionSetList{})
+		Invokes(testing.NewListActionWithOptions(actionsetsResource, actionsetsKind, c.ns, opts), emptyResult)
 
 	if obj == nil {
-		return nil, err
+		return emptyResult, err
 	}
 
 	label, _, _ := testing.ExtractFromListOptions(opts)
@@ -77,28 +79,30 @@ func (c *FakeActionSets) List(ctx context.Context, opts v1.ListOptions) (result 
 // Watch returns a watch.Interface that watches the requested actionSets.
 func (c *FakeActionSets) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(actionsetsResource, c.ns, opts))
+		InvokesWatch(testing.NewWatchActionWithOptions(actionsetsResource, c.ns, opts))
 
 }
 
 // Create takes the representation of a actionSet and creates it.  Returns the server's representation of the actionSet, and an error, if there is any.
 func (c *FakeActionSets) Create(ctx context.Context, actionSet *v1alpha1.ActionSet, opts v1.CreateOptions) (result *v1alpha1.ActionSet, err error) {
+	emptyResult := &v1alpha1.ActionSet{}
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(actionsetsResource, c.ns, actionSet), &v1alpha1.ActionSet{})
+		Invokes(testing.NewCreateActionWithOptions(actionsetsResource, c.ns, actionSet, opts), emptyResult)
 
 	if obj == nil {
-		return nil, err
+		return emptyResult, err
 	}
 	return obj.(*v1alpha1.ActionSet), err
 }
 
 // Update takes the representation of a actionSet and updates it. Returns the server's representation of the actionSet, and an error, if there is any.
 func (c *FakeActionSets) Update(ctx context.Context, actionSet *v1alpha1.ActionSet, opts v1.UpdateOptions) (result *v1alpha1.ActionSet, err error) {
+	emptyResult := &v1alpha1.ActionSet{}
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(actionsetsResource, c.ns, actionSet), &v1alpha1.ActionSet{})
+		Invokes(testing.NewUpdateActionWithOptions(actionsetsResource, c.ns, actionSet, opts), emptyResult)
 
 	if obj == nil {
-		return nil, err
+		return emptyResult, err
 	}
 	return obj.(*v1alpha1.ActionSet), err
 }
@@ -113,7 +117,7 @@ func (c *FakeActionSets) Delete(ctx context.Context, name string, opts v1.Delete
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeActionSets) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(actionsetsResource, c.ns, listOpts)
+	action := testing.NewDeleteCollectionActionWithOptions(actionsetsResource, c.ns, opts, listOpts)
 
 	_, err := c.Fake.Invokes(action, &v1alpha1.ActionSetList{})
 	return err
@@ -121,11 +125,12 @@ func (c *FakeActionSets) DeleteCollection(ctx context.Context, opts v1.DeleteOpt
 
 // Patch applies the patch and returns the patched actionSet.
 func (c *FakeActionSets) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.ActionSet, err error) {
+	emptyResult := &v1alpha1.ActionSet{}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(actionsetsResource, c.ns, name, pt, data, subresources...), &v1alpha1.ActionSet{})
+		Invokes(testing.NewPatchSubresourceActionWithOptions(actionsetsResource, c.ns, name, pt, data, opts, subresources...), emptyResult)
 
 	if obj == nil {
-		return nil, err
+		return emptyResult, err
 	}
 	return obj.(*v1alpha1.ActionSet), err
 }
@@ -143,11 +148,12 @@ func (c *FakeActionSets) Apply(ctx context.Context, actionSet *crv1alpha1.Action
 	if name == nil {
 		return nil, fmt.Errorf("actionSet.Name must be provided to Apply")
 	}
+	emptyResult := &v1alpha1.ActionSet{}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(actionsetsResource, c.ns, *name, types.ApplyPatchType, data), &v1alpha1.ActionSet{})
+		Invokes(testing.NewPatchSubresourceActionWithOptions(actionsetsResource, c.ns, *name, types.ApplyPatchType, data, opts.ToPatchOptions()), emptyResult)
 
 	if obj == nil {
-		return nil, err
+		return emptyResult, err
 	}
 	return obj.(*v1alpha1.ActionSet), err
 }

--- a/pkg/client/clientset/versioned/typed/cr/v1alpha1/fake/fake_blueprint.go
+++ b/pkg/client/clientset/versioned/typed/cr/v1alpha1/fake/fake_blueprint.go
@@ -43,22 +43,24 @@ var blueprintsKind = v1alpha1.SchemeGroupVersion.WithKind("Blueprint")
 
 // Get takes name of the blueprint, and returns the corresponding blueprint object, and an error if there is any.
 func (c *FakeBlueprints) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.Blueprint, err error) {
+	emptyResult := &v1alpha1.Blueprint{}
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(blueprintsResource, c.ns, name), &v1alpha1.Blueprint{})
+		Invokes(testing.NewGetActionWithOptions(blueprintsResource, c.ns, name, options), emptyResult)
 
 	if obj == nil {
-		return nil, err
+		return emptyResult, err
 	}
 	return obj.(*v1alpha1.Blueprint), err
 }
 
 // List takes label and field selectors, and returns the list of Blueprints that match those selectors.
 func (c *FakeBlueprints) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.BlueprintList, err error) {
+	emptyResult := &v1alpha1.BlueprintList{}
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(blueprintsResource, blueprintsKind, c.ns, opts), &v1alpha1.BlueprintList{})
+		Invokes(testing.NewListActionWithOptions(blueprintsResource, blueprintsKind, c.ns, opts), emptyResult)
 
 	if obj == nil {
-		return nil, err
+		return emptyResult, err
 	}
 
 	label, _, _ := testing.ExtractFromListOptions(opts)
@@ -77,28 +79,30 @@ func (c *FakeBlueprints) List(ctx context.Context, opts v1.ListOptions) (result 
 // Watch returns a watch.Interface that watches the requested blueprints.
 func (c *FakeBlueprints) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(blueprintsResource, c.ns, opts))
+		InvokesWatch(testing.NewWatchActionWithOptions(blueprintsResource, c.ns, opts))
 
 }
 
 // Create takes the representation of a blueprint and creates it.  Returns the server's representation of the blueprint, and an error, if there is any.
 func (c *FakeBlueprints) Create(ctx context.Context, blueprint *v1alpha1.Blueprint, opts v1.CreateOptions) (result *v1alpha1.Blueprint, err error) {
+	emptyResult := &v1alpha1.Blueprint{}
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(blueprintsResource, c.ns, blueprint), &v1alpha1.Blueprint{})
+		Invokes(testing.NewCreateActionWithOptions(blueprintsResource, c.ns, blueprint, opts), emptyResult)
 
 	if obj == nil {
-		return nil, err
+		return emptyResult, err
 	}
 	return obj.(*v1alpha1.Blueprint), err
 }
 
 // Update takes the representation of a blueprint and updates it. Returns the server's representation of the blueprint, and an error, if there is any.
 func (c *FakeBlueprints) Update(ctx context.Context, blueprint *v1alpha1.Blueprint, opts v1.UpdateOptions) (result *v1alpha1.Blueprint, err error) {
+	emptyResult := &v1alpha1.Blueprint{}
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(blueprintsResource, c.ns, blueprint), &v1alpha1.Blueprint{})
+		Invokes(testing.NewUpdateActionWithOptions(blueprintsResource, c.ns, blueprint, opts), emptyResult)
 
 	if obj == nil {
-		return nil, err
+		return emptyResult, err
 	}
 	return obj.(*v1alpha1.Blueprint), err
 }
@@ -113,7 +117,7 @@ func (c *FakeBlueprints) Delete(ctx context.Context, name string, opts v1.Delete
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeBlueprints) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(blueprintsResource, c.ns, listOpts)
+	action := testing.NewDeleteCollectionActionWithOptions(blueprintsResource, c.ns, opts, listOpts)
 
 	_, err := c.Fake.Invokes(action, &v1alpha1.BlueprintList{})
 	return err
@@ -121,11 +125,12 @@ func (c *FakeBlueprints) DeleteCollection(ctx context.Context, opts v1.DeleteOpt
 
 // Patch applies the patch and returns the patched blueprint.
 func (c *FakeBlueprints) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.Blueprint, err error) {
+	emptyResult := &v1alpha1.Blueprint{}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(blueprintsResource, c.ns, name, pt, data, subresources...), &v1alpha1.Blueprint{})
+		Invokes(testing.NewPatchSubresourceActionWithOptions(blueprintsResource, c.ns, name, pt, data, opts, subresources...), emptyResult)
 
 	if obj == nil {
-		return nil, err
+		return emptyResult, err
 	}
 	return obj.(*v1alpha1.Blueprint), err
 }
@@ -143,11 +148,12 @@ func (c *FakeBlueprints) Apply(ctx context.Context, blueprint *crv1alpha1.Bluepr
 	if name == nil {
 		return nil, fmt.Errorf("blueprint.Name must be provided to Apply")
 	}
+	emptyResult := &v1alpha1.Blueprint{}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(blueprintsResource, c.ns, *name, types.ApplyPatchType, data), &v1alpha1.Blueprint{})
+		Invokes(testing.NewPatchSubresourceActionWithOptions(blueprintsResource, c.ns, *name, types.ApplyPatchType, data, opts.ToPatchOptions()), emptyResult)
 
 	if obj == nil {
-		return nil, err
+		return emptyResult, err
 	}
 	return obj.(*v1alpha1.Blueprint), err
 }

--- a/pkg/client/clientset/versioned/typed/cr/v1alpha1/fake/fake_profile.go
+++ b/pkg/client/clientset/versioned/typed/cr/v1alpha1/fake/fake_profile.go
@@ -43,22 +43,24 @@ var profilesKind = v1alpha1.SchemeGroupVersion.WithKind("Profile")
 
 // Get takes name of the profile, and returns the corresponding profile object, and an error if there is any.
 func (c *FakeProfiles) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.Profile, err error) {
+	emptyResult := &v1alpha1.Profile{}
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(profilesResource, c.ns, name), &v1alpha1.Profile{})
+		Invokes(testing.NewGetActionWithOptions(profilesResource, c.ns, name, options), emptyResult)
 
 	if obj == nil {
-		return nil, err
+		return emptyResult, err
 	}
 	return obj.(*v1alpha1.Profile), err
 }
 
 // List takes label and field selectors, and returns the list of Profiles that match those selectors.
 func (c *FakeProfiles) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.ProfileList, err error) {
+	emptyResult := &v1alpha1.ProfileList{}
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(profilesResource, profilesKind, c.ns, opts), &v1alpha1.ProfileList{})
+		Invokes(testing.NewListActionWithOptions(profilesResource, profilesKind, c.ns, opts), emptyResult)
 
 	if obj == nil {
-		return nil, err
+		return emptyResult, err
 	}
 
 	label, _, _ := testing.ExtractFromListOptions(opts)
@@ -77,28 +79,30 @@ func (c *FakeProfiles) List(ctx context.Context, opts v1.ListOptions) (result *v
 // Watch returns a watch.Interface that watches the requested profiles.
 func (c *FakeProfiles) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(profilesResource, c.ns, opts))
+		InvokesWatch(testing.NewWatchActionWithOptions(profilesResource, c.ns, opts))
 
 }
 
 // Create takes the representation of a profile and creates it.  Returns the server's representation of the profile, and an error, if there is any.
 func (c *FakeProfiles) Create(ctx context.Context, profile *v1alpha1.Profile, opts v1.CreateOptions) (result *v1alpha1.Profile, err error) {
+	emptyResult := &v1alpha1.Profile{}
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(profilesResource, c.ns, profile), &v1alpha1.Profile{})
+		Invokes(testing.NewCreateActionWithOptions(profilesResource, c.ns, profile, opts), emptyResult)
 
 	if obj == nil {
-		return nil, err
+		return emptyResult, err
 	}
 	return obj.(*v1alpha1.Profile), err
 }
 
 // Update takes the representation of a profile and updates it. Returns the server's representation of the profile, and an error, if there is any.
 func (c *FakeProfiles) Update(ctx context.Context, profile *v1alpha1.Profile, opts v1.UpdateOptions) (result *v1alpha1.Profile, err error) {
+	emptyResult := &v1alpha1.Profile{}
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(profilesResource, c.ns, profile), &v1alpha1.Profile{})
+		Invokes(testing.NewUpdateActionWithOptions(profilesResource, c.ns, profile, opts), emptyResult)
 
 	if obj == nil {
-		return nil, err
+		return emptyResult, err
 	}
 	return obj.(*v1alpha1.Profile), err
 }
@@ -113,7 +117,7 @@ func (c *FakeProfiles) Delete(ctx context.Context, name string, opts v1.DeleteOp
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeProfiles) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(profilesResource, c.ns, listOpts)
+	action := testing.NewDeleteCollectionActionWithOptions(profilesResource, c.ns, opts, listOpts)
 
 	_, err := c.Fake.Invokes(action, &v1alpha1.ProfileList{})
 	return err
@@ -121,11 +125,12 @@ func (c *FakeProfiles) DeleteCollection(ctx context.Context, opts v1.DeleteOptio
 
 // Patch applies the patch and returns the patched profile.
 func (c *FakeProfiles) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.Profile, err error) {
+	emptyResult := &v1alpha1.Profile{}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(profilesResource, c.ns, name, pt, data, subresources...), &v1alpha1.Profile{})
+		Invokes(testing.NewPatchSubresourceActionWithOptions(profilesResource, c.ns, name, pt, data, opts, subresources...), emptyResult)
 
 	if obj == nil {
-		return nil, err
+		return emptyResult, err
 	}
 	return obj.(*v1alpha1.Profile), err
 }
@@ -143,11 +148,12 @@ func (c *FakeProfiles) Apply(ctx context.Context, profile *crv1alpha1.ProfileApp
 	if name == nil {
 		return nil, fmt.Errorf("profile.Name must be provided to Apply")
 	}
+	emptyResult := &v1alpha1.Profile{}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(profilesResource, c.ns, *name, types.ApplyPatchType, data), &v1alpha1.Profile{})
+		Invokes(testing.NewPatchSubresourceActionWithOptions(profilesResource, c.ns, *name, types.ApplyPatchType, data, opts.ToPatchOptions()), emptyResult)
 
 	if obj == nil {
-		return nil, err
+		return emptyResult, err
 	}
 	return obj.(*v1alpha1.Profile), err
 }

--- a/pkg/client/clientset/versioned/typed/cr/v1alpha1/fake/fake_repositoryserver.go
+++ b/pkg/client/clientset/versioned/typed/cr/v1alpha1/fake/fake_repositoryserver.go
@@ -43,22 +43,24 @@ var repositoryserversKind = v1alpha1.SchemeGroupVersion.WithKind("RepositoryServ
 
 // Get takes name of the repositoryServer, and returns the corresponding repositoryServer object, and an error if there is any.
 func (c *FakeRepositoryServers) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.RepositoryServer, err error) {
+	emptyResult := &v1alpha1.RepositoryServer{}
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(repositoryserversResource, c.ns, name), &v1alpha1.RepositoryServer{})
+		Invokes(testing.NewGetActionWithOptions(repositoryserversResource, c.ns, name, options), emptyResult)
 
 	if obj == nil {
-		return nil, err
+		return emptyResult, err
 	}
 	return obj.(*v1alpha1.RepositoryServer), err
 }
 
 // List takes label and field selectors, and returns the list of RepositoryServers that match those selectors.
 func (c *FakeRepositoryServers) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.RepositoryServerList, err error) {
+	emptyResult := &v1alpha1.RepositoryServerList{}
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(repositoryserversResource, repositoryserversKind, c.ns, opts), &v1alpha1.RepositoryServerList{})
+		Invokes(testing.NewListActionWithOptions(repositoryserversResource, repositoryserversKind, c.ns, opts), emptyResult)
 
 	if obj == nil {
-		return nil, err
+		return emptyResult, err
 	}
 
 	label, _, _ := testing.ExtractFromListOptions(opts)
@@ -77,40 +79,43 @@ func (c *FakeRepositoryServers) List(ctx context.Context, opts v1.ListOptions) (
 // Watch returns a watch.Interface that watches the requested repositoryServers.
 func (c *FakeRepositoryServers) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(repositoryserversResource, c.ns, opts))
+		InvokesWatch(testing.NewWatchActionWithOptions(repositoryserversResource, c.ns, opts))
 
 }
 
 // Create takes the representation of a repositoryServer and creates it.  Returns the server's representation of the repositoryServer, and an error, if there is any.
 func (c *FakeRepositoryServers) Create(ctx context.Context, repositoryServer *v1alpha1.RepositoryServer, opts v1.CreateOptions) (result *v1alpha1.RepositoryServer, err error) {
+	emptyResult := &v1alpha1.RepositoryServer{}
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(repositoryserversResource, c.ns, repositoryServer), &v1alpha1.RepositoryServer{})
+		Invokes(testing.NewCreateActionWithOptions(repositoryserversResource, c.ns, repositoryServer, opts), emptyResult)
 
 	if obj == nil {
-		return nil, err
+		return emptyResult, err
 	}
 	return obj.(*v1alpha1.RepositoryServer), err
 }
 
 // Update takes the representation of a repositoryServer and updates it. Returns the server's representation of the repositoryServer, and an error, if there is any.
 func (c *FakeRepositoryServers) Update(ctx context.Context, repositoryServer *v1alpha1.RepositoryServer, opts v1.UpdateOptions) (result *v1alpha1.RepositoryServer, err error) {
+	emptyResult := &v1alpha1.RepositoryServer{}
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(repositoryserversResource, c.ns, repositoryServer), &v1alpha1.RepositoryServer{})
+		Invokes(testing.NewUpdateActionWithOptions(repositoryserversResource, c.ns, repositoryServer, opts), emptyResult)
 
 	if obj == nil {
-		return nil, err
+		return emptyResult, err
 	}
 	return obj.(*v1alpha1.RepositoryServer), err
 }
 
 // UpdateStatus was generated because the type contains a Status member.
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
-func (c *FakeRepositoryServers) UpdateStatus(ctx context.Context, repositoryServer *v1alpha1.RepositoryServer, opts v1.UpdateOptions) (*v1alpha1.RepositoryServer, error) {
+func (c *FakeRepositoryServers) UpdateStatus(ctx context.Context, repositoryServer *v1alpha1.RepositoryServer, opts v1.UpdateOptions) (result *v1alpha1.RepositoryServer, err error) {
+	emptyResult := &v1alpha1.RepositoryServer{}
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(repositoryserversResource, "status", c.ns, repositoryServer), &v1alpha1.RepositoryServer{})
+		Invokes(testing.NewUpdateSubresourceActionWithOptions(repositoryserversResource, "status", c.ns, repositoryServer, opts), emptyResult)
 
 	if obj == nil {
-		return nil, err
+		return emptyResult, err
 	}
 	return obj.(*v1alpha1.RepositoryServer), err
 }
@@ -125,7 +130,7 @@ func (c *FakeRepositoryServers) Delete(ctx context.Context, name string, opts v1
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeRepositoryServers) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(repositoryserversResource, c.ns, listOpts)
+	action := testing.NewDeleteCollectionActionWithOptions(repositoryserversResource, c.ns, opts, listOpts)
 
 	_, err := c.Fake.Invokes(action, &v1alpha1.RepositoryServerList{})
 	return err
@@ -133,11 +138,12 @@ func (c *FakeRepositoryServers) DeleteCollection(ctx context.Context, opts v1.De
 
 // Patch applies the patch and returns the patched repositoryServer.
 func (c *FakeRepositoryServers) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.RepositoryServer, err error) {
+	emptyResult := &v1alpha1.RepositoryServer{}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(repositoryserversResource, c.ns, name, pt, data, subresources...), &v1alpha1.RepositoryServer{})
+		Invokes(testing.NewPatchSubresourceActionWithOptions(repositoryserversResource, c.ns, name, pt, data, opts, subresources...), emptyResult)
 
 	if obj == nil {
-		return nil, err
+		return emptyResult, err
 	}
 	return obj.(*v1alpha1.RepositoryServer), err
 }
@@ -155,11 +161,12 @@ func (c *FakeRepositoryServers) Apply(ctx context.Context, repositoryServer *crv
 	if name == nil {
 		return nil, fmt.Errorf("repositoryServer.Name must be provided to Apply")
 	}
+	emptyResult := &v1alpha1.RepositoryServer{}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(repositoryserversResource, c.ns, *name, types.ApplyPatchType, data), &v1alpha1.RepositoryServer{})
+		Invokes(testing.NewPatchSubresourceActionWithOptions(repositoryserversResource, c.ns, *name, types.ApplyPatchType, data, opts.ToPatchOptions()), emptyResult)
 
 	if obj == nil {
-		return nil, err
+		return emptyResult, err
 	}
 	return obj.(*v1alpha1.RepositoryServer), err
 }
@@ -178,11 +185,12 @@ func (c *FakeRepositoryServers) ApplyStatus(ctx context.Context, repositoryServe
 	if name == nil {
 		return nil, fmt.Errorf("repositoryServer.Name must be provided to Apply")
 	}
+	emptyResult := &v1alpha1.RepositoryServer{}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(repositoryserversResource, c.ns, *name, types.ApplyPatchType, data, "status"), &v1alpha1.RepositoryServer{})
+		Invokes(testing.NewPatchSubresourceActionWithOptions(repositoryserversResource, c.ns, *name, types.ApplyPatchType, data, opts.ToPatchOptions(), "status"), emptyResult)
 
 	if obj == nil {
-		return nil, err
+		return emptyResult, err
 	}
 	return obj.(*v1alpha1.RepositoryServer), err
 }

--- a/pkg/client/clientset/versioned/typed/cr/v1alpha1/profile.go
+++ b/pkg/client/clientset/versioned/typed/cr/v1alpha1/profile.go
@@ -19,9 +19,6 @@ package v1alpha1
 
 import (
 	"context"
-	json "encoding/json"
-	"fmt"
-	"time"
 
 	v1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/client/applyconfiguration/cr/v1alpha1"
@@ -29,7 +26,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
-	rest "k8s.io/client-go/rest"
+	gentype "k8s.io/client-go/gentype"
 )
 
 // ProfilesGetter has a method to return a ProfileInterface.
@@ -54,154 +51,18 @@ type ProfileInterface interface {
 
 // profiles implements ProfileInterface
 type profiles struct {
-	client rest.Interface
-	ns     string
+	*gentype.ClientWithListAndApply[*v1alpha1.Profile, *v1alpha1.ProfileList, *crv1alpha1.ProfileApplyConfiguration]
 }
 
 // newProfiles returns a Profiles
 func newProfiles(c *CrV1alpha1Client, namespace string) *profiles {
 	return &profiles{
-		client: c.RESTClient(),
-		ns:     namespace,
+		gentype.NewClientWithListAndApply[*v1alpha1.Profile, *v1alpha1.ProfileList, *crv1alpha1.ProfileApplyConfiguration](
+			"profiles",
+			c.RESTClient(),
+			scheme.ParameterCodec,
+			namespace,
+			func() *v1alpha1.Profile { return &v1alpha1.Profile{} },
+			func() *v1alpha1.ProfileList { return &v1alpha1.ProfileList{} }),
 	}
-}
-
-// Get takes name of the profile, and returns the corresponding profile object, and an error if there is any.
-func (c *profiles) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.Profile, err error) {
-	result = &v1alpha1.Profile{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("profiles").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do(ctx).
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of Profiles that match those selectors.
-func (c *profiles) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.ProfileList, err error) {
-	var timeout time.Duration
-	if opts.TimeoutSeconds != nil {
-		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
-	}
-	result = &v1alpha1.ProfileList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("profiles").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do(ctx).
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested profiles.
-func (c *profiles) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
-	var timeout time.Duration
-	if opts.TimeoutSeconds != nil {
-		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
-	}
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("profiles").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch(ctx)
-}
-
-// Create takes the representation of a profile and creates it.  Returns the server's representation of the profile, and an error, if there is any.
-func (c *profiles) Create(ctx context.Context, profile *v1alpha1.Profile, opts v1.CreateOptions) (result *v1alpha1.Profile, err error) {
-	result = &v1alpha1.Profile{}
-	err = c.client.Post().
-		Namespace(c.ns).
-		Resource("profiles").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Body(profile).
-		Do(ctx).
-		Into(result)
-	return
-}
-
-// Update takes the representation of a profile and updates it. Returns the server's representation of the profile, and an error, if there is any.
-func (c *profiles) Update(ctx context.Context, profile *v1alpha1.Profile, opts v1.UpdateOptions) (result *v1alpha1.Profile, err error) {
-	result = &v1alpha1.Profile{}
-	err = c.client.Put().
-		Namespace(c.ns).
-		Resource("profiles").
-		Name(profile.Name).
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Body(profile).
-		Do(ctx).
-		Into(result)
-	return
-}
-
-// Delete takes name of the profile and deletes it. Returns an error if one occurs.
-func (c *profiles) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
-	return c.client.Delete().
-		Namespace(c.ns).
-		Resource("profiles").
-		Name(name).
-		Body(&opts).
-		Do(ctx).
-		Error()
-}
-
-// DeleteCollection deletes a collection of objects.
-func (c *profiles) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	var timeout time.Duration
-	if listOpts.TimeoutSeconds != nil {
-		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
-	}
-	return c.client.Delete().
-		Namespace(c.ns).
-		Resource("profiles").
-		VersionedParams(&listOpts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Body(&opts).
-		Do(ctx).
-		Error()
-}
-
-// Patch applies the patch and returns the patched profile.
-func (c *profiles) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.Profile, err error) {
-	result = &v1alpha1.Profile{}
-	err = c.client.Patch(pt).
-		Namespace(c.ns).
-		Resource("profiles").
-		Name(name).
-		SubResource(subresources...).
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Body(data).
-		Do(ctx).
-		Into(result)
-	return
-}
-
-// Apply takes the given apply declarative configuration, applies it and returns the applied profile.
-func (c *profiles) Apply(ctx context.Context, profile *crv1alpha1.ProfileApplyConfiguration, opts v1.ApplyOptions) (result *v1alpha1.Profile, err error) {
-	if profile == nil {
-		return nil, fmt.Errorf("profile provided to Apply must not be nil")
-	}
-	patchOpts := opts.ToPatchOptions()
-	data, err := json.Marshal(profile)
-	if err != nil {
-		return nil, err
-	}
-	name := profile.Name
-	if name == nil {
-		return nil, fmt.Errorf("profile.Name must be provided to Apply")
-	}
-	result = &v1alpha1.Profile{}
-	err = c.client.Patch(types.ApplyPatchType).
-		Namespace(c.ns).
-		Resource("profiles").
-		Name(*name).
-		VersionedParams(&patchOpts, scheme.ParameterCodec).
-		Body(data).
-		Do(ctx).
-		Into(result)
-	return
 }

--- a/pkg/client/clientset/versioned/typed/cr/v1alpha1/repositoryserver.go
+++ b/pkg/client/clientset/versioned/typed/cr/v1alpha1/repositoryserver.go
@@ -19,9 +19,6 @@ package v1alpha1
 
 import (
 	"context"
-	json "encoding/json"
-	"fmt"
-	"time"
 
 	v1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/client/applyconfiguration/cr/v1alpha1"
@@ -29,7 +26,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
-	rest "k8s.io/client-go/rest"
+	gentype "k8s.io/client-go/gentype"
 )
 
 // RepositoryServersGetter has a method to return a RepositoryServerInterface.
@@ -42,6 +39,7 @@ type RepositoryServersGetter interface {
 type RepositoryServerInterface interface {
 	Create(ctx context.Context, repositoryServer *v1alpha1.RepositoryServer, opts v1.CreateOptions) (*v1alpha1.RepositoryServer, error)
 	Update(ctx context.Context, repositoryServer *v1alpha1.RepositoryServer, opts v1.UpdateOptions) (*v1alpha1.RepositoryServer, error)
+	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, repositoryServer *v1alpha1.RepositoryServer, opts v1.UpdateOptions) (*v1alpha1.RepositoryServer, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
@@ -50,206 +48,25 @@ type RepositoryServerInterface interface {
 	Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error)
 	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.RepositoryServer, err error)
 	Apply(ctx context.Context, repositoryServer *crv1alpha1.RepositoryServerApplyConfiguration, opts v1.ApplyOptions) (result *v1alpha1.RepositoryServer, err error)
+	// Add a +genclient:noStatus comment above the type to avoid generating ApplyStatus().
 	ApplyStatus(ctx context.Context, repositoryServer *crv1alpha1.RepositoryServerApplyConfiguration, opts v1.ApplyOptions) (result *v1alpha1.RepositoryServer, err error)
 	RepositoryServerExpansion
 }
 
 // repositoryServers implements RepositoryServerInterface
 type repositoryServers struct {
-	client rest.Interface
-	ns     string
+	*gentype.ClientWithListAndApply[*v1alpha1.RepositoryServer, *v1alpha1.RepositoryServerList, *crv1alpha1.RepositoryServerApplyConfiguration]
 }
 
 // newRepositoryServers returns a RepositoryServers
 func newRepositoryServers(c *CrV1alpha1Client, namespace string) *repositoryServers {
 	return &repositoryServers{
-		client: c.RESTClient(),
-		ns:     namespace,
+		gentype.NewClientWithListAndApply[*v1alpha1.RepositoryServer, *v1alpha1.RepositoryServerList, *crv1alpha1.RepositoryServerApplyConfiguration](
+			"repositoryservers",
+			c.RESTClient(),
+			scheme.ParameterCodec,
+			namespace,
+			func() *v1alpha1.RepositoryServer { return &v1alpha1.RepositoryServer{} },
+			func() *v1alpha1.RepositoryServerList { return &v1alpha1.RepositoryServerList{} }),
 	}
-}
-
-// Get takes name of the repositoryServer, and returns the corresponding repositoryServer object, and an error if there is any.
-func (c *repositoryServers) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.RepositoryServer, err error) {
-	result = &v1alpha1.RepositoryServer{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("repositoryservers").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do(ctx).
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of RepositoryServers that match those selectors.
-func (c *repositoryServers) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.RepositoryServerList, err error) {
-	var timeout time.Duration
-	if opts.TimeoutSeconds != nil {
-		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
-	}
-	result = &v1alpha1.RepositoryServerList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("repositoryservers").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do(ctx).
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested repositoryServers.
-func (c *repositoryServers) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
-	var timeout time.Duration
-	if opts.TimeoutSeconds != nil {
-		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
-	}
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("repositoryservers").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch(ctx)
-}
-
-// Create takes the representation of a repositoryServer and creates it.  Returns the server's representation of the repositoryServer, and an error, if there is any.
-func (c *repositoryServers) Create(ctx context.Context, repositoryServer *v1alpha1.RepositoryServer, opts v1.CreateOptions) (result *v1alpha1.RepositoryServer, err error) {
-	result = &v1alpha1.RepositoryServer{}
-	err = c.client.Post().
-		Namespace(c.ns).
-		Resource("repositoryservers").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Body(repositoryServer).
-		Do(ctx).
-		Into(result)
-	return
-}
-
-// Update takes the representation of a repositoryServer and updates it. Returns the server's representation of the repositoryServer, and an error, if there is any.
-func (c *repositoryServers) Update(ctx context.Context, repositoryServer *v1alpha1.RepositoryServer, opts v1.UpdateOptions) (result *v1alpha1.RepositoryServer, err error) {
-	result = &v1alpha1.RepositoryServer{}
-	err = c.client.Put().
-		Namespace(c.ns).
-		Resource("repositoryservers").
-		Name(repositoryServer.Name).
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Body(repositoryServer).
-		Do(ctx).
-		Into(result)
-	return
-}
-
-// UpdateStatus was generated because the type contains a Status member.
-// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
-func (c *repositoryServers) UpdateStatus(ctx context.Context, repositoryServer *v1alpha1.RepositoryServer, opts v1.UpdateOptions) (result *v1alpha1.RepositoryServer, err error) {
-	result = &v1alpha1.RepositoryServer{}
-	err = c.client.Put().
-		Namespace(c.ns).
-		Resource("repositoryservers").
-		Name(repositoryServer.Name).
-		SubResource("status").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Body(repositoryServer).
-		Do(ctx).
-		Into(result)
-	return
-}
-
-// Delete takes name of the repositoryServer and deletes it. Returns an error if one occurs.
-func (c *repositoryServers) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
-	return c.client.Delete().
-		Namespace(c.ns).
-		Resource("repositoryservers").
-		Name(name).
-		Body(&opts).
-		Do(ctx).
-		Error()
-}
-
-// DeleteCollection deletes a collection of objects.
-func (c *repositoryServers) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	var timeout time.Duration
-	if listOpts.TimeoutSeconds != nil {
-		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
-	}
-	return c.client.Delete().
-		Namespace(c.ns).
-		Resource("repositoryservers").
-		VersionedParams(&listOpts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Body(&opts).
-		Do(ctx).
-		Error()
-}
-
-// Patch applies the patch and returns the patched repositoryServer.
-func (c *repositoryServers) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.RepositoryServer, err error) {
-	result = &v1alpha1.RepositoryServer{}
-	err = c.client.Patch(pt).
-		Namespace(c.ns).
-		Resource("repositoryservers").
-		Name(name).
-		SubResource(subresources...).
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Body(data).
-		Do(ctx).
-		Into(result)
-	return
-}
-
-// Apply takes the given apply declarative configuration, applies it and returns the applied repositoryServer.
-func (c *repositoryServers) Apply(ctx context.Context, repositoryServer *crv1alpha1.RepositoryServerApplyConfiguration, opts v1.ApplyOptions) (result *v1alpha1.RepositoryServer, err error) {
-	if repositoryServer == nil {
-		return nil, fmt.Errorf("repositoryServer provided to Apply must not be nil")
-	}
-	patchOpts := opts.ToPatchOptions()
-	data, err := json.Marshal(repositoryServer)
-	if err != nil {
-		return nil, err
-	}
-	name := repositoryServer.Name
-	if name == nil {
-		return nil, fmt.Errorf("repositoryServer.Name must be provided to Apply")
-	}
-	result = &v1alpha1.RepositoryServer{}
-	err = c.client.Patch(types.ApplyPatchType).
-		Namespace(c.ns).
-		Resource("repositoryservers").
-		Name(*name).
-		VersionedParams(&patchOpts, scheme.ParameterCodec).
-		Body(data).
-		Do(ctx).
-		Into(result)
-	return
-}
-
-// ApplyStatus was generated because the type contains a Status member.
-// Add a +genclient:noStatus comment above the type to avoid generating ApplyStatus().
-func (c *repositoryServers) ApplyStatus(ctx context.Context, repositoryServer *crv1alpha1.RepositoryServerApplyConfiguration, opts v1.ApplyOptions) (result *v1alpha1.RepositoryServer, err error) {
-	if repositoryServer == nil {
-		return nil, fmt.Errorf("repositoryServer provided to Apply must not be nil")
-	}
-	patchOpts := opts.ToPatchOptions()
-	data, err := json.Marshal(repositoryServer)
-	if err != nil {
-		return nil, err
-	}
-
-	name := repositoryServer.Name
-	if name == nil {
-		return nil, fmt.Errorf("repositoryServer.Name must be provided to Apply")
-	}
-
-	result = &v1alpha1.RepositoryServer{}
-	err = c.client.Patch(types.ApplyPatchType).
-		Namespace(c.ns).
-		Resource("repositoryservers").
-		Name(*name).
-		SubResource("status").
-		VersionedParams(&patchOpts, scheme.ParameterCodec).
-		Body(data).
-		Do(ctx).
-		Into(result)
-	return
 }

--- a/pkg/client/informers/externalversions/factory.go
+++ b/pkg/client/informers/externalversions/factory.go
@@ -227,6 +227,7 @@ type SharedInformerFactory interface {
 
 	// Start initializes all requested informers. They are handled in goroutines
 	// which run until the stop channel gets closed.
+	// Warning: Start does not block. When run in a go-routine, it will race with a later WaitForCacheSync.
 	Start(stopCh <-chan struct{})
 
 	// Shutdown marks a factory as shutting down. At that point no new

--- a/pkg/client/listers/cr/v1alpha1/profile.go
+++ b/pkg/client/listers/cr/v1alpha1/profile.go
@@ -19,8 +19,8 @@ package v1alpha1
 
 import (
 	v1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/listers"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -37,25 +37,17 @@ type ProfileLister interface {
 
 // profileLister implements the ProfileLister interface.
 type profileLister struct {
-	indexer cache.Indexer
+	listers.ResourceIndexer[*v1alpha1.Profile]
 }
 
 // NewProfileLister returns a new ProfileLister.
 func NewProfileLister(indexer cache.Indexer) ProfileLister {
-	return &profileLister{indexer: indexer}
-}
-
-// List lists all Profiles in the indexer.
-func (s *profileLister) List(selector labels.Selector) (ret []*v1alpha1.Profile, err error) {
-	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
-		ret = append(ret, m.(*v1alpha1.Profile))
-	})
-	return ret, err
+	return &profileLister{listers.New[*v1alpha1.Profile](indexer, v1alpha1.Resource("profile"))}
 }
 
 // Profiles returns an object that can list and get Profiles.
 func (s *profileLister) Profiles(namespace string) ProfileNamespaceLister {
-	return profileNamespaceLister{indexer: s.indexer, namespace: namespace}
+	return profileNamespaceLister{listers.NewNamespaced[*v1alpha1.Profile](s.ResourceIndexer, namespace)}
 }
 
 // ProfileNamespaceLister helps list and get Profiles.
@@ -73,26 +65,5 @@ type ProfileNamespaceLister interface {
 // profileNamespaceLister implements the ProfileNamespaceLister
 // interface.
 type profileNamespaceLister struct {
-	indexer   cache.Indexer
-	namespace string
-}
-
-// List lists all Profiles in the indexer for a given namespace.
-func (s profileNamespaceLister) List(selector labels.Selector) (ret []*v1alpha1.Profile, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
-		ret = append(ret, m.(*v1alpha1.Profile))
-	})
-	return ret, err
-}
-
-// Get retrieves the Profile from the indexer for a given namespace and name.
-func (s profileNamespaceLister) Get(name string) (*v1alpha1.Profile, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
-	if err != nil {
-		return nil, err
-	}
-	if !exists {
-		return nil, errors.NewNotFound(v1alpha1.Resource("profile"), name)
-	}
-	return obj.(*v1alpha1.Profile), nil
+	listers.ResourceIndexer[*v1alpha1.Profile]
 }

--- a/pkg/client/listers/cr/v1alpha1/repositoryserver.go
+++ b/pkg/client/listers/cr/v1alpha1/repositoryserver.go
@@ -19,8 +19,8 @@ package v1alpha1
 
 import (
 	v1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/listers"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -37,25 +37,17 @@ type RepositoryServerLister interface {
 
 // repositoryServerLister implements the RepositoryServerLister interface.
 type repositoryServerLister struct {
-	indexer cache.Indexer
+	listers.ResourceIndexer[*v1alpha1.RepositoryServer]
 }
 
 // NewRepositoryServerLister returns a new RepositoryServerLister.
 func NewRepositoryServerLister(indexer cache.Indexer) RepositoryServerLister {
-	return &repositoryServerLister{indexer: indexer}
-}
-
-// List lists all RepositoryServers in the indexer.
-func (s *repositoryServerLister) List(selector labels.Selector) (ret []*v1alpha1.RepositoryServer, err error) {
-	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
-		ret = append(ret, m.(*v1alpha1.RepositoryServer))
-	})
-	return ret, err
+	return &repositoryServerLister{listers.New[*v1alpha1.RepositoryServer](indexer, v1alpha1.Resource("repositoryserver"))}
 }
 
 // RepositoryServers returns an object that can list and get RepositoryServers.
 func (s *repositoryServerLister) RepositoryServers(namespace string) RepositoryServerNamespaceLister {
-	return repositoryServerNamespaceLister{indexer: s.indexer, namespace: namespace}
+	return repositoryServerNamespaceLister{listers.NewNamespaced[*v1alpha1.RepositoryServer](s.ResourceIndexer, namespace)}
 }
 
 // RepositoryServerNamespaceLister helps list and get RepositoryServers.
@@ -73,26 +65,5 @@ type RepositoryServerNamespaceLister interface {
 // repositoryServerNamespaceLister implements the RepositoryServerNamespaceLister
 // interface.
 type repositoryServerNamespaceLister struct {
-	indexer   cache.Indexer
-	namespace string
-}
-
-// List lists all RepositoryServers in the indexer for a given namespace.
-func (s repositoryServerNamespaceLister) List(selector labels.Selector) (ret []*v1alpha1.RepositoryServer, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
-		ret = append(ret, m.(*v1alpha1.RepositoryServer))
-	})
-	return ret, err
-}
-
-// Get retrieves the RepositoryServer from the indexer for a given namespace and name.
-func (s repositoryServerNamespaceLister) Get(name string) (*v1alpha1.RepositoryServer, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
-	if err != nil {
-		return nil, err
-	}
-	if !exists {
-		return nil, errors.NewNotFound(v1alpha1.Resource("repositoryserver"), name)
-	}
-	return obj.(*v1alpha1.RepositoryServer), nil
+	listers.ResourceIndexer[*v1alpha1.RepositoryServer]
 }

--- a/pkg/param/param.go
+++ b/pkg/param/param.go
@@ -59,9 +59,13 @@ type TemplateParams struct {
 	Object           map[string]interface{}
 	Phases           map[string]*Phase
 	DeferPhase       *Phase
-	PodOverride      crv1alpha1.JSONMap
-	PodAnnotations   map[string]string
-	PodLabels        map[string]string
+	// PhasePodOverrides should be used to access pod override in a phase function
+	// using CurrentPhase value
+	PhasePodOverrides map[string]crv1alpha1.JSONMap
+	// PodOverride field should not be used and will be deprecated
+	PodOverride    crv1alpha1.JSONMap
+	PodAnnotations map[string]string
+	PodLabels      map[string]string
 }
 
 // DeploymentConfigParams are params for deploymentconfig, will be used if working on open shift cluster
@@ -194,16 +198,17 @@ func New(ctx context.Context, cli kubernetes.Interface, dynCli dynamic.Interface
 	}
 	now := time.Now().UTC()
 	tp := TemplateParams{
-		ArtifactsIn:      as.Artifacts,
-		ConfigMaps:       cms,
-		Secrets:          secrets,
-		Profile:          prof,
-		RepositoryServer: repoServer,
-		Time:             now.Format(timeFormat),
-		Options:          as.Options,
-		PodOverride:      as.PodOverride,
-		PodAnnotations:   as.PodAnnotations,
-		PodLabels:        as.PodLabels,
+		ArtifactsIn:       as.Artifacts,
+		ConfigMaps:        cms,
+		Secrets:           secrets,
+		Profile:           prof,
+		RepositoryServer:  repoServer,
+		Time:              now.Format(timeFormat),
+		Options:           as.Options,
+		PhasePodOverrides: as.PhasePodOverrides,
+		PodOverride:       as.PodOverride,
+		PodAnnotations:    as.PodAnnotations,
+		PodLabels:         as.PodLabels,
 	}
 	var gvr schema.GroupVersionResource
 	namespace := as.Object.Namespace


### PR DESCRIPTION
## Change Overview

Currently if ActionSet has multiple phases, all of them will use the same podOverride.

This change allows setting override per phase.

phasePodOverrides is a map with keys being phase names and values being overrides.
podOverride now should be deprecated, but until it's removed it will be used as default
unless phasePodOverride is defined for a specific phase

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [x] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :building_construction: Build

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
