### PR TITLE
test: Add retries for test runs to cleanup flake runs

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -87,7 +87,12 @@ jobs:
         make install-csi-hostpath-driver
         make install-minio
       if: matrix.testSuite == 'test'
-    - run: make ${{ matrix.testSuite }}
+    - uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
+      with:
+        timeout_minutes: 30
+        max_attempts: 2
+        command: make ${{ matrix.testSuite }}
+
   build:
     runs-on: ubuntu-20.04
     needs: gomod


### PR DESCRIPTION
## Change Overview

We have seen quite a few flakes in the integration test related to remote infra used there.
Adding retry might improve QOL for testing. 
One potential downside could be missing common test failures if they only happen <50% of the time.
We have not seen those so far and most flakes were remote infra related.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [x] :robot: Test
- [ ] :building_construction: Build

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
