### PR TITLE
feat(kopia/command): add MaxConcurrencyMultiplier to ServerStartCommandArgs

### DIFF
--- a/pkg/kopia/command/server.go
+++ b/pkg/kopia/command/server.go
@@ -15,6 +15,7 @@
 package command
 
 import (
+	"fmt"
 	"strconv"
 
 	"github.com/kanisterio/kanister/pkg/kopia/cli/args"
@@ -36,7 +37,13 @@ type ServerStartCommandArgs struct {
 	Background           bool
 	EnablePprof          bool
 	MetricsListenAddress string
-	MaxConcurrency       int
+	// MaxConcurrency sets --max-concurrency to a fixed value. Zero means use
+	// kopia's default (2 * NumCPU on the server pod).
+	MaxConcurrency int
+	// MaxConcurrencyMultiplier sets --max-concurrency to multiplier * $(nproc)
+	// evaluated on the server pod at startup, so the ceiling scales with the
+	// pod's actual CPU count. Ignored when MaxConcurrency > 0.
+	MaxConcurrencyMultiplier int
 }
 
 func commonCommand(cmdArgs ServerStartCommandArgs) logsafe.Cmd {
@@ -75,7 +82,13 @@ func commonCommand(cmdArgs ServerStartCommandArgs) logsafe.Cmd {
 		args = args.AppendLoggableKV(metricsListerAddress, cmdArgs.MetricsListenAddress)
 	}
 
-	if cmdArgs.MaxConcurrency > 0 {
+	switch {
+	case cmdArgs.MaxConcurrencyMultiplier > 0:
+		// Evaluate $(nproc) on the server pod at startup so the ceiling
+		// scales with the pod's CPU count, not the caller's.
+		expr := fmt.Sprintf("$(( $(nproc) * %d ))", cmdArgs.MaxConcurrencyMultiplier)
+		args = args.AppendLoggableKV(maxConcurrencyFlag, expr)
+	case cmdArgs.MaxConcurrency > 0:
 		args = args.AppendLoggableKV(maxConcurrencyFlag, strconv.Itoa(cmdArgs.MaxConcurrency))
 	}
 

--- a/pkg/kopia/command/server_test.go
+++ b/pkg/kopia/command/server_test.go
@@ -189,6 +189,31 @@ func (kServer *KopiaServerTestSuite) TestServerCommands(c *check.C) {
 		},
 		{
 			f: func() []string {
+				args := ServerStartCommandArgs{
+					CommandArgs:              commandArgs,
+					CacheArgs:                cacheArgs,
+					CacheDirectory:           "cache/dir",
+					ServerAddress:            "a-server-address",
+					TLSCertFile:              "/path/to/cert/tls.crt",
+					TLSKeyFile:               "/path/to/key/tls.key",
+					ServerUsername:           "a-username@a-hostname",
+					ServerPassword:           "a-user-password",
+					AutoGenerateCert:         false,
+					Background:               true,
+					MaxConcurrencyMultiplier: 4,
+				}
+				return ServerStart(args)
+			},
+			expectedLog: "bash -o errexit -c kopia --log-level=error --config-file=path/kopia.config --log-dir=cache/log " +
+				"server start --address=a-server-address --tls-cert-file=/path/to/cert/tls.crt " +
+				"--tls-key-file=/path/to/key/tls.key --server-username=a-username@a-hostname " +
+				"--server-password=a-user-password --server-control-username=a-username@a-hostname " +
+				"--server-control-password=a-user-password --cache-directory=cache/dir " +
+				"--content-cache-size-limit-mb=500 --metadata-cache-size-limit-mb=500 " +
+				"--max-concurrency=$(( $(nproc) * 4 )) > /dev/null 2>&1 &",
+		},
+		{
+			f: func() []string {
 				args := ServerStatusCommandArgs{
 					CommandArgs:    commandArgs,
 					ServerAddress:  "a-server-address",


### PR DESCRIPTION
## Summary

Adds `MaxConcurrencyMultiplier int` to `ServerStartCommandArgs`.

When set, `ServerStart` generates:
```
--max-concurrency=$(( $(nproc) * N ))
```
The shell arithmetic is evaluated **inside the server pod's bash context at startup**, so `$(nproc)` reflects the pod's actual CPU count rather than the caller's — fixing the cross-pod CPU mismatch that occurred when callers computed `multiplier × runtime.NumCPU()` on a different pod.

`MaxConcurrency` (static absolute value, added in #4093) continues to work as before; `MaxConcurrencyMultiplier` takes precedence when both are set.

## Changes

- `server.go`: add `MaxConcurrencyMultiplier` field; switch `commonCommand` to emit the shell expression when multiplier > 0
- `server_test.go`: add test case asserting the generated command contains `--max-concurrency=$(( $(nproc) * 4 ))`

## Test plan

- Unit tests: `go test ./pkg/kopia/command/...` — passes