### PR TITLE
feat: Allow quiet operation in KanX; fixup logging.

### DIFF
--- a/pkg/kando/kando.go
+++ b/pkg/kando/kando.go
@@ -34,12 +34,7 @@ var logLevel string
 func Execute() {
 	root := newRootCommand()
 	if err := root.Execute(); err != nil {
-		// check to see if the error is a gRPC error
-		if status.Convert(err) != nil {
-			log.Info().WithError(err).Print("Kando failed to execute gRPC call")
-			os.Exit(69)
-		}
-		log.Info().WithError(err).Print("Kando failed to execute")
+		log.WithError(err).Print("Kando failed to execute")
 		os.Exit(1)
 	}
 }

--- a/pkg/kando/kando.go
+++ b/pkg/kando/kando.go
@@ -34,7 +34,12 @@ var logLevel string
 func Execute() {
 	root := newRootCommand()
 	if err := root.Execute(); err != nil {
-		log.WithError(err).Print("Kando failed to execute")
+		// check to see if the error is a gRPC error
+		if status.Convert(err) != nil {
+			log.Info().WithError(err).Print("Kando failed to execute gRPC call")
+			os.Exit(69)
+		}
+		log.Info().WithError(err).Print("Kando failed to execute")
 		os.Exit(1)
 	}
 }

