### PR TITLE
Update build image and linters config to support go1.24

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,7 +20,7 @@ linters:
     # - depguard # Disabling temporarily due to https://github.com/golangci/golangci-lint/issues/3906
     - dogsled
     - dupl
-    - exportloopref
+    # - exportloopref
     - importas
     - misspell
     - nestif

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -19,7 +19,7 @@ COPY --from=goreleaser/goreleaser:v1.26.2 /usr/bin/goreleaser /usr/local/bin/
 
 COPY --from=alpine/helm:3.12.2 /usr/bin/helm /usr/local/bin/
 
-COPY --from=golangci/golangci-lint:v1.60.1 /usr/bin/golangci-lint /usr/local/bin/
+COPY --from=golangci/golangci-lint:v1.64.7 /usr/bin/golangci-lint /usr/local/bin/
 
 RUN wget -O /usr/local/bin/kind \
       https://github.com/kubernetes-sigs/kind/releases/download/v0.18.0/kind-$(echo $TARGETPLATFORM | tr / -) \


### PR DESCRIPTION
## Change Overview

There are issues with staticcheck in go1.24 requiring golangci update in the build image.

`exportloopref` is deprecated in go1.24, need to be removed to work with new build image

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [x] :building_construction: Build

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
