### PR TITLE
fix(location): thread location region into AWS STS role assumption

### DIFF
--- a/pkg/location/location.go
+++ b/pkg/location/location.go
@@ -187,7 +187,7 @@ func getBucket(ctx context.Context, pType objectstore.ProviderType, profile para
 		Region:        profile.Location.Region,
 		SkipSSLVerify: profile.SkipSSLVerify,
 	}
-	secret, err := getOSSecret(ctx, pType, profile.Credential)
+	secret, err := getOSSecret(ctx, pType, profile.Credential, profile.Location.Region)
 	if err != nil {
 		return nil, err
 	}
@@ -198,11 +198,11 @@ func getBucket(ctx context.Context, pType objectstore.ProviderType, profile para
 	return provider.GetBucket(ctx, profile.Location.Bucket)
 }
 
-func getOSSecret(ctx context.Context, pType objectstore.ProviderType, cred param.Credential) (*objectstore.Secret, error) {
+func getOSSecret(ctx context.Context, pType objectstore.ProviderType, cred param.Credential, region string) (*objectstore.Secret, error) {
 	secret := &objectstore.Secret{}
 	switch pType {
 	case objectstore.ProviderTypeS3:
-		return getAWSSecret(ctx, cred)
+		return getAWSSecret(ctx, cred, region)
 	case objectstore.ProviderTypeGCS:
 		secret.Type = objectstore.SecretTypeGcpServiceAccountKey
 		secret.Gcp = &objectstore.SecretGcp{
@@ -238,7 +238,7 @@ func getAzureSecret(cred param.Credential) (*objectstore.Secret, error) {
 	return os, nil
 }
 
-func getAWSSecret(ctx context.Context, cred param.Credential) (*objectstore.Secret, error) {
+func getAWSSecret(ctx context.Context, cred param.Credential, region string) (*objectstore.Secret, error) {
 	os := &objectstore.Secret{
 		Type: objectstore.SecretTypeAwsAccessKey,
 	}
@@ -250,7 +250,7 @@ func getAWSSecret(ctx context.Context, cred param.Credential) (*objectstore.Secr
 		}
 		return os, nil
 	case param.CredentialTypeSecret:
-		creds, err := secrets.ExtractAWSCredentials(ctx, cred.Secret, aws.AssumeRoleDurationDefault)
+		creds, err := secrets.ExtractAWSCredentials(ctx, cred.Secret, aws.AssumeRoleDurationDefault, region)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/location/location_test.go
+++ b/pkg/location/location_test.go
@@ -94,7 +94,7 @@ func (s *LocationSuite) SetUpSuite(c *check.C) {
 		Region:   s.region,
 		Endpoint: os.Getenv("LOCATION_ENDPOINT"),
 	}
-	secret, err := getOSSecret(ctx, s.osType, s.profile.Credential)
+	secret, err := getOSSecret(ctx, s.osType, s.profile.Credential, s.region)
 	c.Check(err, check.IsNil)
 	s.provider, err = objectstore.NewProvider(ctx, pc, secret)
 	c.Check(err, check.IsNil)

--- a/pkg/secrets/aws.go
+++ b/pkg/secrets/aws.go
@@ -92,7 +92,12 @@ func ValidateAWSCredentials(secret *corev1.Secret) error {
 // of the IAM role - The setting can be viewed using instructions here
 // https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html#id_roles_use_view-role-max-session.
 // The IAM role's max duration setting can be modified between 1h to 12h.
-func ExtractAWSCredentials(ctx context.Context, secret *corev1.Secret, assumeRoleDuration time.Duration) (*aws.Credentials, error) {
+//
+// An optional region may be provided as the last argument. When the secret
+// includes an IAM role to assume, AWS SDK v2 requires an explicit region to
+// construct the STS endpoint. If omitted, region is resolved from the
+// AWS_REGION / AWS_DEFAULT_REGION environment variables.
+func ExtractAWSCredentials(ctx context.Context, secret *corev1.Secret, assumeRoleDuration time.Duration, region ...string) (*aws.Credentials, error) {
 	if err := ValidateAWSCredentials(secret); err != nil {
 		return nil, err
 	}
@@ -101,6 +106,9 @@ func ExtractAWSCredentials(ctx context.Context, secret *corev1.Secret, assumeRol
 		kaws.SecretAccessKey:    string(secret.Data[AWSSecretAccessKey]),
 		kaws.ConfigRole:         string(secret.Data[ConfigRole]),
 		kaws.AssumeRoleDuration: assumeRoleDuration.String(),
+	}
+	if len(region) > 0 && region[0] != "" {
+		config[kaws.ConfigRegion] = region[0]
 	}
 	credProvider, err := kaws.GetCredentials(ctx, config)
 	if err != nil {


### PR DESCRIPTION
## Change Overview

AWS SDK v2 requires an explicit region to construct the STS endpoint when assuming an IAM role via AssumeRole. The old SDK v1 defaulted to the global sts.amazonaws.com endpoint and worked without a region.

ExtractAWSCredentials now accepts an optional region variadic parameter. When provided it is added to the config map under ConfigRegion so that resolveRegion returns it before falling back to env-var lookup.

getBucket already had profile.Location.Region but did not thread it through getOSSecret → getAWSSecret → ExtractAWSCredentials. That omission caused CredentialTypeSecret profiles with a role to fail immediately with "region required" when no AWS_REGION env var was present in the pod.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :building_construction: Build

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
