### PR TITLE
test: E: Add command-line unit tests for KanX commands under Kan-Do

### DIFF
--- a/pkg/kando/kanx_cmd_test.go
+++ b/pkg/kando/kanx_cmd_test.go
@@ -1,0 +1,97 @@
+package kando
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) { TestingT(t) }
+
+type KanXCmdSuite struct{}
+
+var _ = Suite(&KanXCmdSuite{})
+
+func startServer(ctx context.Context, addr string, stdout, stderr io.Writer) error {
+	rc := newRootCommand()
+	rc.SetArgs([]string{"process", "server", "-a", addr})
+	rc.SetOut(stdout)
+	rc.SetErr(stderr)
+	return rc.ExecuteContext(ctx)
+}
+
+func waitSock(ctx context.Context, addr string) error {
+	lst, err := os.Lstat(addr)
+	for ctx.Err() == nil && (err != nil || lst.Mode()&os.ModeSocket == 0) {
+		lst, err = os.Lstat(addr)
+	}
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	return err
+}
+
+func (s *KanXCmdSuite) TestProcessServer(c *C) {
+	addr := c.MkDir() + "/kanister.sock"
+	ctx, can := context.WithCancel(context.Background())
+	rc := newRootCommand()
+	rc.SetArgs([]string{"process", "server", "-a", addr})
+	go func() {
+		err := rc.ExecuteContext(ctx)
+		c.Assert(err, IsNil)
+	}()
+	err := waitSock(ctx, addr)
+	c.Assert(err, IsNil)
+	can()
+}
+
+type ProcessResult struct {
+	Pid   string `json:"pid"`
+	State string `json:"state"`
+}
+
+func (s *KanXCmdSuite) TestProcessClient(c *C) {
+	addr := c.MkDir() + "/kanister.sock"
+	ctx, can := context.WithCancel(context.Background())
+	defer can()
+	go func() {
+		err := startServer(ctx, addr, nil, nil)
+		c.Assert(err, IsNil)
+	}()
+	err := waitSock(ctx, addr)
+	c.Assert(err, IsNil)
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	rc := newRootCommand()
+	rc.SetErr(stderr)
+	rc.SetOut(stdout)
+	rc.SetArgs([]string{"process", "client", "--as-json", "-a", addr, "create", "sleep", "2s"})
+	// create command to test
+	err = rc.ExecuteContext(ctx)
+	c.Assert(err, IsNil)
+	stdouts := stdout.String()
+	stderrs := stderr.String()
+	pr := &ProcessResult{}
+	err = json.Unmarshal([]byte(stdouts), pr)
+	c.Assert(err, IsNil)
+	c.Assert(stderrs, Equals, "")
+	// get output
+	stdout.Reset()
+	stderr.Reset()
+	rc = newRootCommand()
+	rc.SetErr(stderr)
+	rc.SetOut(stdout)
+	rc.SetArgs([]string{"process", "client", "-a", addr, "output", pr.Pid})
+	err = rc.ExecuteContext(ctx)
+	c.Assert(err, IsNil)
+	stdouts = stdout.String()
+	stderrs = stderr.String()
+	c.Assert(stdouts, Equals, "")
+	c.Assert(stderrs, Equals, "")
+}

--- a/pkg/kando/kanx_cmd_test.go
+++ b/pkg/kando/kanx_cmd_test.go
@@ -56,7 +56,7 @@ type ProcessResult struct {
 	State string `json:"state"`
 }
 
