### PR TITLE
perform streaming uploads for kando push

### DIFF
--- a/pkg/stream/stream.go
+++ b/pkg/stream/stream.go
@@ -13,21 +13,22 @@
 // limitations under the License.
 
 // Package stream provides functionality to stream data to an object store
-// by reading it from a given endpoint into an in-memory filesystem.
+// by reading it from a given endpoint without loading it into memory.
 package stream
 
 import (
 	"context"
+	"net/http"
 	"os"
-	"path/filepath"
 
 	"github.com/kanisterio/errkit"
+	"github.com/kopia/kopia/fs"
+	"github.com/kopia/kopia/fs/virtualfs"
 	"github.com/kopia/kopia/snapshot"
 	"github.com/kopia/kopia/snapshot/upload"
 
 	"github.com/kanisterio/kanister/pkg/kopia/repository"
 	kansnapshot "github.com/kanisterio/kanister/pkg/kopia/snapshot"
-	"github.com/kanisterio/kanister/pkg/virtualfs"
 )
 
 const (
@@ -35,24 +36,36 @@ const (
 	defaultPermissions  os.FileMode = 0777
 )
 
-// Push streams data to object store by reading it from the given endpoint into an in-memory filesystem
+// Push streams data to object store by reading it from the given endpoint using Kopia's streaming capabilities
 func Push(ctx context.Context, configFile, dirPath, filePath, password, sourceEndpoint string) error {
 	rep, err := repository.Open(ctx, configFile, password, "kanister stream push")
 	if err != nil {
 		return errkit.Wrap(err, "Failed to open kopia repository")
 	}
-	// Initialize a directory tree with given file
-	// The following will create <dirPath>/<filePath> objects
-	// Example: If dirPath is `/mnt/data` and filePath is `dir/file`,
-	// `data` will be the root directory and
-	// `dir/file` objects will be created under it
-	root, err := virtualfs.NewDirectory(filepath.Base(dirPath))
+
+	// Create an HTTP client to stream from the source endpoint
+	req, err := http.NewRequestWithContext(ctx, "GET", sourceEndpoint, nil)
 	if err != nil {
-		return errkit.Wrap(err, "Failed to create root directory")
+		return errkit.Wrap(err, "Failed to create HTTP request")
 	}
-	if _, err = virtualfs.AddFileWithStreamSource(root, filePath, sourceEndpoint, defaultPermissions, defaultPermissions); err != nil {
-		return errkit.Wrap(err, "Failed to add file with the given stream source to the root directory")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return errkit.Wrap(err, "Failed to make HTTP request")
 	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return errkit.New("HTTP request failed", "status", resp.Status)
+	}
+
+	// Use Kopia's streaming virtualfs which doesn't load data into memory
+	// This creates a virtual directory tree rooted at dirPath 
+	// with a streaming file as the child entry
+	rootDir := virtualfs.NewStaticDirectory(dirPath, []fs.Entry{
+		virtualfs.StreamingFileFromReader(filePath, resp.Body),
+	})
 
 	// Setup kopia uploader
 	u := upload.NewUploader(rep)
@@ -67,6 +80,6 @@ func Push(ctx context.Context, configFile, dirPath, filePath, password, sourceEn
 	}
 
 	// Create a kopia snapshot
-	_, _, err = kansnapshot.SnapshotSource(ctx, rep, u, sourceInfo, root, snapshotDescription)
+	_, _, err = kansnapshot.SnapshotSource(ctx, rep, u, sourceInfo, rootDir, snapshotDescription)
 	return errkit.Wrap(err, "Failed to create kopia snapshot")
 }


### PR DESCRIPTION
## Change Overview

Kando consumes excessive memory when uploading large files to S3. See https://github.com/kanisterio/kanister/issues/3036

This PR changes the upload method to streaming. This is memory efficient.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :building_construction: Build

## Issues

- fixes #3036

## Test Plan

Tested uploading a 2.7GB gz file and monitored the pod memory usage. It hovered around 600 MB. 

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E