### PR TITLE
Fix password propagation into MySQL and MariaDB helm charts

### DIFF
--- a/pkg/app/mariadb.go
+++ b/pkg/app/mariadb.go
@@ -53,8 +53,9 @@ func NewMariaDB(name string) App {
 			Chart:    "mariadb",
 			RepoName: helm.BitnamiRepoName,
 			Values: map[string]string{
-				"auth.rootPassword": "mysecretpassword",
-				"image.pullPolicy":  "Always",
+				"auth.usePasswordFiles": "false",
+				"auth.rootPassword":     "mysecretpassword",
+				"image.pullPolicy":      "Always",
 			},
 		},
 	}

--- a/pkg/app/mysql.go
+++ b/pkg/app/mysql.go
@@ -54,10 +54,10 @@ func NewMysqlDB(name string) HelmApp {
 			Chart:    "mysql",
 			RepoName: helm.BitnamiRepoName,
 			Values: map[string]string{
-				"auth.rootPassword": "mysecretpassword",
-				"image.pullPolicy":  "Always",
+				"auth.usePasswordFiles": "false",
+				"auth.rootPassword":     "mysecretpassword",
+				"image.pullPolicy":      "Always",
 			},
-			Version: "12.2.4",
 		},
 	}
 }


### PR DESCRIPTION
## Change Overview

The newest chart versions use password files by default. Set this flag back to false.

This also effectively reverts https://github.com/kanisterio/kanister/pull/3382.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :building_construction: Build

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
