### PR TITLE
Remove build support for kafka-adobe-s3 connector images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -101,7 +101,6 @@ updates:
       - "/docker/couchbase-tools"
       - "/docker/docs-build"
       - "/docker/foundationdb"
-      - "/docker/kafka-adobes3Connector/image"
       - "/docker/kanister-elasticsearch/image"
       - "/docker/kanister-mongodb-replicaset"
       - "/docker/kanister-mysql"

--- a/.github/workflows/build_example_images.yaml
+++ b/.github/workflows/build_example_images.yaml
@@ -71,42 +71,6 @@ jobs:
         org.opencontainers.image.title=kanister mysql sidecar
         org.opencontainers.image.description=Image for kanister maysql example blueprints
 
-  build_kafka-adobe-s3-sink-connector:
-    permissions:
-      packages: write
-      contents: read
-    uses: ./.github/workflows/build_docker.yaml
-    with:
-      image_file: docker/kafka-adobes3Connector/image/adobeSink.Dockerfile
-      image_name: kanisterio/kafka-adobe-s3-sink-connector
-      image_tag: ${{ inputs.image_tag }}
-      extra_tags: ${{ inputs.extra_tags }}
-      ref:  ${{ inputs.ref }}
-      platforms: ${{ inputs.platforms }}
-      build-args: |
-        TOOLS_IMAGE=ghcr.io/kanisterio/kanister-tools:${{ inputs.image_tag }}
-      labels: |
-        org.opencontainers.image.title=kanister kafka sink connector
-        org.opencontainers.image.description=Image for kanister kafka example blueprints
-
-  build_kafka-adobe-s3-source-connector:
-    permissions:
-      packages: write
-      contents: read
-    uses: ./.github/workflows/build_docker.yaml
-    with:
-      image_file: docker/kafka-adobes3Connector/image/adobeSource.Dockerfile
-      image_name: kanisterio/kafka-adobe-s3-source-connector
-      image_tag: ${{ inputs.image_tag }}
-      extra_tags: ${{ inputs.extra_tags }}
-      ref:  ${{ inputs.ref }}
-      platforms: ${{ inputs.platforms }}
-      build-args: |
-        TOOLS_IMAGE=ghcr.io/kanisterio/kanister-tools:${{ inputs.image_tag }}
-      labels: |
-        org.opencontainers.image.title=kanister kafka source connector
-        org.opencontainers.image.description=Image for kanister kafka example blueprints
-
   build_postgres-kanister-tools:
     permissions:
       packages: write

--- a/build/example_images.json
+++ b/build/example_images.json
@@ -2,13 +2,11 @@
     "image_registry": "ghcr.io/kanisterio",
     "images": [
         "mysql-sidecar",
-        "kafka-adobe-s3-sink-connector",
         "postgres-kanister-tools",
         "postgresql",
         "cassandra",
         "mongodb",
         "es-sidecar",
-        "kafka-adobe-s3-source-connector",
         "mssql-tools"
     ],
     "tag": "v9.99.9-dev"


### PR DESCRIPTION
## Change Overview

Removes the `kafka-adobe-s3-sink-connector` and `kafka-adobe-s3-source-connector` images from the build pipeline, CI image scanning, and Dependabot. The Dockerfiles under `docker/kafka-adobes3Connector/image` are retained as examples.

Changes:
- `build/example_images.json` — dropped both connector images from the example images list (used by the build pipeline and the `example-images-scanning` workflow).
- `.github/workflows/build_example_images.yaml` — removed the `build_kafka-adobe-s3-sink-connector` and `build_kafka-adobe-s3-source-connector` jobs.
- `.github/dependabot.yml` — removed the `/docker/kafka-adobes3Connector/image` directory entry.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [x] :building_construction: Build

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- N/A

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E

Validated that `build/example_images.json` is still valid JSON and the workflow/dependabot YAML no longer reference the removed images.