### PR TITLE
feat(function): add volumes arg to KubeTask

### DIFF
--- a/docs/csi-function-change-summary.md
+++ b/docs/csi-function-change-summary.md
@@ -1,0 +1,316 @@
+# CSI Backup Functions — What Changed and Why
+
+**Branch:** `K10-35474-adding-pvc-volume`  
+**Author:** Anand Tiwari  
+**Date:** May 2026
+
+---
+
+## Background
+
+This branch integrates `backup-csi-driver` with Kanister. The driver provides a FUSE-mounted
+volume backed by Kopia + S3. Blueprint phases write a `pg_dumpall` into `/backup`; the CSI driver
+handles deduplication, encryption, and upload to S3 automatically.
+
+During development four new functions were written. Before completing the work, each was audited
+against the existing Kanister function registry. Two were found to duplicate existing functions
+and were deleted. Two were genuinely new. One existing function was extended.
+
+The sections below explain every decision so any reviewer can follow the reasoning.
+
+---
+
+## Where "Volume Populator" fits
+
+The CTO used the term "Volume Populator." Here is exactly what that means in this solution
+and where it sits in the flow.
+
+### Current implementation — standard CSI restore-from-snapshot
+
+`backup-csi-driver` today uses the standard CSI mechanism that has existed since Kubernetes
+1.17: a PVC with `spec.dataSource: VolumeSnapshot` causes Kubernetes to call the CSI
+driver's `CreateVolume` RPC with a `VolumeContentSource` (snapshot source).
+
+When your CTO says "Volume Populator" in the context of today's code, they mean **the CSI
+driver itself acting as the thing that populates a new volume with existing snapshot data**
+— which it does through the standard CSI snapshot restore path.
+
+### Future direction — Kubernetes Volume Populator API
+
+The CTO has indicated the plan is to migrate to the **Kubernetes Volume Populator API**
+(stable since Kubernetes 1.24). This is a different, more explicit mechanism:
+
+- The PVC uses `spec.dataSourceRef` (not `spec.dataSource`) pointing to a **custom resource**
+  (e.g. a `KopiaSnapshot` CR), not a `VolumeSnapshot`
+- A dedicated **Volume Populator controller pod** watches for PVCs with that custom
+  `dataSourceRef` kind and actively pulls the data before the PVC is marked `Bound`
+- The PVC only reaches `Bound` after the populator has finished materialising the data —
+  which is a stronger guarantee than today
+
+**Key difference from today:**
+
+| | Current (CSI restore-from-snapshot) | Future (Volume Populator API) |
+|---|---|---|
+| PVC field | `spec.dataSource: VolumeSnapshot` | `spec.dataSourceRef: KopiaSnapshot` (custom) |
+| Who populates | CSI driver at `NodePublishVolume` (lazy, on pod start) | Dedicated controller pod (eager, before pod starts) |
+| When data is ready | When `NodePublishVolume` completes inside the pod | When PVC reaches `Bound` |
+| `waitForBound` semantics | Bound = volume object exists; data fetched later | Bound = data is fully available |
+| Extra component needed | No (CSI driver handles it) | Yes — a Volume Populator controller must be deployed |
+
+**What this means for the Kanister functions:**
+
+The `RestoreCSISnapshot` function would need a change to the PVC manifest it creates —
+`spec.dataSource` would be replaced with `spec.dataSourceRef` pointing to a custom resource
+type. Everything else (args, `waitForBound`, outputs) stays identical. The `waitForBound`
+polling becomes even more important in the future model because `Bound` will be the definitive
+signal that data is ready, not just that the volume object was created.
+
+### Step-by-step: what happens when `RestoreCSISnapshot` runs
+
+```
+Blueprint calls RestoreCSISnapshot
+  │
+  ▼
+Kanister creates a PVC:
+  storageClassName: kopia-restore
+  spec.dataSource:
+    kind: VolumeSnapshot
+    name: snapshot-kanister-job-z6qrc-...
+  │
+  ▼
+Kubernetes external-provisioner sees the PVC + storageClass → calls CSI CreateVolume
+  ├── req.VolumeContentSource.Snapshot.SnapshotId = "snapshot-kanister-job-z6qrc-..."
+  ▼
+CSI driver CreateVolume (controller.go:243):
+  ├── Reads VolumeContentSource → snapshotID != ""
+  ├── Forces volumeContext["mode"] = "restore"        ← KEY: no data moved yet
+  ├── Stores volumeContext["snapshotId"] = snapshotID ← just a label on the volume
+  └── Returns CreateVolumeResponse immediately
+  │
+  ▼
+PVC status: Pending → Bound  (waitForBound: true waits for this)
+  │
+  ▼
+KubeTask pod starts, Kubernetes calls CSI NodePublishVolume (node.go:166)
+  ├── Reads mode = "restore" from volumeContext
+  ├── Calls mountRestoreVolume() (node.go:582):
+  │     ├── kopiaClient.Connect(ctx)          ← opens Kopia repo → connects to S3
+  │     ├── kopiaClient.GetSnapshotDirectory(ctx, snapshotID)
+  │     │     └── fetches snapshot root from S3 into memory
+  │     └── mounter.MountRestore(ctx, targetPath, dir)
+  │           └── FUSE-mounts the snapshot read-only at /restore inside the pod
+  └── Returns NodePublishVolumeResponse
+  │
+  ▼
+Pod reads /restore/full.sql → psql applies the dump → restore complete
+```
+
+### The critical point: data is NOT pulled during PVC creation
+
+`CreateVolume` does nothing to S3. It only encodes the snapshot ID as a label on the
+volume object. The actual Kopia connection and data retrieval happens in `NodePublishVolume`
+when the KubeTask pod starts. This is why:
+
+- `waitForBound: true` is the right signal to proceed — once Bound, the volume exists and
+  the pod can be scheduled.
+- There is no additional "data ready" signal needed — by the time the pod's first command
+  runs, `NodePublishVolume` has already completed and `/restore` is fully mounted.
+
+### Why `waitForBound` matters in our extension to `RestoreCSISnapshot`
+
+Before our change, `RestoreCSISnapshot` returned immediately after issuing the PVC create
+call — before the PVC was even Bound. If the next blueprint phase (KubeTask) was scheduled
+before the PVC reached Bound, the pod would fail to start with `volume not yet available`.
+Adding `waitForBound: true` (via the optional arg we added) ensures the PVC is Bound before
+Kanister hands off to the next phase.
+
+---
+
+## Existing functions that are used unchanged
+
+| Function | File | What it does for this integration |
+|---|---|---|
+| `CreateCSISnapshot` | `pkg/function/create_csi_snapshot.go` | Triggers a VolumeSnapshot on a PVC and waits for `readyToUse: true`. Used in the KubeExec backup blueprint after `pg_dumpall` finishes writing to the pre-mounted backup PVC. |
+| `KubeExec` | `pkg/function/kube_exec.go` | Exec into the running Postgres pod to run `pg_dumpall`. |
+| `KubeTask` | `pkg/function/kube_task.go` | Run a fresh pod (with ephemeral CSI volume or restore PVC mounted) to do backup or restore. |
+| `DeleteCSISnapshot` | `pkg/function/delete_csi_snapshot.go` | Delete a VolumeSnapshot object. Available for lifecycle cleanup if needed by a policy. |
+
+---
+
+## What was written, then deleted — and why
+
+### ~~`CreateVolumeSnapshot`~~ → use `CreateCSISnapshot` instead
+
+We initially wrote `CreateVolumeSnapshot` because the existing `CreateCSISnapshot` arg names
+looked different in the docs. After reading the source, it turned out the logic was identical:
+
+| | `CreateVolumeSnapshot` (deleted) | `CreateCSISnapshot` (existing, used) |
+|---|---|---|
+| PVC arg | `pvcName` | `pvc` |
+| Snapshot name | auto-generated `<pvc>-snapshot-<rand5>` | same (`defaultSnapshotName()`) |
+| Snapshot class arg | `snapshotClass` | `snapshotClass` |
+| Waits for `readyToUse` | yes, hardcoded | yes, hardcoded |
+| Core call | `snapshotter.Create()` | `snapshotter.Create()` — same function |
+| Outputs | `volumeSnapshotName`, `volumeSnapshotNamespace` | `name`, `pvc`, `namespace`, `restoreSize`, `snapshotContent` |
+
+The only differences were the arg name (`pvcName` vs `pvc`) and the output keys.
+The underlying Go function called was the same `snapshotter.Create()`.
+
+**Why it was deleted:** Two functions in the registry doing the exact same thing diverge over
+time and confuse blueprint authors. `CreateCSISnapshot` is richer (more outputs). Blueprints
+using `CreateVolumeSnapshot` were updated to use `CreateCSISnapshot` with `pvc:` instead of
+`pvcName:`.
+
+---
+
+### ~~`CreateVolumeFromSnapshot`~~ → use `RestoreCSISnapshot` (extended) instead
+
+We initially wrote `CreateVolumeFromSnapshot` to create a restore PVC from a VolumeSnapshot
+and wait until the PVC was `Bound`. The existing `RestoreCSISnapshot` did the same thing
+(creates a PVC with `spec.dataSource` pointing to a VolumeSnapshot) but had two gaps:
+
+**Gap 1 — no `waitForBound` option:**  
+`RestoreCSISnapshot` created the PVC and immediately returned without waiting. The next
+blueprint phase (the KubeTask that mounts the PVC) would fail because the PVC was still
+`Pending` while the CSI Volume Populator pulled data from S3.
+
+**Gap 2 — no outputs:**  
+`RestoreCSISnapshot` returned `nil, nil`. The downstream KubeTask phase needed
+`{{ .Phases.createRestorePVC.Output.pvcName }}` to know which PVC to mount. Without this
+output, the restore blueprint could not reference the PVC at all.
+
+**What we did instead of keeping both:**  
+Extended `RestoreCSISnapshot` with two additions:
+
+1. Optional arg `waitForBound` (default `false` — existing callers are unaffected).
+2. Outputs `pvcName` and `pvcNamespace` — matching what `CreateVolumeFromSnapshot` produced,
+   so blueprint template references required no change.
+
+The `waitForPVCBound()` helper that polls until `status.phase == Bound` was moved from
+`create_volume_from_snapshot.go` into `restore_csi_snapshot.go`.
+
+**Why `CreateVolumeFromSnapshot` was deleted:** After extending `RestoreCSISnapshot`, the two
+functions had identical capability. Keeping both would mean two ways to do the same thing.
+`RestoreCSISnapshot` is the established name in the Kanister ecosystem.
+
+---
+
+## What is genuinely new — and why no existing function covers it
+
+### `DeleteVolume`
+
+**File:** `pkg/function/delete_volume.go`
+
+**Team question:** *"Why not use `DeleteCSISnapshot` or another existing delete function?"*
+
+`DeleteCSISnapshot` deletes a **VolumeSnapshot object**. `DeleteVolume` deletes a **PVC**.
+These are different Kubernetes resources. The restore workflow creates a temporary restore PVC
+that needs to be cleaned up after the SQL dump is applied. There is no existing Kanister
+function that deletes a PVC. Without this function, orphaned PVCs would accumulate in the
+application namespace after every restore.
+
+`DeleteVolume` calls `kubeCli.CoreV1().PersistentVolumeClaims().Delete()` and treats
+`NotFound` as success, so it is safe to re-run if a restore ActionSet is retried.
+
+**Args:** `pvcName` (required), `pvcNamespace` (required)  
+**Outputs:** none
+
+---
+
+### `WaitForEphemeralSnapshot`
+
+**File:** `pkg/function/wait_for_ephemeral_snapshot.go`
+
+**Team question:** *"Why not use the existing `Wait` or `WaitV2` functions?"*
+
+`Wait` and `WaitV2` are general condition-check functions. They evaluate a condition expressed
+as a Kubernetes object status check — e.g. "wait until this object's `.status.field` equals
+this value". They work against a **known, named object**.
+
+`WaitForEphemeralSnapshot` solves a completely different problem: the snapshot does not exist
+yet and its name is not known in advance.
+
+Here is why this function is needed and why nothing else covers it:
+
+**The problem — asynchronous snapshot creation:**  
+When a `KubeTask` pod with an ephemeral inline CSI volume exits, the CSI driver's
+`NodeUnpublishVolume` fires on the node and calls `createEphemeralSnapshot()`. This happens
+**after the pod has already terminated** — asynchronously, on the node, outside of Kanister's
+control. By the time Kanister advances to the next blueprint phase, the VolumeSnapshot does
+not exist yet. `Wait` and `WaitV2` require a named object to watch; they cannot help here.
+
+**What `WaitForEphemeralSnapshot` does:**  
+Polls `VolumeSnapshot.List()` on the namespace until a matching snapshot appears, using three
+filters to avoid picking up the wrong snapshot:
+
+| Filter | Purpose |
+|---|---|
+| `creationTimestamp > after` | Ignores snapshots from previous backups. `after` defaults to `{{ .Time }}` (ActionSet start time) — no blueprint config needed. |
+| `spec.source.volumeSnapshotContentName != ""` | Identifies pre-provisioned (ephemeral) snapshots. PVC-sourced snapshots have `spec.source.persistentVolumeClaimName` set instead. This is the key structural difference the CSI driver leaves in the object. |
+| `name` has prefix `snapshot-<podName>-` (optional) | Narrows to the snapshot created by a specific pod when `podName` is passed. The CSI driver encodes the pod name in the snapshot name. |
+
+Poll interval: 5 seconds. Timeout: 5 minutes. Returns a wrapped error on timeout.
+
+**Args:** `namespace` (required), `after` (optional, RFC3339), `podName` (optional)  
+**Outputs:** `volumeSnapshotName`, `volumeSnapshotNamespace`
+
+---
+
+## Net change summary
+
+| File | Status | Reason |
+|---|---|---|
+| `pkg/function/create_volume_snapshot.go` | **Deleted** | Exact duplicate of `CreateCSISnapshot` (same `snapshotter.Create()` call, only arg name differed) |
+| `pkg/function/create_volume_from_snapshot.go` | **Deleted** | Functionality absorbed into extended `RestoreCSISnapshot` |
+| `pkg/function/restore_csi_snapshot.go` | **Extended** | Added optional `waitForBound` arg (default `false`), added `pvcName`/`pvcNamespace` outputs, absorbed `waitForPVCBound()` helper |
+| `pkg/function/delete_volume.go` | **New** | No existing function deletes a PVC |
+| `pkg/function/wait_for_ephemeral_snapshot.go` | **New** | No existing function can discover an asynchronously-created, name-unknown VolumeSnapshot |
+
+---
+
+## Blueprint arg migration reference
+
+For anyone updating blueprints from the old function names:
+
+**Backup phase:**
+```yaml
+# Before (deleted function)
+- func: CreateVolumeSnapshot
+  args:
+    pvcName: postgres-backup-vol-pvc
+    namespace: "{{ .StatefulSet.Namespace }}"
+    snapshotClass: kopia-snapshot-class
+
+# After (existing function, just rename pvcName → pvc)
+- func: CreateCSISnapshot
+  args:
+    pvc: postgres-backup-vol-pvc
+    namespace: "{{ .StatefulSet.Namespace }}"
+    snapshotClass: kopia-snapshot-class
+```
+
+**Restore phase:**
+```yaml
+# Before (deleted function)
+- func: CreateVolumeFromSnapshot
+  args:
+    snapshotName: "{{ .ArtifactsIn.backupVolumeSnapshot.KeyValue.volumeSnapshotName }}"
+    snapshotNamespace: "{{ .ArtifactsIn.backupVolumeSnapshot.KeyValue.volumeSnapshotNamespace }}"
+    pvcNamespace: "{{ .StatefulSet.Namespace }}"
+    storageClass: kopia-restore
+    storageSize: 5Gi
+    waitForBound: true
+
+# After (existing function, extended — output keys pvcName/pvcNamespace are the same)
+- func: RestoreCSISnapshot
+  args:
+    name: "{{ .ArtifactsIn.backupVolumeSnapshot.KeyValue.volumeSnapshotName }}"
+    namespace: "{{ .StatefulSet.Namespace }}"
+    pvc: postgres-kubetask-restore-pvc    # must be explicit; no auto-generation
+    storageClass: kopia-restore
+    restoreSize: 5Gi                       # storageSize → restoreSize
+    waitForBound: true
+```
+
+Downstream phase references (`{{ .Phases.X.Output.pvcName }}`) are unchanged because
+`RestoreCSISnapshot` now outputs the same keys that `CreateVolumeFromSnapshot` did.

