### PR TITLE
fix: Fixup handling of exit codes from child processes.

### DIFF
--- a/pkg/kando/kanx_cmd_test.go
+++ b/pkg/kando/kanx_cmd_test.go
@@ -95,6 +95,7 @@ func (s *KanXCmdSuite) TestProcessClientCreate(c *C) {
 	c.Assert(stderr.String(), Equals, "")
 }
 
+// TestProcessClientOutput check that output command outputs stdout and stderr to their respective FDs.
 func (s *KanXCmdSuite) TestProcessClientOutput(c *C) {
 	addr := c.MkDir() + "/kanister.sock"
 	ctx, can := context.WithCancel(context.Background())
@@ -107,7 +108,7 @@ func (s *KanXCmdSuite) TestProcessClientOutput(c *C) {
 	c.Assert(err, IsNil)
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
-	err = executeCommand(ctx, stdout, stderr, "process", "client", "--as-json", "-a", addr, "create", "echo", "hello world")
+	err = executeCommand(ctx, stdout, stderr, "process", "client", "--as-json", "-a", addr, "create", "--", "bash", "-c", "echo 'hello world 1' && echo 'hello world 2' 1>&2")
 	c.Assert(err, IsNil)
 	pr := &ProcessResult{}
 	err = json.Unmarshal(stdout.Bytes(), pr)
@@ -116,7 +117,83 @@ func (s *KanXCmdSuite) TestProcessClientOutput(c *C) {
 	// get output
 	err = executeCommandWithReset(ctx, stdout, stderr, "process", "client", "-a", addr, "output", pr.Pid)
 	c.Assert(err, IsNil)
-	c.Assert(stdout.String(), Equals, "hello world\n")
+	c.Assert(stdout.String(), Equals, "hello world 1\n")
+	c.Assert(stderr.String(), Equals, "hello world 2\n")
+}
+
+// TestProcessClientExecute_RedirectStdout checks that stdout contains JSON process metadata and process output without additional output from logging.
+func (s *KanXCmdSuite) TestProcessClientExecute_RedirectStdout(c *C) {
+	addr := c.MkDir() + "/kanister.sock"
+	ctx, can := context.WithCancel(context.Background())
+	defer can()
+	go func() {
+		err := startServer(ctx, addr, nil, nil)
+		c.Assert(err, IsNil)
+	}()
+	err := waitSock(ctx, addr)
+	c.Assert(err, IsNil)
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	err = executeCommand(ctx, stdout, stderr, "process", "client", "--as-json", "-a", addr, "execute", "echo", "hello world")
+	c.Assert(err, IsNil)
+	bs := stdout.Bytes()
+	pr := &ProcessResult{}
+	dc := json.NewDecoder(bytes.NewReader(bs))
+	err = dc.Decode(pr)
+	c.Assert(err, IsNil)
+	c.Assert(dc.More(), Equals, true)
+	rest := dc.InputOffset()
+	c.Assert(string(bs[rest:]), Equals, "hello world\n")
+	c.Assert(stderr.String(), Equals, "")
+}
+
+// TestProcessClientExecute_RedirectStderr checks that stderr without additional output from logging.
+func (s *KanXCmdSuite) TestProcessClientExecute_RedirectStderr(c *C) {
+	addr := c.MkDir() + "/kanister.sock"
+	ctx, can := context.WithCancel(context.Background())
+	defer can()
+	go func() {
+		err := startServer(ctx, addr, nil, nil)
+		c.Assert(err, IsNil)
+	}()
+	err := waitSock(ctx, addr)
+	c.Assert(err, IsNil)
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	err = executeCommand(ctx, stdout, stderr, "process", "client", "--as-json", "-a", addr, "execute", "--", "bash", "-c", "echo 'hello world' 1>&2")
+	c.Assert(err, IsNil)
+	bs := stdout.Bytes()
+	pr := &ProcessResult{}
+	dc := json.NewDecoder(bytes.NewReader(bs))
+	err = dc.Decode(pr)
+	c.Assert(err, IsNil)
+	c.Assert(stderr.String(), Equals, "hello world\n")
+}
+
+// TestProcessClientExecute_Exit1 test that non-zero exit code from the child process is reflected in the kando command.
+func (s *KanXCmdSuite) TestProcessClientExecute_Exit1(c *C) {
+	addr := c.MkDir() + "/kanister.sock"
+	ctx, can := context.WithCancel(context.Background())
+	defer can()
+	go func() {
+		err := startServer(ctx, addr, nil, nil)
+		c.Assert(err, IsNil)
+	}()
+	err := waitSock(ctx, addr)
+	c.Assert(err, IsNil)
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	err = executeCommand(ctx, stdout, stderr, "process", "client", "--as-json", "-a", addr, "execute", "--", "/bin/bash", "-c", "exit 1")
+	c.Assert(err, NotNil)
+	c.Assert(err.Error(), Equals, "exit status 1")
+	bs := stdout.Bytes()
+	pr := &ProcessResult{}
+	dc := json.NewDecoder(bytes.NewReader(bs))
+	err = dc.Decode(pr)
+	c.Assert(err, IsNil)
+	c.Assert(pr.Pid, Not(Equals), "")
+	c.Assert(pr.State, Equals, "PROCESS_STATE_RUNNING")
+	c.Assert(stdout.String(), Equals, "")
 	c.Assert(stderr.String(), Equals, "")
 }
 

--- a/pkg/kando/kanx_cmd_test.go
+++ b/pkg/kando/kanx_cmd_test.go
@@ -18,11 +18,9 @@ type KanXCmdSuite struct{}
 
 var _ = Suite(&KanXCmdSuite{})
 
-func startServer(ctx context.Context, addr string, stdout, stderr io.Writer) error {
+func startServer(ctx context.Context, addr string) error {
 	rc := newRootCommand()
 	rc.SetArgs([]string{"process", "server", "-a", addr})
-	rc.SetOut(stdout)
-	rc.SetErr(stderr)
 	return rc.ExecuteContext(ctx)
 }
 
@@ -75,7 +73,7 @@ func (s *KanXCmdSuite) TestProcessClientCreate(c *C) {
 	ctx, can := context.WithCancel(context.Background())
 	defer can()
 	go func() {
-		err := startServer(ctx, addr, nil, nil)
+		err := startServer(ctx, addr)
 		c.Assert(err, IsNil)
 	}()
 	err := waitSock(ctx, addr)
@@ -101,7 +99,7 @@ func (s *KanXCmdSuite) TestProcessClientOutput(c *C) {
 	ctx, can := context.WithCancel(context.Background())
 	defer can()
 	go func() {
-		err := startServer(ctx, addr, nil, nil)
+		err := startServer(ctx, addr)
 		c.Assert(err, IsNil)
 	}()
 	err := waitSock(ctx, addr)
@@ -127,7 +125,7 @@ func (s *KanXCmdSuite) TestProcessClientExecute_RedirectStdout(c *C) {
 	ctx, can := context.WithCancel(context.Background())
 	defer can()
 	go func() {
-		err := startServer(ctx, addr, nil, nil)
+		err := startServer(ctx, addr)
 		c.Assert(err, IsNil)
 	}()
 	err := waitSock(ctx, addr)
@@ -153,7 +151,7 @@ func (s *KanXCmdSuite) TestProcessClientExecute_RedirectStderr(c *C) {
 	ctx, can := context.WithCancel(context.Background())
 	defer can()
 	go func() {
-		err := startServer(ctx, addr, nil, nil)
+		err := startServer(ctx, addr)
 		c.Assert(err, IsNil)
 	}()
 	err := waitSock(ctx, addr)
@@ -176,7 +174,7 @@ func (s *KanXCmdSuite) TestProcessClientExecute_Exit1(c *C) {
 	ctx, can := context.WithCancel(context.Background())
 	defer can()
 	go func() {
-		err := startServer(ctx, addr, nil, nil)
+		err := startServer(ctx, addr)
 		c.Assert(err, IsNil)
 	}()
 	err := waitSock(ctx, addr)
@@ -202,7 +200,7 @@ func (s *KanXCmdSuite) TestProcessClientGet(c *C) {
 	ctx, can := context.WithCancel(context.Background())
 	defer can()
 	go func() {
-		err := startServer(ctx, addr, nil, nil)
+		err := startServer(ctx, addr)
 		c.Assert(err, IsNil)
 	}()
 	err := waitSock(ctx, addr)

--- a/pkg/kando/process_client_execute.go
+++ b/pkg/kando/process_client_execute.go
@@ -29,6 +29,10 @@ import (
 	"github.com/kanisterio/kanister/pkg/kanx"
 )
 
+var (
+	exit = os.Exit
+)
+
 const (
 	GrpcCodeOffset = 15
 )
@@ -52,13 +56,13 @@ func runProcessClientExecute(cmd *cobra.Command, args []string) error {
 	// err is a positive command exit code
 	err0, ok := err.(kanx.ProcessExitCode)
 	if ok {
-		os.Exit(int(err0))
+		exit(int(err0))
 	}
 	// err is gRPC error.  this will tell users of connectivity problems
 	// with the server
 	err1, ok := status.FromError(err)
 	if ok && err1.Code() != codes.OK {
-		os.Exit(int(GrpcCodeOffset + err1.Code()))
+		exit(int(GrpcCodeOffset + err1.Code()))
 	}
 	return err
 }
@@ -111,6 +115,7 @@ func runProcessClientExecuteWithOutput(stdout, stderr io.Writer, cmd *cobra.Comm
 			err = errkit.Append(err, err0)
 		}
 	}
+	close(errc)
 	if err != nil {
 		return err
 	}

--- a/pkg/kando/process_client_execute.go
+++ b/pkg/kando/process_client_execute.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	GRPC_CODE_OFFSET = 15
+	GrpcCodeOffset = 15
 )
 
 func newProcessClientExecuteCommand() *cobra.Command {
@@ -58,7 +58,7 @@ func runProcessClientExecute(cmd *cobra.Command, args []string) error {
 	// with the server
 	err1, ok := status.FromError(err)
 	if ok && err1.Code() != codes.OK {
-		os.Exit(int(GRPC_CODE_OFFSET + err1.Code()))
+		os.Exit(int(GrpcCodeOffset + err1.Code()))
 	}
 	return err
 }

--- a/pkg/kando/process_server.go
+++ b/pkg/kando/process_server.go
@@ -15,8 +15,6 @@
 package kando
 
 import (
-	"context"
-
 	"github.com/spf13/cobra"
 
 	"github.com/kanisterio/kanister/pkg/kanx"
@@ -39,5 +37,5 @@ func runProcessServer(cmd *cobra.Command, args []string) error {
 	}
 	cmd.SilenceUsage = true
 
-	return kanx.NewServer().Serve(context.Background(), address)
+	return kanx.NewServer().Serve(cmd.Context(), address)
 }

--- a/pkg/kanx/client.go
+++ b/pkg/kanx/client.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net"
 	"net/url"
+	"os"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -46,7 +47,12 @@ func GetProcess(ctx context.Context, addr string, pid int64) (*Process, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer conn.Close() //nolint:errcheck
+	defer func() {
+		err := conn.Close()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s\n", err.Error())
+		}
+	}()
 	c := NewProcessServiceClient(conn)
 	wpc, err := c.GetProcess(ctx, &ProcessPidRequest{
 		Pid: pid,

--- a/pkg/kanx/client.go
+++ b/pkg/kanx/client.go
@@ -2,6 +2,7 @@ package kanx
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net"
 	"net/url"
@@ -149,4 +150,10 @@ func output(ctx context.Context, out io.Writer, sc recver) error {
 			return err
 		}
 	}
+}
+
+type ProcessExitCode int
+
+func (e ProcessExitCode) Error() string {
+	return fmt.Sprintf("exit status %d", e)
 }

--- a/pkg/kopia/command/common.go
+++ b/pkg/kopia/command/common.go
@@ -65,7 +65,6 @@ func bashCommand(args logsafe.Cmd) []string {
 }
 
 func MakeKanxCommand(args []string) []string {
-	log.Info().Print("KanX Command", field.M{"Command": args})
 	return append([]string{"kando", "process", "client", "execute", "--signal-proxy", "--quiet", "--"}, args...)
 }
 


### PR DESCRIPTION
## Change Overview

This PR fixes client exit code processing from processes forked by the KanX server.

## Pull request type

Please check the type of change your PR introduces:
- [X] :bug: Bugfix

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

There is no github issue for this PR

## Test Plan

- [X] :zap: Unit test
