### PR TITLE
deps(go): prevent upgrades for EOL AWS SDK v1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,7 @@ updates:
       common-golang:
         patterns:
         - "cloud.google.com/*"
+        - "github.com/aws/aws-sdk-go-v2"
         - "github.com/aws/aws-sdk-go-v2/*"
         - "github.com/Azure/azure-sdk-for-go/sdk/*"
         - "github.com/minio/minio-go/*"


### PR DESCRIPTION
## Change Overview

Modify the group pattern to only include AWS v2 modules, which in turn excludes the V1 EOL package.


## Pull request type

- [x] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [x] :building_construction: Build


## Test Plan

- [x] @dependabot's automatic validation.

## References

- #3637
- #3603