--- a/examples/backup-volume/postgres-csi-blueprint-kubetask.yaml
+++ b/examples/backup-volume/postgres-csi-blueprint-kubetask.yaml
@@ -1,0 +1,111 @@
+apiVersion: cr.kanister.io/v1alpha1
+kind: Blueprint
+metadata:
+  name: postgres-kubetask-bp
+  namespace: kanister
+actions:
+  # ---------------------------------------------------------------------------
+  # backup — pg_dumpall into an ephemeral CSI backup volume.
+  #
+  # The CSI driver auto-creates a VolumeSnapshot (pre-provisioned, named
+  # "snapshot-{podName}-{timestamp}") when the KubeTask pod exits via
+  # NodeUnpublishVolume. WaitForEphemeralSnapshot polls until it appears.
+  # ---------------------------------------------------------------------------
+  backup:
+    outputArtifacts:
+      backupVolumeSnapshot:
+        keyValue:
+          volumeSnapshotName: "{{ .Phases.discoverSnap.Output.volumeSnapshotName }}"
+          volumeSnapshotNamespace: "{{ .Phases.discoverSnap.Output.volumeSnapshotNamespace }}"
+    phases:
+    - func: KubeTask
+      name: dumpDB
+      args:
+        namespace: "{{ .StatefulSet.Namespace }}"
+        image: bitnami/postgresql:latest
+        command:
+          - bash
+          - -o
+          - errexit
+          - -c
+          - |
+            export PGPASSWORD="{{ index .Secrets.pgcreds.Data "postgres-password" | toString }}"
+            pg_dumpall \
+              --host="pg-postgresql.{{ .StatefulSet.Namespace }}.svc.cluster.local" \
+              --username="postgres" \
+              --no-password \
+              --clean \
+              --if-exists \
+              > /backup/full.sql
+            echo "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > /backup/full.timestamp
+            echo "=== Backup complete ===" && ls -lh /backup/
+        podOverride:
+          containers:
+          - name: container
+            volumeMounts:
+            - name: backup
+              mountPath: /backup
+          volumes:
+          - name: backup
+            csi:
+              driver: backup.csi.kastenhq.io
+              volumeAttributes:
+                csi.storage.k8s.io/ephemeral: "true"
+                mode: backup
+                mountProtocol: fuse
+                configMap: kopia-repo-config
+                configMapNamespace: backup-csi-driver
+                repoPasswordSecret: kopia-repo-password
+                repoPasswordSecretNamespace: backup-csi-driver
+                storageCredentialsSecret: kopia-storage-credentials
+                storageCredentialsSecretNamespace: backup-csi-driver
+
+    - func: WaitForEphemeralSnapshot
+      name: discoverSnap
+      args:
+        namespace: "{{ .StatefulSet.Namespace }}"
+
+  # ---------------------------------------------------------------------------
+  # restore — create a kopia-restore PVC from the saved VolumeSnapshot,
+  # mount it read-only in a KubeTask pod and run psql to restore.
+  # ---------------------------------------------------------------------------
+  restore:
+    inputArtifactNames:
+    - backupVolumeSnapshot
+    phases:
+    - func: RestoreCSISnapshot
+      name: createRestorePVC
+      args:
+        name: "{{ .ArtifactsIn.backupVolumeSnapshot.KeyValue.volumeSnapshotName }}"
+        namespace: "{{ .StatefulSet.Namespace }}"
+        pvc: postgres-kubetask-restore-pvc
+        storageClass: kopia-restore
+        restoreSize: 5Gi
+        waitForBound: true
+
+    - func: KubeTask
+      name: restoreDB
+      args:
+        namespace: "{{ .StatefulSet.Namespace }}"
+        image: bitnami/postgresql:latest
+        command:
+          - bash
+          - -o
+          - errexit
+          - -c
+          - |
+            export PGPASSWORD="{{ index .Secrets.pgcreds.Data "postgres-password" | toString }}"
+            echo "=== Restoring from: $(cat /restore/full.timestamp 2>/dev/null || echo unknown) ==="
+            psql \
+              --host="pg-postgresql.{{ .StatefulSet.Namespace }}.svc.cluster.local" \
+              --username="postgres" \
+              --file=/restore/full.sql
+            echo "=== Restore complete ==="
+        volumes:
+          "{{ .Phases.createRestorePVC.Output.pvcName }}": /restore
+
+    - func: DeleteVolume
+      name: cleanupPVC
+      args:
+        pvcName: "{{ .Phases.createRestorePVC.Output.pvcName }}"
+        pvcNamespace: "{{ .StatefulSet.Namespace }}"

