### PR TITLE
fix(postgres): close rows and check iteration error in ListDatabases

### DIFF
--- a/pkg/postgres/client.go
+++ b/pkg/postgres/client.go
@@ -54,15 +54,19 @@ func (pg Client) ListDatabases(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close() //nolint:errcheck
 
 	var dbList []string
 	for rows.Next() {
 		var db string
 		err = rows.Scan(&db)
 		if err != nil {
-			break
+			return nil, err
 		}
 		dbList = append(dbList, db)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 	return dbList, nil
 }

--- a/pkg/postgres/client_test.go
+++ b/pkg/postgres/client_test.go
@@ -1,0 +1,158 @@
+// Copyright 2026 The Kanister Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"io"
+	"testing"
+
+	"gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) { check.TestingT(t) }
+
+type ClientSuite struct{}
+
+var _ = check.Suite(&ClientSuite{})
+
+// errQueryFailed and errRowFailed are stub-driver errors used to drive the
+// ListDatabases error paths.
+var (
+	errQueryFailed = errors.New("query failed")
+	errRowFailed   = errors.New("row iteration failed")
+)
+
+// fakeDriver is a minimal database/sql/driver stub used to exercise
+// ListDatabases without a live Postgres. Each Open returns a fresh fakeConn
+// configured from the package-level fakeConnConfig set by the test.
+type fakeDriver struct{}
+
+// fakeConnConfig configures the behavior of the stub connection.
+type fakeConnConfig struct {
+	// values are the datname rows returned by QueryContext.
+	values []string
+	// queryErr, if set, is returned by QueryContext instead of any rows.
+	queryErr error
+	// rowErr, if set, is returned by Rows.Next after all values have been
+	// yielded, simulating a mid-iteration error (e.g. a dropped connection).
+	rowErr error
+	// rowsClosed records whether Rows.Close was called.
+	rowsClosed bool
+}
+
+var fakeConn = &fakeConnConfig{}
+
+func (fakeDriver) Open(string) (driver.Conn, error) {
+	return &fakeConnImpl{cfg: fakeConn}, nil
+}
+
+type fakeConnImpl struct {
+	cfg *fakeConnConfig
+}
+
+func (c *fakeConnImpl) QueryContext(_ context.Context, _ string, _ []driver.NamedValue) (driver.Rows, error) {
+	if c.cfg.queryErr != nil {
+		return nil, c.cfg.queryErr
+	}
+	return &fakeRows{cfg: c.cfg}, nil
+}
+
+func (c *fakeConnImpl) Prepare(string) (driver.Stmt, error) {
+	return nil, errors.New("Prepare not implemented")
+}
+
+func (c *fakeConnImpl) Close() error { return nil }
+
+func (c *fakeConnImpl) Begin() (driver.Tx, error) {
+	return nil, errors.New("Begin not implemented")
+}
+
+type fakeRows struct {
+	cfg *fakeConnConfig
+	pos int
+}
+
+func (r *fakeRows) Columns() []string { return []string{"datname"} }
+
+func (r *fakeRows) Close() error {
+	r.cfg.rowsClosed = true
+	return nil
+}
+
+func (r *fakeRows) Next(dest []driver.Value) error {
+	if r.pos >= len(r.cfg.values) {
+		if r.cfg.rowErr != nil {
+			return r.cfg.rowErr
+		}
+		return io.EOF
+	}
+	dest[0] = r.cfg.values[r.pos]
+	r.pos++
+	return nil
+}
+
+func (s *ClientSuite) SetUpSuite(_ *check.C) {
+	sql.Register("kanister-postgres-fake", fakeDriver{})
+}
+
+func (s *ClientSuite) SetUpTest(_ *check.C) {
+	fakeConn = &fakeConnConfig{}
+}
+
+func (s *ClientSuite) newClient(c *check.C) *Client {
+	db, err := sql.Open("kanister-postgres-fake", "")
+	c.Assert(err, check.IsNil)
+	return &Client{db}
+}
+
+func (s *ClientSuite) TestListDatabasesReturnsAllRows(c *check.C) {
+	fakeConn.values = []string{"postgres", "template1", "app"}
+
+	client := s.newClient(c)
+	dbList, err := client.ListDatabases(context.Background())
+
+	c.Assert(err, check.IsNil)
+	c.Assert(dbList, check.DeepEquals, []string{"postgres", "template1", "app"})
+	c.Assert(fakeConn.rowsClosed, check.Equals, true)
+}
+
+// TestListDatabasesPropagatesRowError guards against silently truncating the
+// database list: a mid-iteration error must surface as an error rather than
+// returning a partial list with a nil error.
+func (s *ClientSuite) TestListDatabasesPropagatesRowError(c *check.C) {
+	fakeConn.values = []string{"postgres"}
+	fakeConn.rowErr = errRowFailed
+
+	client := s.newClient(c)
+	dbList, err := client.ListDatabases(context.Background())
+
+	c.Assert(err, check.NotNil)
+	c.Assert(dbList, check.IsNil)
+	c.Assert(fakeConn.rowsClosed, check.Equals, true)
+}
+
+func (s *ClientSuite) TestListDatabasesPropagatesQueryError(c *check.C) {
+	fakeConn.queryErr = errQueryFailed
+
+	client := s.newClient(c)
+	dbList, err := client.ListDatabases(context.Background())
+
+	c.Assert(err, check.NotNil)
+	c.Assert(dbList, check.IsNil)
+}


### PR DESCRIPTION

## Change Overview

`postgres.Client.ListDatabases` iterates over `*sql.Rows` but does not honor the
`database/sql` contract: it never calls `rows.Close()` and never checks
`rows.Err()`.

Two concrete problems:

1. **Leaked connection on a Scan error.** `database/sql` auto-closes `Rows` only
   when `Next()` returns `false` naturally. The loop previously `break`ed on a
   `Scan` error without closing, so the `Rows` (and its underlying pooled
   connection) leaked. Since `Client` embeds a long-lived `*sql.DB` pool, that
   connection is not reclaimed.
2. **Silently truncated database list.** `Next()` returns `false` on both
   end-of-rows and a mid-iteration error (for example a dropped connection or a
   decode failure). Without a `rows.Err()` check, a mid-iteration error produced
   a partial `dbList` with a `nil` error, so a truncated list looked like a
   complete success.

`ListDatabases` drives the RDS Postgres backup path
(`pkg/function/export_rds_snapshot_location.go` -> `findDBList` ->
`filterRestrictedDB` -> `postgresBackupCommand`), so a silently short list means
databases can be dropped from an RDS Postgres backup without any error surfacing.

The fix applies the standard `database/sql` idiom:
- `defer rows.Close()` right after the query succeeds (with the repo's
  established `//nolint:errcheck` convention for `defer x.Close()`),
- return the `Scan` error instead of `break`ing (closing is now handled by the
  defer),
- check `rows.Err()` after the loop.

No signature change and no behavior change on the success path.

Adds `pkg/postgres/client_test.go` with a self-contained `database/sql/driver`
stub (no new dependency) covering the happy path, a mid-iteration row error (the
truncation regression), and a query error.


Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [x] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :building_construction: Build

## Issues

<!-- No existing issue tracks this; found while reading the postgres client. -->
N/A

## Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E

`go test ./pkg/postgres/...` (3 cases, all pass).

The `TestListDatabasesPropagatesRowError` case is a genuine regression guard: on
the pre-fix code it returns `(partialList, nil)` (silent truncation); after the
fix it returns `(nil, err)`. Also ran `go vet ./pkg/postgres/...`,
`go build ./pkg/postgres/... ./pkg/function/...`, and
`golangci-lint run --config=.golangci.yml ./pkg/postgres/...` (v2.10.1, matching
CI) with 0 issues.
