### PR TITLE
Add example to configure SA for KubeTask pod

### DIFF
--- a/docs/functions.md
+++ b/docs/functions.md
@@ -95,7 +95,9 @@ Example:
 ### KubeTask
 
 KubeTask spins up a new container and executes a command via a Pod. This
-allows you to run a new Pod from a Blueprint.
+allows you to run a new Pod from a Blueprint. The ServiceAccount of the newly
+created Pod can configured using the `podOverride` function argument like shown
+below: 
 
   | Argument    | Required | Type                    | Description |
   | ----------- | :------: | ----------------------- | ----------- |
@@ -115,6 +117,7 @@ Example:
     namespace: "{{ .Deployment.Namespace }}"
     image: busybox
     podOverride:
+      serviceAccountName: <sa-name>
       containers:
       - name: container
         imagePullPolicy: IfNotPresent


### PR DESCRIPTION
## Change Overview

Even though the ServiceAccount of the pod created for KubeTask function can be configured using the `serviceAccountName` field in the `podOverride` function argument, it is not very clear in the docs.
This PR mentions it explicitly for the KubeTask function.  

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :building_construction: Build

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
