### PR TITLE
Adding liveness and readiness probe for Kanister operator

### DIFF
--- a/helm/kanister-operator/templates/_helpers.tpl
+++ b/helm/kanister-operator/templates/_helpers.tpl
@@ -131,3 +131,37 @@ Define a security Context at Container level
       {{ toYaml .Values.containerSecurityContext | nindent 6 }}
     {{- end }}
 {{- end -}}
+
+{{/*
+Define a livenessprobe
+*/}}
+{{- define "livenessProbe" -}}
+    {{- if .Values.livenessProbe.enabled }}
+    livenessProbe:
+      httpGet:
+        path: {{ .Values.livenessProbe.httpGet.path }}
+        port: {{ .Values.livenessProbe.httpGet.port }}
+      initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+      periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+      timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+      failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+      successThreshold: {{ .Values.livenessProbe.successThreshold }}
+    {{- end }}
+{{- end -}}
+
+{{/*
+Define a readinessprobe
+*/}}
+{{- define "readinessProbe" -}}
+    {{- if .Values.readinessProbe.enabled }}
+    readinessProbe:
+      httpGet:
+        path: {{ .Values.readinessProbe.httpGet.path }}
+        port: {{ .Values.readinessProbe.httpGet.port }}
+      initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+      periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+      timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+      failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+      successThreshold: {{ .Values.readinessProbe.successThreshold }}
+    {{- end }}
+{{- end -}}

--- a/helm/kanister-operator/templates/deployment.yaml
+++ b/helm/kanister-operator/templates/deployment.yaml
@@ -47,6 +47,8 @@ spec:
         - name: KANISTER_METRICS_ENABLED
           value: {{ .Values.controller.metrics.enabled | quote }}
 {{ include "containerSecurityContext" . | indent 4 }}
+{{ include "livenessProbe" . | indent 4 }}
+{{ include "readinessProbe" . | indent 4 }}
 {{- if .Values.resources }}
         resources:
 {{ toYaml .Values.resources | indent 12 }}

--- a/helm/kanister-operator/values.yaml
+++ b/helm/kanister-operator/values.yaml
@@ -103,3 +103,25 @@ containerSecurityContext:
   capabilities:
     drop:
     - ALL
+
+livenessProbe:
+  enabled: true
+  httpGet:
+    path: /healthz
+    port: 8081
+  initialDelaySeconds: 10
+  periodSeconds: 20
+  timeoutSeconds: 2
+  failureThreshold: 5
+  successThreshold: 1
+
+readinessProbe:
+  enabled: true
+  httpGet:
+    path: /readyz
+    port: 8081
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 2
+  failureThreshold: 3
+  successThreshold: 1

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -17,7 +17,9 @@
 package handler
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 
@@ -25,6 +27,8 @@ import (
 	"github.com/kanisterio/errkit"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
@@ -36,9 +40,10 @@ import (
 )
 
 const (
-	healthCheckPath = "/v0/healthz"
+	healthCheckAddr = ":8081"
+	livenessPath    = "/healthz"
+	readinessPath   = "/readyz"
 	metricsPath     = "/metrics"
-	healthCheckAddr = ":8000"
 	whHandlePath    = "/validate/v1alpha1/blueprint"
 )
 
@@ -65,13 +70,43 @@ func (*healthCheckHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	_, _ = io.Writer.Write(w, js)
 }
 
+func combinedReadinessCheck(mgr ctrl.Manager) healthz.Checker {
+	return func(_ *http.Request) error {
+		if !mgr.GetCache().WaitForCacheSync(context.Background()) {
+			return fmt.Errorf("controller cache not synced")
+		}
+
+		// Do we need to check for leader election? as well for reposervercontroller I can see
+		// leader election is disabled.
+		// Can add more checks if any downstream dependency is there.
+
+		return nil
+	}
+}
+
 // RunWebhookServer starts the validating webhook resources for blueprint kanister resources
 func RunWebhookServer(c *rest.Config) error {
 	log.SetLogger(logr.New(log.NullLogSink{}))
-	mgr, err := manager.New(c, manager.Options{})
+	mgr, err := manager.New(c, manager.Options{
+		HealthProbeBindAddress: healthCheckAddr,
+		LivenessEndpointName:   livenessPath,
+		ReadinessEndpointName:  readinessPath,
+	})
 	if err != nil {
 		return errkit.Wrap(err, "Failed to create new webhook manager")
 	}
+
+	// Register liveness probe.
+	// This will always return true, unless the container is down.
+	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+		return errkit.Wrap(err, "Failed to add health check")
+	}
+
+	// Register readiness probe.
+	if err := mgr.AddReadyzCheck("readyz", combinedReadinessCheck(mgr)); err != nil {
+		return errkit.Wrap(err, "Failed to add readiness check")
+	}
+
 	bpValidator := &validatingwebhook.BlueprintValidator{}
 	decoder := admission.NewDecoder(mgr.GetScheme())
 	if err = bpValidator.InjectDecoder(&decoder); err != nil {
@@ -81,7 +116,6 @@ func RunWebhookServer(c *rest.Config) error {
 	hookServerOptions := webhook.Options{CertDir: validatingwebhook.WHCertsDir}
 	hookServer := webhook.NewServer(hookServerOptions)
 	hookServer.Register(whHandlePath, &webhook.Admission{Handler: bpValidator})
-	hookServer.Register(healthCheckPath, &healthCheckHandler{})
 	hookServer.Register(metricsPath, promhttp.Handler())
 
 	if err := mgr.Add(hookServer); err != nil {
@@ -97,7 +131,7 @@ func RunWebhookServer(c *rest.Config) error {
 
 func NewServer() *http.Server {
 	m := &http.ServeMux{}
-	m.Handle(healthCheckPath, &healthCheckHandler{})
+	m.Handle(livenessPath, &healthCheckHandler{})
 	m.Handle(metricsPath, promhttp.Handler())
 	return &http.Server{Addr: healthCheckAddr, Handler: m}
 }


### PR DESCRIPTION
## Change Overview

 Adding liveness and readiness probe for Kanister operator

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :building_construction: Build

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes https://github.com/kanisterio/kanister/issues/2998

## Test Plan
- [x] :muscle: Manual
- [x] :zap: Unit test
- [x] :green_heart: E2E

1. Unit tests are passing. 
2. Deployment rendering as expected and applied on kind cluster. 
3. Integration test for mysql is passing