--- a/pkg/kando/process_client.go
+++ b/pkg/kando/process_client.go
@@ -31,6 +31,7 @@ import (
 const (
 	processSignalProxyFlagName = "signal-proxy"
 	processAsJSONFlagName      = "as-json"
+	processAsQuietFlagName     = "quiet"
 )
 
 func newProcessClientCommand() *cobra.Command {
@@ -45,11 +46,20 @@ func newProcessClientCommand() *cobra.Command {
 	cmd.AddCommand(newProcessClientSignalCommand())
 	cmd.AddCommand(newProcessClientOutputCommand())
 	cmd.PersistentFlags().BoolP(processAsJSONFlagName, "j", false, "Display output as json")
+	cmd.PersistentFlags().BoolP(processAsQuietFlagName, "q", false, "Quiet process information output")
 	return cmd
 }
 
 func processAsJSONFlagValue(cmd *cobra.Command) bool {
 	b, err := cmd.Flags().GetBool(processAsJSONFlagName)
+	if err != nil {
+		panic(err.Error())
+	}
+	return b
+}
+
+func processAsQuietFlagValue(cmd *cobra.Command) bool {
+	b, err := cmd.Flags().GetBool(processAsQuietFlagName)
 	if err != nil {
 		panic(err.Error())
 	}

--- a/pkg/kando/process_client_create.go
+++ b/pkg/kando/process_client_create.go
@@ -45,9 +45,6 @@ func runProcessClientCreateWithOutput(out io.Writer, cmd *cobra.Command, args []
 	}
 	asJSON := processAsJSONFlagValue(cmd)
 	asQuiet := processAsQuietFlagValue(cmd)
-	if asQuiet {
-		cmd.SilenceErrors = true
-	}
 	cmd.SilenceUsage = true
 	p, err := kanx.CreateProcess(cmd.Context(), addr, args[0], args[1:])
 	if err != nil {

--- a/pkg/kando/process_client_create.go
+++ b/pkg/kando/process_client_create.go
@@ -62,4 +62,5 @@ func runProcessClientCreateWithOutput(out io.Writer, cmd *cobra.Command, args []
 	} else {
 		fmt.Fprintln(out, "Process: ", p)
 	}
+	return nil
 }

--- a/pkg/kando/process_client_create.go
+++ b/pkg/kando/process_client_create.go
@@ -50,16 +50,16 @@ func runProcessClientCreateWithOutput(out io.Writer, cmd *cobra.Command, args []
 	if err != nil {
 		return err
 	}
-	if !asQuiet {
-		if asJSON {
-			buf, err := protojson.Marshal(p)
-			if err != nil {
-				return err
-			}
-			fmt.Fprintln(out, string(buf))
-		} else {
-			fmt.Fprintln(out, "Process: ", p)
-		}
+	if asQuiet {
+		return nil
 	}
-	return nil
+	if asJSON {
+		buf, err := protojson.Marshal(p)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(out, string(buf))
+	} else {
+		fmt.Fprintln(out, "Process: ", p)
+	}
 }

--- a/pkg/kando/process_client_create.go
+++ b/pkg/kando/process_client_create.go
@@ -44,19 +44,25 @@ func runProcessClientCreateWithOutput(out io.Writer, cmd *cobra.Command, args []
 		return err
 	}
 	asJSON := processAsJSONFlagValue(cmd)
+	asQuiet := processAsQuietFlagValue(cmd)
+	if asQuiet {
+		cmd.SilenceErrors = true
+	}
 	cmd.SilenceUsage = true
 	p, err := kanx.CreateProcess(cmd.Context(), addr, args[0], args[1:])
 	if err != nil {
 		return err
 	}
-	if asJSON {
-		buf, err := protojson.Marshal(p)
-		if err != nil {
-			return err
+	if !asQuiet {
+		if asJSON {
+			buf, err := protojson.Marshal(p)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintln(out, string(buf))
+		} else {
+			fmt.Fprintln(out, "Process: ", p)
 		}
-		fmt.Fprintln(out, string(buf))
-	} else {
-		fmt.Fprintln(out, "Process: ", p)
 	}
 	return nil
 }

--- a/pkg/kando/process_client_execute.go
+++ b/pkg/kando/process_client_execute.go
@@ -51,6 +51,7 @@ func runProcessClientExecuteWithOutput(stdout, stderr io.Writer, cmd *cobra.Comm
 		return err
 	}
 	asJSON := processAsJSONFlagValue(cmd)
+	asQuiet := processAsQuietFlagValue(cmd)
 	cmd.SilenceUsage = true
 	ctx, canfn := context.WithCancel(cmd.Context())
 	defer canfn()
@@ -58,14 +59,16 @@ func runProcessClientExecuteWithOutput(stdout, stderr io.Writer, cmd *cobra.Comm
 	if err != nil {
 		return err
 	}
-	if asJSON {
-		buf, err := protojson.Marshal(p)
-		if err != nil {
-			return err
+	if !asQuiet {
+		if asJSON {
+			buf, err := protojson.Marshal(p)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintln(stdout, string(buf))
+		} else {
+			fmt.Fprintln(stdout, "Process: ", p)
 		}
-		fmt.Fprintln(stdout, string(buf))
-	} else {
-		fmt.Fprintln(stdout, "Process: ", p)
 	}
 
 	pid := p.Pid

--- a/pkg/kando/process_client_get.go
+++ b/pkg/kando/process_client_get.go
@@ -55,16 +55,17 @@ func runProcessClientGetWithOutput(out io.Writer, cmd *cobra.Command, args []str
 	if err != nil {
 		return err
 	}
-	if !asQuiet {
-		if asJSON {
-			buf, err := protojson.Marshal(p)
-			if err != nil {
-				return err
-			}
-			fmt.Fprintln(out, string(buf))
-		} else {
-			fmt.Fprintln(out, "Process: ", p)
+	if asQuiet {
+		return nil
+	}
+	if asJSON {
+		buf, err := protojson.Marshal(p)
+		if err != nil {
+			return err
 		}
+		fmt.Fprintln(out, string(buf))
+	} else {
+		fmt.Fprintln(out, "Process: ", p)
 	}
 	return nil
 }

--- a/pkg/kando/process_client_get.go
+++ b/pkg/kando/process_client_get.go
@@ -40,7 +40,7 @@ func runProcessClientGet(cmd *cobra.Command, args []string) error {
 }
 
 func runProcessClientGetWithOutput(out io.Writer, cmd *cobra.Command, args []string) error {
-	pid, err := strconv.Atoi(args[0])
+	pid, err := strconv.ParseInt(args[0], 0, 64)
 	if err != nil {
 		return err
 	}
@@ -48,20 +48,26 @@ func runProcessClientGetWithOutput(out io.Writer, cmd *cobra.Command, args []str
 	if err != nil {
 		return err
 	}
+	asQuiet := processAsQuietFlagValue(cmd)
+	if asQuiet {
+		cmd.SilenceErrors = true
+	}
 	asJSON := processAsJSONFlagValue(cmd)
 	cmd.SilenceUsage = true
-	p, err := kanx.GetProcess(cmd.Context(), addr, int64(pid))
+	p, err := kanx.GetProcess(cmd.Context(), addr, pid)
 	if err != nil {
 		return err
 	}
-	if asJSON {
-		buf, err := protojson.Marshal(p)
-		if err != nil {
-			return err
+	if !asQuiet {
+		if asJSON {
+			buf, err := protojson.Marshal(p)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintln(out, string(buf))
+		} else {
+			fmt.Fprintln(out, "Process: ", p)
 		}
-		fmt.Fprintln(out, string(buf))
-	} else {
-		fmt.Fprintln(out, "Process: ", p)
 	}
 	return nil
 }

--- a/pkg/kando/process_client_get.go
+++ b/pkg/kando/process_client_get.go
@@ -49,9 +49,6 @@ func runProcessClientGetWithOutput(out io.Writer, cmd *cobra.Command, args []str
 		return err
 	}
 	asQuiet := processAsQuietFlagValue(cmd)
-	if asQuiet {
-		cmd.SilenceErrors = true
-	}
 	asJSON := processAsJSONFlagValue(cmd)
 	cmd.SilenceUsage = true
 	p, err := kanx.GetProcess(cmd.Context(), addr, pid)

--- a/pkg/kando/process_client_signal.go
+++ b/pkg/kando/process_client_signal.go
@@ -53,9 +53,6 @@ func runProcessClientSignalWithOutput(out io.Writer, cmd *cobra.Command, args []
 		return err
 	}
 	asQuiet := processAsQuietFlagValue(cmd)
-	if asQuiet {
-		cmd.SilenceErrors = true
-	}
 	asJSON := processAsJSONFlagValue(cmd)
 	cmd.SilenceUsage = true
 	p, err := kanx.SignalProcess(cmd.Context(), addr, pid, signal)

--- a/pkg/kando/process_client_signal.go
+++ b/pkg/kando/process_client_signal.go
@@ -52,20 +52,26 @@ func runProcessClientSignalWithOutput(out io.Writer, cmd *cobra.Command, args []
 	if err != nil {
 		return err
 	}
+	asQuiet := processAsQuietFlagValue(cmd)
+	if asQuiet {
+		cmd.SilenceErrors = true
+	}
 	asJSON := processAsJSONFlagValue(cmd)
 	cmd.SilenceUsage = true
 	p, err := kanx.SignalProcess(cmd.Context(), addr, pid, signal)
 	if err != nil {
 		return err
 	}
-	if asJSON {
-		buf, err := protojson.Marshal(p)
-		if err != nil {
-			return err
+	if !asQuiet {
+		if asJSON {
+			buf, err := protojson.Marshal(p)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintln(out, string(buf))
+		} else {
+			fmt.Fprintln(out, "Process: ", p)
 		}
-		fmt.Fprintln(out, string(buf))
-	} else {
-		fmt.Fprintln(out, "Process: ", p)
 	}
 	return nil
 }

--- a/pkg/kando/process_client_signal.go
+++ b/pkg/kando/process_client_signal.go
@@ -59,16 +59,17 @@ func runProcessClientSignalWithOutput(out io.Writer, cmd *cobra.Command, args []
 	if err != nil {
 		return err
 	}
-	if !asQuiet {
-		if asJSON {
-			buf, err := protojson.Marshal(p)
-			if err != nil {
-				return err
-			}
-			fmt.Fprintln(out, string(buf))
-		} else {
-			fmt.Fprintln(out, "Process: ", p)
+	if asQuiet {
+		return nil
+	}
+	if asJSON {
+		buf, err := protojson.Marshal(p)
+		if err != nil {
+			return err
 		}
+		fmt.Fprintln(out, string(buf))
+	} else {
+		fmt.Fprintln(out, "Process: ", p)
 	}
 	return nil
 }

--- a/pkg/kopia/command/common.go
+++ b/pkg/kopia/command/common.go
@@ -69,14 +69,9 @@ func bashCommandAsLogSafe(args logsafe.Cmd) logsafe.Cmd {
 	return logsafe.NewLoggable("bash", "-o", "errexit", "-c").Combine(args)
 }
 
-func kanxCommand(args logsafe.Cmd) []string {
-	log.Info().Print("Kopia Command", field.M{"Command": args.String()})
-	return append([]string{"kando", "process", "client", "execute", "--signal-proxy", "--as-json", "--"}, args.StringSliceCMD()...)
-}
-
 func MakeKanxCommand(args []string) []string {
 	log.Info().Print("KanX Command", field.M{"Command": args})
-	return append([]string{"kando", "process", "client", "execute", "--signal-proxy", "--as-json", "--"}, args...)
+	return append([]string{"kando", "process", "client", "execute", "--signal-proxy", "--quiet", "--"}, args...)
 }
 
 func stringSliceCommand(args logsafe.Cmd) []string {

--- a/pkg/kopia/command/common.go
+++ b/pkg/kopia/command/common.go
@@ -64,11 +64,6 @@ func bashCommand(args logsafe.Cmd) []string {
 	return []string{"bash", "-o", "errexit", "-c", args.PlainText()}
 }
 
-func bashCommandAsLogSafe(args logsafe.Cmd) logsafe.Cmd {
-	log.Info().Print("Kopia Command", field.M{"Command": args.String()})
-	return logsafe.NewLoggable("bash", "-o", "errexit", "-c").Combine(args)
-}
-
 func MakeKanxCommand(args []string) []string {
 	log.Info().Print("KanX Command", field.M{"Command": args})
 	return append([]string{"kando", "process", "client", "execute", "--signal-proxy", "--quiet", "--"}, args...)

--- a/pkg/kopia/command/server.go
+++ b/pkg/kopia/command/server.go
@@ -86,7 +86,7 @@ func ServerStart(cmdArgs ServerStartCommandArgs) []string {
 
 // ServerStartKanx returns the kopia command for starting the Kopia API Server
 func ServerStartKanx(cmdArgs ServerStartCommandArgs) []string {
-	return kanxCommand(bashCommandAsLogSafe(commonCommand(cmdArgs)))
+	return MakeKanxCommand(ServerStart(cmdArgs))
 }
 
 type ServerRefreshCommandArgs struct {

--- a/pkg/kopia/maintenance/get_maintenance_owner.go
+++ b/pkg/kopia/maintenance/get_maintenance_owner.go
@@ -62,6 +62,41 @@ func GetMaintenanceOwnerForConnectedRepository(
 	cmd := command.MaintenanceInfo(args)
 
 	var stdout, stderr bytes.Buffer
+	err = commandExecutor.Exec(ctx, cmd, nil, &stdout, &stderr)
+	format.LogWithCtx(ctx, pod.Name, container, stdout.String())
+	format.LogWithCtx(ctx, pod.Name, container, stderr.String())
+	if err != nil {
+		return "", err
+	}
+
+	return parseOwner(stdout.Bytes())
+}
+
+// GetMaintenanceOwnerForConnectedRepositoryKanx executes maintenance info command,
+// and returns maintenance owner.
+func GetMaintenanceOwnerForConnectedRepositoryKanx(
+	ctx context.Context,
+	podController kube.PodController,
+	configFilePath,
+	logDirectory string,
+) (string, error) {
+	pod := podController.Pod()
+	container := pod.Spec.Containers[0].Name
+	commandExecutor, err := podController.GetCommandExecutor()
+	if err != nil {
+		return "", err
+	}
+
+	args := command.MaintenanceInfoCommandArgs{
+		CommandArgs: &command.CommandArgs{
+			ConfigFilePath: configFilePath,
+			LogDirectory:   logDirectory,
+		},
+		GetJSONOutput: true,
+	}
+	cmd := command.MaintenanceInfo(args)
+
+	var stdout, stderr bytes.Buffer
 	err = commandExecutor.Exec(ctx, command.MakeKanxCommand(cmd), nil, &stdout, &stderr)
 	format.LogWithCtx(ctx, pod.Name, container, stdout.String())
 	format.LogWithCtx(ctx, pod.Name, container, stderr.String())

--- a/pkg/kopia/maintenance/get_maintenance_owner.go
+++ b/pkg/kopia/maintenance/get_maintenance_owner.go
@@ -62,7 +62,7 @@ func GetMaintenanceOwnerForConnectedRepository(
 	cmd := command.MaintenanceInfo(args)
 
 	var stdout, stderr bytes.Buffer
-	err = commandExecutor.Exec(ctx, cmd, nil, &stdout, &stderr)
+	err = commandExecutor.Exec(ctx, command.MakeKanxCommand(cmd), nil, &stdout, &stderr)
 	format.LogWithCtx(ctx, pod.Name, container, stdout.String())
 	format.LogWithCtx(ctx, pod.Name, container, stderr.String())
 	if err != nil {


### PR DESCRIPTION
## Change Overview

This PR adds a `--quiet` option which suppresses output of PID and process information (metadata) to stdout.  Also included is a fix for better control of logging.

## Pull request type

Please check the type of change your PR introduces:
- [X] :sunflower: Feature

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- There is not github issue for this PR

## Test Plan

- [X] :zap: Unit test
