### PR TITLE
test: Change checking for biringcrypto to check for internal fips lib

### DIFF
--- a/pkg/kube/fips_test.go
+++ b/pkg/kube/fips_test.go
@@ -86,7 +86,7 @@ func (s *FIPSSuite) TearDownSuite(c *check.C) {
 	}
 }
 
-func (s *FIPSSuite) TestFIPSBoringEnabled(c *check.C) {
+func (s *FIPSSuite) TestFIPSPresent(c *check.C) {
 	for _, tool := range []string{
 		"/usr/local/bin/kopia",
 		"/usr/local/bin/kando",
@@ -98,16 +98,16 @@ func (s *FIPSSuite) TestFIPSBoringEnabled(c *check.C) {
 			c.Assert(err, check.IsNil)
 			c.Assert(stderr, check.Equals, "")
 			scanner := bufio.NewScanner(strings.NewReader(stdout))
-			fipsModeSet := false
+			fipsLibPresent := false
 			for scanner.Scan() {
-				if strings.Contains(scanner.Text(), "FIPS") {
+				if strings.Contains(scanner.Text(), "fips") {
 					c.Log(scanner.Text())
 				}
-				if strings.Contains(scanner.Text(), "FIPS_mode_set") {
-					fipsModeSet = true
+				if strings.Contains(scanner.Text(), "crypto/internal/fips140") {
+					fipsLibPresent = true
 				}
 			}
-			c.Assert(fipsModeSet, check.Equals, true)
+			c.Assert(fipsLibPresent, check.Equals, true)
 		}
 	}
 }


### PR DESCRIPTION
## Change Overview

After #3496 boringcrypto is no longer in the standard images.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [x] :robot: Test
- [ ] :building_construction: Build

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [x] :green_heart: E2E
