### PR TITLE
deps(go): rollback aws-sdk-go dependency to prevent downstream linter issues

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.10.1 // indirect
 	github.com/Masterminds/semver v1.5.0
 	github.com/Masterminds/sprig v2.22.0+incompatible
-	github.com/aws/aws-sdk-go v1.55.8
+	github.com/aws/aws-sdk-go v1.55.7
 	github.com/dustin/go-humanize v1.0.1
 	github.com/go-logr/logr v1.4.3
 	github.com/go-openapi/strfmt v0.23.0

--- a/go.sum
+++ b/go.sum
@@ -117,8 +117,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
-github.com/aws/aws-sdk-go v1.55.8 h1:JRmEUbU52aJQZ2AjX4q4Wu7t4uZjOu71uyNmaWlUkJQ=
-github.com/aws/aws-sdk-go v1.55.8/go.mod h1:ZkViS9AqA6otK+JBBNH2++sx1sgxrPKcSzPPvQkUtXk=
+github.com/aws/aws-sdk-go v1.55.7 h1:UJrkFq7es5CShfBwlWAC8DA077vp8PyVbQd3lqLiztE=
+github.com/aws/aws-sdk-go v1.55.7/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=

--- a/pkg/app/rds_aurora_mysql.go
+++ b/pkg/app/rds_aurora_mysql.go
@@ -20,11 +20,8 @@ import (
 	"os"
 	"strconv"
 
-	//nolint:staticcheck // SA1019
 	awssdk "github.com/aws/aws-sdk-go/aws"
-	//nolint:staticcheck // SA1019
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	//nolint:staticcheck // SA1019
 	awsrds "github.com/aws/aws-sdk-go/service/rds"
 	"github.com/kanisterio/errkit"
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/app/rds_postgres.go
+++ b/pkg/app/rds_postgres.go
@@ -21,11 +21,8 @@ import (
 	"strconv"
 	"time"
 
-	//nolint:staticcheck // SA1019
 	awssdk "github.com/aws/aws-sdk-go/aws"
-	//nolint:staticcheck // SA1019
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	//nolint:staticcheck // SA1019
 	awsrds "github.com/aws/aws-sdk-go/service/rds"
 	"github.com/kanisterio/errkit"
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -21,14 +21,10 @@ import (
 	"os"
 	"time"
 
-	//nolint:staticcheck // SA1019
 	"github.com/aws/aws-sdk-go/aws"
-	//nolint:staticcheck // SA1019
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
-	//nolint:staticcheck // SA1019
 	"github.com/aws/aws-sdk-go/aws/session"
-	//nolint:staticcheck // SA1019
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/aws/aws-sdk-go/service/sts/stsiface"
 	"github.com/kanisterio/errkit"

--- a/pkg/aws/aws_test.go
+++ b/pkg/aws/aws_test.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"testing"
 
-	//nolint:staticcheck // SA1019
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/aws/aws-sdk-go/service/sts/stsiface"
 	"gopkg.in/check.v1"

--- a/pkg/aws/ec2/ec2.go
+++ b/pkg/aws/ec2/ec2.go
@@ -19,11 +19,8 @@ package ec2
 import (
 	"context"
 
-	//nolint:staticcheck // SA1019
 	"github.com/aws/aws-sdk-go/aws"
-	//nolint:staticcheck // SA1019
 	"github.com/aws/aws-sdk-go/aws/session"
-	//nolint:staticcheck // SA1019
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/kanisterio/errkit"
 )

--- a/pkg/aws/rds/rds.go
+++ b/pkg/aws/rds/rds.go
@@ -21,13 +21,9 @@ import (
 	"fmt"
 	"time"
 
-	//nolint:staticcheck // SA1019
 	"github.com/aws/aws-sdk-go/aws"
-	//nolint:staticcheck // SA1019
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	//nolint:staticcheck // SA1019
 	"github.com/aws/aws-sdk-go/aws/session"
-	//nolint:staticcheck // SA1019
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/kanisterio/errkit"
 

--- a/pkg/aws/role/role.go
+++ b/pkg/aws/role/role.go
@@ -19,12 +19,9 @@ import (
 	"context"
 	"time"
 
-	//nolint:staticcheck // SA1019
 	"github.com/aws/aws-sdk-go/aws"
-	//nolint:staticcheck // SA1019
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
-	//nolint:staticcheck // SA1019
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/kanisterio/errkit"
 )

--- a/pkg/function/delete_rds_snapshot.go
+++ b/pkg/function/delete_rds_snapshot.go
@@ -18,9 +18,7 @@ import (
 	"context"
 	"time"
 
-	//nolint:staticcheck // SA1019
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	//nolint:staticcheck // SA1019
 	awsrds "github.com/aws/aws-sdk-go/service/rds"
 	"github.com/kanisterio/errkit"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/function/rds_utils.go
+++ b/pkg/function/rds_utils.go
@@ -4,11 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	//nolint:staticcheck // SA1019
 	awssdk "github.com/aws/aws-sdk-go/aws"
-	//nolint:staticcheck // SA1019
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	//nolint:staticcheck // SA1019
 	rdserr "github.com/aws/aws-sdk-go/service/rds"
 	"github.com/kanisterio/errkit"
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/function/restore_rds_snapshot.go
+++ b/pkg/function/restore_rds_snapshot.go
@@ -20,11 +20,8 @@ import (
 	"strconv"
 	"time"
 
-	//nolint:staticcheck // SA1019
 	"github.com/aws/aws-sdk-go/aws"
-	//nolint:staticcheck // SA1019
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	//nolint:staticcheck // SA1019
 	rdserr "github.com/aws/aws-sdk-go/service/rds"
 	"github.com/hashicorp/go-version"
 	"github.com/kanisterio/errkit"

--- a/pkg/objectstore/aws.go
+++ b/pkg/objectstore/aws.go
@@ -20,11 +20,8 @@ import (
 	"net/http"
 	"strings"
 
-	//nolint:staticcheck // SA1019
 	"github.com/aws/aws-sdk-go/aws"
-	//nolint:staticcheck // SA1019
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	//nolint:staticcheck // SA1019
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/kanisterio/errkit"
 

--- a/pkg/objectstore/bucket.go
+++ b/pkg/objectstore/bucket.go
@@ -21,15 +21,10 @@ import (
 	"fmt"
 	"path"
 
-	//nolint:staticcheck // SA1019
 	"github.com/aws/aws-sdk-go/aws"
-	//nolint:staticcheck // SA1019
 	"github.com/aws/aws-sdk-go/aws/request"
-	//nolint:staticcheck // SA1019
 	"github.com/aws/aws-sdk-go/aws/session"
-	//nolint:staticcheck // SA1019
 	"github.com/aws/aws-sdk-go/service/s3"
-	//nolint:staticcheck // SA1019
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/graymeta/stow"
 	"github.com/kanisterio/errkit"

--- a/pkg/secrets/aws.go
+++ b/pkg/secrets/aws.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"time"
 
-	//nolint:staticcheck // SA1019
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/kanisterio/errkit"
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/secrets/aws_test.go
+++ b/pkg/secrets/aws_test.go
@@ -17,7 +17,6 @@ package secrets
 import (
 	"context"
 
-	//nolint:staticcheck // SA1019
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"gopkg.in/check.v1"
 	corev1 "k8s.io/api/core/v1"


### PR DESCRIPTION
## Change Overview

Rolled back `aws-sdk-go` to `1.55.7`
This is a better way to address linter issues for now then ignoring them.
Related to https://github.com/kanisterio/kanister/issues/3603

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [x] :building_construction: Build

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
