### PR TITLE
docs(tutorial): add RBAC binding step for example app

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -50,6 +50,18 @@ spec:
 EOF
 ```
 
+By default, Kanister can only access resources within its own namespace, so the
+controller in the `kanister` namespace cannot act on `time-logger` in `default`.
+Grant Kanister's Service Account `edit` access in the application namespace by
+creating a `RoleBinding`. For more details and granular alternatives, see
+[RBAC Configuration](rbac).
+
+``` bash
+kubectl create rolebinding kanister-edit-binding --clusterrole=edit \
+--serviceaccount=kanister:kanister-kanister-operator \
+--namespace=default
+```
+
 ## Invoking Kanister Actions
 
 Kanister CustomResources are created in the same namespace as the


### PR DESCRIPTION
## Change Overview

Since #3134 limited the default RBAC granted to the Kanister operator, the
controller can no longer act on resources outside its own namespace. The
tutorial deploys `time-logger` in `default` and runs ActionSets against it from
the `kanister` namespace, but never has the user create a `RoleBinding`, so a
from-scratch run errors before the first action completes.

This adds a short step right after the example app deploys: grant Kanister's
Service Account `edit` access in the `default` namespace. The command mirrors
the one already documented in `docs/rbac.md`, concretized to the tutorial's
release name/namespaces, and links back to RBAC Configuration for granular
alternatives. Docs only.

## Pull request type

- [x] :world_map: Documentation

## Issues

Ref #3654

## Test Plan

- [x] :muscle: Manual

Built the VitePress docs locally (`cd docs && npm install && npm run docs:build`):
clean build, no broken-link warnings, the tutorial renders the new step and the
`rbac` link resolves. Markdown only, no Go build/test impact.
