### PR TITLE
Add missing max-errors flag to kopia snapshot cmd builder

### DIFF
--- a/pkg/kopia/command/snapshot.go
+++ b/pkg/kopia/command/snapshot.go
@@ -208,6 +208,10 @@ func SnapshotVerify(cmdArgs SnapshotVerifyCommandArgs) []string {
 		args = args.AppendLoggableKV(verifyFilesPercentFlag, fmt.Sprintf("%v", *cmdArgs.VerifyFilesPercent))
 	}
 
+	if cmdArgs.MaxErrors != nil {
+		args = args.AppendLoggableKV(maxErrorsFlag, strconv.Itoa(*cmdArgs.MaxErrors))
+	}
+
 	if cmdArgs.Parallelism != nil {
 		parallelismStr := strconv.Itoa(*cmdArgs.Parallelism)
 		args = args.AppendLoggableKV(parallelFlag, parallelismStr)

--- a/pkg/kopia/command/snapshot_test.go
+++ b/pkg/kopia/command/snapshot_test.go
@@ -199,9 +199,11 @@ func (kSnapshot *KopiaSnapshotTestSuite) TestSnapshotCommands(c *check.C) {
 				p := 123
 				fql := 456
 				fp := 890
+				maxErr := 11235
 				args := SnapshotVerifyCommandArgs{
 					CommandArgs:        commandArgs,
 					VerifyFilesPercent: &vfp,
+					MaxErrors:          &maxErr,
 					Parallelism:        &p,
 					FileQueueLength:    &fql,
 					FileParallelism:    &fp,
@@ -213,7 +215,7 @@ func (kSnapshot *KopiaSnapshotTestSuite) TestSnapshotCommands(c *check.C) {
 				}
 				return SnapshotVerify(args)
 			},
-			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log --password=encr-key snapshot verify --verify-files-percent=12.345 --parallel=123 --file-queue-length=456 --file-parallelism=890 --directory-id=d1 --directory-id=d2 --file-id=f1 --file-id=f2 --sources=s1 --sources=s2 --json id1 id2",
+			expectedLog: "kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log --password=encr-key snapshot verify --verify-files-percent=12.345 --max-errors=11235 --parallel=123 --file-queue-length=456 --file-parallelism=890 --directory-id=d1 --directory-id=d2 --file-id=f1 --file-id=f2 --sources=s1 --sources=s2 --json id1 id2",
 		},
 	} {
 		cmd := strings.Join(tc.f(), " ")


### PR DESCRIPTION
## Change Overview

Add missing `--max-errors` flag to the kopia snapshot command builder.

Field was added in https://github.com/kanisterio/kanister/pull/3141 but somehow was not hooked up to the cmd argv output.

## Pull request type

Please check the type of change your PR introduces:
- [x] :bug: Bugfix

## Test Plan

- [x] :zap: Unit test
