### PR TITLE
fix(tests): isolate concurrent BucketSuite and DataSuite runs against S3

### DIFF
--- a/pkg/function/data_test.go
+++ b/pkg/function/data_test.go
@@ -24,6 +24,7 @@ import (
 	"gopkg.in/check.v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes"
 	k8sscheme "k8s.io/client-go/kubernetes/scheme"
@@ -102,21 +103,19 @@ func (s *DataSuite) TearDownSuite(c *check.C) {
 }
 
 func (s *DataSuite) cleanupObjectStoreData(c *check.C) {
-	if c.Failed() {
-		ctx := context.Background()
-		profile := s.profile
-		if s.profileLocalEndpoint != nil {
-			profile = s.profileLocalEndpoint
-		}
-		c.Log("Cleaning up object store data after test failure from location", field.M{
-			"test":     c.TestName(),
-			"endpoint": profile.Location.Endpoint,
-			"bucket":   profile.Location.Bucket,
-		})
-		err := location.Delete(ctx, *profile, "")
-		if err != nil {
-			c.Log("Failed to clean data from location:", err)
-		}
+	ctx := context.Background()
+	profile := s.profile
+	if s.profileLocalEndpoint != nil {
+		profile = s.profileLocalEndpoint
+	}
+	c.Log("Cleaning up object store data from location", field.M{
+		"test":     c.TestName(),
+		"endpoint": profile.Location.Endpoint,
+		"bucket":   profile.Location.Bucket,
+	})
+	err := location.Delete(ctx, *profile, "")
+	if err != nil {
+		c.Log("Failed to clean data from location:", err)
 	}
 }
 
@@ -339,7 +338,8 @@ func (s *DataSuite) getTemplateParamsAndPVCName(c *check.C, replicas int32) (*pa
 func (s *DataSuite) TestBackupRestoreDeleteData(c *check.C) {
 	tp, pvcs := s.getTemplateParamsAndPVCName(c, 1)
 
-	// cleanup in case of test failure
+	// Always clean up object store data so the next test in this suite
+	// starts with an empty kopia repository at the suite's prefix.
 	defer s.cleanupObjectStoreData(c)
 
 	for _, pvc := range pvcs {
@@ -398,7 +398,8 @@ func (s *DataSuite) TestBackupRestoreDeleteDataAll(c *check.C) {
 	replicas := int32(2)
 	tp, pvcs := s.getTemplateParamsAndPVCName(c, replicas)
 
-	// cleanup in case of test failure
+	// Always clean up object store data so the next test in this suite
+	// starts with an empty kopia repository at the suite's prefix.
 	defer s.cleanupObjectStoreData(c)
 
 	// Test backup
@@ -791,7 +792,9 @@ func (s *DataSuite) createNewTestProfile(c *check.C, profileName string, localEn
 	default:
 		c.Fatalf("Unrecognized objectstore '%s'", s.providerType)
 	}
-	location.Prefix = "testBackupRestoreLocDelete"
+	// Append a random suffix so concurrent invocations of DataSuite use
+	// disjoint kopia repositories under the shared test bucket.
+	location.Prefix = fmt.Sprintf("testBackupRestoreLocDelete-%s", rand.String(8))
 	location.Bucket = testBucketName
 	if endpoint, ok := os.LookupEnv("LOCATION_CLUSTER_ENDPOINT"); ok && !localEndpoint {
 		location.Endpoint = endpoint

--- a/pkg/objectstore/bucket_test.go
+++ b/pkg/objectstore/bucket_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"gopkg.in/check.v1"
+	"k8s.io/apimachinery/pkg/util/rand"
 )
 
 type BucketSuite struct{}
@@ -63,7 +64,10 @@ func (s *BucketSuite) TestValidS3ClientBucketRegionMismatch(c *check.C) {
 
 	ctx := context.Background()
 	const pt = ProviderTypeS3
-	const bn = `kanister-test-bucket-us-west-1`
+	// Append a random suffix so concurrent invocations of this test against
+	// AWS use distinct, globally-unique bucket names instead of racing on a
+	// shared bucket.
+	bn := fmt.Sprintf("kanister-test-bucket-us-west-1-%s", rand.String(8))
 	const r1 = `us-west-1`
 	const r2 = `us-west-2`
 


### PR DESCRIPTION
## Change Overview

`TestValidS3ClientBucketRegionMismatch` in `pkg/objectstore` and several `DataSuite` tests in `pkg/function` use hardcoded, globally-shared S3 bucket and prefix names. Concurrent invocations of `go test ./...` against AWS race on these names and fail intermittently with errors such as:

```
OperationAborted: A conflicting conditional operation is currently in
progress against this resource. (status code 409)

kopia: unable to open config file: Stat: The specified key does not
exist.
```

This PR removes the two collision points:

- **`pkg/objectstore/bucket_test.go`** — append a random suffix to the test bucket name in `TestValidS3ClientBucketRegionMismatch` so each run uses a globally-unique bucket name.
- **`pkg/function/data_test.go`** — append a random suffix to `DataSuite`'s `location.Prefix` so concurrent suite invocations use disjoint kopia repositories under the shared test bucket, and drop the `if c.Failed()` guard in `cleanupObjectStoreData` so the suite always cleans up its S3 state at the end of each test, preventing stale kopia repositories from interfering with the next test in the same run.

The shared bucket name (`testBucketName = "kio-store-tests"`) is unchanged; isolation is achieved at the prefix level, which is sufficient because S3 path-level separation is enough to keep concurrent runs from observing each other's repositories.

## Pull request type

- [x] :bug: Bugfix
- [x] :robot: Test

## Issues

No related issue.

## Test Plan

- [x] :muscle: Manual — `go test ./pkg/objectstore/... -run BucketSuite` and `go test ./pkg/function/... -run DataSuite` against AWS, including two simultaneous invocations to confirm there is no longer a collision on bucket / prefix names.