### PR TITLE
Adding security context at pod and container level for Kanister operator

### DIFF
--- a/helm/kanister-operator/templates/_helpers.tpl
+++ b/helm/kanister-operator/templates/_helpers.tpl
@@ -111,3 +111,23 @@ Define a custom kanister-tools image
 {{- define "kanister-tools.image" -}}
     {{- printf "%s:%s" (.Values.kanisterToolsImage.image) (.Values.kanisterToolsImage.tag) -}}
 {{- end -}}
+
+{{/*
+Define a security Context at Pod level
+*/}}
+{{- define "podSecurityContext" -}}
+    {{- if .Values.podSecurityContext }}
+    securityContext: 
+      {{ toYaml .Values.podSecurityContext  | nindent 6  }}
+    {{- end }}
+{{- end -}}
+
+{{/*
+Define a security Context at Container level
+*/}}
+{{- define "containerSecurityContext" -}}
+    {{- if .Values.containerSecurityContext }}
+    securityContext:
+      {{ toYaml .Values.containerSecurityContext | nindent 6 }}
+    {{- end }}
+{{- end -}}

--- a/helm/kanister-operator/templates/deployment.yaml
+++ b/helm/kanister-operator/templates/deployment.yaml
@@ -15,6 +15,7 @@ spec:
 {{ include "kanister-operator.helmLabels" . | indent 8}}
     spec:
       serviceAccountName: {{ template "kanister-operator.serviceAccountName" . }}
+{{ include "podSecurityContext" . | indent 2 }}
 {{- if or .Values.bpValidatingWebhook.enabled .Values.validatingWebhook.repositoryserver.enabled }}
       volumes:
         - name: webhook-certs
@@ -45,6 +46,7 @@ spec:
           value: {{ .Values.dataStore.parallelism.download | quote }}
         - name: KANISTER_METRICS_ENABLED
           value: {{ .Values.controller.metrics.enabled | quote }}
+{{ include "containerSecurityContext" . | indent 4 }}
 {{- if .Values.resources }}
         resources:
 {{ toYaml .Values.resources | indent 12 }}

--- a/helm/kanister-operator/values.yaml
+++ b/helm/kanister-operator/values.yaml
@@ -89,3 +89,17 @@ tolerations: []
 #
 # node labels for pod assignment. Evaluated as template
 nodeSelector: {}
+
+podSecurityContext:
+  runAsUser: 1000
+  runAsGroup: 3000
+  fsGroup: 2000
+  runAsNonRoot: true
+
+containerSecurityContext:
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  privileged: false
+  capabilities:
+    drop:
+    - ALL

--- a/pkg/testing/helm/helm_test.go
+++ b/pkg/testing/helm/helm_test.go
@@ -199,6 +199,121 @@ func (h *HelmTestSuite) TestSelectedDeploymentAttrFromKanisterHelmDryRunInstall(
 	}
 }
 
