### PR TITLE
chore(ci): only allow patch upgrades for Golang Docker image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -80,8 +80,12 @@ updates:
     groups:
       base-images:
         patterns:
-        - "golang*"
         - "*ubi9*"
+      golang:
+        patterns:
+        - "golang*"
+        update-types:
+        - patch
     directories:
       - "/"
       - "/docker/build"


### PR DESCRIPTION
## Change Overview

Prevent automatic Golang minor version upgrades, for example from 1.25.x to 1.26.y.
This breaks the build.

## Pull request type

Please check the type of change your PR introduces:
- [x] :construction: Work in Progress
- [x] :building_construction: Build

## Test Plan

- [x] 🤖 dependabot config validation
