### PR TITLE
build(docker): fix qemu version for building arm64 build image

### DIFF
--- a/.github/workflows/kanister-image-build.yaml
+++ b/.github/workflows/kanister-image-build.yaml
@@ -53,6 +53,9 @@ jobs:
     steps:
     - name: Set up QEMU
       uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+      with:
+        cache-image: false
+        image: tonistiigi/binfmt:qemu-v8.0.4
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
     - name: Image metadata


### PR DESCRIPTION
## Change Overview

Current quemu version causes a segfault when building arm64 build image. Fix it for now to older version which works

Build without this change: https://github.com/kanisterio/kanister/actions/runs/13272827698
Build with this change: https://github.com/kanisterio/kanister/actions/runs/13291136722

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [x] :building_construction: Build

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
