### PR TITLE
Add details about images for air-gapped environment

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -64,6 +64,18 @@ version to install.
 The source of the `values.yaml` file can be found on
 [GitHub](https://github.com/kanisterio/kanister/blob/master/helm/kanister-operator/values.yaml).
 
+## Installation in air-gapped environment
+
+In the situation where the K8s cluster is isolated from the internet, below are
+the images that need to be copied to the local container registry, to make
+Kanister work successfully.
+
+- Kanister Controller (ghcr.io/kanisterio/controller)
+- Kanister Tools (ghcr.io/kanisterio/kanister-tools)
+
+Apart from above images, the images that are being used in the blueprint would
+also need to be present in the local container registry.
+
 ## Managing Custom Resource Definitions (CRDs)
 
 The default RBAC settings in the Helm chart permit Kanister to manage


### PR DESCRIPTION
## Change Overview

This commit adds a list of images that need to be present in local container registry in case of the airgapped kanister installation.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :building_construction: Build

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
