### PR TITLE
Salt to the location.Prefix generation for data_test.go

### DIFF
--- a/pkg/function/data_test.go
+++ b/pkg/function/data_test.go
@@ -24,6 +24,7 @@ import (
 	"gopkg.in/check.v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes"
 	k8sscheme "k8s.io/client-go/kubernetes/scheme"
@@ -764,7 +765,7 @@ func (s *DataSuite) createNewTestProfile(c *check.C, profileName string, localEn
 	default:
 		c.Fatalf("Unrecognized objectstore '%s'", s.providerType)
 	}
-	location.Prefix = "testBackupRestoreLocDelete"
+	location.Prefix = fmt.Sprintf("DataSuite-%s", rand.String(8))
 	location.Bucket = testBucketName
 	if endpoint, ok := os.LookupEnv("LOCATION_CLUSTER_ENDPOINT"); ok && !localEndpoint {
 		location.Endpoint = endpoint


### PR DESCRIPTION
## Change Overview

Adds a random 8-char salt to the object store location prefix when creating test profiles in `pkg/function/data_test.go`. This ensures unique artifact paths per test run (across parallel S3/GCS executions), reducing collisions and flakiness in backup/restore and repository checks.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :building_construction: Build

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [x] :green_heart: E2E
