### PR TITLE
Support templating of WaitV2 timeout

### DIFF
--- a/docs/functions.md
+++ b/docs/functions.md
@@ -1264,7 +1264,7 @@ Arguments:
 
   | Argument   | Required | Type                     | Description |
   | ---------- | :------: | ------------------------ | ----------- |
-  | timeout    | Yes      | string                   | wait timeout, rendered as a Go template against the Blueprint's template params before being parsed (e.g. `{{ .Options.waitTimeout }}`) |
+  | timeout    | Yes      | string                   | wait timeout, rendered as a Go template against the Blueprint's template params before being parsed (see example below) |
   | conditions | Yes      | map[string]interface{}   | keys should be `allOf` and/or `anyOf` with value as `[]Condition`. Unlike `timeout`, these are **not** rendered against the template params; each `condition` is instead evaluated as a Go template per-poll against the fetched object |
 
 `Condition` struct:

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -1264,8 +1264,8 @@ Arguments:
 
   | Argument   | Required | Type                     | Description |
   | ---------- | :------: | ------------------------ | ----------- |
-  | timeout    | Yes      | string                   | wait timeout |
-  | conditions | Yes      | map[string]interface{}   | keys should be `allOf` and/or `anyOf` with value as `[]Condition` |
+  | timeout    | Yes      | string                   | wait timeout, rendered as a Go template against the Blueprint's template params before being parsed (e.g. `{{ .Options.waitTimeout }}`) |
+  | conditions | Yes      | map[string]interface{}   | keys should be `allOf` and/or `anyOf` with value as `[]Condition`. Unlike `timeout`, these are **not** rendered against the template params; each `condition` is instead evaluated as a Go template per-poll against the fetched object |
 
 `Condition` struct:
 
@@ -1294,6 +1294,7 @@ Example:
 - func: WaitV2
   name: waitForDeploymentReady
   args:
+    # timeout can also be a template expression, e.g. '{{ .Options.waitTimeout }}'
     timeout: 5m
     conditions:
       anyOf:

--- a/pkg/function/waitv2.go
+++ b/pkg/function/waitv2.go
@@ -60,8 +60,8 @@ func (w *waitV2Func) Exec(ctx context.Context, tp param.TemplateParams, args map
 	w.progressPercent = progress.StartedPercent
 	defer func() { w.progressPercent = progress.CompletedPercent }()
 
-	var timeout string
-	if err := Arg(args, WaitV2TimeoutArg, &timeout); err != nil {
+	timeout, err := renderWaitV2Timeout(args, tp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -82,6 +82,23 @@ func (w *waitV2Func) Exec(ctx context.Context, tp param.TemplateParams, args map
 	}
 	err = waitForCondition(ctx, dynCli, conditions, timeoutDur, tp, evaluateWaitV2Condition)
 	return nil, err
+}
+
+func renderWaitV2Timeout(args map[string]interface{}, tp param.TemplateParams) (string, error) {
+	renderedArgs := args
+	if ArgExists(args, WaitV2TimeoutArg) {
+		rendered, err := param.RenderArgs(map[string]interface{}{WaitV2TimeoutArg: args[WaitV2TimeoutArg]}, tp)
+		if err != nil {
+			return "", err
+		}
+		renderedArgs = rendered
+	}
+
+	var timeout string
+	if err := Arg(renderedArgs, WaitV2TimeoutArg, &timeout); err != nil {
+		return "", err
+	}
+	return timeout, nil
 }
 
 func (*waitV2Func) RequiredArgs() []string {

--- a/pkg/function/waitv2_test.go
+++ b/pkg/function/waitv2_test.go
@@ -228,3 +228,41 @@ func (s *WaitV2Suite) TestWaitV2(c *check.C) {
 		}
 	}
 }
+
+func (s *WaitV2Suite) TestRenderWaitV2Timeout(c *check.C) {
+	for _, tc := range []struct {
+		description string
+		args        map[string]any
+		tp          param.TemplateParams
+		expected    string
+		expectErr   bool
+	}{
+		{
+			description: "plain duration string is unaffected",
+			args:        map[string]any{WaitV2TimeoutArg: "1m"},
+			tp:          param.TemplateParams{},
+			expected:    "1m",
+		},
+		{
+			description: "templated timeout resolves against Options",
+			args:        map[string]any{WaitV2TimeoutArg: "{{ .Options.waitTimeout }}"},
+			tp:          param.TemplateParams{Options: map[string]string{"waitTimeout": "2m30s"}},
+			expected:    "2m30s",
+		},
+		{
+			description: "missing timeout arg errors",
+			args:        map[string]any{},
+			tp:          param.TemplateParams{},
+			expectErr:   true,
+		},
+	} {
+		timeout, err := renderWaitV2Timeout(tc.args, tc.tp)
+		comment := check.Commentf(tc.description)
+		if tc.expectErr {
+			c.Assert(err, check.NotNil, comment)
+			continue
+		}
+		c.Assert(err, check.IsNil, comment)
+		c.Assert(timeout, check.Equals, tc.expected, comment)
+	}
+}

--- a/releasenotes/notes/waitv2-render-timeout-bf427954363813e5.yaml
+++ b/releasenotes/notes/waitv2-render-timeout-bf427954363813e5.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    The ``timeout`` argument of the ``WaitV2`` function is now rendered as a
+    Go template against the Blueprint's template params before being parsed,
+    matching the behavior of the deprecated ``Wait`` function. This allows
+    the timeout to be parameterized, e.g. ``timeout: '{{ .Options.waitTimeout }}'``.


### PR DESCRIPTION
## Change Overview

Allows the `timeout` argument of `WaitV2` functions to be templatized.

This allows definitions like `timeout: {{ .Options.waitTimeout }}` in the blueprint, and dynamically passing a `waitTimeout` value in the options at runtime.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [x] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :building_construction: Build

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #4184

## Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
