### PR TITLE
feat(kopia/command): add MaxConcurrency field to ServerStartCommandArgs

### DIFF
--- a/pkg/kopia/command/const.go
+++ b/pkg/kopia/command/const.go
@@ -92,6 +92,7 @@ const (
 	tlsKeyFilePath            = "--tls-key-file"
 	userPasswordFlag          = "--user-password"
 	enablePprof               = "--enable-pprof"
+	maxConcurrencyFlag        = "--max-concurrency"
 	metricsListerAddress      = "--metrics-listen-addr"
 	htpasswdFilePath          = "--htpasswd-file"
 

--- a/pkg/kopia/command/server.go
+++ b/pkg/kopia/command/server.go
@@ -15,6 +15,8 @@
 package command
 
 import (
+	"strconv"
+
 	"github.com/kanisterio/kanister/pkg/kopia/cli/args"
 	"github.com/kanisterio/kanister/pkg/logsafe"
 )
@@ -34,6 +36,7 @@ type ServerStartCommandArgs struct {
 	Background           bool
 	EnablePprof          bool
 	MetricsListenAddress string
+	MaxConcurrency       int
 }
 
 func commonCommand(cmdArgs ServerStartCommandArgs) logsafe.Cmd {
@@ -70,6 +73,10 @@ func commonCommand(cmdArgs ServerStartCommandArgs) logsafe.Cmd {
 
 	if cmdArgs.MetricsListenAddress != "" {
 		args = args.AppendLoggableKV(metricsListerAddress, cmdArgs.MetricsListenAddress)
+	}
+
+	if cmdArgs.MaxConcurrency > 0 {
+		args = args.AppendLoggableKV(maxConcurrencyFlag, strconv.Itoa(cmdArgs.MaxConcurrency))
 	}
 
 	if cmdArgs.Background {

--- a/pkg/kopia/command/server_test.go
+++ b/pkg/kopia/command/server_test.go
@@ -164,6 +164,31 @@ func (kServer *KopiaServerTestSuite) TestServerCommands(c *check.C) {
 		},
 		{
 			f: func() []string {
+				args := ServerStartCommandArgs{
+					CommandArgs:      commandArgs,
+					CacheArgs:        cacheArgs,
+					CacheDirectory:   "cache/dir",
+					ServerAddress:    "a-server-address",
+					TLSCertFile:      "/path/to/cert/tls.crt",
+					TLSKeyFile:       "/path/to/key/tls.key",
+					ServerUsername:   "a-username@a-hostname",
+					ServerPassword:   "a-user-password",
+					AutoGenerateCert: false,
+					Background:       true,
+					MaxConcurrency:   64,
+				}
+				return ServerStart(args)
+			},
+			expectedLog: "bash -o errexit -c kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log " +
+				"server start --address=a-server-address --tls-cert-file=/path/to/cert/tls.crt " +
+				"--tls-key-file=/path/to/key/tls.key --server-username=a-username@a-hostname " +
+				"--server-password=a-user-password --server-control-username=a-username@a-hostname " +
+				"--server-control-password=a-user-password --cache-directory=cache/dir " +
+				"--content-cache-size-limit-mb=500 --metadata-cache-size-limit-mb=500 " +
+				"--max-concurrency=64 > /dev/null 2>&1 &",
+		},
+		{
+			f: func() []string {
 				args := ServerStatusCommandArgs{
 					CommandArgs:    commandArgs,
 					ServerAddress:  "a-server-address",


### PR DESCRIPTION
## Change Overview

Adds a `MaxConcurrency int` field to `ServerStartCommandArgs` and wires it as `--max-concurrency=N` in the kopia server start command when the value is `> 0`. Zero (the default) preserves the existing behaviour of omitting the flag, letting kopia use its built-in default (`2 * NumCPU`).

Callers that need to widen kopia's session semaphore can now set the field directly instead of post-processing the rendered argv string.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [x] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :building_construction: Build

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- N/A

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E

Added unit test coverage in `pkg/kopia/command/server_test.go` verifying that the flag is rendered when `MaxConcurrency > 0` and omitted otherwise.
