### PR TITLE
Pin mysql chart version to 12.2.4

### DIFF
--- a/pkg/app/mysql.go
+++ b/pkg/app/mysql.go
@@ -57,6 +57,7 @@ func NewMysqlDB(name string) HelmApp {
 				"auth.rootPassword": "mysecretpassword",
 				"image.pullPolicy":  "Always",
 			},
+			Version: "12.2.4",
 		},
 	}
 }


### PR DESCRIPTION
## Change Overview

When using helm chart version `12.3.0`, with `--set auth.rootPassword` flag, the installation is failing. This PR pins the version to `12.2.4` until the issue is fixed.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :building_construction: Build

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
