### PR TITLE
fix(function): avoid data race on shared output in KubeExecAll

### DIFF
--- a/pkg/function/kube_exec_all.go
+++ b/pkg/function/kube_exec_all.go
@@ -118,18 +118,33 @@ func (kef *kubeExecAllFunc) ExecutionProgress() (crv1alpha1.PhaseProgress, error
 	}, nil
 }
 
+// execFunc runs a command in a single pod/container and returns its stdout,
+// stderr and any execution error. It is a seam that defaults to KubeExecAndLog
+// so execAllWith can be unit-tested without a live cluster.
+type execFunc func(ctx context.Context, cli kubernetes.Interface, namespace, pod, container string, cmd []string) (stdout, stderr string, err error)
+
 func execAll(ctx context.Context, cli kubernetes.Interface, namespace string, ps []string, cs []string, cmd []string) (map[string]interface{}, error) {
+	return execAllWith(ctx, cli, namespace, ps, cs, cmd, func(ctx context.Context, cli kubernetes.Interface, namespace, pod, container string, cmd []string) (string, string, error) {
+		return KubeExecAndLog(ctx, cli, namespace, pod, container, cmd, nil)
+	})
+}
+
+func execAllWith(ctx context.Context, cli kubernetes.Interface, namespace string, ps []string, cs []string, cmd []string, exec execFunc) (map[string]interface{}, error) {
 	numContainers := len(ps) * len(cs)
 	errChan := make(chan error, numContainers)
-	output := ""
+	// Each goroutine writes into its own slot, so the shared slice is accessed
+	// race-free; the results are joined only after every goroutine has finished.
+	outputs := make([]string, numContainers)
 	// Run the command
+	i := 0
 	for _, p := range ps {
 		for _, c := range cs {
-			go func(p string, c string) {
-				stdout, _, err := KubeExecAndLog(ctx, cli, namespace, p, c, cmd, nil)
+			go func(idx int, p string, c string) {
+				stdout, _, err := exec(ctx, cli, namespace, p, c, cmd)
+				outputs[idx] = stdout
 				errChan <- err
-				output = output + "\n" + stdout
-			}(p, c)
+			}(i, p, c)
+			i++
 		}
 	}
 	errs := make([]string, 0, numContainers)
@@ -141,6 +156,10 @@ func execAll(ctx context.Context, cli kubernetes.Interface, namespace string, ps
 	}
 	if len(errs) != 0 {
 		return nil, errkit.New(strings.Join(errs, "\n"))
+	}
+	output := ""
+	for _, o := range outputs {
+		output = output + "\n" + o
 	}
 	out, err := parseLogAndCreateOutput(output)
 	if err != nil {

--- a/pkg/function/kube_exec_all_test.go
+++ b/pkg/function/kube_exec_all_test.go
@@ -30,6 +30,7 @@ import (
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	"github.com/kanisterio/kanister/pkg/client/clientset/versioned"
 	"github.com/kanisterio/kanister/pkg/kube"
+	"github.com/kanisterio/kanister/pkg/output"
 	"github.com/kanisterio/kanister/pkg/param"
 	"github.com/kanisterio/kanister/pkg/resource"
 	"github.com/kanisterio/kanister/pkg/testutil"
@@ -140,6 +141,35 @@ func (s *KubeExecAllTest) TestKubeExecAllDeployment(c *check.C) {
 	for _, p := range phases {
 		_, err = p.Exec(ctx, *bp, action, *tp)
 		c.Assert(err, check.IsNil)
+	}
+}
+
+// KubeExecAllOutputTest exercises execAllWith without a live cluster. It runs
+// under `go test -race` and guards against the output of the per-container
+// goroutines racing or being lost when more than one pod/container is targeted.
+type KubeExecAllOutputTest struct{}
+
+var _ = check.Suite(&KubeExecAllOutputTest{})
+
+func (s *KubeExecAllOutputTest) TestExecAllCollectsEveryContainerOutput(c *check.C) {
+	pods := []string{"pod-a", "pod-b", "pod-c", "pod-d"}
+	containers := []string{"c0", "c1", "c2"}
+
+	// Each pod/container emits a distinct phase-output line so a lost or
+	// corrupted concatenation shows up as a missing key.
+	fakeExec := func(_ context.Context, _ kubernetes.Interface, _, pod, container string, _ []string) (string, string, error) {
+		key := fmt.Sprintf("k_%s_%s", pod, container)
+		return fmt.Sprintf("%s{\"key\":\"%s\",\"value\":\"%s\"}", output.PhaseOpString, key, key), "", nil
+	}
+
+	out, err := execAllWith(context.Background(), nil, "ns", pods, containers, []string{"echo"}, fakeExec)
+	c.Assert(err, check.IsNil)
+	c.Assert(out, check.HasLen, len(pods)*len(containers))
+	for _, pod := range pods {
+		for _, container := range containers {
+			key := fmt.Sprintf("k_%s_%s", pod, container)
+			c.Check(out[key], check.Equals, key)
+		}
 	}
 }
 

--- a/releasenotes/notes/fix-kube-exec-all-output-race-a72b6e34ec0ee53b.yaml
+++ b/releasenotes/notes/fix-kube-exec-all-output-race-a72b6e34ec0ee53b.yaml
@@ -1,0 +1,3 @@
+---
+fixes:
+  - Fixed a data race in the ``KubeExecAll`` function where per-container command output could be raced or lost when more than one pod or container was targeted.


### PR DESCRIPTION

## Change Overview

`KubeExecAll` runs a command across every pod/container in parallel. `execAll`
spawned one goroutine per pod/container, and each goroutine appended its command
stdout to a single shared string:

```go
output := ""
...
go func(p string, c string) {
    stdout, _, err := KubeExecAndLog(ctx, cli, namespace, p, c, cmd, nil)
    errChan <- err
    output = output + "\n" + stdout   // shared, unsynchronized
}(p, c)
```

That is an unsynchronized read-modify-write of `output` shared across all N
goroutines, which is a data race on the string and can silently drop
concatenations when two appends interleave (lost update). It also writes
`output` *after* the send on `errChan`, so draining the error channel in the main
goroutine establishes no happens-before with that write: that same goroutine can
read `output` in `parseLogAndCreateOutput` while goroutines are still writing,
racing the read against the writes. Any `KubeExecAll` phase that targets more
than one pod or container (its whole purpose) can therefore drop or corrupt exec
output.

The fix keeps the change confined to `execAll`:

- Each goroutine writes into its own slot of a preallocated `outputs` slice keyed
  by index. Distinct indices never overlap, so the concurrent writes are
  race-free by construction (no mutex needed).
- The slot write now happens *before* the send on `errChan`. The main goroutine
  receives all N errors before joining any slot, so every per-container write
  happens-before the read in `parseLogAndCreateOutput`. Both the write/write and
  the read/write races are removed.
- Output is joined in the deterministic pod/container iteration order (it was
  previously nondeterministic goroutine-completion order). This does not change
  semantics: `parseLogAndCreateOutput` parses order-independent phase-output
  key/value lines into a map.

To make the concurrent path testable without a live cluster, the core is
extracted into `execAllWith(..., exec execFunc)` with an injectable exec seam
that defaults to `KubeExecAndLog`. `execAll`'s signature and its only caller are
unchanged.

A release note is included under `releasenotes/notes/`.


- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :building_construction: Build

## Issues

<!-- No existing issue tracks this; found by code review. Can file one to link if
maintainers prefer. Intentionally not auto-closing anything. -->

- N/A

## Test Plan

- [x] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E

Added `TestExecAllCollectsEveryContainerOutput` (new `KubeExecAllOutputTest`
gocheck suite) in `pkg/function/kube_exec_all_test.go`. It fans out 4 pods x 3
containers through a fake exec that emits a distinct phase-output line per
pod/container, then asserts the parsed output map contains all 12 keys, so a lost
or corrupted concatenation shows up as a missing key. Run under the race
detector:

```
go test -race -run 'Test/TestExecAllCollectsEveryContainerOutput' \
  ./pkg/function/ -check.f 'KubeExecAllOutputTest'
```

The test fails under `-race` on the pre-fix body (the race detector fires on the
shared `output` string) and passes after the fix.

Also verified locally: `go build -race ./pkg/function/...`, `go vet
./pkg/function/`, and golangci-lint with the repo config on `pkg/function` (0
issues). The existing live-cluster suites (`TestKubeExecAllDeployment`,
`TestKubeExecAllStatefulSet`) still compile; they need a kubeconfig and were not
run locally.
