### PR TITLE
Update stow and go. Fix bucket tests to accomodate new stow version

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -89,6 +89,10 @@ linters:
       - linters:
           - unparam
         text: 'ctx is unused'
+      - linters:
+          - revive
+        path: "pkg/utils/.+"
+        text: "var-naming: avoid meaningless package names"
     paths:
       - pkg/client/applyconfiguration/cr/v1alpha1
       - pkg/client/clientset

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.6-bullseye@sha256:2cdc80dc25edcb96ada1654f73092f2928045d037581fa4aa7c40d18af7dd85a
+FROM golang:1.25.3-bookworm@sha256:ee420c17fa013f71eca6b35c3547b854c838d4f26056a34eb6171bba5bf8ece4
 LABEL maintainer="Kanister maintainers<kanister.maintainers@veeam.com>"
 
 ARG TARGETPLATFORM
@@ -19,7 +19,7 @@ COPY --from=goreleaser/goreleaser:v1.26.2 /usr/bin/goreleaser /usr/local/bin/
 
 COPY --from=alpine/helm:3.12.2 /usr/bin/helm /usr/local/bin/
 
-COPY --from=golangci/golangci-lint:v2.1.6 /usr/bin/golangci-lint /usr/local/bin/
+COPY --from=golangci/golangci-lint:v2.5.0 /usr/bin/golangci-lint /usr/local/bin/
 
 RUN wget -O /usr/local/bin/kind \
       https://github.com/kubernetes-sigs/kind/releases/download/v0.18.0/kind-$(echo $TARGETPLATFORM | tr / -) \
@@ -30,10 +30,17 @@ RUN git config --global --add safe.directory /go/src/github.com/kanisterio/kanis
 # Adding CRD documentation generation tool.
 RUN GOBIN=/usr/local/bin go install github.com/ahmetb/gen-crd-api-reference-docs@v0.3.0
 
-RUN apt-get update && apt-get install -y pip
+RUN apt-get update && apt-get install -y python3-pip python3-venv
 
 COPY requirements.txt requirements.txt
-RUN pip install -r requirements.txt
+
+# Create and activate a virtual environment, then install requirements
+RUN python3 -m venv /opt/venv \
+    && /opt/venv/bin/pip install --upgrade pip \
+    && /opt/venv/bin/pip install -r requirements.txt
+
+# Make sure the venv Python is used by default
+ENV PATH="/opt/venv/bin:$PATH"
 
 RUN apt-get install -y vim
 

--- a/docker/tools/Dockerfile
+++ b/docker/tools/Dockerfile
@@ -1,5 +1,5 @@
 # Build Kopia binary
-FROM golang:1.24.6-bullseye@sha256:2cdc80dc25edcb96ada1654f73092f2928045d037581fa4aa7c40d18af7dd85a AS builder
+FROM golang:1.25.3-bookworm@sha256:ee420c17fa013f71eca6b35c3547b854c838d4f26056a34eb6171bba5bf8ece4 AS builder
 
 ARG kopia_build_commit=master
 ARG kopia_repo_org=kopia
@@ -53,7 +53,7 @@ RUN GO111MODULE=on GOOS=linux GOARCH=amd64 go build -o kopia \
             -X github.com/kopia/kopia/repo.BuildInfo=$(git show --no-patch --format='%cI-%H')-${kopia_build_commit} \
             -X github.com/kopia/kopia/repo.BuildGitHubRepo=${kopia_repo_org}" .
 
-RUN adduser kopia && addgroup kopia kopia
+RUN adduser --disabled-password --gecos "" kopia
 USER kopia:kopia
 
 COPY --chown=kopia . /kopia

--- a/pkg/objectstore/bucket_test.go
+++ b/pkg/objectstore/bucket_test.go
@@ -17,7 +17,11 @@ func (s *BucketSuite) SetUpSuite(c *check.C) {
 	getEnvOrSkip(c, "AWS_SECRET_ACCESS_KEY")
 }
 
-const ahmRe = `[\w\W]*AuthorizationHeaderMalformed[\w\W]*`
+const (
+	ahmRe             = `[\w\W]*AuthorizationHeaderMalformed[\w\W]*`
+	badRequestRegex   = `[\w\W]*BadRequest[\w\W]*`
+	bucketRegionRegex = `[\w\W]*BucketRegionError[\w\W]*`
+)
 
 func (s *BucketSuite) TestInvalidS3RegionEndpointMismatch(c *check.C) {
 	ctx := context.Background()
@@ -40,7 +44,7 @@ func (s *BucketSuite) TestInvalidS3RegionEndpointMismatch(c *check.C) {
 
 	// Get Bucket will use the region's correct endpoint.
 	_, err = p.GetBucket(ctx, bn)
-	c.Assert(err, check.ErrorMatches, ahmRe)
+	c.Assert(err, check.ErrorMatches, badRequestRegex)
 	c.Assert(err, check.NotNil)
 
 	_, err = p.CreateBucket(ctx, bn)
@@ -116,7 +120,7 @@ func (s *BucketSuite) TestValidS3ClientBucketRegionMismatch(c *check.C) {
 	// Specifying an the wrong endpoint causes bucket ops to fail.
 	err = checkProviderWithBucket(ctx, c, p3, bn, r1)
 	c.Assert(err, check.NotNil)
-	c.Assert(err, check.ErrorMatches, ahmRe)
+	c.Assert(err, check.ErrorMatches, bucketRegionRegex)
 }
 
 func checkProviderWithBucket(ctx context.Context, c *check.C, p Provider, bucketName, region string) error {
@@ -160,7 +164,7 @@ func (s *BucketSuite) TestGetRegionForBucket(c *check.C) {
 	pc := ProviderConfig{
 		Type:   pt,
 		Region: testRegionS3,
-		//Region:   "tom-minio-region",
+		// Region:   "tom-minio-region",
 		Endpoint: minioEnpoint,
 	}
 	p, err := NewProvider(ctx, pc, secret)


### PR DESCRIPTION
## Change Overview

- upgrade stow version
- upgrade go image to 1.25 as it is required by new stow version
- change go base image to bookworm
- upgrade golangci-lint
- update bucket tests which would be broken stow upgrade

<!-- Insert PR description-->

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [x] :robot: Test
- [ ] :building_construction: Build

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
