### PR TITLE
ResticTest(DataSuite): added cleanup incase of failure

### DIFF
--- a/pkg/function/data_test.go
+++ b/pkg/function/data_test.go
@@ -115,7 +115,7 @@ func (s *DataSuite) cleanupObjectStoreData(c *check.C) {
 		})
 		err := location.Delete(ctx, *profile, "")
 		if err != nil {
-			c.Log("Failed to clean data from location:", err)
+			c.Log("Failed to clean data from location", field.M{"error": err, "bucket": profile.Location.Bucket})
 		}
 	}
 }


### PR DESCRIPTION
## Change Overview

This pull request adds a cleanup for the object store data in the `DataSuite` tests ensuring that test artifacts are removed if a test fails

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :building_construction: Build

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes [K10-31247](https://kasten.atlassian.net/browse/K10-31247)

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [x] :green_heart: E2E