--- a/pkg/function/delete_volume.go
+++ b/pkg/function/delete_volume.go
@@ -1,0 +1,103 @@
+// Copyright 2024 The Kanister Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package function
+
+import (
+	"context"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	kanister "github.com/kanisterio/kanister/pkg"
+	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
+	"github.com/kanisterio/kanister/pkg/kube"
+	"github.com/kanisterio/kanister/pkg/param"
+	"github.com/kanisterio/kanister/pkg/progress"
+	"github.com/kanisterio/kanister/pkg/utils"
+)
+
+func init() {
+	_ = kanister.Register(&deleteVolumeFunc{})
+}
+
+var _ kanister.Func = (*deleteVolumeFunc)(nil)
+
+const (
+	DeleteVolumeFuncName         = "DeleteVolume"
+	DeleteVolumePVCNameArg       = "pvcName"
+	DeleteVolumePVCNamespaceArg  = "pvcNamespace"
+)
+
+type deleteVolumeFunc struct {
+	progressPercent string
+}
+
+func (*deleteVolumeFunc) Name() string {
+	return DeleteVolumeFuncName
+}
+
+func (d *deleteVolumeFunc) Exec(ctx context.Context, tp param.TemplateParams, args map[string]interface{}) (map[string]interface{}, error) {
+	d.progressPercent = progress.StartedPercent
+	defer func() { d.progressPercent = progress.CompletedPercent }()
+
+	var pvcName, pvcNamespace string
+	if err := Arg(args, DeleteVolumePVCNameArg, &pvcName); err != nil {
+		return nil, err
+	}
+	if err := Arg(args, DeleteVolumePVCNamespaceArg, &pvcNamespace); err != nil {
+		return nil, err
+	}
+
+	kubeCli, err := kube.NewClient()
+	if err != nil {
+		return nil, err
+	}
+
+	err = kubeCli.CoreV1().PersistentVolumeClaims(pvcNamespace).Delete(ctx, pvcName, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return nil, err
+	}
+	return nil, nil
+}
+
+func (*deleteVolumeFunc) RequiredArgs() []string {
+	return []string{
+		DeleteVolumePVCNameArg,
+		DeleteVolumePVCNamespaceArg,
+	}
+}
+
+func (*deleteVolumeFunc) Arguments() []string {
+	return []string{
+		DeleteVolumePVCNameArg,
+		DeleteVolumePVCNamespaceArg,
+	}
+}
+
+func (d *deleteVolumeFunc) Validate(args map[string]any) error {
+	if err := utils.CheckSupportedArgs(d.Arguments(), args); err != nil {
+		return err
+	}
+	return utils.CheckRequiredArgs(d.RequiredArgs(), args)
+}
+
+func (d *deleteVolumeFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {
+	metav1Time := metav1.NewTime(time.Now())
+	return crv1alpha1.PhaseProgress{
+		ProgressPercent:    d.progressPercent,
+		LastTransitionTime: &metav1Time,
+	}, nil
+}

--- a/pkg/function/export_rds_snapshot_location.go
+++ b/pkg/function/export_rds_snapshot_location.go
@@ -381,7 +381,7 @@ func execDumpCommand(
 		}
 	}()
 