-func executeCommand(c *C, ctx context.Context, stdout, stderr io.Writer, args ...string) error {
+func executeCommand(ctx context.Context, stdout, stderr io.Writer, args ...string) error {
 	rc := newRootCommand()
 	rc.SetErr(stderr)
 	rc.SetOut(stdout)
@@ -64,10 +64,10 @@ func executeCommand(c *C, ctx context.Context, stdout, stderr io.Writer, args ..
 	return rc.ExecuteContext(ctx)
 }
 
-func executeCommandWithReset(c *C, ctx context.Context, stdout, stderr *bytes.Buffer, args ...string) error {
+func executeCommandWithReset(ctx context.Context, stdout, stderr *bytes.Buffer, args ...string) error {
 	stdout.Reset()
 	stderr.Reset()
-	return executeCommand(c, ctx, stdout, stderr, args...)
+	return executeCommand(ctx, stdout, stderr, args...)
 }
 
 func (s *KanXCmdSuite) TestProcessClientCreate(c *C) {
@@ -82,14 +82,14 @@ func (s *KanXCmdSuite) TestProcessClientCreate(c *C) {
 	c.Assert(err, IsNil)
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
-	err = executeCommand(c, ctx, stdout, stderr, "process", "client", "--as-json", "-a", addr, "create", "sleep", "2s")
+	err = executeCommand(ctx, stdout, stderr, "process", "client", "--as-json", "-a", addr, "create", "sleep", "2s")
 	c.Assert(err, IsNil)
 	pr := &ProcessResult{}
-	err = json.Unmarshal([]byte(stdout.String()), pr)
+	err = json.Unmarshal(stdout.Bytes(), pr)
 	c.Assert(err, IsNil)
 	c.Assert(stderr.String(), Equals, "")
 	// get output
-	err = executeCommandWithReset(c, ctx, stdout, stderr, "process", "client", "-a", addr, "output", pr.Pid)
+	err = executeCommandWithReset(ctx, stdout, stderr, "process", "client", "-a", addr, "output", pr.Pid)
 	c.Assert(err, IsNil)
 	c.Assert(stdout.String(), Equals, "")
 	c.Assert(stderr.String(), Equals, "")
@@ -107,14 +107,14 @@ func (s *KanXCmdSuite) TestProcessClientOutput(c *C) {
 	c.Assert(err, IsNil)
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
-	err = executeCommand(c, ctx, stdout, stderr, "process", "client", "--as-json", "-a", addr, "create", "echo", "hello world")
+	err = executeCommand(ctx, stdout, stderr, "process", "client", "--as-json", "-a", addr, "create", "echo", "hello world")
 	c.Assert(err, IsNil)
 	pr := &ProcessResult{}
-	err = json.Unmarshal([]byte(stdout.String()), pr)
+	err = json.Unmarshal(stdout.Bytes(), pr)
 	c.Assert(err, IsNil)
 	c.Assert(stderr.String(), Equals, "")
 	// get output
-	err = executeCommandWithReset(c, ctx, stdout, stderr, "process", "client", "-a", addr, "output", pr.Pid)
+	err = executeCommandWithReset(ctx, stdout, stderr, "process", "client", "-a", addr, "output", pr.Pid)
 	c.Assert(err, IsNil)
 	c.Assert(stdout.String(), Equals, "hello world\n")
 	c.Assert(stderr.String(), Equals, "")
@@ -132,23 +132,23 @@ func (s *KanXCmdSuite) TestProcessClientGet(c *C) {
 	c.Assert(err, IsNil)
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
-	err = executeCommand(c, ctx, stdout, stderr, "process", "client", "--as-json", "-a", addr, "create", "echo", "hello world")
+	err = executeCommand(ctx, stdout, stderr, "process", "client", "--as-json", "-a", addr, "create", "echo", "hello world")
 	c.Assert(err, IsNil)
 	pr := &ProcessResult{}
-	err = json.Unmarshal([]byte(stdout.String()), pr)
+	err = json.Unmarshal(stdout.Bytes(), pr)
 	c.Assert(err, IsNil)
 	c.Assert(pr.Pid, Not(Equals), "")
 	c.Assert(pr.State, Equals, "PROCESS_STATE_RUNNING")
 	c.Assert(stderr.String(), Equals, "")
 	// get output
-	err = executeCommandWithReset(c, ctx, stdout, stderr, "process", "client", "-a", addr, "output", pr.Pid)
+	err = executeCommandWithReset(ctx, stdout, stderr, "process", "client", "-a", addr, "output", pr.Pid)
 	c.Assert(err, IsNil)
 	c.Assert(stdout.String(), Equals, "hello world\n")
 	c.Assert(stderr.String(), Equals, "")
-	err = executeCommandWithReset(c, ctx, stdout, stderr, "process", "client", "--as-json", "-a", addr, "get", pr.Pid)
+	err = executeCommandWithReset(ctx, stdout, stderr, "process", "client", "--as-json", "-a", addr, "get", pr.Pid)
 	c.Assert(err, IsNil)
 	pr = &ProcessResult{}
-	err = json.Unmarshal([]byte(stdout.String()), pr)
+	err = json.Unmarshal(stdout.Bytes(), pr)
 	c.Assert(err, IsNil)
 	c.Assert(pr.Pid, Not(Equals), "")
 	c.Assert(pr.State, Equals, "PROCESS_STATE_SUCCEEDED")

--- a/pkg/kando/process_client.go
+++ b/pkg/kando/process_client.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	processAsJSONFlagName           = "as-json"
+	processAsJSONFlagName = "as-json"
 )
 
 func newProcessClientCommand() *cobra.Command {

--- a/pkg/kando/process_client.go
+++ b/pkg/kando/process_client.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	processAsJSONFlagName = "as-json"
+	processAsJSONFlagName           = "as-json"
 )
 
 func newProcessClientCommand() *cobra.Command {


### PR DESCRIPTION
## Change Overview

This PR add unit tests for the Kan-Do KanX commands.  The tests demonstrate a technique for using Cobra to execute commands that normally require sub-processes inside go-routines, simplifying testing for shell commands.
## Pull request type

Please check the type of change your PR introduces:
- [X] :robot: Test

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

There is no GitHub issue associated with this PR.

## Test Plan

- [X] :zap: Unit test
