### PR TITLE
feat:support for conditional phase execution

### DIFF
--- a/pkg/apis/cr/v1alpha1/types.go
+++ b/pkg/apis/cr/v1alpha1/types.go
@@ -190,6 +190,8 @@ const (
 	StateFailed State = "failed"
 	// StateComplete means this action or phase finished successfully.
 	StateComplete State = "complete"
+	// StateSkipped means this action or phase was skipped due to condition not met
+	StateSkipped State = "skipped"
 )
 
 // Error represents an error that occurred when executing an actionset.
@@ -208,6 +210,8 @@ type Phase struct {
 	Output map[string]interface{} `json:"output,omitempty"`
 	// Progress represents the phase execution progress.
 	Progress PhaseProgress `json:"progress,omitempty"`
+	// Reason shows why a phase skipped. It doesn't have significance in other phase states yet.
+	Reason string `json:"reason,omitempty"`
 }
 
 // PhaseProgress represents the execution state of the phase.
@@ -294,10 +298,14 @@ type BlueprintAction struct {
 	DeferPhase *BlueprintPhase `json:"deferPhase,omitempty"`
 }
 
-// BlueprintPhase is a an individual unit of execution.
+// BlueprintPhase is an individual unit of execution.
 type BlueprintPhase struct {
 	// Func is the name of a registered Kanister function.
 	Func string `json:"func"`
+	// If contains conditional expression in go template format. The phase function will be executed only if
+	// the expression evaluates to `true`. To maintain backwards compatibility, the function will be executed
+	// if this field is absent in the phase.
+	If string `json:"if,omitempty"`
 	// Name contains name of the phase.
 	Name string `json:"name"`
 	// ObjectRefs represents a map of references to the Kubernetes objects that

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -536,6 +536,10 @@ func (c *Controller) runAction(ctx context.Context, t *tomb.Tomb, as *crv1alpha1
 				coreErr = nil
 				rf = func(ras *crv1alpha1.ActionSet) error {
 					ras.Status.Actions[aIDX].Phases[i].State = crv1alpha1.StateComplete
+					if p.PhaseSkipped() {
+						ras.Status.Actions[aIDX].Phases[i].State = crv1alpha1.StateSkipped
+						ras.Status.Actions[aIDX].Phases[i].Reason = p.SkipReason()
+					}
 					pp, err := p.Progress()
 					if err != nil {
 						log.Error().WithError(err)
@@ -726,7 +730,7 @@ func (c *Controller) maybeSetActionSetStateComplete(ctx context.Context,
 
 		for _, as := range ras.Status.Actions {
 			for _, p := range as.Phases {
-				if p.State != crv1alpha1.StateComplete {
+				if !(p.State == crv1alpha1.StateComplete || p.State == crv1alpha1.StateSkipped) {
 					log.WithContext(ctx).Print(
 						"Finished action, but other action's phase is still running. Not setting state to complete.",
 						field.M{

--- a/pkg/customresource/actionset.yaml
+++ b/pkg/customresource/actionset.yaml
@@ -288,6 +288,8 @@ spec:
                               type: object
                             state:
                               type: string
+                            reason:
+                              type: string
                             progress:
                               properties:
                                 progressPercent:

--- a/pkg/customresource/blueprint.yaml
+++ b/pkg/customresource/blueprint.yaml
@@ -85,6 +85,8 @@ spec:
                         type: object
                       func:
                         type: string
+                      if:
+                        type: string
                       name:
                         type: string
                       objects:

--- a/pkg/phase.go
+++ b/pkg/phase.go
@@ -15,12 +15,16 @@
 package kanister
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"strings"
+	"text/template"
+	"time"
 
 	"github.com/Masterminds/semver"
 	"github.com/kanisterio/errkit"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	crv1alpha1 "github.com/kanisterio/kanister/pkg/apis/cr/v1alpha1"
 	"github.com/kanisterio/kanister/pkg/field"
@@ -34,12 +38,19 @@ var skipRenderFuncs = map[string]bool{
 	"waitv2": true,
 }
 
+var ErrParsePhaseCondition = errkit.NewSentinelErr("Failed to parse phase condition")
+var ErrExecutePhaseCondition = errkit.NewSentinelErr("Failed to execute phase condition")
+var ErrPhaseExpressionNotConditional = errkit.NewSentinelErr("Phase condition is not conditional expression")
+
 // Phase is an atomic unit of execution.
 type Phase struct {
-	name    string
-	args    map[string]interface{}
-	objects map[string]crv1alpha1.ObjectReference
-	f       Func
+	name         string
+	args         map[string]interface{}
+	objects      map[string]crv1alpha1.ObjectReference
+	condition    string
+	f            Func
+	phaseSkipped bool
+	skipReason   string
 }
 
 // Name returns the name of this phase.
@@ -49,6 +60,13 @@ func (p *Phase) Name() string {
 
 // Progress return execution progress of the phase.
 func (p *Phase) Progress() (crv1alpha1.PhaseProgress, error) {
+	if p.phaseSkipped {
+		phaseTime := metav1.NewTime(time.Now())
+		return crv1alpha1.PhaseProgress{
+			ProgressPercent:    "100",
+			LastTransitionTime: &phaseTime,
+		}, nil
+	}
 	return p.f.ExecutionProgress()
 }
 
@@ -80,8 +98,29 @@ func (p *Phase) Exec(ctx context.Context, bp crv1alpha1.Blueprint, action string
 	}
 	// To simplify usage of the phase secrets in phase functions
 	tp.CurrentPhase = tp.Phases[p.name]
+
+	phaseShouldBeExecuted, err := p.shouldBeExecuted(tp)
+	if err != nil {
+		return nil, err
+	}
+	if !phaseShouldBeExecuted {
+		skipReason := fmt.Sprintf("if=`%s` evaluated to false.", p.condition)
+		log.Print(fmt.Sprintf("SKIP: phase skipped from execution. %s", skipReason))
+		p.phaseSkipped = true
+		p.skipReason = skipReason
+		return nil, nil
+	}
+
 	// Execute the function
 	return p.f.Exec(ctx, tp, p.args)
+}
+
+func (p *Phase) PhaseSkipped() bool {
+	return p.phaseSkipped
+}
+
+func (p *Phase) SkipReason() string {
+	return p.skipReason
 }
 
 func (p *Phase) setPhaseArgs(phases []crv1alpha1.BlueprintPhase, tp param.TemplateParams) error {
@@ -106,6 +145,29 @@ func (p *Phase) setPhaseArgs(phases []crv1alpha1.BlueprintPhase, tp param.Templa
 		p.args = args
 	}
 	return nil
+}
+
+func (p *Phase) shouldBeExecuted(tp param.TemplateParams) (bool, error) {
+	if p.condition == "" {
+		return true, nil
+	}
+	t, parseErr := template.New("config").Parse(p.condition)
+	if parseErr != nil {
+		return false, errkit.WithCause(parseErr, ErrParsePhaseCondition)
+	}
+
+	buf := new(bytes.Buffer)
+	execErr := t.Execute(buf, tp)
+	if execErr != nil {
+		return false, errkit.WithCause(execErr, ErrExecutePhaseCondition)
+	}
+
+	evalResult := strings.ToLower(strings.TrimSpace(buf.String()))
+	if !(evalResult == "true" || evalResult == "false") {
+		err := errkit.New(fmt.Sprintf("if=`%s` expression is not conditional expression", p.condition))
+		return false, errkit.WithCause(err, ErrPhaseExpressionNotConditional)
+	}
+	return evalResult == "true", nil
 }
 
 func renderFuncArgs(
@@ -194,16 +256,22 @@ func GetPhases(bp crv1alpha1.Blueprint, action, version string, tp param.Templat
 			return nil, err
 		}
 		phases = append(phases, &Phase{
-			name:    p.Name,
-			objects: objs,
-			f:       funcs[p.Func][regVersion],
+			name:      p.Name,
+			objects:   objs,
+			condition: p.If,
+			f:         funcs[p.Func][regVersion],
 		})
 	}
 	return phases, nil
 }
 
-// Validate gets the provided arguments from a blueprint and calls Validate method of function to valdiate a function.
+// Validate gets the provided arguments from a blueprint and calls Validate method of function to validate a function.
 func (p *Phase) Validate(args map[string]any) error {
+	err := validatePhaseCondition(p.condition)
+	if err != nil {
+		return err
+	}
+
 	return p.f.Validate(args)
 }
 
@@ -222,4 +290,17 @@ func getFunctionVersion(version string) (*semver.Version, *semver.Version, error
 		}
 		return dv, fv, nil
 	}
+}
+
+func validatePhaseCondition(condition string) error {
+	if condition == "" {
+		return nil
+	}
+
+	_, parseErr := template.New("condition").Parse(condition)
+	if parseErr != nil {
+		return errkit.Wrap(parseErr, "Failed to parse phase's 'if' condition")
+	}
+
+	return nil
 }

--- a/pkg/phase_test.go
+++ b/pkg/phase_test.go
@@ -16,6 +16,8 @@ package kanister
 
 import (
 	"context"
+	"errors"
+	"log"
 
 	"gopkg.in/check.v1"
 
@@ -217,5 +219,85 @@ func (s *PhaseSuite) TestRegFuncVersion(c *check.C) {
 		semVer, err := regFuncVersion(tc.f.Name(), tc.queryVersion)
 		c.Assert(err, check.IsNil)
 		c.Assert(semVer.Original(), check.Equals, tc.expectedVersion)
+	}
+}
+
+func (s *PhaseSuite) TestPhaseCondition(c *check.C) {
+	for _, tc := range []struct {
+		artifact      string
+		condition     string
+		expectedError error
+		argument      string
+		expected      string
+	}{
+		{
+			// Incorrect phase condition throws error
+			artifact:      "hello",
+			argument:      "{{ .Options.test }} world",
+			condition:     "{{",
+			expectedError: ErrParsePhaseCondition,
+			expected:      "",
+		},
+		{
+			// Phase expression that doesn't result in either `true` or `false` throws error
+			artifact:      "hello",
+			argument:      "{{ .Options.test }} world",
+			condition:     "{{\"test\"}}",
+			expectedError: ErrPhaseExpressionNotConditional,
+			expected:      "",
+		},
+		{
+			artifact:      "hello",
+			argument:      "{{ .Options.test }} world",
+			condition:     "{{ .Invalid.Option }}",
+			expectedError: ErrExecutePhaseCondition,
+			expected:      "",
+		},
+		{
+			// Empty phase expression results in running the phase function
+			artifact:      "hello",
+			argument:      "{{ .Options.test }} world",
+			condition:     "",
+			expectedError: nil,
+			expected:      "hello world",
+		},
+		{
+			// Phase function is executed when condition evaluates to `true`
+			artifact:      "hello",
+			argument:      "{{ .Options.test }} world",
+			condition:     "{{ eq .Options.test \"hello\" }}",
+			expectedError: nil,
+			expected:      "hello world",
+		},
+		{
+			// Phase function isn't executed when condition evaluates to `false`
+			artifact:      "hello",
+			argument:      "{{ .Options.test }} world",
+			condition:     "{{ eq .Options.test \"HELLO\" }}",
+			expectedError: nil,
+			expected:      "",
+		},
+	} {
+		var output string
+		tf := &testFunc{output: &output}
+		tp := param.TemplateParams{
+			Options: map[string]string{
+				"test": tc.artifact,
+			},
+		}
+		rawArgs := map[string]interface{}{
+			"testKey": tc.argument,
+		}
+		args, err := param.RenderArgs(rawArgs, tp)
+		c.Assert(err, check.IsNil)
+		p := Phase{args: args, f: tf, condition: tc.condition}
+		_, err = p.Exec(context.Background(), crv1alpha1.Blueprint{}, "", tp)
+		if tc.expectedError != nil {
+			log.Printf("******** Error received: %s", err)
+			c.Assert(errors.Is(err, tc.expectedError), check.Equals, true)
+		} else {
+			c.Assert(err, check.IsNil)
+			c.Assert(output, check.Equals, tc.expected)
+		}
 	}
 }

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -96,6 +96,7 @@ func actionSetStatus(as *crv1alpha1.ActionSetStatus) error {
 		crv1alpha1.StateRunning:  false,
 		crv1alpha1.StateFailed:   false,
 		crv1alpha1.StateComplete: false,
+		crv1alpha1.StateSkipped:  false,
 	}
 	for _, a := range as.Actions {
 		for _, p := range a.Phases {
@@ -129,7 +130,7 @@ func actionSetStatusActions(as []crv1alpha1.ActionStatus) error {
 			if !sawNotComplete {
 				lastNonComplete = p.State
 			}
-			sawNotComplete = p.State != crv1alpha1.StateComplete
+			sawNotComplete = !(p.State == crv1alpha1.StateComplete || p.State == crv1alpha1.StateSkipped)
 		}
 	}
 	return nil

--- a/pkg/validate/validate_test.go
+++ b/pkg/validate/validate_test.go
@@ -476,6 +476,75 @@ func (s *ValidateSuite) TestActionSetStatus(c *check.C) {
 			},
 			checker: check.NotNil,
 		},
+		{
+			as: &crv1alpha1.ActionSetStatus{
+				State: crv1alpha1.StateComplete,
+				Actions: []crv1alpha1.ActionStatus{
+					{
+						Phases: []crv1alpha1.Phase{
+							{
+								State: crv1alpha1.StateSkipped,
+							},
+						},
+					},
+				},
+			},
+			checker: check.IsNil,
+		},
+		{
+			as: &crv1alpha1.ActionSetStatus{
+				State: crv1alpha1.StateFailed,
+				Actions: []crv1alpha1.ActionStatus{
+					{
+						Phases: []crv1alpha1.Phase{
+							{
+								State: crv1alpha1.StateSkipped,
+							},
+							{
+								State: crv1alpha1.StateFailed,
+							},
+						},
+					},
+				},
+			},
+			checker: check.IsNil,
+		},
+		{
+			as: &crv1alpha1.ActionSetStatus{
+				State: crv1alpha1.StateComplete,
+				Actions: []crv1alpha1.ActionStatus{
+					{
+						Phases: []crv1alpha1.Phase{
+							{
+								State: crv1alpha1.StateSkipped,
+							},
+							{
+								State: crv1alpha1.StateComplete,
+							},
+						},
+					},
+				},
+			},
+			checker: check.IsNil,
+		},
+		{
+			as: &crv1alpha1.ActionSetStatus{
+				State: crv1alpha1.StatePending,
+				Actions: []crv1alpha1.ActionStatus{
+					{
+						Phases: []crv1alpha1.Phase{
+							{
+								State: crv1alpha1.StateSkipped,
+							},
+							{
+								State: crv1alpha1.StatePending,
+							},
+						},
+					},
+				},
+			},
+			checker: check.IsNil,
+		},
 	} {
 		err := actionSetStatus(tc.as)
 		c.Check(err, tc.checker)


### PR DESCRIPTION
## Change Overview

Add support to execute a phase based on condition. This PR introduces support for a new field `if` that can be added to a phase. The `if` field supports an expression in go template format. The expression must be conditional. i.e. it should evaluated to either `true` or `false`. If the expression evaluates to `true` then the phase will be executed. If it evaluates to `false`, the phase will be skipped from execution and status will reflect accordingly. To preserve backward compatibility, if a phase doesn't have `if` field, it will be executed.
Example of phase with `if` condition:
```
apiVersion: cr.kanister.io/v1alpha1
kind: Blueprint
metadata:
  name: time-log-bp
  namespace: kanister
actions:
  backup:
    phases:
    - func: KubeExec
      name: backupToS3
      if: '{{ eq .Deployment.Namespace "time-logger-ns" }}'
      args:
        namespace: "{{ .Deployment.Namespace }}"
        pod: "{{ index .Deployment.Pods 0 }}"
        container: test-container
        command:
          - sh
          - -c
          - echo /var/log/time.log
```


## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [x] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :building_construction: Build

## Issues <!-- to auto-close the issue, add the "fixes" keyword -->

- fixes #issue-number

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
