### PR TITLE
Increase timeout for test TestContextTimeout

### DIFF
--- a/pkg/kube/exec_test.go
+++ b/pkg/kube/exec_test.go
@@ -294,9 +294,9 @@ func (s *ExecSuite) TestKopiaCommand(c *check.C) {
 // TestContextTimeout verifies that when context is cancelled during command execution,
 // execution will be interrupted and proper error will be returned. The stdout, stderr streams should be captured.
 func (s *ExecSuite) TestContextTimeout(c *check.C) {
-	ctx, cancel := context.WithTimeout(context.Background(), 1000*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 2000*time.Millisecond)
 	defer cancel()
-	cmd := []string{"sh", "-c", "echo abc && sleep 2 && echo def"}
+	cmd := []string{"sh", "-c", "echo abc && sleep 3 && echo def"}
 	for _, cs := range s.pod.Status.ContainerStatuses {
 		stdout, stderr, err := Exec(ctx, s.cli, s.pod.Namespace, s.pod.Name, cs.Name, cmd, nil)
 		c.Assert(err, check.NotNil)


### PR DESCRIPTION
## Change Overview

It was observed that TestContextTimeout unit test fails on GKE clusters. Probably due to time exec API takes more time and the context gets cancelled before that.
This PR increases the timeout to execute the test on GKE cluster.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :building_construction: Build


## Test Plan

Verified that the test passes on GKE cluster

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
