### PR TITLE
Disable mssql app in integration test

### DIFF
--- a/build/integration-test.sh
+++ b/build/integration-test.sh
@@ -26,7 +26,11 @@ TEST_TIMEOUT="30m"
 TEST_OPTIONS="-tags=integration -timeout ${TEST_TIMEOUT} -check.suitep ${DOP}"
 # Regex to match apps to run in short mode
 # Temporary disable ES test. Issue to track https://github.com/kanisterio/kanister/issues/1920
-SHORT_APPS="^PostgreSQL$|^MySQL$|^MongoDB$|^MSSQL$"
+
+# TODO (#3779): Temporary disable the MSSQL tests will we fix minio storage issue.
+# See for more details https://github.com/kanisterio/kanister/issues/3779
+#SHORT_APPS="^PostgreSQL$|^MySQL$|^MongoDB$|^MSSQL$"
+SHORT_APPS="^PostgreSQL$|^MySQL$|^MongoDB$"
 # OCAPPS has all the apps that are to be tested against openshift cluster
 OC_APPS3_11="MysqlDBDepConfig$|MongoDBDepConfig$|PostgreSQLDepConfig$"
 OC_APPS4_4="MysqlDBDepConfig4_4|MongoDBDepConfig4_4|PostgreSQLDepConfig4_4"


### PR DESCRIPTION
## Change Overview

This PR temporarily disables mssql app from integration test to unblock CI.
This will be reverted on https://github.com/kanisterio/kanister/issues/3779 is fixed

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :building_construction: Build