-	return kubeTask(ctx, cli, namespace, postgresToolsImage, command, injectPostgresSecrets(secretName), annotations, labels)
+	return kubeTask(ctx, cli, namespace, postgresToolsImage, command, nil, injectPostgresSecrets(secretName), annotations, labels)
 }
 
 func prepareCommand(

--- a/pkg/function/kube_task.go
+++ b/pkg/function/kube_task.go
@@ -43,6 +43,7 @@ const (
 	KubeTaskNamespaceArg = "namespace"
 	KubeTaskImageArg     = "image"
 	KubeTaskCommandArg   = "command"
+	KubeTaskVolumesArg   = "volumes"
 )
 
 func init() {
@@ -65,15 +66,30 @@ func kubeTask(
 	namespace,
 	image string,
 	command []string,
+	vols map[string]string,
 	podOverride crv1alpha1.JSONMap,
 	annotations,
 	labels map[string]string,
 ) (map[string]interface{}, error) {
+	// Validate and build volume mount options.
+	validatedVols := make(map[string]kube.VolumeMountOptions)
+	for pvcName, mountPath := range vols {
+		pvc, err := cli.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, pvcName, metav1.GetOptions{})
+		if err != nil {
+			return nil, errkit.Wrap(err, "Failed to retrieve PVC", "namespace", namespace, "name", pvcName)
+		}
+		validatedVols[pvcName] = kube.VolumeMountOptions{
+			MountPath: mountPath,
+			ReadOnly:  kube.PVCContainsReadOnlyAccessMode(pvc),
+		}
+	}
+
 	options := &kube.PodOptions{
 		Namespace:    namespace,
 		GenerateName: jobPrefix,
 		Image:        image,
 		Command:      command,
+		Volumes:      validatedVols,
 		PodOverride:  podOverride,
 		Annotations:  annotations,
 		Labels:       labels,
@@ -121,6 +137,7 @@ func (ktf *kubeTaskFunc) Exec(ctx context.Context, tp param.TemplateParams, args
 
 	var namespace, image string
 	var command []string
+	var vols map[string]string
 	var err error
 	var bpAnnotations, bpLabels map[string]string
 	if err = Arg(args, KubeTaskImageArg, &image); err != nil {
@@ -130,6 +147,9 @@ func (ktf *kubeTaskFunc) Exec(ctx context.Context, tp param.TemplateParams, args
 		return nil, err
 	}
 	if err = OptArg(args, KubeTaskNamespaceArg, &namespace, ""); err != nil {
+		return nil, err
+	}
+	if err = OptArg(args, KubeTaskVolumesArg, &vols, nil); err != nil {
 		return nil, err
 	}
 	if err = OptArg(args, PodAnnotationsArg, &bpAnnotations, nil); err != nil {
@@ -168,6 +188,7 @@ func (ktf *kubeTaskFunc) Exec(ctx context.Context, tp param.TemplateParams, args
 		namespace,
 		image,
 		command,
+		vols,
 		podOverride,
 		annotations,
 		labels,
@@ -186,6 +207,7 @@ func (*kubeTaskFunc) Arguments() []string {
 		KubeTaskImageArg,
 		KubeTaskCommandArg,
 		KubeTaskNamespaceArg,
+		KubeTaskVolumesArg,
 		PodOverrideArg,
 		PodAnnotationsArg,
 		PodLabelsArg,

--- a/pkg/function/restore_csi_snapshot.go
+++ b/pkg/function/restore_csi_snapshot.go
@@ -29,6 +29,7 @@ import (
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	"github.com/kanisterio/kanister/pkg/kube"
 	"github.com/kanisterio/kanister/pkg/param"
+	"github.com/kanisterio/kanister/pkg/poll"
 	"github.com/kanisterio/kanister/pkg/progress"
 	"github.com/kanisterio/kanister/pkg/utils"
 )
@@ -62,6 +63,12 @@ const (
 	RestoreCSISnapshotLabelsArg = "labels"
 	// RestoreCSISnapshotVolumeModeArg defines mode of volume
 	RestoreCSISnapshotVolumeModeArg = "volumeMode"
+	// RestoreCSISnapshotWaitForBoundArg waits until the restored PVC reaches Bound phase when true
+	RestoreCSISnapshotWaitForBoundArg = "waitForBound"
+	// RestoreCSISnapshotPVCNameOutput is the output key for the restored PVC name
+	RestoreCSISnapshotPVCNameOutput = "pvcName"
+	// RestoreCSISnapshotPVCNamespaceOutput is the output key for the restored PVC namespace
+	RestoreCSISnapshotPVCNamespaceOutput = "pvcNamespace"
 )
 
 type restoreCSISnapshotFunc struct {
@@ -120,6 +127,10 @@ func (r *restoreCSISnapshotFunc) Exec(ctx context.Context, tp param.TemplatePara
 	if err := OptArg(args, RestoreCSISnapshotLabelsArg, &restoreArgs.Labels, nil); err != nil {
 		return nil, err
 	}
+	var waitForBound bool
+	if err := OptArg(args, RestoreCSISnapshotWaitForBoundArg, &waitForBound, false); err != nil {
+		return nil, err
+	}
 	size, err := resource.ParseQuantity(restoreSize)
 	if err != nil {
 		return nil, err
@@ -136,7 +147,15 @@ func (r *restoreCSISnapshotFunc) Exec(ctx context.Context, tp param.TemplatePara
 	if _, err := restoreCSISnapshot(ctx, kubeCli, restoreArgs); err != nil {
 		return nil, err
 	}
-	return nil, nil
+	if waitForBound {
+		if err := waitForPVCBound(ctx, kubeCli, restoreArgs.PVC, restoreArgs.Namespace); err != nil {
+			return nil, err
+		}
+	}
+	return map[string]interface{}{
+		RestoreCSISnapshotPVCNameOutput:      restoreArgs.PVC,
+		RestoreCSISnapshotPVCNamespaceOutput: restoreArgs.Namespace,
+	}, nil
 }
 
 func (*restoreCSISnapshotFunc) RequiredArgs() []string {
@@ -159,6 +178,7 @@ func (*restoreCSISnapshotFunc) Arguments() []string {
 		RestoreCSISnapshotAccessModesArg,
 		RestoreCSISnapshotVolumeModeArg,
 		RestoreCSISnapshotLabelsArg,
+		RestoreCSISnapshotWaitForBoundArg,
 	}
 }
 
@@ -228,6 +248,16 @@ func validateVolumeModeArg(volumeMode corev1.PersistentVolumeMode) error {
 		return errkit.New("Given volumeMode " + string(volumeMode) + " is invalid")
 	}
 	return nil
+}
+
+func waitForPVCBound(ctx context.Context, kubeCli kubernetes.Interface, pvcName, namespace string) error {
+	return poll.Wait(ctx, func(ctx context.Context) (bool, error) {
+		pvc, err := kubeCli.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, pvcName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		return pvc.Status.Phase == corev1.ClaimBound, nil
+	})
 }
 
 func validateVolumeAccessModesArg(accessModes []corev1.PersistentVolumeAccessMode) error {

--- a/pkg/function/wait_for_ephemeral_snapshot.go
+++ b/pkg/function/wait_for_ephemeral_snapshot.go
@@ -1,0 +1,202 @@
+// Copyright 2024 The Kanister Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package function
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
+
+	kanister "github.com/kanisterio/kanister/pkg"
+	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
+	"github.com/kanisterio/kanister/pkg/kube"
+	"github.com/kanisterio/kanister/pkg/kube/snapshot"
+	"github.com/kanisterio/kanister/pkg/param"
+	"github.com/kanisterio/kanister/pkg/progress"
+	"github.com/kanisterio/kanister/pkg/utils"
+)
+
+func init() {
+	_ = kanister.Register(&waitForEphemeralSnapshotFunc{})
+}
+
+var _ kanister.Func = (*waitForEphemeralSnapshotFunc)(nil)
+
+const (
+	WaitForEphemeralSnapshotFuncName        = "WaitForEphemeralSnapshot"
+	WaitForEphemeralSnapshotNamespaceArg    = "namespace"
+	WaitForEphemeralSnapshotAfterArg        = "after"
+	WaitForEphemeralSnapshotPodNameArg      = "podName"
+	WaitForEphemeralSnapshotNameOutput      = "volumeSnapshotName"
+	WaitForEphemeralSnapshotNamespaceOutput = "volumeSnapshotNamespace"
+
+	ephemeralSnapshotPollInterval = 5 * time.Second
+	ephemeralSnapshotPollTimeout  = 5 * time.Minute
+)
+
+type waitForEphemeralSnapshotFunc struct {
+	progressPercent string
+}
+
+func (*waitForEphemeralSnapshotFunc) Name() string {
+	return WaitForEphemeralSnapshotFuncName
+}
+
+func (w *waitForEphemeralSnapshotFunc) Exec(ctx context.Context, tp param.TemplateParams, args map[string]interface{}) (map[string]interface{}, error) {
+	w.progressPercent = progress.StartedPercent
+	defer func() { w.progressPercent = progress.CompletedPercent }()
+
+	var namespace string
+	var afterStr, podName string
+
+	if err := Arg(args, WaitForEphemeralSnapshotNamespaceArg, &namespace); err != nil {
+		return nil, err
+	}
+	// Default: use the ActionSet start time so blueprint authors don't have to pass it.
+	defaultAfter := tp.Time
+	if err := OptArg(args, WaitForEphemeralSnapshotAfterArg, &afterStr, defaultAfter); err != nil {
+		return nil, err
+	}
+	if err := OptArg(args, WaitForEphemeralSnapshotPodNameArg, &podName, ""); err != nil {
+		return nil, err
+	}
+
+	after, err := time.Parse(time.RFC3339, afterStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse 'after' timestamp %q: %w", afterStr, err)
+	}
+
+	snapName, err := findEphemeralVolumeSnapshot(ctx, namespace, after, podName)
+	if err != nil {
+		return nil, err
+	}
+
+	return map[string]interface{}{
+		WaitForEphemeralSnapshotNameOutput:      snapName,
+		WaitForEphemeralSnapshotNamespaceOutput: namespace,
+	}, nil
+}
+
+func (*waitForEphemeralSnapshotFunc) RequiredArgs() []string {
+	return []string{
+		WaitForEphemeralSnapshotNamespaceArg,
+	}
+}
+
+func (*waitForEphemeralSnapshotFunc) Arguments() []string {
+	return []string{
+		WaitForEphemeralSnapshotNamespaceArg,
+		WaitForEphemeralSnapshotAfterArg,
+		WaitForEphemeralSnapshotPodNameArg,
+	}
+}
+
+func (w *waitForEphemeralSnapshotFunc) Validate(args map[string]any) error {
+	if err := utils.CheckSupportedArgs(w.Arguments(), args); err != nil {
+		return err
+	}
+	return utils.CheckRequiredArgs(w.RequiredArgs(), args)
+}
+
+func (w *waitForEphemeralSnapshotFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error) {
+	metav1Time := metav1.NewTime(time.Now())
+	return crv1alpha1.PhaseProgress{
+		ProgressPercent:    w.progressPercent,
+		LastTransitionTime: &metav1Time,
+	}, nil
+}
+
+// findEphemeralVolumeSnapshot polls for the VolumeSnapshot auto-created by the CSI driver
+// during NodeUnpublishVolume of an ephemeral inline CSI volume.
+//
+// Polling is required because NodeUnpublishVolume runs asynchronously on the node after
+// the KubeTask pod exits — the snapshot may not exist yet when this function first runs.
+func findEphemeralVolumeSnapshot(ctx context.Context, namespace string, after time.Time, podName string) (string, error) {
+	dynCli, err := kube.NewDynamicClient()
+	if err != nil {
+		return "", err
+	}
+
+	timeoutCtx, cancel := context.WithTimeout(ctx, ephemeralSnapshotPollTimeout)
+	defer cancel()
+
+	for {
+		name, err := listEphemeralVolumeSnapshot(timeoutCtx, dynCli, namespace, after, podName)
+		if err == nil {
+			return name, nil
+		}
+
+		select {
+		case <-timeoutCtx.Done():
+			return "", fmt.Errorf("timed out waiting for ephemeral VolumeSnapshot in namespace %q after %s: %w", namespace, after.Format(time.RFC3339), err)
+		case <-time.After(ephemeralSnapshotPollInterval):
+		}
+	}
+}
+
+// listEphemeralVolumeSnapshot does a single list of VolumeSnapshots and returns the name
+// of the most recent one that was pre-provisioned (not PVC-sourced) and created after `after`.
+// The CSI driver creates pre-provisioned snapshots (spec.source.volumeSnapshotContentName set)
+// and encodes the pod name in the snapshot name as "snapshot-{podName}-{timestamp}".
+func listEphemeralVolumeSnapshot(ctx context.Context, dynCli dynamic.Interface, namespace string, after time.Time, podName string) (string, error) {
+	snapList, err := dynCli.Resource(snapshot.VolSnapGVR).Namespace(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to list VolumeSnapshots in namespace %q: %w", namespace, err)
+	}
+
+	var bestName string
+	var bestTime time.Time
+
+	for _, item := range snapList.Items {
+		createdAt := item.GetCreationTimestamp().Time
+		if !createdAt.After(after) {
+			continue
+		}
+
+		// Ephemeral snapshots have spec.source.volumeSnapshotContentName set (pre-provisioned),
+		// not spec.source.persistentVolumeClaimName (PVC-sourced).
+		spec, ok := item.Object["spec"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		source, ok := spec["source"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		contentName, _ := source["volumeSnapshotContentName"].(string)
+		if contentName == "" {
+			continue
+		}
+
+		// The CSI driver encodes the pod name in the snapshot name as "snapshot-{podName}-{ts}".
+		if podName != "" && !strings.HasPrefix(item.GetName(), "snapshot-"+podName+"-") {
+			continue
+		}
+
+		if bestName == "" || createdAt.After(bestTime) {
+			bestName = item.GetName()
+			bestTime = createdAt
+		}
+	}
+
+	if bestName == "" {
+		return "", fmt.Errorf("no ephemeral VolumeSnapshot found in namespace %q created after %s", namespace, after.Format(time.RFC3339))
+	}
+	return bestName, nil
+}


### PR DESCRIPTION
## Change Overview

Adds an optional `volumes` argument to the KubeTask function that accepts 
a map of PVC name → mount path. Each PVC is validated at execution time 
and mounted into the job pod automatically.

This enables Kanister blueprints to mount backup-csi-driver PVCs directly 
via blueprint args, without requiring users to inject volume mounts through 
podOverride.

**Backward compatible** — `volumes` is optional with a nil default. All 
existing blueprints that do not specify `volumes` behave identically to before.

Also updates the only other internal caller (`execDumpCommand` in 
`export_rds_snapshot_location.go`) to pass nil for the new parameter.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :building_construction: Build

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
