### PR TITLE
fix(objectstore): sign GetBucketLocation for AWS global endpoint

### DIFF
--- a/pkg/objectstore/bucket.go
+++ b/pkg/objectstore/bucket.go
@@ -21,7 +21,9 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http"
+	"net/url"
 	"path"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	s3manager "github.com/aws/aws-sdk-go-v2/feature/s3/manager"
@@ -211,9 +213,21 @@ func s3BucketRegion(ctx context.Context, cfg ProviderConfig, sec Secret, bucketN
 	// s3-compatible stores may not support s3manager.GetBucketRegion() API, so
 	// prefer to use the get-bucket-location API instead
 	if cfg.Endpoint != "" {
+		locationOpts := []func(*s3.Options){}
+		// GetBucketLocation against the AWS global S3 endpoint (s3.amazonaws.com)
+		// must be signed for us-east-1: the global endpoint is the legacy
+		// us-east-1 endpoint, so signing it with the user-supplied region (e.g.
+		// eu-west-1) is rejected with AuthorizationHeaderMalformed. Override the
+		// signing region for this single call only; region-specific AWS endpoints
+		// and s3-compatible stores (MinIO/Ceph) keep the configured region.
+		if isAWSGlobalS3Endpoint(cfg.Endpoint) {
+			locationOpts = append(locationOpts, func(o *s3.Options) {
+				o.Region = defaultS3region
+			})
+		}
 		resp, err := svc.GetBucketLocation(ctx, &s3.GetBucketLocationInput{
 			Bucket: aws.String(bucketName),
-		})
+		}, locationOpts...)
 		if err == nil {
 			// per the AWS SDK doc an empty location constraint means us-east-1
 			if resp.LocationConstraint == "" {
@@ -270,4 +284,29 @@ const awsS3EndpointFmt = "https://s3.%s.amazonaws.com"
 
 func awsS3Endpoint(region string) string {
 	return fmt.Sprintf(awsS3EndpointFmt, region)
+}
+
+// awsGlobalS3Host is the AWS global (legacy us-east-1) S3 endpoint host. Unlike
+// region-specific hosts (s3.<region>.amazonaws.com), requests to it must be
+// signed for us-east-1.
+const awsGlobalS3Host = "s3.amazonaws.com"
+
+// isAWSGlobalS3Endpoint reports whether endpoint points at the AWS global S3
+// endpoint (s3.amazonaws.com). Region-specific AWS endpoints
+// (e.g. s3.eu-west-1.amazonaws.com) and s3-compatible endpoints return false.
+func isAWSGlobalS3Endpoint(endpoint string) bool {
+	if endpoint == "" {
+		return false
+	}
+	// The endpoint may be configured without a scheme (e.g. "s3.amazonaws.com"),
+	// in which case url.Parse treats the whole value as a path; add a scheme so
+	// the host is parsed.
+	if !strings.Contains(endpoint, "://") {
+		endpoint = "https://" + endpoint
+	}
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return false
+	}
+	return u.Hostname() == awsGlobalS3Host
 }

--- a/pkg/objectstore/bucket_test.go
+++ b/pkg/objectstore/bucket_test.go
@@ -280,3 +280,34 @@ func (s *BucketSuite) TestGetRegionForBucket(c *check.C) {
 		}
 	}
 }
+
+// S3EndpointSuite holds tests that do not require live AWS credentials.
+type S3EndpointSuite struct{}
+
+var _ = check.Suite(&S3EndpointSuite{})
+
+func (s *S3EndpointSuite) TestIsAWSGlobalS3Endpoint(c *check.C) {
+	for _, tc := range []struct {
+		endpoint string
+		expected bool
+	}{
+		// AWS global endpoint must be detected, with or without a scheme or
+		// trailing slash, so GetBucketLocation is signed for us-east-1.
+		{endpoint: "s3.amazonaws.com", expected: true},
+		{endpoint: "https://s3.amazonaws.com", expected: true},
+		{endpoint: "https://s3.amazonaws.com/", expected: true},
+		{endpoint: "http://s3.amazonaws.com", expected: true},
+		// Region-specific AWS endpoints keep the configured region. The first
+		// guards TestInvalidS3RegionEndpointMismatch's endpoint.
+		{endpoint: "https://s3.us-gov-west-1.amazonaws.com", expected: false},
+		{endpoint: "https://s3.eu-west-1.amazonaws.com", expected: false},
+		{endpoint: awsS3Endpoint("us-west-2"), expected: false},
+		// s3-compatible stores (MinIO/Ceph) are never the AWS global endpoint.
+		{endpoint: "https://minio.example.com:9000", expected: false},
+		{endpoint: "https://play.min.io", expected: false},
+		{endpoint: "", expected: false},
+	} {
+		cmt := check.Commentf("endpoint: %q", tc.endpoint)
+		c.Check(isAWSGlobalS3Endpoint(tc.endpoint), check.Equals, tc.expected, cmt)
+	}
+}


### PR DESCRIPTION
## Change Overview

When a profile sets an explicit endpoint of `s3.amazonaws.com` together with a
non `us-east-1` region (e.g. `eu-west-1`), bucket region validation fails:

```
GetBucketLocation: AuthorizationHeaderMalformed: The authorization header is
malformed; the region 'eu-west-1' is wrong; expecting 'us-east-1'
```

`s3.amazonaws.com` is the legacy global (us-east-1) S3 endpoint, so requests to
it must be signed for `us-east-1`. The SDK was signing `GetBucketLocation` with
the user-supplied region, which S3 rejects. This broke `kanctl create profile`
and `kando` whenever an AWS endpoint was provided for a bucket outside
us-east-1; the documented workaround is to drop `--endpoint`.

This overrides the signing region to `us-east-1` for that single
`GetBucketLocation` call, gated to the AWS global endpoint only. Region-specific
AWS endpoints (`s3.<region>.amazonaws.com`) and s3-compatible stores
(MinIO/Ceph) keep the configured region, so `TestInvalidS3RegionEndpointMismatch`
and existing behaviour are unaffected.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :building_construction: Build

## Issues

- Ref #3613

## Test Plan

- [x] :zap: Unit test - added a credential-free `TestIsAWSGlobalS3Endpoint`
  covering scheme-less / scheme / trailing-slash global endpoints, region-specific
  AWS endpoints, MinIO/Ceph, and empty input.
- [x] :green_heart: E2E - the existing live-AWS objectstore suite is exercised in
  CI (it requires AWS creds / MinIO and is skipped without them).

```
go test ./pkg/objectstore/                # global-endpoint detection runs; live-AWS suites skip
gofmt -l pkg/objectstore/bucket.go        # clean
```
