### PR TITLE
build: Pin ubi-minimal images using SHA256 in dockerfiles

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -1,5 +1,5 @@
 ARG base_image=default
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5 AS default
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5@sha256:ac61c96b93894b9169221e87718733354dd3765dd4a62b275893c7ff0d876869 AS default
 
 FROM ${base_image}
 ARG kanister_version

--- a/docker/controller/Dockerfile
+++ b/docker/controller/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5@sha256:ac61c96b93894b9169221e87718733354dd3765dd4a62b275893c7ff0d876869
 
 LABEL maintainer="Kanister maintainers<kanister.maintainers@veeam.com>"
 

--- a/docker/repo-server-controller/Dockerfile
+++ b/docker/repo-server-controller/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5@sha256:ac61c96b93894b9169221e87718733354dd3765dd4a62b275893c7ff0d876869
 
 LABEL maintainer="Kanister maintainers<kanister.maintainers@veeam.com>"
 

--- a/docker/tools/Dockerfile
+++ b/docker/tools/Dockerfile
@@ -74,7 +74,7 @@ RUN apt-get update && apt-get -y install ca-certificates && \
 USER kopia:kopia
 
 # Build tools image
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5@sha256:ac61c96b93894b9169221e87718733354dd3765dd4a62b275893c7ff0d876869
 ARG kan_tools_version="test-version"
 LABEL name="kanister-tools" \
     vendor="Kanister" \


### PR DESCRIPTION
## Change Overview

Address `Pinned dependencies` alerts like https://github.com/kanisterio/kanister/security/code-scanning/211 by pinning ubi-minimal images with SHA256 digest.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [x] :building_construction: Build

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
