### PR TITLE
Bump postgres-kanister-tools base image to postgres:18-bookworm

### DIFF
--- a/docker/postgres-kanister-tools/Dockerfile
+++ b/docker/postgres-kanister-tools/Dockerfile
@@ -4,7 +4,7 @@ ARG TOOLS_IMAGE
 FROM ${TOOLS_IMAGE} AS tools_image
 
 # Actual image base
-FROM postgres:17-bookworm@sha256:2e783c36c1c10112e5ee214157ad32e46d0cd5e4eee3403edc640c31a7738583
+FROM postgres:18-bookworm@sha256:a8824b3eef0c73d7a494881d625411060f5bf3c87280394cbc84197c6fa4bde5
 
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
## Change Overview

AWS RDS PostgreSQL now defaults to major version 18 when no `EngineVersion` is specified. `pg_dump` from a `postgres:17` base image cannot dump from a v18 server, which is why `pkg/aws/rds/rds.go:74` currently pins `EngineVersion = "17.7"` as a temporary workaround.

This PR bumps the `postgres-kanister-tools` base image to `postgres:18-bookworm` (digest `sha256:a8824b3eef0c73d7a494881d625411060f5bf3c87280394cbc84197c6fa4bde5`, resolving to `18.3-bookworm`) so the bundled `pg_dump` matches the new RDS default.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [x] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [x] :building_construction: Build

## Issues

N/A

## Test Plan

- [x] :muscle: Manual: verified `pg_dump` version inside the rebuilt image
  - Built and pushed `ghcr.io/kanisterio/kanister-tools:short-commit-574f7373658` for this commit
  - Dispatched `Build integration app example images` workflow against this branch with `image_tag=short-commit-574f7373658` — run [#25362625550](https://github.com/kanisterio/kanister/actions/runs/25362625550) finished with all 9 image-build jobs successful, including `build_postgres-kanister-tools / build_image`
  - Pulled the published image `ghcr.io/kanisterio/postgres-kanister-tools:short-commit-574f7373658` (digest `sha256:57f4842e906f756f89e290cd13300afa9afb0d3aa0399144f5cdb1bfe35df0cc`) and ran `pg_dump --version`:
    ```
    pg_dump (PostgreSQL) 18.3 (Debian 18.3-1.pgdg12+1)
    ```