### PR TITLE
feat(helm): add imagePullSecrets support to kanister-operator chart

### DIFF
--- a/helm/kanister-operator/templates/deployment.yaml
+++ b/helm/kanister-operator/templates/deployment.yaml
@@ -15,6 +15,10 @@ spec:
 {{ include "kanister-operator.helmLabels" . | indent 8}}
     spec:
       serviceAccountName: {{ template "kanister-operator.serviceAccountName" . }}
+{{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
+{{- end }}
 {{ include "podSecurityContext" . | indent 2 }}
 {{- if .Values.bpValidatingWebhook.enabled }}
       volumes:

--- a/helm/kanister-operator/values.yaml
+++ b/helm/kanister-operator/values.yaml
@@ -9,6 +9,11 @@ kanisterToolsImage:
   override: false
   image: ghcr.io/kanisterio/kanister-tools
   tag: 0.119.0
+# imagePullSecrets is used to specify secrets for pulling the operator image from a private registry.
+# Example:
+# imagePullSecrets:
+#   - name: my-registry-secret
+imagePullSecrets: []
 # secureDefaultsForJobPods is responsible for applying secure default configurations to kanister Job pods.
 secureDefaultsForJobPods: false
 rbac:

--- a/pkg/testing/helm/helm_test.go
+++ b/pkg/testing/helm/helm_test.go
@@ -434,6 +434,71 @@ func (h *HelmTestSuite) TestSecureDefaultsEnvVariable(c *check.C) {
 	}
 }
 
+// TestImagePullSecretsFromHelmChart validates that imagePullSecrets are correctly rendered
+// in the Deployment spec when configured via Helm values.
+func (h *HelmTestSuite) TestImagePullSecretsFromHelmChart(c *check.C) {
+	var testCases = []struct {
+		testName              string
+		helmValues            map[string]string
+		expectedSecretNames   []string
+	}{
+		{
+			testName: "imagePullSecrets is set with a single secret",
+			helmValues: map[string]string{
+				"bpValidatingWebhook.enabled":  "false",
+				"imagePullSecrets[0].name":     "my-registry-secret",
+			},
+			expectedSecretNames: []string{"my-registry-secret"},
+		},
+		{
+			testName: "imagePullSecrets is set with multiple secrets",
+			helmValues: map[string]string{
+				"bpValidatingWebhook.enabled":  "false",
+				"imagePullSecrets[0].name":     "secret-one",
+				"imagePullSecrets[1].name":     "secret-two",
+			},
+			expectedSecretNames: []string{"secret-one", "secret-two"},
+		},
+		{
+			testName: "imagePullSecrets is not set (default empty)",
+			helmValues: map[string]string{
+				"bpValidatingWebhook.enabled": "false",
+			},
+			expectedSecretNames: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		c.Logf("Test name: %s", tc.testName)
+
+		testApp, err := NewHelmApp(tc.helmValues, kanisterName, "../../../helm/kanister-operator", kanisterName, "", true)
+		c.Assert(err, check.IsNil)
+
+		out, err := testApp.Install()
+		c.Assert(err, check.IsNil)
+
+		resources := helm.ResourcesFromRenderedManifest(out, func(kind helm.K8sObjectType) bool {
+			return kind == helm.K8sObjectTypeDeployment
+		})
+		c.Assert(len(resources), check.Equals, 1)
+
+		deployments, err := helm.K8sObjectsFromRenderedResources[*appsv1.Deployment](resources)
+		c.Assert(err, check.IsNil)
+
+		obj := deployments[h.deploymentName]
+		c.Assert(obj, check.NotNil)
+
+		if tc.expectedSecretNames == nil {
+			c.Assert(obj.Spec.Template.Spec.ImagePullSecrets, check.IsNil)
+		} else {
+			c.Assert(len(obj.Spec.Template.Spec.ImagePullSecrets), check.Equals, len(tc.expectedSecretNames))
+			for i, secret := range obj.Spec.Template.Spec.ImagePullSecrets {
+				c.Assert(secret.Name, check.Equals, tc.expectedSecretNames[i])
+			}
+		}
+	}
+}
+
 func boolPtr(b bool) *bool {
 	return &b
 }


### PR DESCRIPTION
## Summary

Fixes #2999

Allow users to configure imagePullSecrets on the kanister-operator Deployment via the Helm chart values.

### Problem
In air-gapped environments or clusters that use private container registries with authentication, the operator pod fails to pull the controller image because there was no way to pass imagePullSecrets through the Helm chart.

### Solution
- Added imagePullSecrets: [] to alues.yaml with an inline example comment
- Conditionally rendered imagePullSecrets in deployment.yaml when the list is non-empty (zero overhead for the default case)
- Added TestImagePullSecretsFromHelmChart test covering:
  - Single pull secret
  - Multiple pull secrets
  - Default (empty list → field absent from rendered manifest)

### Usage
\\\yaml
# values.yaml
imagePullSecrets:
  - name: my-registry-secret
\\\
or via CLI:
\\\ash
helm install kanister kanister/kanister-operator \
  --set 'imagePullSecrets[0].name=my-registry-secret'
\\\

### Testing
Validated with \helm lint --strict\ and \helm template\ — chart passes with 0 failures.