### PR TITLE
fix: fixup gRPC buffer overflow bug with unit test.

### DIFF
--- a/pkg/kando/kando.go
+++ b/pkg/kando/kando.go
@@ -15,8 +15,8 @@
 package kando
 
 import (
-	"os"
 	"fmt"
+	"os"
 
 	"github.com/kanisterio/errkit"
 	"github.com/sirupsen/logrus"

--- a/pkg/kando/kando.go
+++ b/pkg/kando/kando.go
@@ -16,6 +16,7 @@ package kando
 
 import (
 	"os"
+	"fmt"
 
 	"github.com/kanisterio/errkit"
 	"github.com/sirupsen/logrus"

--- a/pkg/kando/kando.go
+++ b/pkg/kando/kando.go
@@ -15,13 +15,13 @@
 package kando
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/kanisterio/errkit"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc/grpclog"
+	"google.golang.org/grpc/status"
 
 	"github.com/kanisterio/kanister/pkg/log"
 	"github.com/kanisterio/kanister/pkg/version"
@@ -34,7 +34,12 @@ var logLevel string
 func Execute() {
 	root := newRootCommand()
 	if err := root.Execute(); err != nil {
-		log.WithError(err).Print("Kando failed to execute")
+		// check to see if the error is a gRPC error
+		if status.Convert(err) != nil {
+			log.Info().WithError(err).Print("Kando failed to execute gRPC call")
+			os.Exit(69)
+		}
+		log.Info().WithError(err).Print("Kando failed to execute")
 		os.Exit(1)
 	}
 }
@@ -68,7 +73,7 @@ func newRootCommand() *cobra.Command {
 func setLogLevel(v string) error {
 	lgl, err := logrus.ParseLevel(v)
 	if err != nil {
-		return errkit.Wrap(err, fmt.Sprintf("Invalid log level: %s", v))
+		return errkit.New(fmt.Sprintf("Invalid log level: %s", v))
 	}
 	// set application logger log level. (kanister/log/log.go)
 	log.SetLevel(log.Level(lgl))

--- a/pkg/kanx/server.go
+++ b/pkg/kanx/server.go
@@ -1,7 +1,6 @@
 package kanx
 
 import (
-	"bytes"
 	"context"
 	"io"
 	"net"
@@ -23,7 +22,7 @@ const (
 	tailTickDuration  = 3 * time.Second
 	tempStdoutPattern = "kando.*.stdout"
 	tempStderrPattern = "kando.*.stderr"
-	streamBufferBytes = 4 * 1024 * 1024
+	streamBufferBytes = (4 * 1024 * 1024) / 2 // must be below gRPC's 4MiB over-the-wire message limit
 )
 
 type processServiceServer struct {
@@ -177,7 +176,7 @@ var errProcessNotFound = errkit.NewSentinelErr("Process not found")
 func (s *processServiceServer) Stdout(por *ProcessPidRequest, ss ProcessService_StdoutServer) error {
 	p, ok := s.loadProcess(por.Pid)
 	if !ok {
-		return errkit.WithStack(errProcessNotFound)
+		return errProcessNotFound
 	}
 	fh, err := os.Open(p.stdout.Name())
 	if err != nil {
@@ -189,7 +188,7 @@ func (s *processServiceServer) Stdout(por *ProcessPidRequest, ss ProcessService_
 func (s *processServiceServer) Stderr(por *ProcessPidRequest, ss ProcessService_StderrServer) error {
 	p, ok := s.loadProcess(por.Pid)
 	if !ok {
-		return errkit.WithStack(errProcessNotFound)
+		return errProcessNotFound
 	}
 	fh, err := os.Open(p.stderr.Name())
 	if err != nil {
@@ -203,13 +202,13 @@ type sender interface {
 }
 
 func (s *processServiceServer) streamOutput(ss sender, p *process, fh *os.File) error {
-	buf := bytes.NewBuffer(make([]byte, 0, streamBufferBytes)) // 4MiB is the max size of a GRPC request
+	buf := make([]byte, streamBufferBytes) // 2MiB buffer for gRPC requests
 	t := time.NewTicker(s.tailTickDuration)
 	for {
-		n, err := buf.ReadFrom(fh)
+		n, err0 := fh.Read(buf)
 		switch {
-		case err != nil:
-			return err
+		case err0 != nil && err0 != io.EOF:
+			return err0
 		case n == 0:
 			select {
 			case <-p.doneCh:
@@ -219,10 +218,13 @@ func (s *processServiceServer) streamOutput(ss sender, p *process, fh *os.File) 
 			<-t.C
 			continue
 		}
-		o := &Output{Output: buf.String()}
-		err = ss.Send(o)
-		if err != nil {
-			return err
+		o := &Output{Output: string(buf[:n])}
+		err1 := ss.Send(o)
+		if err1 != nil {
+			return err1
+		}
+		if err0 == io.EOF {
+			return nil
 		}
 	}
 }


### PR DESCRIPTION
## Change Overview

gRPC has a over-the-wire buffer limit of 4MB.  gRPC buffer overflow errors can occur if this figure is use as a before the wire buffer measure as gRPC adds overhead (JSON overhead) when sending messages from gRPC API clients.

This fix just divides the gRPC buffer limit in half (2MB) which is much smaller than the theoretical max (theoretical_max = 4MB - protocol overhead) but intuitively large enough to hold enough data.

This also includes a fix for using `bytes.Buffer` as a circular buffer, which its not very good at.  Instead a `[]byte` buffer is used.  If performance is a concern then the buffer copy should be split across 2 threads in a bucket brigade.

## Pull request type

Please check the type of change your PR introduces:
- [X] :bug: Bugfix

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

There is no github issue for this fix.

## Test Plan

- [X] :zap: Unit test
