### PR TITLE
fix(docker): use multi-stage build for kafka-adobe-s3 connectors to fix missing microdnf in cp-kafka-connect:8.3.0

### DIFF
--- a/docker/kafka-adobes3Connector/image/adobeSink.Dockerfile
+++ b/docker/kafka-adobes3Connector/image/adobeSink.Dockerfile
@@ -1,27 +1,21 @@
 ARG TOOLS_IMAGE
 FROM ${TOOLS_IMAGE} AS TOOLS_IMAGE
 
-FROM confluentinc/cp-kafka-connect:8.3.0
+FROM eclipse-temurin:11-jdk AS builder
 
-USER root
-
-RUN microdnf install -y lsof platform-python python3-libs
-
-# TODO: maybe use builder image for that
-RUN microdnf install -y java-11-openjdk-headless
-ENV JAVA_HOME /usr/lib/jvm/jre-11-openjdk
-
-RUN microdnf install git -y
+RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
 
 RUN git clone https://github.com/adobe/kafka-connect-s3.git
 # Temp patch until vulnerable deps are fixed
 RUN sed -i "s/versions.awsSdkS3 = '1.11.803'/versions.awsSdkS3 = '1.12.261'/g" kafka-connect-s3/dependencies.gradle
 RUN sed -i "s/versions.jackson = '2.10.4'/versions.jackson = '2.12.7.1'/g" kafka-connect-s3/dependencies.gradle
 RUN cd kafka-connect-s3 && ./gradlew shadowJar
-# copy the jar files
-RUN cp ./kafka-connect-s3/build/libs/kafka-connect-s3-chart/kafka-connect/0.0.4-2a8a4aa-all.jar /opt/
-# cleanup
-RUN rm -rf ~/.gradle ./kafka-connect-s3
+
+FROM confluentinc/cp-kafka-connect:8.3.0
+
+USER root
+
+COPY --from=builder /kafka-connect-s3/build/libs/kafka-connect-s3-chart/kafka-connect/0.0.4-2a8a4aa-all.jar /opt/
 
 # Install kando
 COPY --from=TOOLS_IMAGE /usr/local/bin/kando /usr/local/bin/kando

--- a/docker/kafka-adobes3Connector/image/adobeSource.Dockerfile
+++ b/docker/kafka-adobes3Connector/image/adobeSource.Dockerfile
@@ -1,24 +1,18 @@
-FROM confluentinc/cp-kafka-connect:8.3.0
+FROM eclipse-temurin:11-jdk AS builder
 
-USER root
+RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
 
-RUN microdnf install -y \
-   platform-python python3-libs
-
-RUN microdnf install -y java-11-openjdk-headless
-ENV JAVA_HOME /usr/lib/jvm/jre-11-openjdk
-
-RUN microdnf install git -y
-RUN java -version
 RUN git clone https://github.com/adobe/kafka-connect-s3.git
 # Temp patch until vulnerable deps are fixed
 RUN sed -i "s/versions.awsSdkS3 = '1.11.803'/versions.awsSdkS3 = '1.12.261'/g" kafka-connect-s3/dependencies.gradle
 RUN sed -i "s/versions.jackson = '2.10.4'/versions.jackson = '2.12.7.1'/g" kafka-connect-s3/dependencies.gradle
 RUN cd kafka-connect-s3 && ./gradlew shadowJar
-# copy the jar files
-RUN cp ./kafka-connect-s3/build/libs/kafka-connect-s3-chart/kafka-connect/0.0.4-2a8a4aa-all.jar /opt/
-# cleanup
-RUN rm -rf ~/.gradle ./kafka-connect-s3
+
+FROM confluentinc/cp-kafka-connect:8.3.0
+
+USER root
+
+COPY --from=builder /kafka-connect-s3/build/libs/kafka-connect-s3-chart/kafka-connect/0.0.4-2a8a4aa-all.jar /opt/
 
 # adding script to monitor source connector
 COPY docker/kafka-adobes3Connector/image/adobe-monitorsource.sh monitorconnect.sh


### PR DESCRIPTION
## Change Overview

`confluentinc/cp-kafka-connect:8.3.0` ships without any package manager (`microdnf`, `dnf`, `yum` are all absent). Both `adobeSource.Dockerfile` and `adobeSink.Dockerfile` relied on `microdnf` to install `git`, `java`, and Python. Thus, image build fail with exit code 127 (command not found).

The fix converts both Dockerfiles to multi-stage builds: an `eclipse-temurin:11-jdk` builder stage handles cloning and compiling the Adobe S3 connector jar, while the final stage remains `confluentinc/cp-kafka-connect:8.3.0`. Python and Java are already bundled in the 8.3.0 image so those installs are removed entirely.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :building_construction: Build

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E