### PR TITLE
Use persistence storage for minio in test

### DIFF
--- a/build/minio.sh
+++ b/build/minio.sh
@@ -19,7 +19,7 @@ set -o nounset
 
 # Default bucket name
 S3_BUCKET="tests.kanister.io"
-MINIO_CHART_VERSION="5.0.14"
+MINIO_CHART_VERSION="5.4.0"
 
 install_minio ()
 {
@@ -39,6 +39,9 @@ install_minio ()
     --set buckets[0].name=${S3_BUCKET} \
     --set rootUser=AKIAIOSFODNN7EXAMPLE,rootPassword=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY \
     minio/minio --wait --timeout 3m
+
+    kubectl get storageclasses
+    kubectl get pvc -n minio
 
     # export default creds for minio
     # https://github.com/helm/charts/tree/master/stable/minio


### PR DESCRIPTION
## Change Overview

We use minio as a storage in integration test. We started facing issue in integration test about hitting storage limit in minio.
```
Error: failed to write contents to bucket 'tests.kanister.io': PutObject, putting object: XMinioStorageFull: Storage backend has reached its minimum free drive threshold. Please delete a few objects to proceed.
```
This PR fix the issue by using persistence storage with 1Gi size for minio.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :building_construction: Build



## Test Plan


- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