+// Test for Pod and Container-level securityContext in the Helm chart
+func (h *HelmTestSuite) TestSecurityContextInHelmChart(c *check.C) {
+	defaultPodSecurityValues := corev1.PodSecurityContext{
+		RunAsUser:    intPtr(1000),
+		FSGroup:      intPtr(2000),
+		RunAsNonRoot: boolPtr(true),
+		RunAsGroup:   intPtr(3000),
+	}
+
+	defaultContainerSecurityValues := corev1.SecurityContext{
+		ReadOnlyRootFilesystem:   boolPtr(true),
+		AllowPrivilegeEscalation: boolPtr(false),
+		Privileged:               boolPtr(false),
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{"ALL"},
+		},
+	}
+
+	podSecurity := corev1.PodSecurityContext{
+		RunAsUser:    intPtr(9000),
+		FSGroup:      intPtr(9000),
+		RunAsNonRoot: boolPtr(true),
+		RunAsGroup:   intPtr(9000),
+	}
+
+	containerSecurity := corev1.SecurityContext{
+		ReadOnlyRootFilesystem:   boolPtr(false),
+		AllowPrivilegeEscalation: boolPtr(true),
+		Privileged:               boolPtr(true),
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{"ALL"},
+		},
+	}
+
+	var testCases = []struct {
+		testName                  string
+		helmValues                map[string]string
+		expectedPodSecurity       *corev1.PodSecurityContext
+		expectedContainerSecurity *corev1.SecurityContext
+	}{
+		{
+			testName: "Pod and Container security context are set",
+			helmValues: map[string]string{
+				"containerSecurityContext.capabilities.drop[0]":     "ALL",
+				"containerSecurityContext.privileged":               "true",
+				"containerSecurityContext.allowPrivilegeEscalation": "true",
+				"containerSecurityContext.readOnlyRootFilesystem":   "false",
+				"podSecurityContext.runAsUser":                      "9000",
+				"podSecurityContext.fsGroup":                        "9000",
+				"podSecurityContext.runAsNonRoot":                   "true",
+				"podSecurityContext.runAsGroup":                     "9000",
+			},
+			expectedPodSecurity:       &podSecurity,
+			expectedContainerSecurity: &containerSecurity,
+		},
+		{
+			testName: "Only Container security context is getting overwritten",
+			helmValues: map[string]string{
+				"containerSecurityContext.capabilities.drop[0]":     "ALL",
+				"containerSecurityContext.privileged":               "true",
+				"containerSecurityContext.allowPrivilegeEscalation": "true",
+				"containerSecurityContext.readOnlyRootFilesystem":   "false",
+			},
+			expectedPodSecurity:       &defaultPodSecurityValues,
+			expectedContainerSecurity: &containerSecurity,
+		},
+		{
+			testName: "Only Pod security context is getting overwritten",
+			helmValues: map[string]string{
+				"podSecurityContext.runAsUser":    "9000",
+				"podSecurityContext.fsGroup":      "9000",
+				"podSecurityContext.runAsNonRoot": "true",
+				"podSecurityContext.runAsGroup":   "9000",
+			},
+			expectedPodSecurity:       &podSecurity,
+			expectedContainerSecurity: &defaultContainerSecurityValues,
+		},
+	}
+
+	for _, tc := range testCases {
+		c.Logf("Test name: %s", tc.testName)
+		defer func() {
+			h.helmApp.dryRun = false
+		}()
+
+		testApp, err := NewHelmApp(tc.helmValues, kanisterName, "../../../helm/kanister-operator", kanisterName, "", true)
+		c.Assert(err, check.IsNil)
+
+		out, err := testApp.Install()
+		c.Assert(err, check.IsNil)
+
+		resources := helm.ResourcesFromRenderedManifest(out, func(kind helm.K8sObjectType) bool {
+			return kind == helm.K8sObjectTypeDeployment
+		})
+		c.Assert(len(resources), check.Equals, 1)
+
+		deployments, err := helm.K8sObjectsFromRenderedResources[*appsv1.Deployment](resources)
+		c.Assert(err, check.IsNil)
+
+		var obj = deployments[h.deploymentName]
+		c.Assert(obj, check.NotNil)
+
+		c.Assert(obj.Spec.Template.Spec.SecurityContext, check.DeepEquals, tc.expectedPodSecurity)
+		c.Assert(obj.Spec.Template.Spec.Containers[0].SecurityContext, check.DeepEquals, tc.expectedContainerSecurity)
+	}
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}
+
+func intPtr(i int64) *int64 {
+	return &i
+}
+
 func (h *HelmTestSuite) TearDownSuite(c *check.C) {
 	c.Log("Uninstalling chart")
 	err := h.helmApp.Uninstall()

--- a/releasenotes/notes/pre-release-0.114.0-cde047dfd4c5ad27.yaml
+++ b/releasenotes/notes/pre-release-0.114.0-cde047dfd4c5ad27.yaml
@@ -1,0 +1,3 @@
+---
+issues:
+  - Security Context of the Kanister operator pod can be configured using the helm fields `podSecurityContext` and `containerSecurityContext`.


### PR DESCRIPTION
## Change Overview

Adding security context at pod and container level for Kanister operator

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [x] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :building_construction: Build

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes https://github.com/kanisterio/kanister/issues/2979

## Test Plan

1. Unit tests are passing.
```
make helm-test
OK: 4 passed
PASS
ok  	github.com/kanisterio/kanister/pkg/testing/helm	12.117s
real 13.61
user 0.01
sys 0.01
```
2. Tried manual helm upgrade. 
